### PR TITLE
Table spec documentation examples

### DIFF
--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <boost/make_shared.hpp>
-
 #define STRIP_FLAG_HELP 1
 #include <gflags/gflags.h>
 
@@ -24,9 +22,15 @@ class Flag {
   /*
    * @brief the instance accessor, but also can register flag data.
    *
+   * The accessor is mostly needless. The static instance and registration of
+   * flag data requires the accessor wrapper.
+   *
    * @param name The 'name' or the options switch data.
    * @param value The default value for this flag.
    * @param desc The description printed to the screen during help.
+   * @param shell_only Only print flag help when using `OSQUERY_TOOL_SHELL`.
+   *
+   * @return A mostly needless flag instance.
    */
   static Flag& get(const std::string& name = "",
                    const std::string& value = "",
@@ -45,7 +49,7 @@ class Flag {
    * @param name The 'name' or the options switch data.
    * @param value The default value for this flag.
    * @param desc The description printed to the screen during help.
-   * @param shell_only Restrict this flag to the shell.
+   * @param shell_only Restrict this flag to the shell help output.
    */
   void add(const std::string& name,
            const std::string& value,
@@ -67,7 +71,13 @@ class Flag {
   std::map<std::string, FlagDetail> flags() { return flags_; }
   /// The public flags instance, usable when parsing `--help` for the shell.
   std::map<std::string, FlagDetail> shellFlags() { return shell_flags_; }
-  static void print_flags(const std::map<std::string, FlagDetail> flags) {
+
+  /*
+   * @brief Print help-style output to stdout for a given flag set.
+   *
+   * @param flags A flag set (usually generated from Flag::flags).
+   */
+  static void printFlags(const std::map<std::string, FlagDetail> flags) {
     for (const auto& flag : flags) {
       fprintf(stdout,
               "  --%s, --%s=VALUE\n    %s (default: %s)\n",
@@ -100,7 +110,15 @@ class Flag {
     Flag flag = Flag::get(#name, #value, #desc);     \
   }
 
-/// Wrapper to bypass osquery help output
+/*
+ * @brief A duplicate of DEFINE_osquery_flag except the help output will only
+ * show when using OSQUERY_TOOL_SHELL (osqueryi).
+ *
+ * @param type The `_type` symbol portion of the gflags define.
+ * @param name The name symbol passed to gflags' `DEFINE_type`.
+ * @param value The default value, use a C++ literal.
+ * @param desc A string literal used for help display.
+ */
 #define DEFINE_shell_flag(type, name, value, desc)     \
   DEFINE_##type(name, value, desc);                    \
   namespace flag_##name {                              \

--- a/osquery/core/init_osquery.cpp
+++ b/osquery/core/init_osquery.cpp
@@ -45,12 +45,12 @@ void initOsquery(int argc, char* argv[], int tool) {
             "The following options control the osquery "
             "daemon and shell.\n\n");
 
-    Flag::print_flags(Flag::get().flags());
+    Flag::printFlags(Flag::get().flags());
 
     if (tool == OSQUERY_TOOL_SHELL) {
       // Print shell flags.
       fprintf(stdout, "\nThe following options control the osquery shell.\n\n");
-      Flag::print_flags(Flag::get().shellFlags());
+      Flag::printFlags(Flag::get().shellFlags());
     }
 
     fprintf(stdout, "\n%s\n", kEpilog.c_str());

--- a/osquery/tables/specs/x/bash_history.table
+++ b/osquery/tables/specs/x/bash_history.table
@@ -1,7 +1,10 @@
 table_name("bash_history")
+description("A line-delimited (command) table of per-user .bash_history data.")
 schema([
     Column(name="username", type="std::string"),
     Column(name="command", type="std::string"),
-    Column(name="history_file", type="std::string"),
+    Column(name="history_file", type="std::string",
+        description="Path to the .bash_history for this user"),
+    ForeignKey(column="username", table="users"),
 ])
 implementation("bash_history@genBashHistory")

--- a/osquery/tables/specs/x/cpuid.table
+++ b/osquery/tables/specs/x/cpuid.table
@@ -1,9 +1,14 @@
 table_name("cpuid")
+description("Useful CPU features from the cpuid ASM call.")
 schema([
     Column(name="feature", type="std::string"),
-    Column(name="value", type="std::string"),
-    Column(name="output_register", type="std::string"),
-    Column(name="output_bit", type="std::string"),
-    Column(name="input_eax", type="std::string"),
+    Column(name="value", type="std::string",
+        description="Bit value or string"),
+    Column(name="output_register", type="std::string",
+        description="Register used to for feature value"),
+    Column(name="output_bit", type="std::string",
+        description="Bit in register value for feature value"),
+    Column(name="input_eax", type="std::string",
+        description="Value of EAX used"),
 ])
 implementation("cpuid@genCPUID")

--- a/osquery/tables/specs/x/crontab.table
+++ b/osquery/tables/specs/x/crontab.table
@@ -1,14 +1,16 @@
 table_name("crontab")
-
+description("Line parsed values from system and user cron/tab.")
 schema([
-    Column(name="event", type="std::string"),
+    Column(name="event", type="std::string",
+        description="The job @event name (rare)"),
     Column(name="minute", type="std::string"),
     Column(name="hour", type="std::string"),
     Column(name="day_of_month", type="std::string"),
     Column(name="month", type="std::string"),    
     Column(name="day_of_week", type="std::string"),
-    Column(name="command", type="std::string"),
-    Column(name="path", type="std::string"),
+    Column(name="command", type="std::string",
+        description="Raw command string"),
+    Column(name="path", type="std::string",
+        description="File parsed"),
 ])
-
 implementation("crontab@genCronTab")

--- a/osquery/tables/specs/x/etc_hosts.table
+++ b/osquery/tables/specs/x/etc_hosts.table
@@ -1,6 +1,8 @@
 table_name("etc_hosts")
+description("Line-parsed /etc/hosts.")
 schema([
     Column(name="address", type="std::string"),
-    Column(name="hostnames", type="std::string"),
+    Column(name="hostnames", type="std::string",
+        description="Raw hosts mapping"),
 ])
 implementation("etc_hosts@genEtcHosts")

--- a/osquery/tables/specs/x/passwd_changes.table
+++ b/osquery/tables/specs/x/passwd_changes.table
@@ -1,8 +1,12 @@
 table_name("passwd_changes")
+description("Mostly an example use of events.")
 schema([
-    Column(name="target_path", type="std::string"),
+    Column(name="target_path", type="std::string",
+        description="The path changed"),
     Column(name="time", type="std::string"),
-    Column(name="action", type="std::string"),
-    Column(name="transaction_id", type="std::string"),
+    Column(name="action", type="std::string",
+        description="Change action (UPDATE, REMOVE, etc)"),
+    Column(name="transaction_id", type="std::string",
+        description="ID used during bulk update"),
 ])
 implementation("passwd_changes@PasswdChangesEventSubscriber::genTable")

--- a/osquery/tables/specs/x/process_envs.table
+++ b/osquery/tables/specs/x/process_envs.table
@@ -1,9 +1,16 @@
 table_name("process_envs")
+description("A key/value table of environment variables for each process.")
 schema([
     Column(name="pid", type="int"),
-    Column(name="name", type="std::string"),
-    Column(name="path", type="std::string"),
-    Column(name="key", type="std::string"),
-    Column(name="value", type="std::string"),
+    Column(name="name", type="std::string",
+        description="Process name"),
+    Column(name="path", type="std::string",
+        description="Process path"),
+    Column(name="key", type="std::string",
+        description="Environment variable name"),
+    Column(name="value", type="std::string",
+        description="Environment variable value"),
+    ForeignKey(column="pid", table="processes"),
+    ForeignKey(column="pid", table="process_open_files"),
 ])
 implementation("system/processes@genProcessEnvs")

--- a/tools/genapi.py
+++ b/tools/genapi.py
@@ -78,8 +78,11 @@ def gen_api(api):
 def gen_spec(tree):
     """Given a table tree, produce a literal of the table representation."""
     exec(compile(tree, "<string>", "exec"))
-    columns = [NoIndent({"name": column.name, "type": column.type})
-        for column in table.columns()]
+    columns = [NoIndent({
+            "name": column.name,
+            "type": column.type,
+            "description": column.description,
+        }) for column in table.columns()]
     foreign_keys = [NoIndent({"column": key.column, "table": key.table})
         for key in table.foreign_keys()]
     return {

--- a/tools/gentable.py
+++ b/tools/gentable.py
@@ -334,6 +334,7 @@ def table_name(name):
     logging.debug("- table_name")
     logging.debug("  - called with: %s" % name)
     table.table_name = name
+    table.description = ""
 
 def schema(schema_list):
     """

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -114,10 +114,12 @@ def check_leaks_linux(shell, query, supp_file=None):
 
 def check_leaks_darwin(shell, query):
     start_time = time.time()
+    # Run the shell with a --delay flag such that leaks can attach before exit.
     proc = subprocess.Popen([shell, "--query", query, "--delay", "1"],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     leak_checks = None
     while proc.poll() is None:
+        # Continue to run leaks until the monitored shell exits.
         leaks = subprocess.Popen(["leaks", "%s" % proc.pid],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, _ = leaks.communicate()
@@ -126,6 +128,7 @@ def check_leaks_darwin(shell, query):
                 if line.find("total leaked bytes") >= 0:
                     leak_checks = line.split(":")[1].strip()
         except:
+            print ("Encountered exception while running leaks:")
             print (stdout)
     return {"definitely": leak_checks}
 
@@ -139,7 +142,7 @@ def profile_leaks(shell, queries, count=1, rounds=1, supp_file=None):
     report = {}
     for name, query in queries.iteritems():
         print ("Analyzing leaks in query: %s" % query)
-        # Apply count
+        # Apply count (optionally run the query several times).
         summary = check_leaks(shell, query * count, supp_file)
         display = []
         for key in summary:


### PR DESCRIPTION
The tables API column names are sometimes vague or borderline meaningless (cpuid) without an explanation. For now, adding a description= for the table and each column will generate better API static output. This will still require a regeneration of the github pages content. 
