### PR TITLE
Adding pip, git dependencies to provision

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -389,8 +389,11 @@ function main() {
 
   elif [[ $OS = "darwin" ]]; then
     type brew >/dev/null 2>&1 || {
-      echo >&2 "could not find homebrew. please install it from http://brew.sh/";
-      exit 1;
+      fatal "could not find homebrew. please install it from http://brew.sh/";
+    }
+
+    type pip >/dev/null 2>&1 || {
+      fatal "could not find pip. please install it using 'sudo easy_install pip'";
     }
 
     brew update


### PR DESCRIPTION
Check if the OS X user has pip installed before performing work. This makes for a better dev experience.
