### PR TITLE
Moving osquery cmake code into the source tree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,46 +8,7 @@ FIND_PACKAGE(Sqlite3 REQUIRED)
 
 INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}")
 INCLUDE_DIRECTORIES("/usr/local/include")
-
 LINK_DIRECTORIES("/usr/local/lib")
 
-ADD_SUBDIRECTORY(osquery/config)
-ADD_SUBDIRECTORY(osquery/core)
-ADD_SUBDIRECTORY(osquery/database)
-ADD_SUBDIRECTORY(osquery/devtools)
-ADD_SUBDIRECTORY(osquery/filesystem)
-ADD_SUBDIRECTORY(osquery/logger)
-ADD_SUBDIRECTORY(osquery/scheduler)
-ADD_SUBDIRECTORY(osquery/tables)
-
-SET(OSQUERY_LIBS
-  gflags
-  glog
-  osquery_config
-  osquery_core
-  osquery_database
-  osquery_devtools
-  osquery_filesystem
-  osquery_logger
-  osquery_scheduler
-  osquery_sqlite
-  osquery_tables
-)
-
-ADD_LIBRARY(osquery_static osquery/main/lib.cpp)
-TARGET_LINK_LIBRARIES(osquery_static ${OSQUERY_LIBS})
-SET_TARGET_PROPERTIES(osquery_static PROPERTIES OUTPUT_NAME osquery)
-
-ADD_EXECUTABLE(shell osquery/main/shell.cpp)
-TARGET_LINK_LIBRARIES(shell osquery_static)
-SET_TARGET_PROPERTIES(shell PROPERTIES OUTPUT_NAME osqueryi)
-SET_TARGET_PROPERTIES(shell PROPERTIES COMPILE_FLAGS "-std=c++11 -stdlib=libc++")
-INSTALL(TARGETS shell DESTINATION bin)
-
-ADD_EXECUTABLE(daemon osquery/main/daemon.cpp)
-TARGET_LINK_LIBRARIES(daemon osquery_static)
-SET_TARGET_PROPERTIES(daemon PROPERTIES OUTPUT_NAME osqueryd)
-SET_TARGET_PROPERTIES(daemon PROPERTIES COMPILE_FLAGS "-std=c++11 -stdlib=libc++")
-INSTALL(TARGETS daemon DESTINATION bin)
-
+ADD_SUBDIRECTORY(osquery)
 ADD_SUBDIRECTORY(tools)

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -1,0 +1,38 @@
+ADD_SUBDIRECTORY(config)
+ADD_SUBDIRECTORY(core)
+ADD_SUBDIRECTORY(database)
+ADD_SUBDIRECTORY(devtools)
+ADD_SUBDIRECTORY(filesystem)
+ADD_SUBDIRECTORY(logger)
+ADD_SUBDIRECTORY(scheduler)
+ADD_SUBDIRECTORY(tables)
+
+SET(OSQUERY_LIBS
+  gflags
+  glog
+  osquery_config
+  osquery_core
+  osquery_database
+  osquery_devtools
+  osquery_filesystem
+  osquery_logger
+  osquery_scheduler
+  osquery_sqlite
+  osquery_tables
+)
+
+ADD_LIBRARY(osquery_static main/lib.cpp)
+TARGET_LINK_LIBRARIES(osquery_static ${OSQUERY_LIBS})
+SET_TARGET_PROPERTIES(osquery_static PROPERTIES OUTPUT_NAME osquery)
+
+ADD_EXECUTABLE(shell main/shell.cpp)
+TARGET_LINK_LIBRARIES(shell osquery_static)
+SET_TARGET_PROPERTIES(shell PROPERTIES OUTPUT_NAME osqueryi)
+SET_TARGET_PROPERTIES(shell PROPERTIES COMPILE_FLAGS "-std=c++11 -stdlib=libc++")
+INSTALL(TARGETS shell DESTINATION bin)
+
+ADD_EXECUTABLE(daemon main/daemon.cpp)
+TARGET_LINK_LIBRARIES(daemon osquery_static)
+SET_TARGET_PROPERTIES(daemon PROPERTIES OUTPUT_NAME osqueryd)
+SET_TARGET_PROPERTIES(daemon PROPERTIES COMPILE_FLAGS "-std=c++11 -stdlib=libc++")
+INSTALL(TARGETS daemon DESTINATION bin)

--- a/package/darwin/osquery.pkgproj
+++ b/package/darwin/osquery.pkgproj
@@ -465,7 +465,7 @@
 												<key>GID</key>
 												<integer>0</integer>
 												<key>PATH</key>
-												<string>../../build/osqueryd</string>
+												<string>../../build/osquery/osqueryd</string>
 												<key>PATH_TYPE</key>
 												<integer>1</integer>
 												<key>PERMISSIONS</key>
@@ -481,7 +481,7 @@
 												<key>GID</key>
 												<integer>0</integer>
 												<key>PATH</key>
-												<string>../../build/osqueryi</string>
+												<string>../../build/osquery/osqueryi</string>
 												<key>PATH_TYPE</key>
 												<integer>1</integer>
 												<key>PERMISSIONS</key>
@@ -953,6 +953,39 @@
 					<dict>
 						<key>CHILDREN</key>
 						<array>
+							<dict>
+								<key>CHILDREN</key>
+								<array>
+									<dict>
+										<key>CHILDREN</key>
+										<array/>
+										<key>GID</key>
+										<integer>0</integer>
+										<key>PATH</key>
+										<string>osquery</string>
+										<key>PATH_TYPE</key>
+										<integer>0</integer>
+										<key>PERMISSIONS</key>
+										<integer>493</integer>
+										<key>TYPE</key>
+										<integer>2</integer>
+										<key>UID</key>
+										<integer>0</integer>
+									</dict>
+								</array>
+								<key>GID</key>
+								<integer>0</integer>
+								<key>PATH</key>
+								<string>log</string>
+								<key>PATH_TYPE</key>
+								<integer>0</integer>
+								<key>PERMISSIONS</key>
+								<integer>493</integer>
+								<key>TYPE</key>
+								<integer>2</integer>
+								<key>UID</key>
+								<integer>0</integer>
+							</dict>
 							<dict>
 								<key>CHILDREN</key>
 								<array>


### PR DESCRIPTION
I like the pattern of the root CMakeLists.txt being the parent file
which sets global parameters and the children doing their level of
compilation.

I also updated the OS X pkg creator.
