### PR TITLE
Clean flags usage in daemon/shell and dbhandle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 # Build Artifacts
 build/
 
+# Run Artifacts
+*.log
+
 # Vagrant Artifacts
 .vagrant
 .sources

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -8,9 +8,12 @@
 
 #include <rocksdb/db.h>
 
+#include "osquery/flags.h"
 #include "osquery/status.h"
 
 namespace osquery {
+
+DECLARE_string(db_path);
 
 /////////////////////////////////////////////////////////////////////////////
 // Constants

--- a/osquery/core/init_osquery.cpp
+++ b/osquery/core/init_osquery.cpp
@@ -1,20 +1,24 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include "osquery/flags.h"
-
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/core.h"
-#include "osquery/database.h"
+#include "osquery/flags.h"
+#include "osquery/filesystem.h"
 #include "osquery/registry.h"
 
 namespace osquery {
 
-const std::string kDefaultLogDir = "/var/log/osquery/";
+
 const std::string kDescription = "your operating system as a high-performance "
   "relational database";
 const std::string kEpilog = "osquery project page <http://osquery.io>.";
+
+DEFINE_osquery_flag(string,
+                    osquery_log_dir,
+                    "/var/log/osquery/",
+                    "Directory to store results logging.")
 
 static const char* basename(const char* filename) {
   const char* sep = strrchr(filename, '/');
@@ -22,11 +26,13 @@ static const char* basename(const char* filename) {
 }
 
 void initOsquery(int argc, char *argv[]) {
-  if (argc > 1 && (std::string(argv[1]) == "--help" ||
-      std::string(argv[1]) == "-h")) {
+  std::string binary(basename(argv[0]));
+  std::string first_arg = (argc > 1) ? std::string(argv[1]) : "";
+
+  if (binary == "osqueryd" && (first_arg == "--help" || first_arg == "-h")) {
     // Parse help options before gflags. Only display osquery-related options.
     fprintf(stdout, "osquery " VERSION ", %s\n", kDescription.c_str());
-    fprintf(stdout, "%s: [OPTION]...\n\n", basename(argv[0]));
+    fprintf(stdout, "%s: [OPTION]...\n\n", binary.c_str());
     fprintf(stdout, "The following options control the osquery "
       "daemon and shell.\n\n");
 
@@ -45,21 +51,15 @@ void initOsquery(int argc, char *argv[]) {
   FLAGS_logbufsecs = 0; // flush the log buffer immediately
   FLAGS_stop_logging_if_full_disk = true;
   FLAGS_max_log_size = 1024; // max size for individual log file is 1GB
-  if (access(kDefaultLogDir.c_str(), W_OK) == 0) {
-    FLAGS_log_dir = kDefaultLogDir;
+
+  // Let gflags parse the non-help options/flags.
+  google::ParseCommandLineNonHelpFlags(&argc, &argv, false);
+
+  if (isWritable(FLAGS_osquery_log_dir.c_str()).ok()) {
+    FLAGS_log_dir = FLAGS_osquery_log_dir;
   }
 
   google::InitGoogleLogging(argv[0]);
   osquery::InitRegistry::get().run();
-
-  try {
-    DBHandle::getInstance();
-  } catch (std::exception& e) {
-    LOG(ERROR) << "osquery failed to start: " << e.what();
-    ::exit(1);
-  }
-
-  // Let gflags parse the non-help options/flags.
-  google::ParseCommandLineNonHelpFlags(&argc, &argv, true);
 }
 }

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -20,21 +20,21 @@ namespace osquery {
 // Constants
 /////////////////////////////////////////////////////////////////////////////
 
-const std::string kDBDefaultPath = "/tmp/rocksdb-osquery";
-
 const std::string kConfigurations = "configurations";
 const std::string kQueries = "queries";
 const std::string kEvents = "events";
 
 const std::vector<std::string> kDomains = {kConfigurations, kQueries, kEvents};
 
-DEFINE_string(db_path,
-              kDBDefaultPath,
-              "If using a disk-based backing store, specificy a path.");
+DEFINE_osquery_flag(string,
+                    db_path,
+                    "/tmp/rocksdb-osquery",
+                    "If using a disk-based backing store, specificy a path.");
 
-DEFINE_bool(use_in_memory_database,
-            false,
-            "Keep osquery backing-store in memory.");
+DEFINE_osquery_flag(bool,
+                    use_in_memory_database,
+                    false,
+                    "Keep osquery backing-store in memory.");
 
 /////////////////////////////////////////////////////////////////////////////
 // constructors and destructors

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -1,7 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include "osquery/filesystem.h"
-
 #include <fstream>
 #include <sstream>
 
@@ -13,6 +11,8 @@
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+
+#include "osquery/filesystem.h"
 
 using osquery::Status;
 
@@ -59,23 +59,13 @@ cleanup:
 
 Status isWritable(const std::string& path) {
   if (!pathExists(path).ok()) {
-    printf("from writeable, path does not exist.\n");
     return Status(1, "Path does not exists.");
   }
 
-  std::ifstream file_h;
-  try {
-    file_h = std::ifstream(path, std::ifstream::out);
-    if (!file_h.good()) {
-      file_h.close();
-      return Status(1, "File open failed.");
-    }
-  } catch (std::exception& e) {
-    return Status(1, e.what());
+  if (access(path.c_str(), W_OK) == 0) {
+    return Status(0, "OK");
   }
-
-  file_h.close();
-  return Status(0, "OK");
+  return Status(1, "Path is not writable.");
 }
 
 Status pathExists(const std::string& path) {

--- a/osquery/main/daemon.cpp
+++ b/osquery/main/daemon.cpp
@@ -7,12 +7,20 @@
 #include "osquery/config.h"
 #include "osquery/config/plugin.h"
 #include "osquery/core.h"
+#include "osquery/database.h"
 #include "osquery/events.h"
 #include "osquery/logger/plugin.h"
 #include "osquery/scheduler.h"
 
 int main(int argc, char* argv[]) {
   osquery::initOsquery(argc, argv);
+
+  try {
+    osquery::DBHandle::getInstance();
+  } catch (std::exception& e) {
+    LOG(ERROR) << "osqueryd failed to start: " << e.what();
+    ::exit(1);
+  }
 
   LOG(INFO) << "Listing all plugins";
 
@@ -37,7 +45,8 @@ int main(int argc, char* argv[]) {
   }
 
   // Start a thread for each appropriate event type
-  osquery::registries::faucet(REGISTERED_EVENTPUBLISHERS, REGISTERED_EVENTSUBSCRIBERS);
+  osquery::registries::faucet(REGISTERED_EVENTPUBLISHERS,
+    REGISTERED_EVENTSUBSCRIBERS);
   osquery::EventFactory::delay();
 
   boost::thread scheduler_thread(osquery::initializeScheduler);

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "osquery/core.h"
+#include "osquery/database.h"
 #include "osquery/devtools.h"
 #include "osquery/events.h"
 
@@ -8,9 +9,11 @@ int main(int argc, char *argv[]) {
   osquery::initOsquery(argc, argv);
 
   // Start a thread for each appropriate event type
-  osquery::registries::faucet(REGISTERED_EVENTPUBLISHERS, REGISTERED_EVENTSUBSCRIBERS);
+  osquery::registries::faucet(REGISTERED_EVENTPUBLISHERS,
+    REGISTERED_EVENTSUBSCRIBERS);
   osquery::EventFactory::delay();
 
+  osquery::FLAGS_db_path = "/tmp/rocksdb-osquery-shell";
   int retcode = osquery::launchIntoShell(argc, argv);
 
   // End any event type threads.


### PR DESCRIPTION
Remove flags parsing from the osqueryi shell (it uses it's own flags).
Add a flag to set the explicit path for the results logging.
Port new db_handle flags to the new osquery-specific flags tracking.
