### PR TITLE
Treat IOKit HID failures as warnings

### DIFF
--- a/osquery/events/darwin/iokit_hid.cpp
+++ b/osquery/events/darwin/iokit_hid.cpp
@@ -56,7 +56,7 @@ void IOKitHIDEventPublisher::restart() {
 
   auto status = IOHIDManagerOpen(manager_, kIOHIDOptionsTypeNone);
   if (status != kIOReturnSuccess) {
-    LOG(ERROR) << "Cannot open IOKit HID Manager";
+    LOG(WARNING) << "[Reference #617] Cannot open IOKit HID Manager";
     return;
   }
 


### PR DESCRIPTION
See: #617 for the inline reference with "slightly more" context on the issue.