### PR TITLE
Pretty shell results

### DIFF
--- a/include/osquery/devtools.h
+++ b/include/osquery/devtools.h
@@ -2,6 +2,10 @@
 
 #pragma once
 
+#include <string>
+
+#include "osquery/database/results.h"
+
 namespace osquery {
 
 /**
@@ -23,5 +27,68 @@ namespace osquery {
  *
  * @return an int which represents the "return code"
  */
-int launchIntoShell(int argc, char **argv);
+int launchIntoShell(int argc, char** argv);
+
+/**
+ * @brief Generate a pretty representation of a QueryData object
+ *
+ * @return The beautified string representation of the supplied QueryData
+ * @param order The order of the keys (since maps are unordered)
+ */
+std::string beautify(const QueryData& q, const std::vector<std::string>& order);
+
+/**
+ * @brief Pretty print a QueryData object
+ *
+ * This is a helper method which called osquery::beautify on the supplied
+ * QueryData object and prints the results to stdout.
+ *
+ * @param q The QueryData object to print
+ * @param order The order of the keys (since maps are unordered)
+ */
+void prettyPrint(const QueryData& q, const std::vector<std::string>& order);
+
+/**
+ * @brief Compute a map of metadata about the supplied QueryData object
+ *
+ * @param q The QueryData object to analyze
+ *
+ * @return A map of string to int such that the key represents the "column" in
+ * the supplied QueryData and the int represents the length of the longest key
+ */
+std::map<std::string, int> computeQueryDataLengths(const QueryData& q);
+
+/**
+ * @brief Generate the separator string for query results
+ *
+ * @param lengths The data returned from computeQueryDataLengths
+ * @param order The order of the keys (since maps are unordered)
+ *
+ * @return A string, with a newline, representing your separator
+ */
+std::string generateSeparator(const std::map<std::string, int>& lengths,
+                              const std::vector<std::string>& order);
+
+/**
+ * @brief Generate the header string for query results
+ *
+ * @param lengths The data returned from computeQueryDataLengths
+ * @param order The order of the keys (since maps are unordered)
+ *
+ * @return A string, with a newline, representing your header
+ */
+std::string generateHeader(const std::map<std::string, int>& lengths,
+                           const std::vector<std::string>& order);
+
+/**
+ * @brief Generate a row string for query results
+ *
+ * @param lengths The data returned from computeQueryDataLengths
+ * @param order The order of the keys (since maps are unordered)
+ *
+ * @return A string, with a newline, representing your row
+ */
+std::string generateRow(const Row& r,
+                        const std::map<std::string, int>& lengths,
+                        const std::vector<std::string>& order);
 }

--- a/osquery/devtools/CMakeLists.txt
+++ b/osquery/devtools/CMakeLists.txt
@@ -1,3 +1,6 @@
 ADD_OSQUERY_LIBRARY(osquery_devtools
   shell.cpp
+  printer.cpp
 )
+
+ADD_OSQUERY_TEST(printer_tests printer_tests.cpp)

--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -1,0 +1,137 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "osquery/devtools.h"
+
+#include <iostream>
+#include <sstream>
+
+#include <glog/logging.h>
+
+namespace osquery {
+
+std::string beautify(const QueryData& q,
+                     const std::vector<std::string>& order) {
+  auto lengths = computeQueryDataLengths(q);
+
+  if (q.size() == 0) {
+    return std::string();
+  }
+
+  auto separator = generateSeparator(lengths, order);
+  std::ostringstream results;
+  results << "\n";
+
+  results << separator;
+  results << generateHeader(lengths, order);
+  results << separator;
+  for (const auto& r : q) {
+    results << generateRow(r, lengths, order);
+  }
+  results << separator;
+
+  return results.str();
+}
+
+std::string generateSeparator(const std::map<std::string, int>& lengths,
+                              const std::vector<std::string>& order) {
+  std::ostringstream separator;
+
+  separator << "+";
+  for (const auto& each : order) {
+    try {
+      for (int i = 0; i < lengths.at(each) + 2; ++i) {
+        separator << "-";
+      }
+    } catch (const std::out_of_range& e) {
+      LOG(ERROR) << "Error retreiving the \"" << each
+                 << "\" key in generateSeparator:  " << e.what();
+    }
+    separator << "+";
+  }
+  separator << "\n";
+
+  return separator.str();
+}
+
+std::string generateHeader(const std::map<std::string, int>& lengths,
+                           const std::vector<std::string>& order) {
+  std::ostringstream header;
+
+  header << "|";
+  for (const auto& each : order) {
+    header << " ";
+    header << each;
+    try {
+      for (int i = 0; i < (lengths.at(each) - each.size() + 1); ++i) {
+        header << " ";
+      }
+    } catch (const std::out_of_range& e) {
+      LOG(ERROR) << "Error retreiving the \"" << each
+                 << "\" key in generateHeader:  " << e.what();
+    }
+    header << "|";
+  }
+  header << "\n";
+
+  return header.str();
+}
+
+std::string generateRow(const Row& r,
+                        const std::map<std::string, int>& lengths,
+                        const std::vector<std::string>& order) {
+  std::ostringstream row;
+
+  row << "|";
+  for (const auto& each : order) {
+    row << " ";
+    try {
+      row << r.at(each);
+      for (int i = 0; i < (lengths.at(each) - r.at(each).size() + 1); ++i) {
+        row << " ";
+      }
+    } catch (const std::out_of_range& e) {
+      LOG(ERROR) << "printing the faulty row";
+      for (const auto& foo : r) {
+        LOG(ERROR) << foo.first << " => " << foo.second;
+      }
+      LOG(ERROR) << "Error retreiving the \"" << each
+                 << "\" key in generateRow:  " << e.what();
+    }
+    row << "|";
+  }
+  row << "\n";
+
+  return row.str();
+}
+
+void prettyPrint(const QueryData& q, const std::vector<std::string>& order) {
+  std::cout << beautify(q, order);
+}
+
+std::map<std::string, int> computeQueryDataLengths(const QueryData& q) {
+  std::map<std::string, int> results;
+
+  if (q.size() == 0) {
+    return results;
+  }
+
+  for (const auto& it : q.front()) {
+    results[it.first] = it.first.size();
+  }
+
+  for (const auto& row : q) {
+    for (const auto& it : row) {
+      try {
+        if (it.second.size() > results[it.first]) {
+          results[it.first] = it.second.size();
+        }
+      } catch (const std::out_of_range& e) {
+        LOG(ERROR) << "Error retreiving the \"" << it.first
+                   << "\" key in computeQueryDataLength:  " << e.what();
+      }
+    }
+  }
+
+  return results;
+}
+}

--- a/osquery/devtools/printer_tests.cpp
+++ b/osquery/devtools/printer_tests.cpp
@@ -1,0 +1,114 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "osquery/devtools.h"
+
+#include <gtest/gtest.h>
+#include <glog/logging.h>
+
+namespace osquery {
+
+class PrinterTests : public testing::Test {
+ public:
+  QueryData q;
+  std::vector<std::string> order;
+  void SetUp() {
+    order = {"name", "age", "favorite_food", "lucky_number"};
+    q = {
+        {
+         {"name", "Mike Jones"},
+         {"age", "39"},
+         {"favorite_food", "mac and cheese"},
+         {"lucky_number", "1"},
+        },
+        {
+         {"name", "John Smith"},
+         {"age", "44"},
+         {"favorite_food", "peanut butter and jelly"},
+         {"lucky_number", "2"},
+        },
+        {
+         {"name", "Doctor Who"},
+         {"age", "2000"},
+         {"favorite_food", "fish sticks and custard"},
+         {"lucky_number", "11"},
+        },
+    };
+  }
+};
+
+TEST_F(PrinterTests, test_compute_query_data_lengths) {
+  auto results = computeQueryDataLengths(q);
+  std::map<std::string, int> expected = {
+      {"name", 10}, {"age", 4}, {"favorite_food", 23}, {"lucky_number", 12},
+  };
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_separator) {
+  auto results = generateSeparator(computeQueryDataLengths(q), order);
+  auto expected =
+      "+------------+------+-------------------------+--------------+\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_separator_2) {
+  auto results =
+      generateSeparator(computeQueryDataLengths(q),
+                        {"lucky_number", "age", "name", "favorite_food"});
+  auto expected =
+      "+--------------+------+------------+-------------------------+\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_header) {
+  auto results = generateHeader(computeQueryDataLengths(q), order);
+  auto expected =
+      "| name       | age  | favorite_food           | lucky_number |\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_header_2) {
+  auto results =
+      generateHeader(computeQueryDataLengths(q),
+                     {"lucky_number", "age", "name", "favorite_food"});
+  auto expected =
+      "| lucky_number | age  | name       | favorite_food           |\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_row) {
+  auto results = generateRow(q.back(), computeQueryDataLengths(q), order);
+  auto expected =
+      "| Doctor Who | 2000 | fish sticks and custard | 11           |\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_generate_row_2) {
+  auto results = generateRow(q.back(),
+                             computeQueryDataLengths(q),
+                             {"lucky_number", "age", "name", "favorite_food"});
+  auto expected =
+      "| 11           | 2000 | Doctor Who | fish sticks and custard |\n";
+  EXPECT_EQ(results, expected);
+}
+
+TEST_F(PrinterTests, test_beautify) {
+  auto result = beautify(q, order);
+  std::string expected = R"(
++------------+------+-------------------------+--------------+
+| name       | age  | favorite_food           | lucky_number |
++------------+------+-------------------------+--------------+
+| Mike Jones | 39   | mac and cheese          | 1            |
+| John Smith | 44   | peanut butter and jelly | 2            |
+| Doctor Who | 2000 | fish sticks and custard | 11           |
++------------+------+-------------------------+--------------+
+)";
+  EXPECT_EQ(result, expected);
+}
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This implements #45.

Example:

```
osquery> select name, program || program_arguments as executable from launchd limit 5;

+----------------------------------+-------------------------------------------------------------------------------+
| name                             | executable                                                                    |
+----------------------------------+-------------------------------------------------------------------------------+
| bootps.plist                     | /usr/libexec/bootpd                                                           |
| com.apple.afpfs_afpLoad.plist    | /System/Library/Filesystems/AppleShare/afpLoad                                |
| com.apple.afpfs_checkafp.plist   | /System/Library/Filesystems/AppleShare/check_afp.app/Contents/MacOS/check_afp |
| com.apple.AirPlayXPCHelper.plist | /usr/libexec/AirPlayXPCHelper                                                 |
| com.apple.airport.wps.plist      | /usr/libexec/wps                                                              |
+----------------------------------+-------------------------------------------------------------------------------+
osquery> .tables
  => alf
  => alf_exceptions
  => alf_explicit_auths
  => alf_services
  => apps
  => ca_certs
  => etc_hosts
  => interface_addresses
  => interface_details
  => kextstat
  => last
  => launchd
  => listening_ports
  => nvram
  => osx_version
  => processes
  => routes
  => time
```
