### PR TITLE
Refactor osquery::fileystem to use boost::filesystem::path rather than std::string

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include "osquery/status.h"
@@ -22,7 +23,7 @@ namespace osquery {
  * @return an instance of Status, indicating the success or failure
  * of the operation.
  */
-Status readFile(const std::string& path, std::string& content);
+Status readFile(const boost::filesystem::path& path, std::string& content);
 
 /**
  * @brief Write text to disk.
@@ -35,11 +36,13 @@ Status readFile(const std::string& path, std::string& content);
  * @return an instance of Status, indicating the success or failure
  * of the operation.
  */
-Status writeTextFile(const std::string& path, const std::string& content,
-                     int permissions = 0660, bool force_permissions = false);
+Status writeTextFile(const boost::filesystem::path& path,
+                     const std::string& content,
+                     int permissions = 0660,
+                     bool force_permissions = false);
 
-Status isWritable(const std::string& path);
-Status isReadable(const std::string& path);
+Status isWritable(const boost::filesystem::path& path);
+Status isReadable(const boost::filesystem::path& path);
 
 /**
  * @brief A helper to check if a path exists on disk or not.
@@ -52,7 +55,7 @@ Status isReadable(const std::string& path);
  * to check path-getter results. The code will be 0 if the path does not exist
  * on disk and 1 if the path does exist on disk.
  */
-Status pathExists(const std::string& path);
+Status pathExists(const boost::filesystem::path& path);
 
 /**
  * @brief List all of the files in a specific directory, non-recursively.
@@ -65,7 +68,7 @@ Status pathExists(const std::string& path);
  * @return an instance of Status, indicating the success or failure
  * of the operation.
  */
-Status listFilesInDirectory(const std::string& path,
+Status listFilesInDirectory(const boost::filesystem::path& path,
                             std::vector<std::string>& results);
 
 /**
@@ -77,7 +80,8 @@ Status listFilesInDirectory(const std::string& path,
  * @return If the input path was a directory this will indicate failure. One
  * should use `isDirectory` before.
  */
-Status getDirectory(const std::string& path, std::string& dirpath);
+Status getDirectory(const boost::filesystem::path& path,
+                    boost::filesystem::path& dirpath);
 
 /**
  * @brief Check if an input path is a directory.
@@ -86,7 +90,7 @@ Status getDirectory(const std::string& path, std::string& dirpath);
  *
  * @return If the input path was a directory.
  */
-Status isDirectory(const std::string& path);
+Status isDirectory(const boost::filesystem::path& path);
 
 /**
  * @brief Parse the users out of a tomcat user config from disk
@@ -100,7 +104,7 @@ Status isDirectory(const std::string& path);
  * of the operation
  */
 Status parseTomcatUserConfigFromDisk(
-    const std::string& path,
+    const boost::filesystem::path& path,
     std::vector<std::pair<std::string, std::string> >& credentials);
 
 /**
@@ -129,7 +133,9 @@ Status parseTomcatUserConfig(
  * @return an instance of Status, indicating the success or failure
  * of the operation.
  */
-Status parsePlist(const std::string& path, boost::property_tree::ptree& tree);
+Status parsePlist(const boost::filesystem::path& path,
+                  boost::property_tree::ptree& tree);
+
 /**
  * @brief Parse property list content into a property tree.
  *

--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -4,6 +4,7 @@
 
 #include <sstream>
 
+#include <boost/filesystem/path.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <glog/logging.h>
@@ -156,7 +157,7 @@ Status parsePlistContent(const std::string& fileContent, pt::ptree& tree) {
   }
 }
 
-Status parsePlist(const std::string& path, pt::ptree& tree) {
+Status parsePlist(const boost::filesystem::path& path, pt::ptree& tree) {
   std::string fileContent;
   Status s = readFile(path, fileContent);
   if (!s.ok()) {

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -1,12 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <exception>
-#include <fstream>
 #include <sstream>
 
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -19,11 +19,14 @@
 using osquery::Status;
 
 namespace pt = boost::property_tree;
+namespace fs = boost::filesystem;
 
 namespace osquery {
 
-Status writeTextFile(const std::string& path, const std::string& content,
-                     int permissions, bool force_permissions) {
+Status writeTextFile(const boost::filesystem::path& path,
+                     const std::string& content,
+                     int permissions,
+                     bool force_permissions) {
   // Open the file with the request permissions.
   int output_fd = open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY,
                        permissions);
@@ -48,7 +51,7 @@ Status writeTextFile(const std::string& path, const std::string& content,
   return Status(0, "OK");
 }
 
-Status readFile(const std::string& path, std::string& content) {
+Status readFile(const boost::filesystem::path& path, std::string& content) {
   auto path_exists = pathExists(path);
   if (!path_exists.ok()) {
     return path_exists;
@@ -58,7 +61,7 @@ Status readFile(const std::string& path, std::string& content) {
   std::string statusMessage = "OK";
   char* buffer;
 
-  std::ifstream file_h(path);
+  fs::ifstream file_h(path);
   if (file_h) {
     file_h.seekg(0, file_h.end);
     int len = file_h.tellg();
@@ -86,7 +89,7 @@ cleanup:
   return Status(statusCode, statusMessage);
 }
 
-Status isWritable(const std::string& path) {
+Status isWritable(const boost::filesystem::path& path) {
   auto path_exists = pathExists(path);
   if (!path_exists.ok()) {
     return path_exists;
@@ -98,7 +101,7 @@ Status isWritable(const std::string& path) {
   return Status(1, "Path is not writable.");
 }
 
-Status isReadable(const std::string& path) {
+Status isReadable(const boost::filesystem::path& path) {
   auto path_exists = pathExists(path);
   if (!path_exists.ok()) {
     return path_exists;
@@ -110,8 +113,8 @@ Status isReadable(const std::string& path) {
   return Status(1, "Path is not readable.");
 }
 
-Status pathExists(const std::string& path) {
-  if (path.length() == 0) {
+Status pathExists(const boost::filesystem::path& path) {
+  if (path.empty()) {
     return Status(1, "-1");
   }
 
@@ -122,7 +125,7 @@ Status pathExists(const std::string& path) {
   return Status(0, "1");
 }
 
-Status listFilesInDirectory(const std::string& path,
+Status listFilesInDirectory(const boost::filesystem::path& path,
                             std::vector<std::string>& results) {
   try {
     if (!boost::filesystem::exists(path)) {
@@ -145,7 +148,8 @@ Status listFilesInDirectory(const std::string& path,
   }
 }
 
-Status getDirectory(const std::string& path, std::string& dirpath) {
+Status getDirectory(const boost::filesystem::path& path,
+                    boost::filesystem::path& dirpath) {
   if (!isDirectory(path).ok()) {
     dirpath = boost::filesystem::path(path).parent_path().string();
     return Status(0, "OK");
@@ -154,7 +158,7 @@ Status getDirectory(const std::string& path, std::string& dirpath) {
   return Status(1, "Path is a directory");
 }
 
-Status isDirectory(const std::string& path) {
+Status isDirectory(const boost::filesystem::path& path) {
   if (boost::filesystem::is_directory(path)) {
     return Status(0, "OK");
   }
@@ -162,7 +166,7 @@ Status isDirectory(const std::string& path) {
 }
 
 Status parseTomcatUserConfigFromDisk(
-    const std::string& path,
+    const boost::filesystem::path& path,
     std::vector<std::pair<std::string, std::string> >& credentials) {
   std::string content;
   auto s = readFile(path, content);


### PR DESCRIPTION
This changes the `filesystem.h` headers and implementation to use `boost::fileystem::path` where it makes sense.

Compilation and all unit tests pass.

This is the first step in #347, next steps would be to refactor other internals to take advantage of this refactor.
