### PR TITLE
230: Added --host_identifier option

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -105,6 +105,13 @@ std::vector<std::string> split(const std::string& s,
 std::string getHostname();
 
 /**
+ * @brief generate a uuid to uniquely identify this machine
+ *
+ * @return uuid string to identify this machine
+ */
+std::string generateHostUuid();
+
+/**
  * @brief Getter for the current time, in a human-readable format.
  *
  * @return the current date/time in the format: "Wed Sep 21 10:27:52 2011"

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -248,8 +248,9 @@ struct ScheduledQueryLogItem {
   /// The name of the scheduled query
   std::string name;
 
-  /// The hostname of the host which the scheduled query was executed on
-  std::string hostname;
+  /// The identifier (hostname, or uuid) of the host on which the query was
+  /// executed
+  std::string hostIdentifier;
 
   /// The time that the query was executed, in unix time
   int unixTime;

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -190,10 +190,10 @@ getSerializedScheduledQueryLogItem() {
   i.name = "foobar";
   i.calendarTime = "Mon Aug 25 12:10:57 2014";
   i.unixTime = 1408993857;
-  i.hostname = "foobaz";
+  i.hostIdentifier = "foobaz";
   root.add_child("diffResults", dr.first);
   root.put<std::string>("name", "foobar");
-  root.put<std::string>("hostname", "foobaz");
+  root.put<std::string>("hostIdentifier", "foobaz");
   root.put<std::string>("calendarTime", "Mon Aug 25 12:10:57 2014");
   root.put<int>("unixTime", 1408993857);
   return std::make_pair(root, i);

--- a/osquery/database/results.cpp
+++ b/osquery/database/results.cpp
@@ -269,7 +269,7 @@ Status serializeScheduledQueryLogItem(const ScheduledQueryLogItem& i,
 
     tree.add_child("diffResults", diffResults);
     tree.put<std::string>("name", i.name);
-    tree.put<std::string>("hostname", i.hostname);
+    tree.put<std::string>("hostIdentifier", i.hostIdentifier);
     tree.put<std::string>("calendarTime", i.calendarTime);
     tree.put<int>("unixTime", i.unixTime);
   } catch (const std::exception& e) {
@@ -282,7 +282,7 @@ Status serializeEvent(const ScheduledQueryLogItem& item,
                       const boost::property_tree::ptree& event,
                       boost::property_tree::ptree& tree) {
   tree.put<std::string>("name", item.name);
-  tree.put<std::string>("hostname", item.hostname);
+  tree.put<std::string>("hostIdentifier", item.hostIdentifier);
   tree.put<std::string>("calendarTime", item.calendarTime);
   tree.put<int>("unixTime", item.unixTime);
 


### PR DESCRIPTION
A potential solution for #230

Adds the `--host_identifier` command line option, which allows you to specify a way of identifying the host.

`--host_identifier=hostname`: use the hostname as the identifier (default behavior)
`--host_identifier=uuid`: use a uuid to identify the host. On OSX, this will attempt to use the uuid from `gethostuuid`. On linux, it will just generate a new uuid and store it in rocksdb.

If anything fails or an invalid argument is given, OsQuery will default to using the hostname.
