### PR TITLE
Fixed small bug in getHostIdentifier method

### DIFF
--- a/osquery/scheduler/scheduler.cpp
+++ b/osquery/scheduler/scheduler.cpp
@@ -24,7 +24,7 @@ DEFINE_osquery_flag(string,
 Status getHostIdentifier(std::string& ident) {
   std::shared_ptr<DBHandle> db;
   try {
-    auto db = DBHandle::getInstance();
+    db = DBHandle::getInstance();
   } catch (const std::exception& e) {
     return Status(1, e.what());
   }


### PR DESCRIPTION
Fixes a small bug in `getHostIdentifier` that seemed to be causing the daemon to segfault occasionally.
