### PR TITLE
[vtable_routes] Added vtable for various network routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 	python tools/gentable.py osquery/tables/specs/launchd.table
 	python tools/gentable.py osquery/tables/specs/cacerts.table
 	python tools/gentable.py osquery/tables/specs/listening_ports.table
+	python tools/gentable.py osquery/tables/specs/routes.table
 	mkdir -p build
 	cd build && cmake .. && make -j5
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -9,6 +9,7 @@ ADD_LIBRARY(osquery_tables
   examples/example.cpp
   networking/etc_hosts.cpp
   networking/listening_ports.cpp
+  networking/routes.cpp
   system/kextstat.cpp
   system/processes.cpp
   system/nvram.cpp

--- a/osquery/tables/networking/routes.cpp
+++ b/osquery/tables/networking/routes.cpp
@@ -1,0 +1,166 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <string>
+#include <iomanip>
+
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <arpa/inet.h>
+#include <net/if_dl.h>
+#include <net/route.h>
+#include <sys/sysctl.h>
+
+#include <boost/lexical_cast.hpp>
+
+#include <glog/logging.h>
+
+#include "osquery/core.h"
+#include "osquery/database.h"
+
+using namespace osquery::core;
+using namespace osquery::db;
+
+namespace osquery {
+namespace tables {
+
+typedef std::pair<int, std::string> RouteType;
+typedef std::map<int, std::string> InterfaceMap;
+
+const std::string kDefaultRoute = "0.0.0.0";
+
+const std::vector<RouteType> kRouteTypes = {
+    std::make_pair(RTF_LOCAL, "local"),
+    std::make_pair(RTF_GATEWAY, "gateway"),
+    std::make_pair(RTF_HOST, "host"),
+    std::make_pair(RTF_DYNAMIC, "dynamic"),
+    std::make_pair(RTF_MODIFIED, "modified"),
+    std::make_pair(RTF_LLINFO, "linklayer"),
+    std::make_pair(RTF_STATIC, "static"),
+    std::make_pair(RTF_BLACKHOLE, "blackhole"),
+    std::make_pair(RTF_ROUTER, "router"),
+    std::make_pair(RTF_PROXY, "proxy"), };
+
+InterfaceMap genInterfaceMap() {
+  InterfaceMap ifmap;
+
+  struct ifaddrs *if_addrs, *if_addr;
+  struct sockaddr_dl *sdl;
+
+  if (getifaddrs(&if_addrs) != 0) {
+    LOG(ERROR) << "Failed to create interface map, getifaddrs() failed.";
+    return ifmap;
+  }
+
+  InterfaceMap::iterator it = ifmap.begin();
+  for (if_addr = if_addrs; if_addr != NULL; if_addr = if_addr->ifa_next) {
+    if (if_addr->ifa_addr != NULL && if_addr->ifa_addr->sa_family == AF_LINK) {
+      sdl = (struct sockaddr_dl *)if_addr->ifa_addr;
+      ifmap.insert(
+          it, std::make_pair(sdl->sdl_index, std::string(if_addr->ifa_name)));
+    }
+  }
+
+  freeifaddrs(if_addrs);
+  return ifmap;
+}
+
+std::string canonicalAddress(const struct sockaddr *in) {
+  char dst[INET6_ADDRSTRLEN];
+  memset(dst, 0, sizeof(dst));
+  void *in_addr;
+
+  if (in->sa_family == AF_INET) {
+    in_addr = (void *)&(((struct sockaddr_in *)in)->sin_addr);
+  } else if (in->sa_family == AF_INET6) {
+    in_addr = (void *)&(((struct sockaddr_in6 *)in)->sin6_addr);
+  } else {
+    return "";
+  }
+
+  inet_ntop(in->sa_family, in_addr, dst, sizeof(dst));
+  return std::string(dst);
+}
+
+void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
+  int mib[] = {CTL_NET, PF_ROUTE, 0, AF_UNSPEC, NET_RT_FLAGS, type.first};
+  size_t table_size;
+  char *table, *p;
+  struct rt_msghdr *route;
+  struct sockaddr *sa;
+  struct sockaddr *sa_table[RTAX_MAX];
+  struct sockaddr_dl *sdl;
+
+  if (sysctl(mib, sizeof(mib) / sizeof(int), 0, &table_size, 0, 0) < 0) {
+    return;
+  }
+
+  if (table_size == 0) {
+    return;
+  }
+
+  table = (char *)malloc(table_size);
+  if (sysctl(mib, sizeof(mib) / sizeof(int), table, &table_size, 0, 0) < 0) {
+    free(table);
+    return;
+  }
+
+  for (p = table; p < table + table_size; p += route->rtm_msglen) {
+    route = (struct rt_msghdr *)p;
+    sa = (struct sockaddr *)(route + 1);
+
+    // Populate route's sockaddr table (dest, gw, mask).
+    for (int i = 0; i < RTAX_MAX; i++) {
+      if (route->rtm_addrs & (1 << i)) {
+        sa_table[i] = sa;
+        sa = (struct sockaddr *)((char *)sa + (sa->sa_len));
+      } else {
+        sa_table[i] = NULL;
+      }
+    }
+
+    Row r;
+    r["type"] = type.second;
+    r["flags"] = boost::lexical_cast<std::string>(route->rtm_flags);
+    r["use"] = boost::lexical_cast<std::string>(route->rtm_use);
+    r["mtu"] = boost::lexical_cast<std::string>(route->rtm_rmx.rmx_mtu);
+
+    if ((route->rtm_addrs & RTA_DST) == RTA_DST) {
+      r["destination"] = canonicalAddress(sa_table[RTAX_DST]);
+    }
+
+    if ((route->rtm_addrs & RTA_GATEWAY) == RTA_GATEWAY) {
+      sdl = (struct sockaddr_dl *)sa_table[RTAX_GATEWAY];
+      r["interface"] = ifmap[(int)sdl->sdl_index];
+      r["gateway"] = canonicalAddress(sa_table[RTAX_GATEWAY]);
+    }
+
+    if (kDefaultRoute.compare(r["destination"]) == 0) {
+      r["netmask"] = kDefaultRoute;
+    } else if ((route->rtm_addrs & RTA_NETMASK) == RTA_NETMASK) {
+      sa_table[RTAX_NETMASK]->sa_family = sa_table[RTAX_DST]->sa_family;
+      r["netmask"] = canonicalAddress(sa_table[RTAX_NETMASK]);
+    }
+
+    results.push_back(r);
+  }
+
+  free(table);
+}
+
+QueryData genRoutes() {
+  QueryData results;
+  InterfaceMap ifmap;
+
+  // Need a map from index->name for each route entry.
+  ifmap = genInterfaceMap();
+
+  for (const auto& route_type : kRouteTypes) {
+    genRouteTableType(route_type, ifmap, results);
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/specs/routes.table
+++ b/osquery/tables/specs/routes.table
@@ -1,0 +1,11 @@
+table_name("routes")
+schema([
+    Column(name="destination", type="std::string"),
+    Column(name="gateway", type="std::string"),
+    Column(name="flags", type="int"),
+    Column(name="use", type="int"),
+    Column(name="interface", type="std::string"),
+    Column(name="mtu", type="int"),
+    Column(name="type", type="std::string"),
+])
+implementation("osquery/tables/networking/routes@genRoutes")


### PR DESCRIPTION
For https://github.com/facebook/osquery/issues/53

There're two gotchas that need to be evaluated:
1. There's not a definite interface name for each route. 
2. The "type" of route seems pretty OS/networking-arcane, because it is! They could change to their API macro name RTF_etc, making it more arcane, but perhaps more understandable for a systems developer.
