### PR TITLE
Codemod to improve include search paths for includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ PROJECT(OSQUERY)
 if(APPLE)
   set(APPLE_MIN_ABI "10.9")
   set(OS_COMPILE_FLAGS "-std=c++11 -stdlib=libc++ -mmacosx-version-min=${APPLE_MIN_ABI}")
+  # Special compile flags for Objective-C++
+  set(OBJCXX_COMPILE_FLAGS "-x objective-c++ -fobjc-arc ")
   set(OS_WHOLELINK_PRE "-Wl,-all_load")
   set(OS_WHOLELINK_POST "")
 else()
@@ -25,8 +27,8 @@ endif()
 
 # Use osquery language to set platform/os
 execute_process(
-  COMMAND ${CMAKE_SOURCE_DIR}/tools/provision.sh get_platform
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND "${CMAKE_SOURCE_DIR}/tools/provision.sh" get_platform
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE PLATFORM
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -37,8 +39,8 @@ list(GET PLATFORM 1 OSQUERY_BUILD_DISTRO)
 
 # Make sure deps were built before compiling
 execute_process(
-  COMMAND ${CMAKE_SOURCE_DIR}/tools/provision.sh check ${CMAKE_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMAND "${CMAKE_SOURCE_DIR}/tools/provision.sh" check "${CMAKE_BINARY_DIR}"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE OSQUERY_DEPS_MESSAGE
   RESULT_VARIABLE OSQUERY_DEPS_CHECK
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -70,7 +72,7 @@ endif()
 
 set(OS_COMPILE_FLAGS "${OS_COMPILE_FLAGS} ${USER_COMPILE_FLAGS}")
 
-SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" "${CMAKE_MODULE_PATH}")
 FIND_PACKAGE(Gtest REQUIRED)
 FIND_PACKAGE(Sqlite3 REQUIRED)
 FIND_PACKAGE(BZip2 REQUIRED)
@@ -103,8 +105,8 @@ FIND_PACKAGE(Doxygen)
 if(DOXYGEN_FOUND)
   ADD_CUSTOM_TARGET(
     docs
-    ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Doxyfile
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    "${DOXYGEN_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/Doxyfile"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Generating API documentation with Doxygen" VERBATIM
   )
 endif(DOXYGEN_FOUND)
@@ -113,14 +115,14 @@ endif(DOXYGEN_FOUND)
 ADD_CUSTOM_TARGET(
   format-all
   find osquery include tools \( -name "*.h" -o -name "*.cpp" -o -name "*.mm" \) -exec clang-format -i {} +
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting all osquery code with clang-format" VERBATIM
 )
 
 ADD_CUSTOM_TARGET(
   format
-  python tools/formatting/git-clang-format.py
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  python "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting code staged code changes with clang-format" VERBATIM
 )
 

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include "osquery/status.h"
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/config/plugin.h
+++ b/include/osquery/config/plugin.h
@@ -5,8 +5,8 @@
 #include <future>
 #include <utility>
 
-#include "osquery/registry.h"
-#include "osquery/status.h"
+#include <osquery/registry.h>
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -5,11 +5,11 @@
 #include <string>
 #include <vector>
 
-#include <sqlite3.h>
-
 #include <boost/filesystem.hpp>
 
-#include "osquery/database/results.h"
+#include <sqlite3.h>
+
+#include <osquery/database/results.h>
 
 #ifndef STR
 #define STR_OF(x) #x

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -2,6 +2,6 @@
 
 #pragma once
 
-#include "osquery/database/db_handle.h"
-#include "osquery/database/query.h"
-#include "osquery/database/results.h"
+#include <osquery/database/db_handle.h>
+#include <osquery/database/query.h>
+#include <osquery/database/results.h>

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -8,8 +8,8 @@
 
 #include <rocksdb/db.h>
 
-#include "osquery/flags.h"
-#include "osquery/status.h"
+#include <osquery/flags.h>
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/database/query.h
+++ b/include/osquery/database/query.h
@@ -8,10 +8,10 @@
 
 #include <gtest/gtest_prod.h>
 
-#include "osquery/config.h"
-#include "osquery/database/db_handle.h"
-#include "osquery/database/results.h"
-#include "osquery/status.h"
+#include <osquery/config.h>
+#include <osquery/database/db_handle.h>
+#include <osquery/database/results.h>
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -9,7 +9,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 
-#include "osquery/status.h"
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/devtools.h
+++ b/include/osquery/devtools.h
@@ -4,7 +4,7 @@
 
 #include <string>
 
-#include "osquery/database/results.h"
+#include <osquery/database/results.h>
 
 namespace osquery {
 
@@ -13,8 +13,8 @@ namespace osquery {
  *
  * @code{.cpp}
  *   // Copyright 2004-present Facebook. All Rights Reserved.
- *   #include "osquery/core.h"
- *   #include "osquery/devtools.h"
+ *   #include <osquery/core.h>
+ *   #include <osquery/devtools.h>
  *
  *   int main(int argc, char *argv[]) {
  *     osquery::initOsquery(argc, argv);

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -17,7 +17,7 @@
 #include <thrift/concurrency/ThreadManager.h>
 #endif
 
-#include "osquery/status.h"
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -12,9 +12,9 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include "osquery/database.h"
-#include "osquery/registry.h"
-#include "osquery/status.h"
+#include <osquery/database.h>
+#include <osquery/registry.h>
+#include <osquery/status.h>
 
 namespace osquery {
 
@@ -85,7 +85,7 @@ extern const std::vector<size_t> kEventTimeLists;
  * following:
  *
  * @code{.cpp}
- *   #include "osquery/events.h"
+ *   #include <osquery/events.h>
  *
  *   class MyEventPublisher: public EventPublisher {
  *     DECLARE_EVENTPUBLISHER(MyEventPublisher, MySubscriptionContext,
@@ -128,7 +128,7 @@ extern const std::vector<size_t> kEventTimeLists;
  * following:
  *
  * @code{.cpp}
- *   #include "osquery/events.h"
+ *   #include <osquery/events.h>
  *
  *   class MyEventSubscriber: public EventSubscriber {
  *     DECLARE_EVENTSUBSCRIBER(MyEventSubscriber, MyEventPublisher);
@@ -164,7 +164,7 @@ extern const std::vector<size_t> kEventTimeLists;
  * callin/callback functions:
  *
  * @code{.cpp}
- *   #include "osquery/events.h"
+ *   #include <osquery/events.h>
  *
  *   class MyEventSubscriber: public EventSubscriber {
  *     DECLARE_EVENTSUBSCRIBER(MyEventSubscriber, MyEventPublisher);
@@ -209,7 +209,7 @@ extern const std::vector<size_t> kEventTimeLists;
  * will be called.
  *
  * @code{.cpp}
- *   #include "osquery/events.h"
+ *   #include <osquery/events.h>
  *
  *   class MyEventSubscriber: public EventSubscriber {
  *     DECLARE_EVENTSUBSCRIBER(MyEventSubscriber, MyEventPublisher);

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -9,7 +9,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/property_tree/ptree.hpp>
 
-#include "osquery/status.h"
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -5,8 +5,8 @@
 #define STRIP_FLAG_HELP 1
 #include <gflags/gflags.h>
 
-#include "osquery/registry.h"
-#include "osquery/status.h"
+#include <osquery/registry.h>
+#include <osquery/status.h>
 
 #define __GFLAGS_NAMESPACE google
 

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -8,8 +8,8 @@
 
 #include <glog/logging.h>
 
-#include "osquery/status.h"
-#include "osquery/database.h"
+#include <osquery/status.h>
+#include <osquery/database.h>
 
 namespace osquery {
 

--- a/include/osquery/logger/plugin.h
+++ b/include/osquery/logger/plugin.h
@@ -4,8 +4,8 @@
 
 #include <memory>
 
-#include "osquery/registry.h"
-#include "osquery/status.h"
+#include <osquery/registry.h>
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -21,7 +21,7 @@ namespace osquery {
  * To use this registry, make a header like so:
  *
  * @code{.cpp}
- *   #include "osquery/registry.h"
+ *   #include <osquery/registry.h>
  *
  *   DECLARE_REGISTRY(MathFuncs, int, std::function<double(double)>)
  *   #define REGISTERED_MATH_FUNCS REGISTRY(MathFuncs)

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "osquery/database/results.h"
+#include <osquery/database/results.h>
 
 namespace osquery {
 

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -10,8 +10,8 @@
 
 #include <sqlite3.h>
 
-#include "osquery/database/results.h"
-#include "osquery/status.h"
+#include <osquery/database/results.h>
+#include <osquery/status.h>
 
 namespace osquery {
 namespace tables {


### PR DESCRIPTION
- Move the Obj-C++ compile flags into the TLD CMakeLists.
- Codemode includes.
- Wrap paths in CMake with quotes #402 
