### PR TITLE
Remove 'host' from OS X route types #483

### DIFF
--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -33,7 +33,6 @@ const std::string kDefaultRoute = "0.0.0.0";
 const std::vector<RouteType> kRouteTypes = {
     std::make_pair(RTF_LOCAL, "local"),
     std::make_pair(RTF_GATEWAY, "gateway"),
-    std::make_pair(RTF_HOST, "host"),
     std::make_pair(RTF_DYNAMIC, "dynamic"),
     std::make_pair(RTF_MODIFIED, "modified"),
     std::make_pair(RTF_STATIC, "static"),


### PR DESCRIPTION
Before:

```
./tools/profile.py --query "select * from routes;"
Profiling query: select * from routes;
manual (1/1):  duration: 0 (0.507874011993)   cpu_time: 0 (0.089365784)   memory: 1 (9289728)   fds: 0 (4)   utilization: 1 (8.8)  
manual   avg:  duration: 0 (0.507874011993)   cpu_time: 0 (0.089365784)   memory: 1 (9289728.0)   fds: 0 (4.0)   utilization: 1 (8.8)  
```

After:

```
./tools/profile.py --query "select * from routes;"
Profiling query: select * from routes;
manual (1/1):  duration: 0 (0.508569955826)   cpu_time: 0 (0.027407109)   memory: 0 (5644288)   fds: 0 (4)   utilization: 0 (2.6)  
manual   avg:  duration: 0 (0.508569955826)   cpu_time: 0 (0.027407109)   memory: 0 (5644288.0)   fds: 0 (4.0)   utilization: 0 (2.6)  
```
