### PR TITLE
[Fix #530] Continue to read from NL socket

### DIFF
--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -44,6 +44,8 @@ Status readNetlink(int socket_fd, int seq, char* output, size_t* size) {
       bytes = recv(socket_fd, output, MAX_NETLINK_SIZE - message_size, 0);
       if (bytes < 0) {
         return Status(1, "Could not read from NETLINK.");
+      } else if (bytes == 0) {
+        ::usleep(20);
       }
     }
 


### PR DESCRIPTION
When `recv` from the NL socket if the return value is 0, continue to read.
