### PR TITLE
Remove clang-format parameters that break clang-format 3.4

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,6 @@ IndentCaseLabels: false
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCSpaceBeforeProtocolList: false
-PenaltyBreakBeforeFirstCallParameter: 10
 PenaltyBreakComment: 60
 PenaltyBreakString: 1000
 PenaltyBreakFirstLessLess: 20
@@ -39,5 +38,4 @@ SpaceInEmptyParentheses: false
 SpacesInCStyleCastParentheses: false
 SpaceAfterControlStatementKeyword: true
 SpaceBeforeAssignmentOperators: true
-ContinuationIndentWidth: 4
 ...


### PR DESCRIPTION
I don't know if this breaks formatting rules that are important to you, but this is what was required for me to run `make format` without error using `clang-format` 3.4.

Fixes #263
