### PR TITLE
Install rpm-devel package on CentOS in provision script

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -359,6 +359,7 @@ function main() {
     package openssl-devel
     package readline-devel
     package procps-devel
+    package rpm-devel
 
     install_boost
     install_gflags


### PR DESCRIPTION
This change will ensure that rpm-devel is installed on CentOS before building.
