### PR TITLE
[Fix #560] Improve config tests

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -10,17 +10,17 @@
 
 #pragma once
 
-#include <future>
 #include <map>
 #include <memory>
-#include <mutex>
-#include <string>
-#include <utility>
 #include <vector>
 
+#include <osquery/flags.h>
 #include <osquery/status.h>
 
 namespace osquery {
+
+/// The builder or invoker may change the default config plugin.
+DECLARE_string(config_retriever);
 
 /**
  * @brief represents the relevant parameters of a scheduled query.
@@ -98,6 +98,13 @@ class Config {
   static std::shared_ptr<Config> getInstance();
 
   /**
+   * @brief Call the genConfig method of the config retriever plugin.
+   *
+   * This may perform a resource load such as TCP request or filesystem read.
+   */
+  Status load();
+
+  /**
    * @brief Get a vector of all scheduled queries.
    *
    * @code{.cpp}
@@ -140,7 +147,7 @@ class Config {
    * Since instances of Config should only be created via getInstance(),
    * Config's constructor is private
    */
-  Config();
+  Config() {}
 
   /**
    * @brief Uses the specified config retriever to populate a config struct.

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -581,6 +581,7 @@ class EventSubscriberCore {
    */
   virtual QueryData get(EventTime start, EventTime stop);
 
+ private:
   /*
    * @brief When `get`ting event results, return EventID%s from time indexes.
    *
@@ -594,7 +595,6 @@ class EventSubscriberCore {
    */
   std::vector<EventRecord> getRecords(const std::vector<std::string>& indexes);
 
- private:
   /**
    * @brief Get a unique storage-related EventID.
    *

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 ADD_OSQUERY_CORE_LIBRARY(osquery_core
   conversions.cpp
-  init_osquery.cpp
+  init.cpp
   sql.cpp
   sqlite_util.cpp
   system.cpp

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -12,6 +12,7 @@
 
 #include <glog/logging.h>
 
+#include <osquery/config.h>
 #include <osquery/core.h>
 #include <osquery/flags.h>
 #include <osquery/filesystem.h>
@@ -76,6 +77,7 @@ void initOsquery(int argc, char* argv[], int tool) {
   std::string binary(fs::path(std::string(argv[0])).filename().string());
   std::string first_arg = (argc > 1) ? std::string(argv[1]) : "";
 
+  // osquery implements a custom help/usage output.
   if ((first_arg == "--help" || first_arg == "-h" || first_arg == "-help") &&
       tool != OSQUERY_TOOL_TEST) {
     printUsage(binary, tool);
@@ -127,5 +129,12 @@ void initOsquery(int argc, char* argv[], int tool) {
 
   google::InitGoogleLogging(argv[0]);
   osquery::InitRegistry::get().run();
+
+// Once command line arguments are parsed load the osquery config.
+#ifdef OSQUERY_DEFAULT_CONFIG_PLUGIN
+  FLAGS_config_retriever = STR(OSQUERY_DEFAULT_CONFIG_PLUGIN);
+#endif
+  auto config = Config::getInstance();
+  config->load();
 }
 }

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include <stdexcept>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/lexical_cast.hpp>
@@ -313,7 +315,14 @@ EventID EventSubscriberCore::getEventID() {
 QueryData EventSubscriberCore::get(EventTime start, EventTime stop) {
   QueryData results;
   Status status;
-  auto db = DBHandle::getInstance();
+
+  std::shared_ptr<DBHandle> db;
+  try {
+    db = DBHandle::getInstance();
+  } catch (const std::runtime_error& e) {
+    LOG(ERROR) << "Cannot retrieve subscriber results database is locked";
+    return results;
+  }
 
   // Get the records for this time range.
   auto indexes = getIndexes(start, stop);
@@ -347,7 +356,13 @@ QueryData EventSubscriberCore::get(EventTime start, EventTime stop) {
 
 Status EventSubscriberCore::add(const Row& r, EventTime time) {
   Status status;
-  auto db = DBHandle::getInstance();
+
+  std::shared_ptr<DBHandle> db;
+  try {
+    db = DBHandle::getInstance();
+  } catch (const std::runtime_error& e) {
+    return Status(1, e.what());
+  }
 
   // Get and increment the EID for this module.
   EventID eid = getEventID();

--- a/tools/tests/test.config
+++ b/tools/tests/test.config
@@ -1,0 +1,9 @@
+{
+  "scheduledQueries": [
+    {
+      "name": "time",
+      "query": "select * from time;",
+      "interval": 1
+    }
+  ]
+}


### PR DESCRIPTION
While catching the expected runtime_error when accessing the DB late during run within an event emit/yield I found that config testing needed some help. To make the config tests more "unit"-y: the ctor is now an explicitly called member function `load`. The config test now forces filesystem as the retriever and uses a known-test config instead of a variable runtime/production config from whatever plugin was used as default.