### PR TITLE
Fix #277, add socket.h to interfaces on darwin

### DIFF
--- a/osquery/tables/networking/darwin/interfaces.cpp
+++ b/osquery/tables/networking/darwin/interfaces.cpp
@@ -5,6 +5,7 @@
 
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <sys/socket.h>
 
 #include <boost/lexical_cast.hpp>
 


### PR DESCRIPTION
If `struct sockaddr` is not declared from an include of `net/if.h`.
