### PR TITLE
Adding a watcher/worker model for osqueryd

### DIFF
--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <osquery/database/results.h>
+#include <osquery/tables.h>
 
 namespace osquery {
 
@@ -88,9 +89,25 @@ class SQL {
   /**
    * @brief Get all, 'SELECT * ...', results given a virtual table name.
    *
+   * @param table The name of the virtual table.
    * @return A QueryData object of the 'SELECT *...' query results.
    */
   static QueryData selectAllFrom(const std::string& table);
+
+  /**
+   * @brief Get all with constraint, 'SELECT * ... where', results given
+   * a virtual table name and single constraint
+   *
+   * @param table The name of the virtual table.
+   * @param column Table column name to apply constraint.
+   * @param op The SQL comparitive operator.
+   * @param expr The constraint expression.
+   * @return A QueryData object of the 'SELECT *...' query results.
+   */
+  static QueryData selectAllFrom(const std::string& table,
+                                 const std::string& column,
+                                 tables::ConstraintOperator op,
+                                 const std::string& expr);
 
  private:
   /**

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -122,7 +122,7 @@ set_target_properties(shell PROPERTIES OUTPUT_NAME osqueryi)
 set_target_properties(shell PROPERTIES COMPILE_FLAGS ${OS_COMPILE_FLAGS})
 install(TARGETS shell RUNTIME DESTINATION bin COMPONENT main)
 
-add_executable(daemon main/daemon.cpp)
+add_executable(daemon main/daemon.cpp core/watcher.cpp)
 TARGET_OSQUERY_LINK_WHOLE(daemon libosquery_basic)
 TARGET_OSQUERY_LINK_WHOLE(daemon libosquery_additional)
 set_target_properties(daemon PROPERTIES OUTPUT_NAME osqueryd)

--- a/osquery/core/sql.cpp
+++ b/osquery/core/sql.cpp
@@ -53,6 +53,13 @@ const std::map<int, std::string> kSQLiteReturnCodes = {
     {101, "SQLITE_DONE: sqlite3_step() has finished executing"},
 };
 
+const std::map<tables::ConstraintOperator, std::string> kSQLOperatorRepr = {
+    {tables::EQUALS, "="},
+    {tables::GREATER_THAN, ">"},
+    {tables::LESS_THAN_OR_EQUALS, "<="},
+    {tables::LESS_THAN, "<"},
+    {tables::GREATER_THAN_OR_EQUALS, ">="}, };
+
 std::string getStringForSQLiteReturnCode(int code) {
   if (kSQLiteReturnCodes.find(code) != kSQLiteReturnCodes.end()) {
     return kSQLiteReturnCodes.at(code);
@@ -84,7 +91,23 @@ std::vector<std::string> SQL::getTableNames() {
 }
 
 QueryData SQL::selectAllFrom(const std::string& table) {
-  std::string query = "select * from " + table + ";";
+  std::string query = "select * from `" + table + "`;";
+  return SQL(query).rows();
+}
+
+QueryData SQL::selectAllFrom(const std::string& table,
+                             const std::string& column,
+                             tables::ConstraintOperator op,
+                             const std::string& expr) {
+  std::string query = "select * from `" + table + "` where `" + column + "`";
+  if (kSQLOperatorRepr.count(op) > 0) {
+    query += kSQLOperatorRepr.at(op);
+  } else {
+    LOG(WARNING) << "Cannot query using unknown SQL operator: " << op;
+    return {};
+  }
+
+  query += "'" + expr + "'";
   return SQL(query).rows();
 }
 }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <cstring>
+#include <sstream>
+
+#include <sys/wait.h>
+#include <signal.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+
+#include "osquery/core/watcher.h"
+
+namespace osquery {
+
+#define WORKER_MEMORY_LIMIT (20 * 1024 * 1024)
+#define WORKER_UTILIZATION_LIMIT 60
+#define WORKER_RESPAWN_LIMIT 20
+#define WORKER_RESPAWN_DELAY 5
+#define WORKER_LATENCY_LIMIT 5
+
+bool Watcher::ok() {
+  ::sleep(1);
+  return (worker_ >= 0);
+}
+
+bool Watcher::watch() {
+  int status;
+  pid_t result = waitpid(worker_, &status, WNOHANG);
+  if (worker_ == 0 || result == worker_) {
+    // Worker does not exist or never existed.
+    return false;
+  } else if (result == 0) {
+    // If the inspect finds problems it will stop/restart the worker.
+    if (!isWorkerSane()) {
+      stopWorker();
+      return false;
+    }
+  }
+  return true;
+}
+
+void Watcher::stopWorker() {
+  kill(worker_, SIGKILL);
+  worker_ = 0;
+  // Clean up the defunct (zombie) process.
+  waitpid(-1, 0, 0);
+}
+
+bool Watcher::isWorkerSane() {
+  auto rows =
+      SQL::selectAllFrom("processes", "pid", tables::EQUALS, INTEGER(worker_));
+  if (rows.size() == 0) {
+    // Could not find worker process?
+    return false;
+  }
+
+  // Compare CPU utilization since last check.
+  size_t user_time = AS_LITERAL(INTEGER_LITERAL, rows[0].at("user_time"));
+  size_t system_time = AS_LITERAL(INTEGER_LITERAL, rows[0].at("system_time"));
+  if (current_user_time_ + WORKER_UTILIZATION_LIMIT < user_time ||
+      current_system_time_ + WORKER_UTILIZATION_LIMIT < system_time) {
+    sustained_latency_++;
+  } else {
+    sustained_latency_ = 0;
+  }
+  current_user_time_ = user_time;
+  current_system_time_ = system_time;
+
+  if (sustained_latency_ >= WORKER_LATENCY_LIMIT) {
+    LOG(WARNING) << "osqueryd worker system performance limits exceeded";
+    return false;
+  }
+
+  size_t footprint = AS_LITERAL(INTEGER_LITERAL, rows[0].at("phys_footprint"));
+  if (footprint > WORKER_MEMORY_LIMIT) {
+    LOG(WARNING) << "osqueryd worker memory limits exceeded";
+    return false;
+  }
+
+  // The worker is sane, no action needed.
+  return true;
+}
+
+bool Watcher::createWorker() {
+  if (last_respawn_time_ > getUnixTime() - WORKER_RESPAWN_LIMIT) {
+    LOG(WARNING) << "osqueryd worker respawning too quickly";
+    ::sleep(WORKER_RESPAWN_DELAY);
+  }
+
+  worker_ = fork();
+  if (worker_ < 0) {
+    // Unrecoverable error, cannot create a worker process.
+    LOG(ERROR) << "osqueryd could not create a worker process";
+    ::exit(EXIT_FAILURE);
+  } else if (worker_ == 0) {
+    // This is the new worker process, no watching needed.
+    initWorker();
+    return true;
+  }
+
+  // This is still the watcher, reset performance monitoring.
+  resetCounters();
+  return false;
+}
+
+void Watcher::resetCounters() {
+  sustained_latency_ = 0;
+  current_user_time_ = 0;
+  current_system_time_ = 0;
+  last_respawn_time_ = getUnixTime();
+}
+
+void Watcher::initWorker() {
+  // Set the worker's process name.
+  size_t name_size = strlen(argv_[0]);
+  for (int i = 0; i < argc_; i++) {
+    if (argv_[i] != nullptr) {
+      memset(argv_[i], 0, strlen(argv_[i]));
+    }
+  }
+  strncpy(argv_[0], name_.c_str(), name_size);
+}
+
+void initWorkerWatcher(const std::string& name, int argc, char* argv[]) {
+  // The watcher will forever monitor and spawn additional workers.
+  Watcher watcher(argc, argv);
+  watcher.setWorkerName(name);
+
+  do {
+    if (!watcher.watch()) {
+      // The watcher failed, create a worker.
+      if (watcher.createWorker()) {
+        // This is the execution of the new worker, break out of watching.
+        break;
+      }
+    }
+  } while (watcher.ok());
+}
+}

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <string>
+
+#include <unistd.h>
+
+namespace osquery {
+
+class Watcher {
+ public:
+  Watcher(int argc, char* argv[]) : worker_(0), argc_(argc), argv_(argv) {
+    resetCounters();
+  }
+
+  void setWorkerName(const std::string& name) { name_ = name; }
+  const std::string& getWorkerName() { return name_; }
+
+  bool ok();
+  /// Begin the worker-watcher process.
+  bool watch();
+  /// Fork a worker process.
+  bool createWorker();
+
+ private:
+  /// The entry point into a a worker child.
+  void initWorker();
+  /// Inspect into the memory, CPU, and other worker process states.
+  bool isWorkerSane();
+  /// If a worker as otherwise gone insane, stop it.
+  void stopWorker();
+  /// Reset the performance counting.
+  void resetCounters();
+
+ private:
+  size_t sustained_latency_;
+  size_t current_user_time_;
+  size_t current_system_time_;
+  size_t last_respawn_time_;
+
+ private:
+  /// Keep the single worker process/thread ID for inspection.
+  pid_t worker_;
+  /// Keep the invocation daemon's argc to iterate through argv.
+  int argc_;
+  /// When a worker child is spawned the argv will be scrubed.
+  char** argv_;
+  /// When a worker child is spawned the process name will be changed.
+  std::string name_;
+};
+
+/**
+ * @brief Daemon tools may want to continually spawn worker processes
+ * and monitor their utilization.
+ *
+ * A daemon may call initWorkerWatcher to begin watching child daemon
+ * processes until it-itself is unscheduled. The basic guarentee is that only
+ * workers will return from the function.
+ *
+ * The worker-watcher will implement performance bounds on CPU utilization
+ * and memory, as well as check for zombie/defunct workers and respawn them
+ * if appropriate. The appropriateness is determined from heuristics around
+ * how the worker exitted. Various exit states and velocities may cause the
+ * watcher to resign.
+ *
+ * @param name The name of the worker process.
+ * @param argc The daemon's argc.
+ * @param argv The daemon's volitle argv.
+ */
+void initWorkerWatcher(const std::string& name, int argc, char* argv[]);
+}

--- a/osquery/filesystem/filesystem_tests.cpp
+++ b/osquery/filesystem/filesystem_tests.cpp
@@ -44,14 +44,14 @@ TEST_F(FilesystemTests, test_list_files_in_directory_not_found) {
   std::vector<std::string> not_found_vector;
   auto not_found = listFilesInDirectory("/foo/bar", not_found_vector);
   EXPECT_FALSE(not_found.ok());
-  EXPECT_EQ(not_found.toString(), "Directory not found");
+  EXPECT_EQ(not_found.toString(), "Directory not found: /foo/bar");
 }
 
 TEST_F(FilesystemTests, test_list_files_in_directory_not_dir) {
   std::vector<std::string> not_dir_vector;
   auto not_dir = listFilesInDirectory("/etc/hosts", not_dir_vector);
   EXPECT_FALSE(not_dir.ok());
-  EXPECT_EQ(not_dir.toString(), "Supplied path is not a directory");
+  EXPECT_EQ(not_dir.toString(), "Supplied path is not a directory: /etc/hosts");
 }
 
 TEST_F(FilesystemTests, test_list_files_in_directorty) {


### PR DESCRIPTION
This adds a watcher/worker model for osqueryd: on load the process will continue to fork and monitor the child for (1) exceptions/aborts, (2) process utilization violations, (3) memory consumption violations. It can also take action if (4) the worker exits, or is killed, too frequently. 

Immediate observations:
* Because of the fork there is a duplication of phys memory on load. 
** In practice on Ubuntu 14.04 this is 800kB of memory.
* The performance limits are defines in worker.cpp and could be part of a configurable profile.
* Rewriting the process name only affects ps/libproc tools.
* tables.h is now an include dependency in sql.h.
