### PR TITLE
Install libunwind8-dev for Ubuntu 14.10

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -292,7 +292,7 @@ function main() {
     if [[ $DISTRO = "precise" ]]; then
       package libunwind7-dev
     fi
-    if [[ $DISTRO = "trusty" ]]; then
+    if [[ $DISTRO = "trusty" || $DISTRO = "utopic" ]]; then
       package libunwind8-dev
     fi
     if [[ $DISTRO = "precise" ]]; then


### PR DESCRIPTION
On fresh `14.10` the `make deps` fails with:

``` bash
[ 77%] Building CXX object osquery/CMakeFiles/daemon.dir/main/daemon.cpp.o
Linking CXX executable osqueryd
/usr/bin/ld: cannot find -lunwind
collect2: error: ld returned 1 exit status
osquery/CMakeFiles/daemon.dir/build.make:87: recipe for target 'osquery/osqueryd' failed
```
