### PR TITLE
Add getQueryColumns function to core

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -79,7 +79,7 @@ osquery::QueryData query(const std::string& q, int& error_return);
  *
  * @param q the query to execute
  * @param error_return an int indicating the success or failure of the query
- * @param db the SQLite3 database the execute query q against
+ * @param db the SQLite3 database to execute query q against
  *
  * @return the results of the query
  */
@@ -91,6 +91,9 @@ osquery::QueryData query(const std::string& q, int& error_return, sqlite3* db);
  * An osquery database is basically just a SQLite3 database with several
  * virtual tables attached. This method is the main abstraction for creating
  * SQLite3 databases within osquery.
+ *
+ * Note: osquery::initOsquery must be called before calling createDB in order
+ * for virtual tables to be registered.
  *
  * @return a SQLite3 database with all virtual tables attached
  */

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -20,6 +20,7 @@
 #include <sqlite3.h>
 
 #include <osquery/registry.h>
+#include <osquery/core.h>
 #include <osquery/database/results.h>
 #include <osquery/status.h>
 
@@ -149,7 +150,7 @@ struct ConstraintList {
   /**
    * @brief Check and return if there are any constraints on this column.
    *
-   * A ConstraintList is used in a ConstraintMap with a column name as the 
+   * A ConstraintList is used in a ConstraintMap with a column name as the
    * map index. Tables that act on optional constraints should check if any
    * constraint was provided.
    *
@@ -173,7 +174,7 @@ struct ConstraintList {
   /**
    * @brief Check if a constraint is missing or matches a type expression.
    *
-   * A ConstraintList is used in a ConstraintMap with a column name as the 
+   * A ConstraintList is used in a ConstraintMap with a column name as the
    * map index. Tables that act on required constraints can make decisions
    * on missing constraints or a constraint match.
    *
@@ -261,6 +262,9 @@ typedef struct Constraint Constraint;
  * To attach a virtual table create a TablePlugin subclass and register the
  * virtual table name as the plugin ID. osquery will enumerate all registered
  * TablePlugins and attempt to attach them to SQLite at instanciation.
+ *
+ * Note: When updating this class, be sure to update the corresponding template
+ * in osquery/tables/templates/default.cpp.in
  */
 class TablePlugin : public Plugin {
  protected:
@@ -296,5 +300,39 @@ class TablePlugin : public Plugin {
 };
 
 CREATE_REGISTRY(TablePlugin, "table");
+
+/**
+ * @brief Analyze a query, providing information about the result columns
+ *
+ * This function asks SQLite to determine what the names and types are of the
+ * result columns of the provided query. Only table columns (not expressions or
+ * subqueries) can have their types determined. Types that are not determined
+ * are indicated with the string "UNKNOWN".
+ *
+ * @param q the query to analyze
+ * @param columns the vector to fill with column information
+ *
+ * @return status indicating success or failure of the operation
+ */
+Status getQueryColumns(const std::string& q, TableColumns& columns);
+
+/**
+ * @brief Analyze a query, providing information about the result columns
+ *
+ * This function asks SQLite to determine what the names and types are of the
+ * result columns of the provided query. Only table columns (not expressions or
+ * subqueries) can have their types determined. Types that are not determined
+ * are indicated with the string "UNKNOWN".
+ *
+ * @param q the query to analyze
+ * @param columns the vector to fill with column information
+ * @param db the SQLite3 database to perform the analysis on
+ *
+ * @return status indicating success or failure of the operation
+ */
+Status getQueryColumns(const std::string& q,
+                       TableColumns& columns,
+                       sqlite3* db);
+
 }
 }

--- a/osquery/core/sqlite_util.cpp
+++ b/osquery/core/sqlite_util.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -63,4 +63,5 @@ int query_data_callback(void* argument,
   (*qData).push_back(r);
   return 0;
 }
+
 }

--- a/osquery/core/sqlite_util_tests.cpp
+++ b/osquery/core/sqlite_util_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -48,6 +48,7 @@ TEST_F(SQLiteUtilTests, test_aggregate_query) {
   sqlite3_close(db);
   EXPECT_EQ(err, 0);
 }
+
 }
 
 int main(int argc, char* argv[]) {

--- a/osquery/core/tables_tests.cpp
+++ b/osquery/core/tables_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -110,10 +110,55 @@ TEST_F(TablesTests, test_constraint_map) {
 
   EXPECT_TRUE(cm["path"].matches("some"));
 }
+
+TEST_F(TablesTests, test_get_query_columns) {
+  std::unique_ptr<sqlite3, decltype(sqlite3_close)*> db_managed(createDB(),
+                                                                sqlite3_close);
+  sqlite3* db = db_managed.get();
+
+  std::string query;
+  Status status;
+  TableColumns results;
+
+  query =
+      "SELECT hour, minutes, seconds, version, config_md5, config_path, \
+           pid FROM time JOIN osquery_info";
+  status = getQueryColumns(query, results, db);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(7, results.size());
+  EXPECT_EQ(std::make_pair(std::string("hour"), std::string("INTEGER")),
+            results[0]);
+  EXPECT_EQ(std::make_pair(std::string("minutes"), std::string("INTEGER")),
+            results[1]);
+  EXPECT_EQ(std::make_pair(std::string("seconds"), std::string("INTEGER")),
+            results[2]);
+  EXPECT_EQ(std::make_pair(std::string("version"), std::string("TEXT")),
+            results[3]);
+  EXPECT_EQ(std::make_pair(std::string("config_md5"), std::string("TEXT")),
+            results[4]);
+  EXPECT_EQ(std::make_pair(std::string("config_path"), std::string("TEXT")),
+            results[5]);
+  EXPECT_EQ(std::make_pair(std::string("pid"), std::string("INTEGER")),
+            results[6]);
+
+  query = "SELECT hour + 1 AS hour1, minutes + 1 FROM time";
+  status = getQueryColumns(query, results, db);
+  ASSERT_TRUE(status.ok());
+  ASSERT_EQ(2, results.size());
+  EXPECT_EQ(std::make_pair(std::string("hour1"), std::string("UNKNOWN")),
+            results[0]);
+  EXPECT_EQ(std::make_pair(std::string("minutes + 1"), std::string("UNKNOWN")),
+            results[1]);
+
+  query = "SELECT * FROM foo";
+  status = getQueryColumns(query, results, db);
+  ASSERT_FALSE(status.ok());
+}
 }
 }
 
 int main(int argc, char* argv[]) {
   testing::InitGoogleTest(&argc, argv);
+  osquery::initOsquery(argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/osquery/core/virtual_table.cpp
+++ b/osquery/core/virtual_table.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/templates/default.cpp.in
+++ b/osquery/tables/templates/default.cpp.in
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */


### PR DESCRIPTION
This new getQueryColumns function allows us to determine what columns
will be returned by executing a given query. It is intended to be used
with the distributed query system, to determine a schema for the
results before sending the query.

Tested by unit tests. Also used valgrind and did not find errors that
looked related to this change (though there appear to be many errors
related to glog logging).