### PR TITLE
Ensure that libblkid-devel is installed on CentOS

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -364,6 +364,7 @@ function main() {
     package readline-devel
     package procps-devel
     package rpm-devel
+    package libblkid-devel
 
     install_boost
     install_gflags


### PR DESCRIPTION
This will have the provision script install the libblkid-devel package on CentOS.
