### PR TITLE
Separate IOKit devicetree from registry

### DIFF
--- a/osquery/tables/specs/darwin/iokit_devicetree.table
+++ b/osquery/tables/specs/darwin/iokit_devicetree.table
@@ -1,11 +1,13 @@
-table_name("iokit_registry")
+table_name("iokit_devicetree")
 schema([
     Column("name", TEXT),
     Column("class", TEXT),
     Column("id", BIGINT),
     Column("parent", BIGINT),
+    Column("device_path", TEXT),
+    Column("service", INTEGER),
     Column("busy_state", INTEGER),
     Column("retain_count", INTEGER),
     Column("depth", INTEGER),
 ])
-implementation("system/iokit_registry@genIOKitRegistry")
+implementation("system/iokit_registry@genIOKitDeviceTree")


### PR DESCRIPTION
To address #640, this removes `location` and `service` (a boolean to mean the device provides an IOService) from `iokit_registry` and removes the device tree constraint from the IOKit query. Then `iokit_registry` becomes a more-latent query and is not device-centric. Since a non-plane-specific request to IOKit does NOT mean a result superset of all planes we include a `iokit_devicetree`. This device tree is only IOKit plane represented as a table in osquery as it is quite important and other plane (ACPI/PCI/USB) information is surfaced in more-agnostic forms.

The `iokit_devicetree` has a bit of overlap with `iokit_registry`. However, the `name` will differ since the IOKit entry was queried using the DeviceTree plane (odd, but OK). The most important addition to the new table is the additional rows not in the generic registry list and the `device_tree` path. 