### PR TITLE
Installing gems in Ubuntu 12 to avoid error

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -394,6 +394,7 @@ function main() {
     set_cxx clang++
 
     if [[ $DISTRO = "precise" ]]; then
+      package rubygems
       package gcc-4.7
       package g++-4.7
       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-4.7


### PR DESCRIPTION
gems is not installed in Ubuntu 12 and it does not install with the ruby-dev package, installing it to avoid the build to break