### PR TITLE
pci_devices: udev_device_get_property_values() can return NULL

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -68,7 +68,10 @@ QueryData genLspci() {
       r["model"] = boost::lexical_cast<std::string>(tmp);
     }
     results.push_back(r);
+    udev_device_unref(dev);
   }
+  udev_enumerate_unref(enumerate);
+  udev_unref(udev);
   return results;
 }
 }


### PR DESCRIPTION
```
osquery> select * from pci_devices;
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_S_construct null not valid
Aborted
```
