### PR TITLE
Added hostUuid to results

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -105,6 +105,13 @@ std::vector<std::string> split(const std::string& s,
 std::string getHostname();
 
 /**
+ * @brief Getter for a host's hardware uuid
+ *
+ * @return a string representing the host's hardware uuid
+ */
+ std::string getHostUuid();
+
+/**
  * @brief Getter for the current time, in a human-readable format.
  *
  * @return the current date/time in the format: "Wed Sep 21 10:27:52 2011"

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -251,6 +251,9 @@ struct ScheduledQueryLogItem {
   /// The hostname of the host which the scheduled query was executed on
   std::string hostname;
 
+  // The hardware uuid of the host which the scheduled query was executed on
+  std::string hostUuid;
+
   /// The time that the query was executed, in unix time
   int unixTime;
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -4,7 +4,9 @@
 
 #include <cstring>
 #include <ctime>
+#include <time.h>
 #include <unistd.h>
+#include <uuid/uuid.h>
 
 #include <boost/algorithm/string/trim.hpp>
 
@@ -17,6 +19,23 @@ std::string getHostname() {
   std::string hostname_string = std::string(hostname);
   boost::algorithm::trim(hostname_string);
   return hostname_string;
+}
+
+std::string getHostUuid(){
+  char uuid[128];
+  memset(uuid, 0, 128);
+  uuid_t id;
+  const timespec wait = {0,0};
+  int result = gethostuuid(id, &wait);
+  if (result == 0){
+    char out[128];
+    uuid_unparse(id, out);
+    std::string uuid_string = std::string(out);
+    boost::algorithm::trim(uuid_string);
+    return uuid_string;
+  }
+  else
+    return "";
 }
 
 std::string getAsciiTime() {

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -191,9 +191,11 @@ getSerializedScheduledQueryLogItem() {
   i.calendarTime = "Mon Aug 25 12:10:57 2014";
   i.unixTime = 1408993857;
   i.hostname = "foobaz";
+  i.hostUuid = "i-am-a-unique-identifier";
   root.add_child("diffResults", dr.first);
   root.put<std::string>("name", "foobar");
   root.put<std::string>("hostname", "foobaz");
+  root.put<std::string>("hostUuid", "i-am-a-unique-identifier");
   root.put<std::string>("calendarTime", "Mon Aug 25 12:10:57 2014");
   root.put<int>("unixTime", 1408993857);
   return std::make_pair(root, i);

--- a/osquery/database/results.cpp
+++ b/osquery/database/results.cpp
@@ -270,6 +270,7 @@ Status serializeScheduledQueryLogItem(const ScheduledQueryLogItem& i,
     tree.add_child("diffResults", diffResults);
     tree.put<std::string>("name", i.name);
     tree.put<std::string>("hostname", i.hostname);
+    tree.put<std::string>("hostUuid", i.hostUuid);
     tree.put<std::string>("calendarTime", i.calendarTime);
     tree.put<int>("unixTime", i.unixTime);
   } catch (const std::exception& e) {
@@ -283,6 +284,7 @@ Status serializeEvent(const ScheduledQueryLogItem& item,
                       boost::property_tree::ptree& tree) {
   tree.put<std::string>("name", item.name);
   tree.put<std::string>("hostname", item.hostname);
+  tree.put<std::string>("hostUuid", item.hostUuid);
   tree.put<std::string>("calendarTime", item.calendarTime);
   tree.put<int>("unixTime", item.unixTime);
 

--- a/osquery/scheduler/scheduler.cpp
+++ b/osquery/scheduler/scheduler.cpp
@@ -43,6 +43,7 @@ void launchQueries(const std::vector<OsqueryScheduledQuery>& queries,
         item.diffResults = diff_results;
         item.name = q.name;
         item.hostname = osquery::getHostname();
+        item.hostUuid = osquery::getHostUuid();
         item.unixTime = osquery::getUnixTime();
         item.calendarTime = osquery::getAsciiTime();
         auto s = logScheduledQueryLogItem(item);


### PR DESCRIPTION
A possible solution for #230 , this grabs the hardware uuid using `getHostUuid` and and includes it in the results.

A few notes:
- `getHostUuid` requires you to specify a wait argument to tell it how long to wait before failing. Currently, it can wait indefinitely. Probably not what we want.
-  This probably doesn't need to to call `getHostUuid` every time query runs; once initially would be best. Mike suggested using RocksDB for this. Can someone elaborate on how I would do this?
- I don't write a lot of C++, might have made some noobie mistakes :)

Things I still need to do:
- make format
- valgrind and such
