### PR TITLE
OS X virtual tables for currently installed applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 	python tools/gentable.py osquery/tables/specs/alf_exceptions.table
 	python tools/gentable.py osquery/tables/specs/alf_explicit_auths.table
 	python tools/gentable.py osquery/tables/specs/alf_services.table
+	python tools/gentable.py osquery/tables/specs/apps.table
 	mkdir -p build
 	cd build && cmake .. && make -j5
 

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -477,5 +477,97 @@ pt::ptree getALFTree() {
   fs::parsePlistContent(content, tree);
   return tree;
 }
+
+std::string getInfoPlistContent() {
+  std::string content = R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>BuildMachineOSBuild</key>
+  <string>13C23</string>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleDocumentTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeExtensions</key>
+      <array>
+        <string>Photo Booth</string>
+      </array>
+      <key>CFBundleTypeIconFile</key>
+      <string>PBLibraryIcon</string>
+      <key>CFBundleTypeName</key>
+      <string>Photo Booth Library</string>
+      <key>CFBundleTypeOSTypes</key>
+      <array>
+        <string>PBLb</string>
+      </array>
+      <key>CFBundleTypeRole</key>
+      <string>Viewer</string>
+      <key>LSTypeIsPackage</key>
+      <true/>
+      <key>NSDocumentClass</key>
+      <string>ArchiveDocument</string>
+    </dict>
+  </array>
+  <key>CFBundleExecutable</key>
+  <string>Photo Booth</string>
+  <key>CFBundleHelpBookFolder</key>
+  <string>PhotoBooth.help</string>
+  <key>CFBundleHelpBookName</key>
+  <string>com.apple.PhotoBooth.help</string>
+  <key>CFBundleIconFile</key>
+  <string>PhotoBooth.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.apple.PhotoBooth</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>6.0</string>
+  <key>CFBundleSignature</key>
+  <string>PhBo</string>
+  <key>CFBundleVersion</key>
+  <string>517</string>
+  <key>DTCompiler</key>
+  <string>com.apple.compilers.llvm.clang.1_0</string>
+  <key>DTPlatformBuild</key>
+  <string>5A2053</string>
+  <key>DTPlatformVersion</key>
+  <string>GM</string>
+  <key>DTSDKBuild</key>
+  <string>13C23</string>
+  <key>DTSDKName</key>
+  <string></string>
+  <key>DTXcode</key>
+  <string>0501</string>
+  <key>DTXcodeBuild</key>
+  <string>5A2053</string>
+  <key>LSApplicationCategoryType</key>
+  <string>public.app-category.entertainment</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>10.7.0</string>
+  <key>NSMainNibFile</key>
+  <string>MainMenu</string>
+  <key>NSPrincipalClass</key>
+  <string>PBApplication</string>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
+  <key>NSSupportsSuddenTermination</key>
+  <string>YES</string>
+</dict>
+</plist>
+)";
+  return content;
+}
+
+pt::ptree getInfoPlistTree() {
+  auto content = getInfoPlistContent();
+  pt::ptree tree;
+  fs::parsePlistContent(content, tree);
+  return tree;
+}
 }
 }

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -102,6 +102,12 @@ std::string getALFcontent();
 
 // generate a test ptree of the content returned by getALFContent
 boost::property_tree::ptree getALFTree();
+
+// generate test content of an Info.plist file
+std::string getInfoPlistContent();
+
+// generate a test ptree of the content returned by getInfoPlistContent
+boost::property_tree::ptree getInfoPlistTree();
 }
 }
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -14,6 +14,7 @@ ADD_LIBRARY(osquery_tables
   ../core/osx/NSProcessInfo+PECocoaBackports.mm
   system/osx_version.mm
   system/firewall.cpp
+  system/apps.cpp
 )
 TARGET_LINK_LIBRARIES(osquery_tables boost_filesystem)
 TARGET_LINK_LIBRARIES(osquery_tables glog)
@@ -37,3 +38,11 @@ TARGET_LINK_LIBRARIES(firewall_tests osquery_core)
 TARGET_LINK_LIBRARIES(firewall_tests osquery_database)
 TARGET_LINK_LIBRARIES(firewall_tests osquery_filesystem)
 TARGET_LINK_LIBRARIES(firewall_tests osquery_tables)
+
+ADD_EXECUTABLE(apps_tests system/apps_tests.cpp)
+TARGET_LINK_LIBRARIES(apps_tests gtest)
+TARGET_LINK_LIBRARIES(apps_tests glog)
+TARGET_LINK_LIBRARIES(apps_tests osquery_core)
+TARGET_LINK_LIBRARIES(apps_tests osquery_database)
+TARGET_LINK_LIBRARIES(apps_tests osquery_filesystem)
+TARGET_LINK_LIBRARIES(apps_tests osquery_tables)

--- a/osquery/tables/specs/apps.table
+++ b/osquery/tables/specs/apps.table
@@ -1,0 +1,20 @@
+table_name("apps")
+schema([
+    Column(name="name", type="std::string"),
+    Column(name="path", type="std::string"),
+    Column(name="bundle_executable", type="std::string"),
+    Column(name="bundle_identifier", type="std::string"),
+    Column(name="bundle_name", type="std::string"),
+    Column(name="bundle_short_version", type="std::string"),
+    Column(name="bundle_version", type="std::string"),
+    Column(name="bundle_package_type", type="std::string"),
+    Column(name="compiler", type="std::string"),
+    Column(name="development_region", type="std::string"),
+    Column(name="display_name", type="std::string"),
+    Column(name="info_string", type="std::string"),
+    Column(name="minimum_system_version", type="std::string"),
+    Column(name="category", type="std::string"),
+    Column(name="applescript_enabled", type="std::string"),
+    Column(name="copyright", type="std::string"),
+])
+implementation("osquery/tables/system/apps@genApps")

--- a/osquery/tables/system/apps.cpp
+++ b/osquery/tables/system/apps.cpp
@@ -1,0 +1,141 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <glog/logging.h>
+
+#include "osquery/core.h"
+#include "osquery/database.h"
+#include "osquery/filesystem.h"
+
+using namespace osquery::db;
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+const std::map<std::string, std::string> kAppsInfoPlistTopLevelStringKeys = {
+    {"CFBundleExecutable", "bundle_executable"},
+    {"CFBundleIdentifier", "bundle_identifier"},
+    {"CFBundleName", "bundle_name"},
+    {"CFBundleShortVersionString", "bundle_short_version"},
+    {"CFBundleVersion", "bundle_version"},
+    {"CFBundlePackageType", "bundle_package_type"},
+    {"CFBundleDevelopmentRegion", "development_region"},
+    {"CFBundleDisplayName", "display_name"},
+    {"CFBundleGetInfoString", "info_string"},
+    {"DTCompiler", "compiler"},
+    {"LSMinimumSystemVersion", "minimum_system_version"},
+    {"LSApplicationCategoryType", "category"},
+    {"NSAppleScriptEnabled", "applescript_enabled"},
+    {"NSHumanReadableCopyright", "copyright"}, };
+
+const std::vector<std::string> kHomeDirSearchPaths = {
+    "/Applications", "/Desktops", "/Downloads", };
+
+std::vector<std::string> getAppInfoPlistPaths() {
+  std::vector<std::string> results;
+
+  std::vector<std::string> slash_applications;
+  auto slash_apps_s =
+      osquery::fs::listFilesInDirectory("/Applications", slash_applications);
+  if (slash_apps_s.ok()) {
+    for (const auto& app_path : slash_applications) {
+      std::string path = app_path + "/Contents/Info.plist";
+      if (boost::filesystem::exists(path)) {
+        results.push_back(path);
+      }
+    }
+  } else {
+    LOG(ERROR) << "Error listing /Applications: " << slash_apps_s.toString();
+  }
+
+  std::vector<std::string> home_dirs;
+  auto home_dirs_s = osquery::fs::listFilesInDirectory("/Users", home_dirs);
+  if (home_dirs_s.ok()) {
+    for (const auto& home_dir : home_dirs) {
+      for (const auto& dir_to_check : kHomeDirSearchPaths) {
+        std::string apps_path = home_dir + dir_to_check;
+        if (boost::filesystem::is_directory(apps_path)) {
+          std::vector<std::string> user_apps;
+          auto user_apps_s =
+              osquery::fs::listFilesInDirectory(apps_path, user_apps);
+          if (!user_apps_s.ok()) {
+            VLOG(1) << "Error listing " << apps_path << ": "
+                    << user_apps_s.toString();
+            continue;
+          }
+          for (const auto& user_app : user_apps) {
+            std::string path = user_app + "/Contents/Info.plist";
+            if (boost::filesystem::exists(path)) {
+              results.push_back(path);
+            }
+          }
+        }
+      }
+    }
+  } else {
+    LOG(ERROR) << "Error listing /Users: " << home_dirs_s.toString();
+  }
+
+  return results;
+}
+
+std::string getNameFromInfoPlistPath(const std::string& path) {
+  auto bits = osquery::core::split(path, "/");
+  if (bits.size() >= 4) {
+    return bits[bits.size() - 3];
+  } else {
+    return "";
+  }
+}
+
+std::string getPathFromInfoPlistPath(const std::string& path) {
+  auto bits = osquery::core::split(path, "/");
+  if (bits.size() >= 4) {
+    bits.pop_back();
+    bits.pop_back();
+    return "/" + boost::algorithm::join(bits, "/");
+  } else {
+    return "";
+  }
+}
+
+Row parseInfoPlist(const std::string& path, const pt::ptree& tree) {
+  Row r;
+  r["name"] = getNameFromInfoPlistPath(path);
+  r["path"] = getPathFromInfoPlistPath(path);
+  for (const auto& it : kAppsInfoPlistTopLevelStringKeys) {
+    try {
+      r[it.second] = tree.get<std::string>(it.first);
+    }
+    catch (const pt::ptree_error& e) {
+      VLOG(1) << "Error retrieving " << it.first << " from " << path << ": "
+              << e.what();
+      r[it.second] = "";
+    }
+  }
+  return r;
+}
+
+QueryData genApps() {
+  QueryData results;
+
+  for (const auto& path : getAppInfoPlistPaths()) {
+    pt::ptree tree;
+    auto s = osquery::fs::parsePlist(path, tree);
+    if (s.ok()) {
+      results.push_back(parseInfoPlist(path, tree));
+    } else {
+      LOG(ERROR) << "Error parsing " << path << ": " << s.toString();
+    }
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/apps_tests.cpp
+++ b/osquery/tables/system/apps_tests.cpp
@@ -1,0 +1,83 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+#include "osquery/core/test_util.h"
+#include "osquery/database.h"
+#include "osquery/filesystem.h"
+
+using namespace osquery::core;
+using namespace osquery::db;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+std::vector<std::string> getAppInfoPlistPaths();
+std::string getNameFromInfoPlistPath(const std::string& path);
+std::string getPathFromInfoPlistPath(const std::string& path);
+Row parseInfoPlist(const std::string& path, const pt::ptree& tree);
+
+class AppsTests : public testing::Test {};
+
+TEST_F(AppsTests, get_name_from_info_plist_path) {
+  EXPECT_EQ(
+      "Foo.app",
+      getNameFromInfoPlistPath("/Applications/Foo.app/Contents/Info.plist"));
+  EXPECT_EQ("Foo Bar.app",
+            getNameFromInfoPlistPath(
+                "/Applications/Foo Bar.app/Contents/Info.plist"));
+  EXPECT_EQ("Foo.app",
+            getNameFromInfoPlistPath(
+                "/Users/marpaia/Applications/Foo.app/Contents/Info.plist"));
+  EXPECT_EQ("Foo Bar.app",
+            getNameFromInfoPlistPath(
+                "/Users/marpaia/Applications/Foo Bar.app/Contents/Info.plist"));
+}
+
+TEST_F(AppsTests, get_path_from_info_plist_path) {
+  EXPECT_EQ(
+      "/Applications/Foo.app",
+      getPathFromInfoPlistPath("/Applications/Foo.app/Contents/Info.plist"));
+  EXPECT_EQ("/Applications/Foo Bar.app",
+            getPathFromInfoPlistPath(
+                "/Applications/Foo Bar.app/Contents/Info.plist"));
+  EXPECT_EQ("/Users/marpaia/Applications/Foo.app",
+            getPathFromInfoPlistPath(
+                "/Users/marpaia/Applications/Foo.app/Contents/Info.plist"));
+  EXPECT_EQ("/Users/marpaia/Applications/Foo Bar.app",
+            getPathFromInfoPlistPath(
+                "/Users/marpaia/Applications/Foo Bar.app/Contents/Info.plist"));
+}
+
+TEST_F(AppsTests, test_parse_info_plist) {
+  auto tree = getInfoPlistTree();
+  Row expected = {{"name", "Foobar.app"},
+                  {"path", "/Applications/Foobar.app"},
+                  {"bundle_executable", "Photo Booth"},
+                  {"bundle_identifier", "com.apple.PhotoBooth"},
+                  {"bundle_name", ""},
+                  {"bundle_short_version", "6.0"},
+                  {"bundle_version", "517"},
+                  {"bundle_package_type", "APPL"},
+                  {"compiler", "com.apple.compilers.llvm.clang.1_0"},
+                  {"development_region", "English"},
+                  {"display_name", ""},
+                  {"info_string", ""},
+                  {"minimum_system_version", "10.7.0"},
+                  {"category", "public.app-category.entertainment"},
+                  {"applescript_enabled", ""},
+                  {"copyright", ""}, };
+  EXPECT_EQ(
+      parseInfoPlist("/Applications/Foobar.app/Contents/Info.plist", tree),
+      expected);
+}
+}
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
All applications which have a `Contents/Info.plist` file and are installed in the following places:
- /Applications
- ~/Applications (for all home directories)
- ~/Desktop (for all home directories)
- ~/Downloads (for all home directories)
#23
