### PR TITLE
Added SHA1 and SHA256 in Hash Table

### DIFF
--- a/include/osquery/hash.h
+++ b/include/osquery/hash.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifdef __APPLE__
+  #import <CommonCrypto/CommonDigest.h>
+#else
+  #include <openssl/sha.h>
+  #include <openssl/md5.h>
+#endif
+
+#include <string>
+#include <iomanip>
+#include <sstream>
+
+std::string processHash(unsigned char* hash, unsigned int length);
+std::string computeMD5(unsigned char* buffer, long fileLen);
+std::string computeSHA1(unsigned char* buffer, long fileLen);
+std::string computeSHA256(unsigned char* buffer, long fileLen);

--- a/include/osquery/hash.h
+++ b/include/osquery/hash.h
@@ -8,16 +8,7 @@
  *
  */
 
-#ifdef __APPLE__
-  #import <CommonCrypto/CommonDigest.h>
-#else
-  #include <openssl/sha.h>
-  #include <openssl/md5.h>
-#endif
-
 #include <string>
-#include <iomanip>
-#include <sstream>
 
 namespace osquery{
 	std::string computeMD5(unsigned char* buffer, long fileLen);

--- a/include/osquery/hash.h
+++ b/include/osquery/hash.h
@@ -19,7 +19,8 @@
 #include <iomanip>
 #include <sstream>
 
-std::string processHash(unsigned char* hash, unsigned int length);
-std::string computeMD5(unsigned char* buffer, long fileLen);
-std::string computeSHA1(unsigned char* buffer, long fileLen);
-std::string computeSHA256(unsigned char* buffer, long fileLen);
+namespace osquery{
+	std::string computeMD5(unsigned char* buffer, long fileLen);
+	std::string computeSHA1(unsigned char* buffer, long fileLen);
+	std::string computeSHA256(unsigned char* buffer, long fileLen);
+}

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -126,14 +126,14 @@ std::vector<OsqueryScheduledQuery> Config::getScheduledQueries() {
   return cfg_.scheduledQueries;
 }
 
-Status Config::getMD5(std::string& hashString) {
+Status Config::getMD5(std::string& hash_string) {
   std::string config_string;
   auto s = genConfig(config_string);
   if (!s.ok()) {
     return s;
   }
 
-  hashString = computeMD5((unsigned char *)hashString.c_str(), hashString.length());
+  hash_string = computeMD5((unsigned char *)hash_string.c_str(), hash_string.length());
 
   return Status(0, "OK");
 }

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -21,7 +21,7 @@
 #include <osquery/config/plugin.h>
 #include <osquery/flags.h>
 
-#include "osquery/core/md5.h"
+#include <osquery/hash.h>
 
 namespace pt = boost::property_tree;
 
@@ -133,8 +133,7 @@ Status Config::getMD5(std::string& hashString) {
     return s;
   }
 
-  osquery::md5::MD5 digest;
-  hashString = std::string(digest.digestString(config_string.c_str()));
+  hashString = computeMD5((unsigned char *)hashString.c_str(), hashString.length());
 
   return Status(0, "OK");
 }

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -18,6 +18,7 @@ ADD_OSQUERY_CORE_LIBRARY(osquery_core
   virtual_table.cpp
   text.cpp
   flags.cpp
+  hash.cpp
 )
 
 ADD_OSQUERY_TEST(status_test status_tests.cpp)

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -8,68 +8,71 @@
  *
  */
  #include <osquery/hash.h>
+ 
+namespace osquery{
 
-std::string processHash(unsigned char* hash, unsigned int length){
-    std::stringstream ss;
-    for(int i = 0; i < length; i++){
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
-    }
-    return ss.str();
-}
+  std::string processHash(unsigned char* hash, unsigned int length){
+      std::stringstream ss;
+      for(int i = 0; i < length; i++){
+          ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+      }
+      return ss.str();
+  }
 
-std::string computeMD5(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_MD5_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_MD5_CTX md5;
-      CC_MD5_Init(&md5);
-      CC_MD5_Update(&md5, buffer, fileLen);
-      CC_MD5_Final(hash, &md5);
-    #else
-      const unsigned int LENGTH = MD5_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      MD5_CTX md5;
-      MD5_Init(&md5);
-      MD5_Update(&md5, buffer, fileLen);
-      MD5_Final(hash, &md5);
-    #endif
-    
-    return processHash(hash, LENGTH);
-}
+  std::string computeMD5(unsigned char* buffer, long fileLen){
+      #ifdef __APPLE__
+        const unsigned int LENGTH = CC_MD5_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        CC_MD5_CTX md5;
+        CC_MD5_Init(&md5);
+        CC_MD5_Update(&md5, buffer, fileLen);
+        CC_MD5_Final(hash, &md5);
+      #else
+        const unsigned int LENGTH = MD5_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        MD5_CTX md5;
+        MD5_Init(&md5);
+        MD5_Update(&md5, buffer, fileLen);
+        MD5_Final(hash, &md5);
+      #endif
+      
+      return processHash(hash, LENGTH);
+  }
 
-std::string computeSHA1(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_SHA1_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_SHA1_CTX sha1;
-      CC_SHA1_Init(&sha1);
-      CC_SHA1_Update(&sha1, buffer, fileLen);
-      CC_SHA1_Final(hash, &sha1);
-    #else
-      const unsigned int LENGTH = SHA_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      SHA_CTX sha1;
-      SHA1_Init(&sha1);
-      SHA1_Update(&sha1, buffer, fileLen);
-      SHA1_Final(hash, &sha1);
-    #endif
-    return processHash(hash, LENGTH);
-}
-std::string computeSHA256(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_SHA256_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_SHA256_CTX sha256;
-      CC_SHA256_Init(&sha256);
-      CC_SHA256_Update(&sha256, buffer, fileLen);
-      CC_SHA256_Final(hash, &sha256);
-    #else
-      const unsigned int LENGTH = SHA256_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      SHA256_CTX sha256;
-      SHA256_Init(&sha256);
-      SHA256_Update(&sha256, buffer, fileLen);
-      SHA256_Final(hash, &sha256);
-    #endif
-    return processHash(hash, LENGTH);
+  std::string computeSHA1(unsigned char* buffer, long fileLen){
+      #ifdef __APPLE__
+        const unsigned int LENGTH = CC_SHA1_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        CC_SHA1_CTX sha1;
+        CC_SHA1_Init(&sha1);
+        CC_SHA1_Update(&sha1, buffer, fileLen);
+        CC_SHA1_Final(hash, &sha1);
+      #else
+        const unsigned int LENGTH = SHA_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        SHA_CTX sha1;
+        SHA1_Init(&sha1);
+        SHA1_Update(&sha1, buffer, fileLen);
+        SHA1_Final(hash, &sha1);
+      #endif
+      return processHash(hash, LENGTH);
+  }
+  std::string computeSHA256(unsigned char* buffer, long fileLen){
+      #ifdef __APPLE__
+        const unsigned int LENGTH = CC_SHA256_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        CC_SHA256_CTX sha256;
+        CC_SHA256_Init(&sha256);
+        CC_SHA256_Update(&sha256, buffer, fileLen);
+        CC_SHA256_Final(hash, &sha256);
+      #else
+        const unsigned int LENGTH = SHA256_DIGEST_LENGTH;
+        unsigned char hash[LENGTH];
+        SHA256_CTX sha256;
+        SHA256_Init(&sha256);
+        SHA256_Update(&sha256, buffer, fileLen);
+        SHA256_Final(hash, &sha256);
+      #endif
+      return processHash(hash, LENGTH);
+  }
 }

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -7,7 +7,17 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- #include <osquery/hash.h>
+#include <osquery/hash.h>
+
+#ifdef __APPLE__
+  #import <CommonCrypto/CommonDigest.h>
+#else
+  #include <openssl/sha.h>
+  #include <openssl/md5.h>
+#endif
+
+#include <iomanip>
+#include <sstream>
  
 namespace osquery{
 

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+ #include <osquery/hash.h>
+
+std::string processHash(unsigned char* hash, unsigned int length){
+    std::stringstream ss;
+    for(int i = 0; i < length; i++){
+        ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+    }
+    return ss.str();
+}
+
+std::string computeMD5(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_MD5_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_MD5_CTX md5;
+      CC_MD5_Init(&md5);
+      CC_MD5_Update(&md5, buffer, fileLen);
+      CC_MD5_Final(hash, &md5);
+    #else
+      const unsigned int LENGTH = MD5_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      MD5_CTX md5;
+      MD5_Init(&md5);
+      MD5_Update(&md5, buffer, fileLen);
+      MD5_Final(hash, &md5);
+    #endif
+    
+    return processHash(hash, LENGTH);
+}
+
+std::string computeSHA1(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_SHA1_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_SHA1_CTX sha1;
+      CC_SHA1_Init(&sha1);
+      CC_SHA1_Update(&sha1, buffer, fileLen);
+      CC_SHA1_Final(hash, &sha1);
+    #else
+      const unsigned int LENGTH = SHA_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      SHA_CTX sha1;
+      SHA1_Init(&sha1);
+      SHA1_Update(&sha1, buffer, fileLen);
+      SHA1_Final(hash, &sha1);
+    #endif
+    return processHash(hash, LENGTH);
+}
+std::string computeSHA256(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_SHA256_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_SHA256_CTX sha256;
+      CC_SHA256_Init(&sha256);
+      CC_SHA256_Update(&sha256, buffer, fileLen);
+      CC_SHA256_Final(hash, &sha256);
+    #else
+      const unsigned int LENGTH = SHA256_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      SHA256_CTX sha256;
+      SHA256_Init(&sha256);
+      SHA256_Update(&sha256, buffer, fileLen);
+      SHA256_Final(hash, &sha256);
+    #endif
+    return processHash(hash, LENGTH);
+}

--- a/osquery/tables/specs/x/hash.table
+++ b/osquery/tables/specs/x/hash.table
@@ -3,5 +3,7 @@ schema([
     Column("path", TEXT, "Must provide a path or directory", required=True),
     Column("directory", TEXT, "Must provide a path or directory", required=True),
     Column("md5", TEXT),
+    Column("sha1", TEXT),
+    Column("sha256", TEXT),
 ])
 implementation("utility/hash@genHash")

--- a/osquery/tables/utility/hash.cpp
+++ b/osquery/tables/utility/hash.cpp
@@ -8,9 +8,16 @@
  *
  */
 
-#include "osquery/core/md5.h"
+#ifdef __APPLE__
+  #import <CommonCrypto/CommonDigest.h>
+#else
+  #include <openssl/sha.h>
+  #include <openssl/md5.h>
+#endif
+#include <iomanip>
 
 #include <boost/filesystem.hpp>
+#include <boost/uuid/sha1.hpp>
 
 #include <osquery/tables.h>
 #include <osquery/filesystem.h>
@@ -18,9 +25,79 @@
 namespace osquery {
 namespace tables {
 
+std::string processHash(unsigned char* hash, unsigned int length){
+    std::stringstream ss;
+    for(int i = 0; i < length; i++){
+        ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+    }
+    return ss.str();
+}
+
+std::string computeMD5(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_MD5_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_MD5_CTX md5;
+      CC_MD5_Init(&md5);
+      CC_MD5_Update(&md5, buffer, fileLen);
+      CC_MD5_Final(hash, &md5);
+    #else
+      const unsigned int LENGTH = MD5_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      MD5_CTX md5;
+      MD5_Init(&md5);
+      MD5_Update(&md5, buffer, fileLen);
+      MD5_Final(hash, &md5);
+    #endif
+    
+    return processHash(hash, LENGTH);
+}
+
+std::string computeSHA1(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_SHA1_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_SHA1_CTX sha1;
+      CC_SHA1_Init(&sha1);
+      CC_SHA1_Update(&sha1, buffer, fileLen);
+      CC_SHA1_Final(hash, &sha1);
+    #else
+      const unsigned int LENGTH = SHA_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      SHA_CTX sha1;
+      SHA1_Init(&sha1);
+      SHA1_Update(&sha1, buffer, fileLen);
+      SHA1_Final(hash, &sha1);
+    #endif
+    return processHash(hash, LENGTH);
+}
+std::string computeSHA256(unsigned char* buffer, long fileLen){
+    #ifdef __APPLE__
+      const unsigned int LENGTH = CC_SHA256_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      CC_SHA256_CTX sha256;
+      CC_SHA256_Init(&sha256);
+      CC_SHA256_Update(&sha256, buffer, fileLen);
+      CC_SHA256_Final(hash, &sha256);
+    #else
+      const unsigned int LENGTH = SHA256_DIGEST_LENGTH;
+      unsigned char hash[LENGTH];
+      SHA256_CTX sha256;
+      SHA256_Init(&sha256);
+      SHA256_Update(&sha256, buffer, fileLen);
+      SHA256_Final(hash, &sha256);
+    #endif
+    return processHash(hash, LENGTH);
+}
+
+void computeAllHashes(Row& r, const std::string& content, long filelen){
+    r["md5"]        = computeMD5(   (unsigned char *)content.c_str(), filelen);
+    r["sha1"]       = computeSHA1(  (unsigned char *)content.c_str(), filelen);
+    r["sha256"]     = computeSHA256((unsigned char *)content.c_str(), filelen);
+}
+
 QueryData genHash(QueryContext& context) {
   QueryData results;
-  osquery::md5::MD5 digest;
 
   auto paths = context.constraints["path"].getAll(EQUALS);
   for (const auto& path_string : paths) {
@@ -28,10 +105,13 @@ QueryData genHash(QueryContext& context) {
     if (!boost::filesystem::is_regular_file(path)) {
       continue;
     }
+    std::string content;
+    auto s = osquery::readFile(path.string(), content);
+    long filelen = (long)content.length();
     Row r;
-    r["path"] = path.string();
-    r["md5"] = std::string(digest.digestFile(path.c_str()));
-    r["directory"] = path.parent_path().string();
+    r["path"]       = path.string();
+    r["directory"]  = path.parent_path().string();
+    computeAllHashes(r, content, filelen);
     results.push_back(r);
   }
 
@@ -49,7 +129,9 @@ QueryData genHash(QueryContext& context) {
       r["path"] = begin->path().string();
       r["directory"] = directory_string;
       if (boost::filesystem::is_regular_file(begin->status())) {
-        r["md5"] = digest.digestFile(begin->path().string().c_str());
+        std::string content;
+        auto s = osquery::readFile(begin->path().string(), content);
+        computeAllHashes(r, content, content.length());
       }
       results.push_back(r);
     }

--- a/osquery/tables/utility/hash.cpp
+++ b/osquery/tables/utility/hash.cpp
@@ -18,8 +18,6 @@
 namespace osquery {
 namespace tables {
 
-
-
 void computeAllHashes(Row& r, const std::string& content, long filelen){
     r["md5"]        = computeMD5(   (unsigned char *)content.c_str(), filelen);
     r["sha1"]       = computeSHA1(  (unsigned char *)content.c_str(), filelen);

--- a/osquery/tables/utility/hash.cpp
+++ b/osquery/tables/utility/hash.cpp
@@ -8,16 +8,9 @@
  *
  */
 
-#ifdef __APPLE__
-  #import <CommonCrypto/CommonDigest.h>
-#else
-  #include <openssl/sha.h>
-  #include <openssl/md5.h>
-#endif
-#include <iomanip>
+#include <osquery/hash.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/uuid/sha1.hpp>
 
 #include <osquery/tables.h>
 #include <osquery/filesystem.h>
@@ -25,70 +18,7 @@
 namespace osquery {
 namespace tables {
 
-std::string processHash(unsigned char* hash, unsigned int length){
-    std::stringstream ss;
-    for(int i = 0; i < length; i++){
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
-    }
-    return ss.str();
-}
 
-std::string computeMD5(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_MD5_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_MD5_CTX md5;
-      CC_MD5_Init(&md5);
-      CC_MD5_Update(&md5, buffer, fileLen);
-      CC_MD5_Final(hash, &md5);
-    #else
-      const unsigned int LENGTH = MD5_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      MD5_CTX md5;
-      MD5_Init(&md5);
-      MD5_Update(&md5, buffer, fileLen);
-      MD5_Final(hash, &md5);
-    #endif
-    
-    return processHash(hash, LENGTH);
-}
-
-std::string computeSHA1(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_SHA1_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_SHA1_CTX sha1;
-      CC_SHA1_Init(&sha1);
-      CC_SHA1_Update(&sha1, buffer, fileLen);
-      CC_SHA1_Final(hash, &sha1);
-    #else
-      const unsigned int LENGTH = SHA_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      SHA_CTX sha1;
-      SHA1_Init(&sha1);
-      SHA1_Update(&sha1, buffer, fileLen);
-      SHA1_Final(hash, &sha1);
-    #endif
-    return processHash(hash, LENGTH);
-}
-std::string computeSHA256(unsigned char* buffer, long fileLen){
-    #ifdef __APPLE__
-      const unsigned int LENGTH = CC_SHA256_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      CC_SHA256_CTX sha256;
-      CC_SHA256_Init(&sha256);
-      CC_SHA256_Update(&sha256, buffer, fileLen);
-      CC_SHA256_Final(hash, &sha256);
-    #else
-      const unsigned int LENGTH = SHA256_DIGEST_LENGTH;
-      unsigned char hash[LENGTH];
-      SHA256_CTX sha256;
-      SHA256_Init(&sha256);
-      SHA256_Update(&sha256, buffer, fileLen);
-      SHA256_Final(hash, &sha256);
-    #endif
-    return processHash(hash, LENGTH);
-}
 
 void computeAllHashes(Row& r, const std::string& content, long filelen){
     r["md5"]        = computeMD5(   (unsigned char *)content.c_str(), filelen);


### PR DESCRIPTION
I have added in SHA1 and SHA256 into the hash table so they can be easily checked against other services.

There is darwin specific code in this which is organized with pre-processor macros. darwin systems use 
`#import <CommonCrypto/CommonDigest.h>`

where as all other systems use 
```
#include <openssl/sha.h>
#include <openssl/md5.h>
```