### PR TITLE
[vtables] CPUID asm call feature information

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -50,6 +50,7 @@ ADD_OSQUERY_LIBRARY(osquery_tables
   networking/etc_hosts.cpp
   utility/time.cpp
   utility/crontab.cpp
+  system/cpuid.cpp
   system/last.cpp
   system/bash_history.cpp
   system/suid_bin.cpp

--- a/osquery/tables/specs/x/cpuid.table
+++ b/osquery/tables/specs/x/cpuid.table
@@ -1,0 +1,9 @@
+table_name("cpuid")
+schema([
+    Column(name="feature", type="std::string"),
+    Column(name="value", type="std::string"),
+    Column(name="output_register", type="std::string"),
+    Column(name="output_bit", type="std::string"),
+    Column(name="input_eax", type="std::string"),
+])
+implementation("cpuid@genCPUID")

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -1,0 +1,144 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iomanip>
+#include <map>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <boost/lexical_cast.hpp>
+
+#include "osquery/core.h"
+#include "osquery/database.h"
+
+#define FEATURE(name, reg, bit) std::make_pair(name, std::make_pair(reg, bit))
+
+namespace osquery {
+namespace tables {
+
+typedef std::pair<std::string, int> RegisterBit_t;
+typedef std::pair<std::string, RegisterBit_t> FeatureDef_t;
+
+std::map<int, std::vector<FeatureDef_t> > kCPUFeatures = {
+    {1,
+     {
+      FEATURE("pae", "edx", 6),
+      FEATURE("msr", "edx", 5),
+      FEATURE("mtrr", "edx", 12),
+      FEATURE("acpi", "edx", 22),
+      FEATURE("htt", "edx", 28),
+      FEATURE("ia64", "edx", 30),
+      FEATURE("vmx", "ecx", 5),
+      FEATURE("smx", "ecx", 6),
+      FEATURE("hypervisor", "ecx", 31),
+      FEATURE("aes", "ecx", 25),
+     }},
+    {7,
+     {
+      FEATURE("mpx", "ebx", 14), FEATURE("sha", "ebx", 29),
+     }},
+};
+
+void cpuid(unsigned int eax, unsigned int ecx, int regs[4]) {
+  asm volatile("cpuid"
+               : "=a"(regs[0]), "=b"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+               : "a"(eax), "c"(ecx));
+}
+
+void registerToString(int reg, std::stringstream& stream) {
+  for (size_t i = 0; i < 4; i++) {
+    stream << ((char*)&reg)[i];
+  }
+}
+
+bool isBitSet(size_t bit, unsigned int reg) {
+  return ((reg & (1 << bit)) != 0);
+}
+
+Status genVendorString(QueryData& results) {
+  int regs[4] = {-1};
+
+  cpuid(0, 0, regs);
+  if (regs[0] < 1) {
+    // The CPUID ASM call is not supported.
+    return Status(1, "Failed to run cpuid");
+  }
+
+  std::stringstream vendor_string;
+  registerToString(regs[1], vendor_string);
+  registerToString(regs[3], vendor_string);
+  registerToString(regs[2], vendor_string);
+
+  Row r;
+  r["feature"] = "vendor";
+  r["value"] = vendor_string.str();
+  r["output_register"] = "ebx,edx,ecx";
+  r["input_eax"] = "0";
+  results.push_back(r);
+
+  return Status(0, "OK");
+}
+
+void genFamily(QueryData& results) {
+  int regs[4] = {-1};
+
+  cpuid(1, 0, regs);
+  int family = regs[0] & 0xf00;
+
+  std::stringstream family_string;
+  family_string << std::hex << std::setw(4) << std::setfill('0') << family;
+
+  Row r;
+  r["feature"] = "family";
+  r["value"] = family_string.str();
+  r["output_register"] = "eax";
+  r["output_bit"] = "";
+  r["input_eax"] = "1";
+
+  results.push_back(r);
+}
+
+QueryData genCPUID() {
+  QueryData results;
+
+  if (!genVendorString(results).ok()) {
+    return results;
+  }
+
+  // Get the CPU meta-data about the model, stepping, family.
+  genFamily(results);
+
+  int regs[4] = {-1};
+  int feature_register, feature_bit;
+  for (auto& feature_set : kCPUFeatures) {
+    int eax = feature_set.first;
+    cpuid(eax, 0, regs);
+
+    for (auto& feature : feature_set.second) {
+      Row r;
+
+      r["feature"] = feature.first;
+
+      // Get the return register holding the feature bit.
+      feature_register = 0;
+      if (feature.second.first == "edx") {
+        feature_register = 3;
+      } else if (feature.second.first == "ebx") {
+        feature_register = 1;
+      } else if (feature.second.first == "ecx") {
+        feature_register = 2;
+      }
+
+      feature_bit = feature.second.second;
+      r["value"] = isBitSet(feature_bit, regs[feature_register]) ? "1" : "0";
+      r["output_register"] = feature.second.first;
+      r["output_bit"] = boost::lexical_cast<std::string>(feature_bit);
+      r["input_eax"] = boost::lexical_cast<std::string>(eax);
+      results.push_back(r);
+    }
+  }
+
+  return results;
+}
+}
+}


### PR DESCRIPTION
The `cpuid` asm call and some of the more interesting (and still used, haha!) CPU feature flags as a table. I'm looking for suggestions to break out the CPU Name, model, family out into a different table. So we could have `cpu_details`, and `cpu_flags`. Right now the output is: 

```
+------------+--------------+-----------------+-----------+
| feature    | value        | output_register | input_eax |
+------------+--------------+-----------------+-----------+
| vendor     | GenuineIntel | ebx,edx,ecx     | 0         |
| family     | 0600         | eax             | 1         |
| pae        | 0            | edx             | 1         |
| msr        | 0            | edx             | 1         |
| mtrr       | 0            | edx             | 1         |
| acpi       | 0            | edx             | 1         |
| htt        | 0            | edx             | 1         |
| ia64       | 0            | edx             | 1         |
| vmx        | 0            | ecx             | 1         |
| smx        | 0            | ecx             | 1         |
| hypervisor | 0            | ecx             | 1         |
| aes        | 0            | ecx             | 1         |
| mpx        | 0            | ebx             | 7         |
| sha        | 0            | ebx             | 7         |
+------------+--------------+-----------------+-----------+
```

Where `feature = 'vendor'` is the only case will registers are multiplexed.
