### PR TITLE
Add throttle to LD plist

### DIFF
--- a/tools/com.facebook.osqueryd.plist
+++ b/tools/com.facebook.osqueryd.plist
@@ -14,5 +14,7 @@
         <string>/usr/local/bin/osqueryd</string>
   <key>RunAtLoad</key>
   <true/>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Since the DB is still on disk, if any corruption happens the daemon/LD may fail. Do not restart osqueryd too quickly. 

WRT: https://github.com/facebook/osquery/issues/443
