### PR TITLE
Cleanup inode table implementations and unblacklist.

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -149,4 +149,39 @@ Status parsePlist(const boost::filesystem::path& path,
 Status parsePlistContent(const std::string& fileContent,
                          boost::property_tree::ptree& tree);
 #endif
+
+#ifdef __linux__
+/**
+ * @brief Iterate over proc process, returns a list of pids.
+ *
+ * @param processes output list of process pids as strings (int paths in proc).
+ *
+ * @return status of iteration.
+ */
+Status procProcesses(std::vector<std::string>& processes);
+
+/**
+ * @brief Iterate over a proc process's descriptors, return a list of fds.
+ *
+ * @param process a string pid from proc.
+ * @param descriptors output list of descriptor numbers as strings.
+ *
+ * @return status of iteration, failure if the process path did not exist.
+ */
+Status procDescriptors(const std::string& process,
+                       std::vector<std::string>& descriptors);
+
+/**
+ * @brief Read a descriptor's virtual path.
+ *
+ * @param process a string pid from proc.
+ * @param descriptor a string descriptor number for a proc.
+ * @param result output variable with value of link.
+ *
+ * @return status of read, failure on permission error or filesystem error.
+ */
+Status procReadDescriptor(const std::string& process,
+                          const std::string& descriptor,
+                          std::string& result);
+#endif
 }

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -4,6 +4,10 @@ if(APPLE)
   )
 
   ADD_OSQUERY_LINK("-framework Foundation")
+elseif(UBUNTU OR CENTOS)
+  ADD_OSQUERY_LIBRARY(osquery_filesystem_linux
+    linux/proc.cpp
+  )
 endif()
 
 ADD_OSQUERY_LIBRARY(osquery_filesystem

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -16,8 +16,6 @@
 
 #include "osquery/filesystem.h"
 
-using osquery::Status;
-
 namespace pt = boost::property_tree;
 namespace fs = boost::filesystem;
 

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -1,0 +1,77 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <exception>
+
+#include <unistd.h>
+
+#include <boost/regex.hpp>
+#include <boost/filesystem.hpp>
+
+#include <glog/logging.h>
+
+#include "osquery/filesystem.h"
+
+namespace osquery {
+
+const std::string kLinuxProcPath = "/proc";
+
+Status procProcesses(std::vector<std::string>& processes) {
+  boost::regex process_filter("\\d+");
+
+  // Iterate over each process-like directory in proc.
+  boost::filesystem::directory_iterator it(kLinuxProcPath), end;
+  try {
+    for (; it != end; ++it) {
+      if (boost::filesystem::is_directory(it->status())) {
+        boost::smatch what;
+        if (boost::regex_match(
+                it->path().leaf().string(), what, process_filter)) {
+          processes.push_back(it->path().leaf().string());
+        }
+      }
+    }
+  } catch (boost::filesystem::filesystem_error& e) {
+    VLOG(1) << "Exception iterating Linux processes " << e.what();
+    return Status(1, e.what());
+  }
+
+  return Status(0, "OK");
+}
+
+Status procDescriptors(const std::string& process,
+                       std::vector<std::string>& descriptors) {
+  auto descriptors_path = kLinuxProcPath + "/" + process + "/fd";
+  try {
+    // Access to the process' /fd may be restricted.
+    boost::filesystem::directory_iterator it(descriptors_path), end;
+    for (; it != end; ++it) {
+      descriptors.push_back(it->path().leaf().string());
+    }
+  } catch (boost::filesystem::filesystem_error& e) {
+    return Status(1, "Cannot access descriptors for " + process);
+  }
+
+  return Status(0, "OK");
+}
+
+Status procReadDescriptor(const std::string& process,
+                          const std::string& descriptor,
+                          std::string& result) {
+  auto link = kLinuxProcPath + "/" + process + "/fd/" + descriptor;
+  auto path_max = pathconf(link.c_str(), _PC_PATH_MAX);
+  auto result_path = (char*)malloc(path_max);
+
+  memset(result_path, 0, path_max);
+  auto size = readlink(link.c_str(), result_path, path_max);
+  if (size >= 0) {
+    result = std::string(result_path);
+  }
+
+  free(result_path);
+  if (size >= 0) {
+    return Status(0, "OK");
+  } else {
+    return Status(1, "Could not read path");
+  }
+}
+}

--- a/osquery/tables/specs/blacklist
+++ b/osquery/tables/specs/blacklist
@@ -4,5 +4,3 @@
 
 quarantine
 suid_bin
-port_inode
-socket_inode

--- a/osquery/tables/specs/linux/port_inode.table
+++ b/osquery/tables/specs/linux/port_inode.table
@@ -5,6 +5,7 @@ schema([
     Column("local_ip", TEXT),
     Column("remote_ip", TEXT),
     Column("inode", TEXT),
+    Column("family", INTEGER),
 ])
 implementation("osquery/tables/networking/linux/port_inode@genPortInode")
 


### PR DESCRIPTION
This addresses #433, #432 by adding some proc API to filesystem for Linux.
- Catch filesystem exceptions wrought from permissions on proc/fd access.
- Add family column to port_inode.
