### PR TITLE
Improves bash code that verifies if homebrew is installed

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -386,9 +386,11 @@ function main() {
     install_rocksdb
 
   elif [[ $OS = "darwin" ]]; then
-    if [[ ! -f "/usr/local/bin/brew" ]]; then
-      fatal "could not find homebrew. please install it from http://brew.sh/"
-    fi
+    type brew >/dev/null 2>&1 || {
+      echo >&2 "could not find homebrew. please install it from http://brew.sh/";
+      exit 1;
+    }
+
     brew update
 
     package rocksdb


### PR DESCRIPTION
The following pull request updates the code that verifies that homebrew is installed to not search for homebrew in a hardcoded location. When I ran the command `make deps` I get this error,

```
$ make deps 
./tools/provision.sh
[+] detected mac os x
[!] could not find homebrew. please install it from http://brew.sh/
make: *** [deps] Error 1
```

I have brew installed in the directory `/opt/boxen/homebrew/bin/brew` which I found out via,

```
$ type brew                                     
brew is /opt/boxen/homebrew/bin/brew
```

Many people use boxen or install homebrew in locations other than `/usr/local/bin/brew` (which is currently hard coded).
