### PR TITLE
Fix permissions on DB handle

### DIFF
--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -179,7 +179,7 @@ class DBHandle {
    * @param in_memory a boolean indicating wether or not the database should
    * be creating in memory or not.
    */
-  DBHandle(std::string path, bool in_memory);
+  DBHandle(const std::string& path, bool in_memory);
 
   /**
    * @brief A method which allows you to override the database path

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -24,6 +24,8 @@ namespace osquery {
  */
 Status readFile(const std::string& path, std::string& content);
 
+Status isWritable(const std::string& path);
+
 /**
  * @brief A helper to check if a path exists on disk or not.
  *

--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -83,6 +83,7 @@ class Status {
    * @see getMessage()
    */
   std::string toString() const { return getMessage(); }
+  std::string what() const { return getMessage(); }
 
  private:
   /// the internal storage of the status code

--- a/osquery/core/init_osquery.cpp
+++ b/osquery/core/init_osquery.cpp
@@ -10,6 +10,7 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "osquery/database.h"
 #include "osquery/registry.h"
 
 using namespace boost::algorithm;
@@ -117,9 +118,17 @@ void initOsquery(int argc, char *argv[]) {
   if (access(kDefaultLogDir.c_str(), W_OK) == 0) {
     FLAGS_log_dir = kDefaultLogDir;
   }
+
   google::InitGoogleLogging(argv[0]);
   osquery::InitRegistry::get().run();
   auto new_args = osquery::parseCommandLineFlags(argc, argv);
   google::ParseCommandLineFlags(&new_args.first, &new_args.second, true);
+
+  try {
+    DBHandle::getInstance();
+  } catch (std::exception& e) {
+    LOG(ERROR) << "osquery failed to start: " << e.what();
+    ::exit(1);
+  }
 }
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -57,6 +57,27 @@ cleanup:
   return Status(statusCode, statusMessage);
 }
 
+Status isWritable(const std::string& path) {
+  if (!pathExists(path).ok()) {
+    printf("from writeable, path does not exist.\n");
+    return Status(1, "Path does not exists.");
+  }
+
+  std::ifstream file_h;
+  try {
+    file_h = std::ifstream(path, std::ifstream::out);
+    if (!file_h.good()) {
+      file_h.close();
+      return Status(1, "File open failed.");
+    }
+  } catch (std::exception& e) {
+    return Status(1, e.what());
+  }
+
+  file_h.close();
+  return Status(0, "OK");
+}
+
 Status pathExists(const std::string& path) {
   if (path.length() == 0) {
     return Status(0, "-1");


### PR DESCRIPTION
The events pub/sub will crash (#242) in the shell if a root-owned `osqueryd` is running, meaning the `/tmp/rocksdb-osquery/` folder is owned by root. 

Now this failure will happen sooner (deterministically) and without causing a SIGSEG. 

The problem isn't 100% completes as the shell does not use the new `--db_path` option. The shell could also generate a random transient folder name for the DB instance. This will be cleaned up after the shell exists. Thoughts?
