### PR TITLE
blacklisting port_inode and socket_inode

### DIFF
--- a/osquery/tables/specs/blacklist
+++ b/osquery/tables/specs/blacklist
@@ -4,3 +4,5 @@
 
 quarantine
 suid_bin
+port_inode
+socket_inode


### PR DESCRIPTION
port_inode and socket_inode have caused a few issues lately and, as of
right now, they both have open issues against them. For the time being,
I'm going to blacklist them. When the tables are production-ready, we
can re-add them back in to the base linux build.
