### PR TITLE
[vtables] Linux kernel modules from procfs

### DIFF
--- a/osquery/tables/specs/linux/kernel_modules.table
+++ b/osquery/tables/specs/linux/kernel_modules.table
@@ -3,10 +3,7 @@ schema([
     Column(name="name", type="std::string"),
     Column(name="size", type="std::string"),
     Column(name="used_by", type="std::string"),
-    Column(name="filename", type="std::string"),
-    Column(name="description", type="std::string"),
-    Column(name="sig_key", type="std::string"),
-    Column(name="version", type="std::string"),
-    Column(name="signer", type="std::string"),
+    Column(name="status", type="std::string"),
+    Column(name="address", type="std::string"),
 ])
 implementation("kernel_modules@genKernelModules")

--- a/osquery/tables/system/linux/kernel_modules.cpp
+++ b/osquery/tables/system/linux/kernel_modules.cpp
@@ -1,5 +1,8 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <fstream>
+
+#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -7,12 +10,55 @@
 
 #include "osquery/core.h"
 #include "osquery/database.h"
+#include "osquery/filesystem.h"
 
 namespace osquery {
 namespace tables {
 
+const std::string kKernelModulePath = "/proc/modules";
+
 QueryData genKernelModules() {
   QueryData results;
+
+  if (!pathExists(kKernelModulePath).ok()) {
+    LOG(ERROR) << "Cannot find kernel modules proc file: " << kKernelModulePath;
+    return results;
+  }
+
+  // Cannot seek to the end of procfs.
+  std::ifstream fd(kKernelModulePath, std::ios::in);
+  if (!fd) {
+    LOG(ERROR) << "Cannot read kernel modules from: " << kKernelModulePath;
+    return results;
+  }
+
+  auto module_info = std::string(std::istreambuf_iterator<char>(fd),
+                                 std::istreambuf_iterator<char>());
+
+  for (const auto& module : split(module_info, "\n")) {
+    Row r;
+    auto module_info = split(module, " ");
+
+    if (module_info.size() < 6) {
+      // Interesting error case, this module line is not well formed.
+      continue;
+    }
+
+    for (auto& detail : module_info) {
+      // Clean up the delimiters
+      boost::trim(detail);
+      if (detail.back() == ',') {
+        detail.pop_back();
+      }
+    }
+
+    r["name"] = module_info[0];
+    r["size"] = module_info[1];
+    r["used_by"] = module_info[3];
+    r["status"] = module_info[4];
+    r["address"] = module_info[5];
+    results.push_back(r);
+  }
 
   return results;
 }


### PR DESCRIPTION
Linux kernel modules parsed from `/proc/modules` the preferred way to list kernel modules.
