### PR TITLE
property list parsing with native C++ data types

### DIFF
--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -236,6 +236,48 @@ std::string getEtcHostsContent() {
   return content;
 }
 
+std::string getPlistContent() {
+  std::string content = R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Disabled</key>
+  <true/>
+  <key>Label</key>
+  <string>com.apple.FileSyncAgent.sshd</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/System/Library/CoreServices/FileSyncAgent.app/Contents/Resources/FileSyncAgent_sshd-keygen-wrapper</string>
+    <string>-i</string>
+    <string>-f</string>
+    <string>/System/Library/CoreServices/FileSyncAgent.app/Contents/Resources/FileSyncAgent_sshd_config</string>
+  </array>
+  <key>SessionCreate</key>
+  <true/>
+  <key>Sockets</key>
+  <dict>
+    <key>Listeners</key>
+    <dict>
+      <key>SockServiceName</key>
+      <string>appleugcontrol</string>
+      <key>Bonjour</key>
+      <true/>
+    </dict>
+  </dict>
+  <key>StandardErrorPath</key>
+  <string>/dev/null</string>
+  <key>inetdCompatibility</key>
+  <dict>
+    <key>Wait</key>
+    <false/>
+  </dict>
+</dict>
+</plist>
+)";
+  return content;
+}
+
 osquery::db::QueryData getEtcHostsExpectedResults() {
   Row row1;
   Row row2;

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -94,6 +94,9 @@ struct SplitStringTestData {
 // generate a set of test data to test osquery::core::splitString
 std::vector<SplitStringTestData> generateSplitStringTestData();
 
+// generate test content of a property list
+std::string getPlistContent();
+
 }}
 
 #endif /* OSQUERY_CORE_TEST_UTIL_H */

--- a/osquery/filesystem.h
+++ b/osquery/filesystem.h
@@ -3,8 +3,11 @@
 #ifndef OSQUERY_FILESYSTEM_H
 #define OSQUERY_FILESYSTEM_H
 
+#include <map>
 #include <string>
 #include <vector>
+
+#include <boost/property_tree/ptree.hpp>
 
 #include "osquery/status.h"
 
@@ -16,6 +19,13 @@ namespace osquery { namespace fs {
 // successful). An osquery::Status is returned indicating the success or
 // failure of the operation.
 osquery::Status readFile(const std::string& path, std::string& content);
+
+#ifdef __APPLE__
+osquery::Status parsePlist(const std::string& path,
+  boost::property_tree::ptree& tree);
+osquery::Status parsePlistContent(const std::string& fileContent,
+  boost::property_tree::ptree& tree);
+#endif
 
 }}
 

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -1,12 +1,33 @@
+if(APPLE)
+ADD_LIBRARY(osquery_filesystem_osx
+  plist.mm
+)
+TARGET_LINK_LIBRARIES(osquery_filesystem_osx boost_program_options)
+TARGET_LINK_LIBRARIES(osquery_filesystem_osx glog)
+TARGET_LINK_LIBRARIES(osquery_filesystem_osx "-fobjc-arc -fobjc-link-runtime -framework Foundation")
+endif()
+
 ADD_LIBRARY(osquery_filesystem
   filesystem.cpp
 )
 TARGET_LINK_LIBRARIES(osquery_filesystem boost_filesystem)
 TARGET_LINK_LIBRARIES(osquery_filesystem boost_system)
+TARGET_LINK_LIBRARIES(osquery_filesystem boost_program_options)
 TARGET_LINK_LIBRARIES(osquery_filesystem boost_thread-mt)
 TARGET_LINK_LIBRARIES(osquery_filesystem gflags)
 TARGET_LINK_LIBRARIES(osquery_filesystem glog)
+if(APPLE)
+TARGET_LINK_LIBRARIES(osquery_filesystem osquery_filesystem_osx)
+endif()
 
 ADD_EXECUTABLE(filesystem_tests filesystem_tests.cpp)
 TARGET_LINK_LIBRARIES(filesystem_tests gtest)
 TARGET_LINK_LIBRARIES(filesystem_tests osquery_filesystem)
+
+if(APPLE)
+ADD_EXECUTABLE(plist_tests plist_tests.mm)
+TARGET_LINK_LIBRARIES(plist_tests glog)
+TARGET_LINK_LIBRARIES(plist_tests gtest)
+TARGET_LINK_LIBRARIES(plist_tests osquery_core)
+TARGET_LINK_LIBRARIES(plist_tests osquery_filesystem)
+endif()

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -29,9 +29,9 @@ Status readFile(const std::string& path, std::string& content) {
      char *buffer = new char [len];
      file_h.read(buffer, len);
      if (!file_h) {
-      return Status(1, "Could not entire file");
+      return Status(1, "Could not read file");
      }
-     content = std::string(buffer);
+     content.assign(buffer, len);
   } else {
     return Status(1, "Could not open file for reading");
   }

--- a/osquery/filesystem/plist.mm
+++ b/osquery/filesystem/plist.mm
@@ -1,0 +1,91 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "osquery/filesystem.h"
+
+#include <sstream>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <glog/logging.h>
+
+#import <Foundation/Foundation.h>
+
+using osquery::Status;
+namespace pt = boost::property_tree;
+
+namespace osquery { namespace fs {
+
+Status parsePlistContent(const std::string& fileContent, pt::ptree& tree) {
+  NSData *plistContent = [NSData dataWithBytes:fileContent.c_str()
+                                        length:fileContent.size()];
+
+  NSError *error;
+  NSPropertyListFormat plistFormat;
+  NSDictionary *plist = (NSDictionary*)
+    [NSPropertyListSerialization propertyListWithData:plistContent
+                                              options:NSPropertyListImmutable
+                                               format:&plistFormat
+                                                error:&error];
+
+  if (plist == nil) {
+    std::string errorMessage([[error localizedFailureReason] UTF8String]);
+    LOG(ERROR) << errorMessage;
+    return Status(1, errorMessage);
+  } else {
+    switch (plistFormat) {
+    case NSPropertyListOpenStepFormat:
+      VLOG(1) << "plist was in openstep format";
+      break;
+    case NSPropertyListXMLFormat_v1_0:
+      VLOG(1) << "plist was in xml format";
+      break;
+    case NSPropertyListBinaryFormat_v1_0:
+      VLOG(1) << "plist was in binary format";
+      break;
+    default:
+      VLOG(1) << "plist was in unknown format";
+      break;
+    }
+  }
+
+  NSData *jsonDataObjc;
+  if ([NSJSONSerialization isValidJSONObject:plist]) {
+    jsonDataObjc = [NSJSONSerialization dataWithJSONObject:plist
+                                                   options:0
+                                                     error:&error];
+  } else {
+    return Status(1, "Valid JSON was not deserialized");
+  }
+  if (jsonDataObjc == nil) {
+    std::string errorMessage([[error localizedFailureReason] UTF8String]);
+    LOG(ERROR) << errorMessage;
+    return Status(1, errorMessage);
+  }
+
+  NSString* jsonStringObjc = [[NSString alloc] initWithBytes:[jsonDataObjc bytes]
+                                                      length:[jsonDataObjc length]
+                                                    encoding:NSUTF8StringEncoding];
+  std::string jsonStringCxx = std::string([jsonStringObjc UTF8String]);
+  VLOG(2) << "Deserialized JSON content from plist: " << jsonStringCxx;
+  std::stringstream ss;
+  ss << jsonStringCxx;
+  try {
+    pt::read_json(ss, tree);
+  } catch(pt::json_parser::json_parser_error &e) {
+    LOG(ERROR) << "Error reading JSON: " << e.what();
+    return Status(1, e.what());
+  }
+
+  return Status(0, "OK");
+}
+
+Status parsePlist(const std::string& path, pt::ptree& tree) {
+  std::string fileContent;
+  Status s = readFile(path, fileContent);
+  if (!s.ok()) {
+    return s;
+  }
+  return parsePlistContent(fileContent, tree);
+}
+
+}}

--- a/osquery/filesystem/plist_tests.mm
+++ b/osquery/filesystem/plist_tests.mm
@@ -1,0 +1,55 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "osquery/filesystem.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#import <Foundation/Foundation.h>
+
+#include "osquery/core/test_util.h"
+
+using namespace osquery::core;
+namespace pt = boost::property_tree;
+
+namespace osquery { namespace fs {
+
+class PlistTests : public testing::Test {};
+
+TEST_F(PlistTests, test_parse_plist) {
+  std::string path = "/System/Library/LaunchDaemons/com.apple.kextd.plist";
+  boost::property_tree::ptree tree;
+  auto s = parsePlist(path, tree);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.toString(), "OK");
+}
+
+TEST_F(PlistTests, test_parse_plist_content) {
+  std::string content = getPlistContent();
+  pt::ptree tree;
+  auto s = parsePlistContent(content, tree);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.toString(), "OK");
+  EXPECT_EQ(tree.get<bool>("Disabled"), true);
+  EXPECT_EQ(tree.get<std::string>("Label"), "com.apple.FileSyncAgent.sshd");
+  std::vector<std::string> program_arguments = {
+    "/System/Library/CoreServices/FileSyncAgent.app/Contents/Resources/FileSyncAgent_sshd-keygen-wrapper",
+    "-i",
+    "-f",
+    "/System/Library/CoreServices/FileSyncAgent.app/Contents/Resources/FileSyncAgent_sshd_config",
+  };
+  pt::ptree program_arguments_tree = tree.get_child("ProgramArguments");
+  std::vector<std::string> program_arguments_parsed;
+  for (const auto& argument : program_arguments_tree) {
+      program_arguments_parsed.push_back(argument.second.get<std::string>(""));
+  }
+  EXPECT_EQ(program_arguments_parsed, program_arguments);
+}
+
+}}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Given a path to a plist, or the content of a plist, return a boost::property_tree::ptree.
