### PR TITLE
Fix #290, add permissions to osqueryd logging

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -24,6 +24,20 @@ namespace osquery {
  */
 Status readFile(const std::string& path, std::string& content);
 
+/**
+ * @brief Write text to disk.
+ *
+ * @param path the path of the file that you would like to write
+ * @param content the text that should be written exactly to disk
+ * @param permissions the filesystem permissions to request when opening
+ * @param force_permissions always chmod the path after opening
+ *
+ * @return an instance of Status, indicating the success or failure
+ * of the operation.
+ */
+Status writeTextFile(const std::string& path, const std::string& content,
+                     int permissions = 0660, bool force_permissions = false);
+
 Status isWritable(const std::string& path);
 Status isReadable(const std::string& path);
 

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -59,7 +59,7 @@ DBHandle::DBHandle(const std::string& path, bool in_memory) {
         cf_name, rocksdb::ColumnFamilyOptions()));
   }
 
-  if (pathExists(path).what() == "1" && !isWritable(path).ok()) {
+  if (pathExists(path).ok() && !isWritable(path).ok()) {
     throw std::domain_error("Cannot write to RocksDB path: " + path);
   }
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -1,11 +1,14 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <exception>
 #include <fstream>
 #include <sstream>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
-
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -20,9 +23,36 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
+Status writeTextFile(const std::string& path, const std::string& content,
+                     int permissions, bool force_permissions) {
+  // Open the file with the request permissions.
+  int output_fd = open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY,
+                       permissions);
+  if (output_fd <= 0) {
+    return Status(1, "Could not create file");
+  }
+
+  // If the file existed with different permissions before our open
+  // they must be restricted.
+  if (chmod(path.c_str(), permissions) != 0) {
+    // Could not change the file to the requested permissions.
+    return Status(1, "Failed to change permissions");
+  }
+
+  auto bytes = write(output_fd, content.c_str(), content.size());
+  if (bytes != content.size()) {
+    close(output_fd);
+    return Status(1, "Failed to write contents");
+  }
+
+  close(output_fd);
+  return Status(0, "OK");
+}
+
 Status readFile(const std::string& path, std::string& content) {
-  if (!boost::filesystem::exists(path)) {
-    return Status(1, "File not found");
+  auto path_exists = pathExists(path);
+  if (!path_exists.ok()) {
+    return path_exists;
   }
 
   int statusCode = 0;
@@ -58,8 +88,9 @@ cleanup:
 }
 
 Status isWritable(const std::string& path) {
-  if (!pathExists(path).ok()) {
-    return Status(1, "Path does not exist.");
+  auto path_exists = pathExists(path);
+  if (!path_exists.ok()) {
+    return path_exists;
   }
 
   if (access(path.c_str(), W_OK) == 0) {
@@ -69,8 +100,9 @@ Status isWritable(const std::string& path) {
 }
 
 Status isReadable(const std::string& path) {
-  if (!pathExists(path).ok()) {
-    return Status(1, "Path does not exist.");
+  auto path_exists = pathExists(path);
+  if (!path_exists.ok()) {
+    return path_exists;
   }
 
   if (access(path.c_str(), R_OK) == 0) {
@@ -81,12 +113,12 @@ Status isReadable(const std::string& path) {
 
 Status pathExists(const std::string& path) {
   if (path.length() == 0) {
-    return Status(0, "-1");
+    return Status(1, "-1");
   }
 
   // A tri-state determination of presence
   if (!boost::filesystem::exists(path)) {
-    return Status(0, "0");
+    return Status(1, "0");
   }
   return Status(0, "1");
 }


### PR DESCRIPTION
Expose a `writeTextFile` that let's the caller open a text file with restrictive ACL permissions. 

The use of `open`, `write`, `close` and not C++/boost stream APIs is intended. Since ACLs diverge across OSes permissions are implemented in compiler/libraries. We are wearing unix goggles so `open` works. 

The `osqueryd.results.log` file may in the future contain sensitive information. Currently, on OS X, with and suid `ps` it already contains potentially sensitive application arguments/ENV variables. 
