### PR TITLE
[events] Events lifecycle complete, passwd_changes vtable

### DIFF
--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -47,7 +47,10 @@ osquery::Status serializeRow(const Row& r, boost::property_tree::ptree& tree);
  * @return an instance of osquery::Status, indicating the success or failure
  * of the operation
  */
-osquery::Status serializeRowJSON(const Row& r, std::string json);
+osquery::Status serializeRowJSON(const Row& r, std::string& json);
+
+osquery::Status deserializeRow(const boost::property_tree::ptree& tree, Row& r);
+osquery::Status deserializeRowJSON(const std::string& json, Row& r);
 
 /////////////////////////////////////////////////////////////////////////////
 // QueryData

--- a/osquery/database/results.cpp
+++ b/osquery/database/results.cpp
@@ -36,7 +36,7 @@ Status serializeRow(const Row& r, pt::ptree& tree) {
   return Status(0, "OK");
 }
 
-Status serializeRowJSON(const Row& r, std::string json) {
+Status serializeRowJSON(const Row& r, std::string& json) {
   pt::ptree tree;
   try {
     auto status = serializeRow(r, tree);
@@ -50,6 +50,32 @@ Status serializeRowJSON(const Row& r, std::string json) {
     return Status(1, e.what());
   }
   return Status(0, "OK");
+}
+
+Status deserializeRow(const pt::ptree& tree, Row& r) {
+  try {
+    for (auto& i : tree) {
+      if (i.first.length() > 0) {
+        r[i.first] = i.second.data();
+      }
+    }
+    return Status(0, "OK");
+  } catch (const std::exception& e) {
+    LOG(ERROR) << e.what();
+    return Status(1, e.what());
+  }
+}
+
+Status deserializeRowJSON(const std::string& json, Row& r) {
+  pt::ptree tree;
+  try {
+    std::stringstream j;
+    j << json;
+    pt::read_json(j, tree);
+  } catch (const std::exception& e) {
+    return Status(1, e.what());
+  }
+  return deserializeRow(tree, r);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/osquery/events/events_database_tests.cpp
+++ b/osquery/events/events_database_tests.cpp
@@ -40,7 +40,7 @@ class AnotherFakeEventModule : public EventModule {
 };
 
 TEST_F(EventsDatabaseTests, test_event_module_id) {
-  auto fake_event_module = FakeEventModule::get();
+  auto fake_event_module = FakeEventModule::getInstance();
   // Not normally available outside of EventModule->Add().
   auto event_id1 = fake_event_module->getEventID();
   EXPECT_EQ(event_id1, "1");
@@ -49,8 +49,8 @@ TEST_F(EventsDatabaseTests, test_event_module_id) {
 }
 
 TEST_F(EventsDatabaseTests, test_unique_event_module_id) {
-  auto fake_event_module = FakeEventModule::get();
-  auto another_fake_event_module = AnotherFakeEventModule::get();
+  auto fake_event_module = FakeEventModule::getInstance();
+  auto another_fake_event_module = AnotherFakeEventModule::getInstance();
   // Not normally available outside of EventModule->Add().
   auto event_id1 = fake_event_module->getEventID();
   EXPECT_EQ(event_id1, "3");
@@ -63,7 +63,7 @@ TEST_F(EventsDatabaseTests, test_event_add) {
   r["testing"] = std::string("hello from space");
   size_t event_time = 10;
 
-  auto fake_event_module = FakeEventModule::get();
+  auto fake_event_module = FakeEventModule::getInstance();
   auto status = fake_event_module->testAdd(1);
   EXPECT_TRUE(status.ok());
 }

--- a/osquery/events/events_tests.cpp
+++ b/osquery/events/events_tests.cpp
@@ -8,7 +8,7 @@ namespace osquery {
 
 class EventsTests : public testing::Test {
  protected:
-  virtual void SetUp() { ef = EventFactory::get(); }
+  virtual void SetUp() { ef = EventFactory::getInstance(); }
 
   virtual void TearDown() { ef->deregisterEventTypes(); }
 
@@ -16,8 +16,8 @@ class EventsTests : public testing::Test {
 };
 
 TEST_F(EventsTests, test_singleton) {
-  auto one = EventFactory::get();
-  auto two = EventFactory::get();
+  auto one = EventFactory::getInstance();
+  auto two = EventFactory::getInstance();
   EXPECT_EQ(one, two);
 }
 
@@ -196,10 +196,7 @@ TEST_F(EventsTests, test_tear_down) {
 
 static int kBellHathTolled = 0;
 
-Status TestTheeCallback(EventContextID ec_id,
-                        EventTime time,
-                        EventContextRef context,
-                        bool reserved) {
+Status TestTheeCallback(EventContextRef context, bool reserved) {
   kBellHathTolled += 1;
   return Status(0, "OK");
 }

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -11,7 +11,7 @@
 
 namespace osquery {
 
-REGISTER_EVENTTYPE("INotifyEventType", INotifyEventType);
+REGISTER_EVENTTYPE(INotifyEventType);
 
 int kINotifyULatency = 200;
 static const uint32_t BUFFER_SIZE =
@@ -63,9 +63,7 @@ Status INotifyEventType::run() {
     // Read timeout.
     return Status(0, "Continue");
   }
-
   ssize_t record_num = ::read(getHandle(), buffer, BUFFER_SIZE);
-  LOG(INFO) << "INotify read " << record_num << " event records";
   if (record_num == 0 || record_num == -1) {
     return Status(1, "INotify read failed");
   }
@@ -144,7 +142,6 @@ Status INotifyEventType::addMonitor(const MonitorRef monitor) {
     LOG(ERROR) << "Could not add inotify watch on: " << mc->path;
     return Status(1, "Add Watch Failed");
   }
-
   descriptors_.push_back(watch);
   path_descriptors_[mc->path] = watch;
   descriptor_paths_[watch] = mc->path;

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -16,6 +16,8 @@
 
 namespace osquery {
 
+extern std::map<int, std::string> kMaskActions;
+
 struct INotifyMonitorContext : public MonitorContext {
   /// Monitor the following filesystem path.
   std::string path;
@@ -25,6 +27,13 @@ struct INotifyMonitorContext : public MonitorContext {
   bool recursive;
 
   INotifyMonitorContext() : mask(0), recursive(false) {}
+  void requireAction(std::string action) {
+    for (const auto& bit : kMaskActions) {
+      if (action == bit.second) {
+        mask = mask | bit.first;
+      }
+    }
+  }
 };
 
 struct INotifyEventContext : public EventContext {

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -15,6 +15,5 @@ int main(int argc, char *argv[]) {
 
   // End any event type threads.
   osquery::EventFactory::end();
-
   return retcode;
 }

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -27,6 +27,7 @@ if(APPLE)
   ADD_OSQUERY_LINK("-framework Security")
 else()
   ADD_OSQUERY_LIBRARY(osquery_tables_linux
+    events/linux/passwd_changes.cpp
     networking/linux/routes.cpp
     system/linux/kernel_modules.cpp
     system/linux/processes.cpp

--- a/osquery/tables/events/linux/passwd_changes.cpp
+++ b/osquery/tables/events/linux/passwd_changes.cpp
@@ -1,0 +1,69 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <vector>
+#include <string>
+
+#include <boost/lexical_cast.hpp>
+
+#include <glog/logging.h>
+
+#include "osquery/core.h"
+#include "osquery/database.h"
+#include "osquery/events/linux/inotify.h"
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Track time, action changes to /etc/passwd
+ *
+ * This is mostly an example EventModule implementation.
+ */
+class PasswdChangesEventModule : public EventModule {
+  DECLARE_EVENTMODULE(PasswdChangesEventModule, INotifyEventType);
+  DECLARE_CALLBACK(Callback, INotifyEventContext);
+
+ public:
+  void init();
+
+  /**
+   * @brief This exports a single Callback for INotifyEventType events.
+   *
+   * @param ec The EventCallback type receives an EventContextRef substruct
+   * for the INotifyEventType declared in this EventModule subclass.
+   *
+   * @return Was the callback successfull.
+   */
+  Status Callback(const INotifyEventContextRef ec);
+};
+
+/**
+ * @brief Each EventModule must register itself so the init method is called.
+ *
+ * This registers PasswdChangesEventModule into the osquery EventModule
+ * pseudo-plugin registry.
+ */
+REGISTER_EVENTMODULE(PasswdChangesEventModule);
+
+void PasswdChangesEventModule::init() {
+  auto mc = INotifyEventType::createMonitorContext();
+  mc->path = "/etc/passwd";
+  mc->mask = IN_ATTRIB | IN_MODIFY | IN_DELETE | IN_CREATE;
+  BIND_CALLBACK(Callback, mc);
+}
+
+Status PasswdChangesEventModule::Callback(const INotifyEventContextRef ec) {
+  Row r;
+  r["action"] = ec->action;
+  r["time"] = ec->time_string;
+  r["target_path"] = ec->path;
+  r["transaction_id"] = boost::lexical_cast<std::string>(ec->event->cookie);
+  if (ec->action != "" && ec->action != "OPENED") {
+    // A callback is somewhat useless unless it changes the EventModule state
+    // or calls `add` to store a marked up event.
+    add(r, ec->time);
+  }
+  return Status(0, "OK");
+}
+}
+}

--- a/osquery/tables/specs/linux/passwd_changes.table
+++ b/osquery/tables/specs/linux/passwd_changes.table
@@ -1,0 +1,8 @@
+table_name("passwd_changes")
+schema([
+    Column(name="target_path", type="std::string"),
+    Column(name="time", type="std::string"),
+    Column(name="action", type="std::string"),
+    Column(name="transaction_id", type="std::string"),
+])
+implementation("events/linux/passwd_changes@PasswdChangesEventModule::genTable")


### PR DESCRIPTION
There's a lot here, the "rest" of the events DB accesses (retrieval), and usage in a table.
1. `tools/gentable.py` is changed to support classnames and static member functions for entrypoints.
2. Events DBHandle data-accessing and toy lookup without using the index/time optimizations.
3. Streamlining EC usage.
4. passwd_changes table.

This is mainly an RFC/FYI/PoC as the code is documented and unit tests are written.
