### PR TITLE
QueryContext unit tests and splay/config updates

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -121,19 +121,6 @@ class Config {
   std::vector<OsqueryScheduledQuery> getScheduledQueries();
 
   /**
-   * @brief Calculate a splayed integer based on a variable splay percentage
-   *
-   * The value of splayPercent must be between 1 and 100. If it's not, the
-   * value of original will be returned.
-   *
-   * @param original The original value to be modified
-   * @param splayPercent The percent in which to splay the original value by
-   *
-   * @return The modified version of original
-   */
-  static int splayValue(int original, int splayPercent);
-
-  /**
    * @brief Calculate the has of the osquery config
    *
    * @return The MD5 of the osquery config

--- a/include/osquery/scheduler.h
+++ b/include/osquery/scheduler.h
@@ -26,4 +26,17 @@ namespace osquery {
  * @endcode
  */
 void initializeScheduler();
+
+/**
+ * @brief Calculate a splayed integer based on a variable splay percentage
+ *
+ * The value of splayPercent must be between 1 and 100. If it's not, the
+ * value of original will be returned.
+ *
+ * @param original The original value to be modified
+ * @param splayPercent The percent in which to splay the original value by
+ *
+ * @return The modified version of original
+ */
+int splayValue(int original, int splayPercent);
 }

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -17,10 +17,14 @@
 #include <boost/lexical_cast.hpp>
 
 #include <sqlite3.h>
-#include <gtest/gtest.h>
 
 #include <osquery/database/results.h>
 #include <osquery/status.h>
+
+#ifndef FRIEND_TEST
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+#endif
 
 namespace osquery {
 namespace tables {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -66,26 +66,6 @@ TEST_F(ConfigTests, test_plugin) {
   EXPECT_EQ(p.first.toString(), "OK");
   EXPECT_EQ(p.second, "foobar");
 }
-
-TEST_F(ConfigTests, test_splay) {
-  auto val1 = Config::splayValue(100, 10);
-  EXPECT_GE(val1, 90);
-  EXPECT_LE(val1, 110);
-
-  auto val2 = Config::splayValue(100, 10);
-  EXPECT_GE(val2, 90);
-  EXPECT_LE(val2, 110);
-
-  auto val3 = Config::splayValue(10, 0);
-  EXPECT_EQ(val3, 10);
-
-  auto val4 = Config::splayValue(100, 1);
-  EXPECT_GE(val4, 99);
-  EXPECT_LE(val4, 101);
-
-  auto val5 = Config::splayValue(1, 10);
-  EXPECT_EQ(val5, 1);
-}
 }
 
 int main(int argc, char* argv[]) {

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -14,6 +14,7 @@
 
 #include <osquery/config/plugin.h>
 #include <osquery/flags.h>
+#include <osquery/logger.h>
 
 namespace fs = boost::filesystem;
 using osquery::Status;
@@ -33,6 +34,7 @@ class FilesystemConfigPlugin : public ConfigPlugin {
       return std::make_pair(Status(1, "config file does not exist"), config);
     }
 
+    VLOG(1) << "Filesystem ConfigPlugin reading: " << FLAGS_config_path;
     std::ifstream config_stream(FLAGS_config_path);
 
     config_stream.seekg(0, std::ios::end);

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -23,6 +23,7 @@ ADD_OSQUERY_CORE_LIBRARY(osquery_core
 ADD_OSQUERY_TEST(status_test status_tests.cpp)
 ADD_OSQUERY_TEST(sql_test sql_tests.cpp)
 ADD_OSQUERY_TEST(sqlite_util_tests sqlite_util_tests.cpp)
+ADD_OSQUERY_TEST(tables_tests tables_tests.cpp)
 ADD_OSQUERY_TEST(test_util_tests test_util_tests.cpp)
 ADD_OSQUERY_TEST(text_tests text_tests.cpp)
 ADD_OSQUERY_TEST(conversions_tests conversions_tests.cpp)

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -10,12 +10,11 @@
 
 #include <syslog.h>
 
-#include <glog/logging.h>
-
 #include <osquery/config.h>
 #include <osquery/core.h>
 #include <osquery/flags.h>
 #include <osquery/filesystem.h>
+#include <osquery/logger.h>
 #include <osquery/registry.h>
 
 namespace osquery {
@@ -128,6 +127,7 @@ void initOsquery(int argc, char* argv[], int tool) {
   }
 
   google::InitGoogleLogging(argv[0]);
+  VLOG(1) << "osquery starting [version=" OSQUERY_VERSION "]";
   osquery::InitRegistry::get().run();
 
 // Once command line arguments are parsed load the osquery config.

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -15,7 +15,7 @@ namespace osquery {
 namespace tables {
 
 bool ConstraintList::matches(const std::string& expr) {
-  // Support each affinity type casting.
+  // Support each SQL affinity type casting.
   if (affinity == "TEXT") {
     return literal_matches<TEXT_LITERAL>(expr);
   } else if (affinity == "INTEGER") {
@@ -36,17 +36,17 @@ bool ConstraintList::matches(const std::string& expr) {
 template <typename T>
 bool ConstraintList::literal_matches(const T& base_expr) {
   bool aggregate = true;
-  for (size_t i = 0; i < constraints.size(); ++i) {
-    T constraint_expr = AS_LITERAL(T, constraints[i].expr);
-    if (constraints[i].op == EQUALS) {
+  for (size_t i = 0; i < constraints_.size(); ++i) {
+    T constraint_expr = AS_LITERAL(T, constraints_[i].expr);
+    if (constraints_[i].op == EQUALS) {
       aggregate = aggregate && (base_expr == constraint_expr);
-    } else if (constraints[i].op == GREATER_THAN) {
+    } else if (constraints_[i].op == GREATER_THAN) {
       aggregate = aggregate && (base_expr > constraint_expr);
-    } else if (constraints[i].op == LESS_THAN) {
+    } else if (constraints_[i].op == LESS_THAN) {
       aggregate = aggregate && (base_expr < constraint_expr);
-    } else if (constraints[i].op == GREATER_THAN_OR_EQUALS) {
+    } else if (constraints_[i].op == GREATER_THAN_OR_EQUALS) {
       aggregate = aggregate && (base_expr >= constraint_expr);
-    } else if (constraints[i].op == LESS_THAN_OR_EQUALS) {
+    } else if (constraints_[i].op == LESS_THAN_OR_EQUALS) {
       aggregate = aggregate && (base_expr <= constraint_expr);
     } else {
       // Unsupported constraint.
@@ -62,23 +62,13 @@ bool ConstraintList::literal_matches(const T& base_expr) {
 
 std::vector<std::string> ConstraintList::getAll(ConstraintOperator op) {
   std::vector<std::string> set;
-  for (size_t i = 0; i < constraints.size(); ++i) {
-    if (constraints[i].op == op) {
+  for (size_t i = 0; i < constraints_.size(); ++i) {
+    if (constraints_[i].op == op) {
       // TODO: this does not apply a distinct.
-      set.push_back(constraints[i].expr);
+      set.push_back(constraints_[i].expr);
     }
   }
   return set;
-}
-
-template <typename T>
-bool ConstraintList::existsAndMatches(const T& expr) {
-  return (exists() && literal_matches<T>(expr));
-}
-
-template <typename T>
-bool ConstraintList::notExistsOrMatches(const T& expr) {
-  return (!exists() || literal_matches<T>(expr));
 }
 }
 }

--- a/osquery/core/tables_tests.cpp
+++ b/osquery/core/tables_tests.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+class TablesTests : public testing::Test {};
+
+TEST_F(TablesTests, test_constraint) {
+  auto constraint = Constraint(EQUALS);
+  constraint.expr = "none";
+
+  EXPECT_EQ(constraint.op, EQUALS);
+  EXPECT_EQ(constraint.expr, "none");
+}
+
+TEST_F(TablesTests, test_constraint_list) {
+  struct ConstraintList cl;
+
+  auto constraint = Constraint(EQUALS);
+  constraint.expr = "some";
+
+  // The constraint list is a simple struct.
+  cl.add(constraint);
+  EXPECT_EQ(cl.constraints_.size(), 1);
+
+  constraint = Constraint(EQUALS);
+  constraint.expr = "some_other";
+  cl.add(constraint);
+
+  constraint = Constraint(GREATER_THAN);
+  constraint.expr = "more_than";
+  cl.add(constraint);
+  EXPECT_EQ(cl.constraints_.size(), 3);
+
+  auto all_equals = cl.getAll(EQUALS);
+  EXPECT_EQ(all_equals.size(), 2);
+}
+
+TEST_F(TablesTests, test_constraint_matching) {
+  struct ConstraintList cl;
+  // An empty constraint list has expectations.
+  EXPECT_FALSE(cl.exists());
+  EXPECT_TRUE(cl.notExistsOrMatches("some"));
+
+  auto constraint = Constraint(EQUALS);
+  constraint.expr = "some";
+  cl.add(constraint);
+
+  EXPECT_TRUE(cl.exists());
+  EXPECT_TRUE(cl.notExistsOrMatches("some"));
+  EXPECT_TRUE(cl.matches("some"));
+  EXPECT_FALSE(cl.notExistsOrMatches("not_some"));
+
+  struct ConstraintList cl2;
+  cl2.affinity = "INTEGER";
+  constraint = Constraint(LESS_THAN);
+  constraint.expr = "1000";
+  cl2.add(constraint);
+  constraint = Constraint(GREATER_THAN);
+  constraint.expr = "1";
+  cl2.add(constraint);
+
+  // Test both SQL-provided string types.
+  EXPECT_TRUE(cl2.matches("10"));
+  // ...and the type literal.
+  EXPECT_TRUE(cl2.matches(10));
+
+  // Test operator lower bounds.
+  EXPECT_FALSE(cl2.matches(0));
+  EXPECT_FALSE(cl2.matches(1));
+
+  // Test operator upper bounds.
+  EXPECT_FALSE(cl2.matches(1000));
+  EXPECT_FALSE(cl2.matches(1001));
+
+  // Now test inclusive bounds.
+  struct ConstraintList cl3;
+  constraint = Constraint(LESS_THAN_OR_EQUALS);
+  constraint.expr = "1000";
+  cl3.add(constraint);
+  constraint = Constraint(GREATER_THAN_OR_EQUALS);
+  constraint.expr = "1";
+  cl3.add(constraint);
+
+  EXPECT_FALSE(cl3.matches(1001));
+  EXPECT_TRUE(cl3.matches(1000));
+
+  EXPECT_FALSE(cl3.matches(0));
+  EXPECT_TRUE(cl3.matches(1));
+}
+
+TEST_F(TablesTests, test_constraint_map) {
+  ConstraintMap cm;
+  ConstraintList cl;
+
+  cl.add(Constraint(EQUALS, "some"));
+  cm["path"] = cl;
+
+  EXPECT_TRUE(cm["path"].matches("some"));
+}
+}
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/osquery/core/virtual_table.cpp
+++ b/osquery/core/virtual_table.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <osquery/logger.h>
+
 #include "osquery/core/virtual_table.h"
 
 namespace osquery {
@@ -75,7 +76,6 @@ std::string TablePlugin::statement(TableName name, TableColumns columns) {
 
 void attachVirtualTables(sqlite3 *db) {
   for (const auto &table : REGISTERED_TABLES) {
-    VLOG(1) << "Attaching virtual table: " << table.first;
     int s = table.second->attachVtable(db);
     if (s != SQLITE_OK) {
       LOG(ERROR) << "Error attaching virtual table: " << table.first << " ("

--- a/osquery/core/virtual_table.h
+++ b/osquery/core/virtual_table.h
@@ -12,19 +12,15 @@
 
 #include <map>
 
-#include <sqlite3.h>
 #include <stdio.h>
 
-#include <osquery/tables.h>
+#include <sqlite3.h>
+
 #include <osquery/registry.h>
+#include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
-
-/// Helper alias for TablePlugin names.
-typedef const std::string TableName;
-typedef const std::vector<std::pair<std::string, std::string> > TableColumns;
-typedef std::map<std::string, std::vector<std::string> > TableData;
 
 /**
  * @brief osquery cursor object.
@@ -50,38 +46,6 @@ struct x_vtab {
   /// To get custom functionality from SQLite virtual tables, add a struct.
   TABLE_PLUGIN *pContent;
 };
-
-/**
- * @brief The TablePlugin defines the name, types, and column information.
- *
- * To attach a virtual table create a TablePlugin subclass and register the
- * virtual table name as the plugin ID. osquery will enumerate all registered
- * TablePlugins and attempt to attach them to SQLite at instanciation.
- */
-class TablePlugin {
- public:
-  TableName name;
-  TableColumns columns;
-  /// Helper method to generate the virtual table CREATE statement.
-  std::string statement(TableName name, TableColumns columns);
-
- public:
-  /// Part of the query state, number of rows generated.
-  int n;
-  /// Part of the query state, column data returned from a query.
-  TableData data;
-  /// Part of the query state, parsed set of query predicate constraints.
-  ConstraintSet constraints;
-
- public:
-  virtual int attachVtable(sqlite3 *db) { return -1; }
-  virtual ~TablePlugin(){};
-
- protected:
-  TablePlugin() { n = 0; };
-};
-
-typedef std::shared_ptr<TablePlugin> TablePluginRef;
 
 int xOpen(sqlite3_vtab *pVTab, sqlite3_vtab_cursor **ppCursor);
 
@@ -171,7 +135,7 @@ static int xBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
       continue;
     }
 
-    const auto &name =
+    const auto& name =
         pContent->columns[pIdxInfo->aConstraint[i].iColumn].first;
     pContent->constraints.push_back(
         std::make_pair(name, Constraint(pIdxInfo->aConstraint[i].op)));

--- a/osquery/scheduler/scheduler_tests.cpp
+++ b/osquery/scheduler/scheduler_tests.cpp
@@ -12,9 +12,32 @@
 
 #include <osquery/scheduler.h>
 
+namespace osquery {
+
 class SchedulerTests : public testing::Test {};
 
 TEST_F(SchedulerTests, test) { EXPECT_EQ(true, true); }
+
+TEST_F(SchedulerTests, test_splay) {
+  auto val1 = splayValue(100, 10);
+  EXPECT_GE(val1, 90);
+  EXPECT_LE(val1, 110);
+
+  auto val2 = splayValue(100, 10);
+  EXPECT_GE(val2, 90);
+  EXPECT_LE(val2, 110);
+
+  auto val3 = splayValue(10, 0);
+  EXPECT_EQ(val3, 10);
+
+  auto val4 = splayValue(100, 1);
+  EXPECT_GE(val4, 99);
+  EXPECT_LE(val4, 101);
+
+  auto val5 = splayValue(1, 10);
+  EXPECT_EQ(val5, 1);
+}
+}
 
 int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This adds basic testing of virtual_table/tables `QueryContext` and constraints usage.

This includes:
1. Moving `TablePlugin` from the internal `virtual_tables.h` to the public `tables.h` such that modules may subclass this directly instead of a forced spec/genapi.py pattern.

There are some addons here:
1. Move the splay operations to scheduler.
2. Announce the osquery version in verbose log during init.
3. Filesystem ConfigPlugin retriever should verbose announce the config path.
