### PR TITLE
Fixing number of cores detection for boost builds

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -101,7 +101,7 @@ function install_boost() {
     fi
     pushd boost_1_55_0
     ./bootstrap.sh
-    n=$([[ $(uname) = 'Darwin' ]] && sysctl -n hw.logicalcpu_max || lscpu -p | egrep -v '^#' | wc -l)
+    n=`getconf _NPROCESSORS_ONLN`
     sudo ./b2 --with=all -j $n toolset=clang install
     sudo ldconfig
     popd


### PR DESCRIPTION
This way of cores detection:

``` bash
cat /proc/cpuinfo | grep "cpu cores" | uniq | awk '{print $NF}'
```

is cumbersome and didn't work in some cases, e.g. for VM on VirtualBox with one CPU.
It's much better to use something else, e.g.

``` bash
getconf _NPROCESSORS_ONLN
```

as stated in
https://stackoverflow.com/questions/6481005/obtain-the-number-of-cpus-cores-in-linux
`nproc` also works well but didn't compatible with MacOS X.
