### PR TITLE
Fix #328, add gflags defines for shell-internal flags

### DIFF
--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -4,6 +4,7 @@
 
 #include <boost/make_shared.hpp>
 
+#define STRIP_FLAG_HELP 1
 #include <gflags/gflags.h>
 
 #include "osquery/registry.h"

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -10,7 +10,6 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/config.h"

--- a/osquery/config/plugins/facebook/configerator.cpp
+++ b/osquery/config/plugins/facebook/configerator.cpp
@@ -6,7 +6,6 @@
 #include <functional>
 #include <thread>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <configerator/distribution/api/api.h>

--- a/osquery/core/init_osquery.cpp
+++ b/osquery/core/init_osquery.cpp
@@ -1,6 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/core.h"

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -82,6 +82,7 @@
 
 #include "osquery/database/results.h"
 #include "osquery/devtools.h"
+#include "osquery/flags.h"
 #include "osquery/registry/registry.h"
 
 /* Make sure isatty() has a prototype.
@@ -4092,6 +4093,45 @@ static char *cmdline_option_value(int argc, char **argv, int i) {
 }
 
 namespace osquery {
+
+/// Define flags used by the shell. They are parsed by the drop-in shell.
+DEFINE_osquery_flag(bool, bail, false, "stop after hitting an error");
+DEFINE_osquery_flag(bool, batch, false, "force batch I/O");
+DEFINE_osquery_flag(bool, column, false, "set output mode to 'column'");
+DEFINE_osquery_flag(string, cmd, "", "run \"COMMAND\" before reading stdin");
+DEFINE_osquery_flag(bool, csv, false, "set output mode to 'csv'");
+DEFINE_osquery_flag(bool, echo, false, "print commands before execution");
+DEFINE_osquery_flag(string, init, "", "read/process named file");
+DEFINE_osquery_flag(bool, header, true, "turn headers on or off");
+DEFINE_osquery_flag(bool, html, false, "set output mode to HTML");
+DEFINE_osquery_flag(bool, interactive, false, "force interactive I/O");
+DEFINE_osquery_flag(bool, line, false, "set output mode to 'line'");
+DEFINE_osquery_flag(bool, list, false, "set output mode to 'list'");
+DEFINE_osquery_flag(int64, mmap, 0, "default mmap size set to N");
+DEFINE_osquery_flag(string,
+                    nullvalue,
+                    "",
+                    "set text string for NULL values. Default ''");
+DEFINE_osquery_flag(string,
+                    separator,
+                    "|",
+                    "set output field separator. Default: '|'");
+DEFINE_osquery_flag(bool,
+                    stats,
+                    false,
+                    "print memory stats before each finalize");
+DEFINE_osquery_flag(string, vfs, "", "use NAME as the default VFS");
+
+/// Optional flags enabled at compile time.
+#if defined(SQLITE_ENABLE_MEMSYS3) || defined(SQLITE_ENABLE_MEMSYS5)
+DEFINE_osquery_flag(int64, heap, 0, "Size of heap for memsys3 or memsys5");
+#endif
+#ifdef SQLITE_ENABLE_MULTIPLEX
+DEFINE_osquery_flag(bool, multiplex, false, "enable the multiplexor VFS");
+#endif
+#ifdef SQLITE_ENABLE_VFSTRACE
+DEFINE_osquery_flag(bool, vfstrace, false, "enable tracing of all VFS calls");
+#endif
 
 int launchIntoShell(int argc, char **argv) {
   char *zErrMsg = 0;

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -1,6 +1,5 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/core/conversions.h"

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -12,7 +12,6 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/filesystem.h"

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -3,10 +3,10 @@
 #include <exception>
 #include <mutex>
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "osquery/filesystem.h"
+#include "osquery/flags.h"
 #include "osquery/logger/plugin.h"
 
 using osquery::Status;


### PR DESCRIPTION
This adds the gflags-required defines for the internal shell flags. Though the shell does not use the gflags API, if the flags don't exist in the gflags registry then a parsing error will be thrown.
