### PR TITLE
More control over logging

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -151,14 +151,16 @@ std::vector<boost::filesystem::path> getHomeDirectories();
 /**
  * @brief Inline helper function for use with utf8StringSize
  */
-template<typename _Iterator1, typename _Iterator2>
+template <typename _Iterator1, typename _Iterator2>
 inline size_t incUtf8StringIterator(_Iterator1& it, const _Iterator2& last) {
-  if(it == last) return 0;
+  if (it == last)
+    return 0;
   unsigned char c;
   size_t res = 1;
-  for(++it; last != it; ++it, ++res) {
+  for (++it; last != it; ++it, ++res) {
     c = *it;
-    if(!(c&0x80) || ((c&0xC0) == 0xC0)) break;
+    if (!(c & 0x80) || ((c & 0xC0) == 0xC0))
+      break;
   }
 
   return res;
@@ -171,10 +173,10 @@ inline size_t incUtf8StringIterator(_Iterator1& it, const _Iterator2& last) {
  *
  * @return the length of the string
  */
-inline size_t utf8StringSize(const std::string& str)  {
+inline size_t utf8StringSize(const std::string& str) {
   size_t res = 0;
   std::string::const_iterator it = str.begin();
-  for(; it != str.end(); incUtf8StringIterator(it, str.end()))
+  for (; it != str.end(); incUtf8StringIterator(it, str.end()))
     res++;
 
   return res;

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -228,7 +228,7 @@ class DBHandle {
    *
    * @return an estimate of a sane environment as an exception.
    */
-   static void requireInstance(const std::string& path, bool in_memory);
+  static void requireInstance(const std::string& path, bool in_memory);
 
  private:
   /////////////////////////////////////////////////////////////////////////////

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -28,14 +28,14 @@ namespace osquery {
  * types they are storing, and more importantly how they are treated at query
  * time.
  */
- #define TEXT(x) std::string(x)
- #define INTEGER(x) boost::lexical_cast<std::string>(x)
- #define BIGINT(x) boost::lexical_cast<std::string>(x)
+#define TEXT(x) std::string(x)
+#define INTEGER(x) boost::lexical_cast<std::string>(x)
+#define BIGINT(x) boost::lexical_cast<std::string>(x)
 
 /**
  * @brief A variant type for the SQLite type affinities.
  */
- typedef std::string RowData;
+typedef std::string RowData;
 
 /**
  * @brief A single row from a database query

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -80,11 +80,11 @@ class Flag {
   static void printFlags(const std::map<std::string, FlagDetail> flags) {
     for (const auto& flag : flags) {
       fprintf(stdout,
-              "  --%s, --%s=VALUE\n    %s (default: %s)\n",
+              "  --%s, --%s=%s\n    %s\n",
               flag.first.c_str(),
               flag.first.c_str(),
-              flag.second.second.c_str(),
-              flag.second.first.c_str());
+              flag.second.first.c_str(),
+              flag.second.second.c_str());
     }
   }
 
@@ -107,7 +107,7 @@ class Flag {
 #define DEFINE_osquery_flag(type, name, value, desc) \
   DEFINE_##type(name, value, desc);                  \
   namespace flag_##name {                            \
-    Flag flag = Flag::get(#name, #value, #desc);     \
+    Flag flag = Flag::get(#name, #value, desc);      \
   }
 
 /*
@@ -119,8 +119,8 @@ class Flag {
  * @param value The default value, use a C++ literal.
  * @param desc A string literal used for help display.
  */
-#define DEFINE_shell_flag(type, name, value, desc)     \
-  DEFINE_##type(name, value, desc);                    \
-  namespace flag_##name {                              \
-    Flag flag = Flag::get(#name, #value, #desc, true); \
+#define DEFINE_shell_flag(type, name, value, desc)    \
+  DEFINE_##type(name, value, desc);                   \
+  namespace flag_##name {                             \
+    Flag flag = Flag::get(#name, #value, desc, true); \
   }

--- a/osquery/core/init_osquery.cpp
+++ b/osquery/core/init_osquery.cpp
@@ -16,10 +16,22 @@ const std::string kDescription =
     "relational database";
 const std::string kEpilog = "osquery project page <http://osquery.io>.";
 
+DEFINE_osquery_flag(bool, debug, false, "Enable debug messages.");
+
+DEFINE_osquery_flag(bool,
+                    verbose_debug,
+                    false,
+                    "Enable verbose debug messages.")
+
+DEFINE_osquery_flag(bool,
+                    disable_logging,
+                    false,
+                    "Disable ERROR/INFO logging.");
+
 DEFINE_osquery_flag(string,
                     osquery_log_dir,
                     "/var/log/osquery/",
-                    "Directory to store results logging.");
+                    "Directory to store ERROR/INFO and results logging.");
 
 static const char* basename(const char* filename) {
   const char* sep = strrchr(filename, '/');
@@ -69,8 +81,23 @@ void initOsquery(int argc, char* argv[], int tool) {
   // Let gflags parse the non-help options/flags.
   __GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, false);
 
+  // The log dir is used for glogging and the filesystem results logs.
   if (isWritable(FLAGS_osquery_log_dir.c_str()).ok()) {
     FLAGS_log_dir = FLAGS_osquery_log_dir;
+  }
+
+  if (FLAGS_verbose_debug) {
+    FLAGS_debug = true;
+    FLAGS_v = 1;
+  }
+
+  if (!FLAGS_debug) {
+    FLAGS_minloglevel = 1; // WARNING
+  }
+
+  if (FLAGS_disable_logging) {
+    FLAGS_logtostderr = true;
+    FLAGS_minloglevel = 2;
   }
 
   google::InitGoogleLogging(argv[0]);


### PR DESCRIPTION
I was trying to think of a simple solution to: https://github.com/facebook/osquery/issues/302 that didn't require implementing common features a first-class log rotation application. But the best you'll get is a few more controls over how the daemon logs.

One UX change and that's by default the LOG level is raised to WARNING for osqueryd. Use `--debug` to restore it back to info.
