### PR TITLE
Use sizeof for length of statically allocated arrays

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -43,8 +43,8 @@ DEFINE_osquery_flag(string,
 
 std::string getHostname() {
   char hostname[256]; // Linux max should be 64.
-  memset(hostname, 0, 256);
-  gethostname(hostname, 255);
+  memset(hostname, 0, sizeof(hostname));
+  gethostname(hostname, sizeof(hostname) - 1);
   std::string hostname_string = std::string(hostname);
   boost::algorithm::trim(hostname_string);
   return hostname_string;
@@ -59,7 +59,7 @@ std::string generateHostUuid() {
 #ifdef __APPLE__
   // Use the hardware uuid available on OSX to identify this machine
   char uuid[128];
-  memset(uuid, 0, 128);
+  memset(uuid, 0, sizeof(uuid));
   uuid_t id;
   // wait at most 5 seconds for gethostuuid to return
   const timespec wait = {5, 0};

--- a/osquery/tables/system/darwin/nvram.cpp
+++ b/osquery/tables/system/darwin/nvram.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -24,7 +24,7 @@ std::string variableFromNumber(const void *value) {
   uint32_t number;
   char number_buffer[10];
 
-  memset(number_buffer, 0, 10);
+  memset(number_buffer, 0, sizeof(number_buffer));
   CFNumberGetValue((CFNumberRef)value, kCFNumberSInt32Type, &number);
   if (number == 0xFFFFFFFF) {
     sprintf(number_buffer, "-1");
@@ -51,12 +51,13 @@ std::string variableFromData(const void *value) {
     return "";
   }
 
-  buffer = (char *)malloc(length * 3 + 1);
+  size_t buffer_length = length * 3 + 1;
+  buffer = (char *)malloc(buffer_length);
   if (buffer == NULL) {
     return "";
   }
 
-  memset(buffer, 0, length * 3 + 1);
+  memset(buffer, 0, buffer_length);
   data_ptr = CFDataGetBytePtr((CFDataRef)value);
   for (count = count2 = 0; count < length; count++) {
     byte = data_ptr[count];

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -34,11 +34,7 @@ namespace tables {
 #endif
 
 std::string proc_name(const proc_t* proc_info) {
-  char cmd[17]; // cmd is a 16 char buffer
-
-  memset(cmd, 0, 17);
-  memcpy(cmd, proc_info->cmd, 16);
-  return std::string(cmd);
+  return std::string(proc_info->cmd);
 }
 
 std::string proc_attr(const std::string& attr, const proc_t* proc_info) {


### PR DESCRIPTION
In some places arrays are statically allocated, then their length is passed as a number in a call like `memset`. We should prefer using `sizeof` when working with statically allocated arrays, as the compiler will automatically pass the correct value, and we will no longer need to ensure consistency between multiple numbers.

Examples:
https://github.com/facebook/osquery/blob/b74ce26a8c5f8c47e76b925a9437ca961a85ad9c/osquery/tables/system/linux/processes.cpp#L40
https://github.com/facebook/osquery/blob/b74ce26a8c5f8c47e76b925a9437ca961a85ad9c/osquery/tables/system/darwin/nvram.cpp#L27
https://github.com/facebook/osquery/blob/454fb01e98a658dafe18cc7ffc7eed6ff9e085de/osquery/core/system.cpp#L46
https://github.com/facebook/osquery/blob/454fb01e98a658dafe18cc7ffc7eed6ff9e085de/osquery/core/system.cpp#L62