### PR TITLE
Add common Emacs/Vim tempfile entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ build/
 # Doxygen Documentation
 doxygen/html
 doxygen/latex
+
+# Editors
+*~
+\#*\#


### PR DESCRIPTION
Cleans up `git status` for those who use Emacs/Vim
