### PR TITLE
Add useful operator implementations to Status

### DIFF
--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -3,13 +3,14 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
 
 #pragma once
 
+#include <sstream>
 #include <string>
 
 namespace osquery {
@@ -92,6 +93,32 @@ class Status {
    */
   std::string toString() const { return getMessage(); }
   std::string what() const { return getMessage(); }
+
+  /**
+   * @brief implicit conversion to bool
+   *
+   * Allows easy use of Status in an if statement, as below:
+   *
+   * @code{.cpp}
+   *   if (doSomethingThatReturnsStatus()) {
+   *     LOG(INFO) << "Success!";
+   *   }
+   * @endcode
+   */
+  operator bool() const { return ok(); }
+
+  // Below operator implementations useful for testing with gtest
+
+  // Enables use of gtest (ASSERT|EXPECT)_EQ
+  bool operator==(const Status& rhs) const {
+    return (code_ == rhs.getCode()) && (message_ == rhs.getMessage());
+  }
+
+  // Enables use of gtest (ASSERT|EXPECT)_NE
+  bool operator!=(const Status& rhs) const { return !operator==(rhs); }
+
+  // Enables pretty-printing in gtest (ASSERT|EXPECT)_(EQ|NE)
+  friend ::std::ostream& operator<<(::std::ostream& os, const Status& s);
 
  private:
   /// the internal storage of the status code

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -259,5 +259,9 @@ osquery::QueryData getEtcHostsExpectedResults() {
   row4["address"] = "fe80::1%lo0";
   row4["hostnames"] = "localhost";
   return {row1, row2, row3, row4};
+}
+
+::std::ostream& operator<<(::std::ostream& os, const Status& s) {
+  return os << "Status(" << s.getCode() << ", \"" << s.getMessage() << "\")";
 }
 }


### PR DESCRIPTION
Adds useful operators to the `Status` class. Enables niceties such as:
```c++
  Status s = doSomething();
  ASSERT_EQ(Status(), s);
```
And when the assertion fails, the expected and actual statuses will be pretty-printed.