### PR TITLE
Add texinfo to CentOS provision

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -433,6 +433,8 @@ function main() {
     if [[ -z $(rpm -qa | grep 'kernel-headers-3.10.0-123.9.3.el7.x86_64') ]]; then
       sudo rpm -iv ftp://rpmfind.net/linux/centos/7.0.1406/updates/x86_64/Packages/kernel-headers-3.10.0-123.9.3.el7.x86_64.rpm
     fi
+
+    package texinfo
     package git-all
     package unzip
     package xz


### PR DESCRIPTION
@marpaia I was trying to build from a base CentOS (vagrant) and noticed that the makeinfo bin was missing, thus this adding texinfo. I think you're build problem in: https://github.com/facebook/osquery/issues/611 is from left-over build targets. Maybe `make distclean` (which will delete third-party package sources in .source) then destroy your centos and try again. 

Can you try without this PR and let me know if makeinfo was installed?