### PR TITLE
Force git to return something if tags aren't found

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -88,7 +88,7 @@ endif()
 
 # Generate version from git
 execute_process(
-  COMMAND git describe --tags HEAD
+  COMMAND git describe --tags HEAD --always
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   OUTPUT_VARIABLE OSQUERY_BUILD_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
If there are no tags in the current repository, this command will fail leaving the OSQUERY_BUILD_VERSION empty, and therefore breaking the package building process (and presumably other things too) due to the empty version flag.  By adding the flag --always, this forces git to fallback to a commit id instead of returning nothing.

Before:

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ git describe --tags HEAD
fatal: No names found, cannot describe anything.
```

After

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ git describe --tags HEAD --always 
3716418
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ git tag 0.1.1-working-modified
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ git describe --tags HEAD --always
0.1.1-working-modified
```
