### PR TITLE
Harden watcher for more perf, use exec and watch from worker

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -53,6 +53,11 @@ enum osqueryTool {
 void initOsquery(int argc, char* argv[], int tool = OSQUERY_TOOL_TEST);
 
 /**
+ * @brief Sets up a process as a osquery daemon.
+ */
+void initOsqueryDaemon();
+
+/**
  * @brief Turns of various aspects of osquery such as event loops.
  *
  */

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -13,12 +13,16 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-#include <osquery/database/results.h>
+#include <osquery/status.h>
 
 #ifndef STR
 #define STR_OF(x) #x
 #define STR(x) STR_OF(x)
+#endif
+
+#ifndef FRIEND_TEST
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
 #endif
 
 namespace osquery {
@@ -104,13 +108,6 @@ std::string getAsciiTime();
  * @return an int representing the amount of seconds since the unix epoch
  */
 int getUnixTime();
-
-/**
- * @brief Return a vector of all home directories on the system
- *
- * @return a vector of strings representing the path of all home directories
- */
-std::vector<boost::filesystem::path> getHomeDirectories();
 
 /**
  * @brief Inline helper function for use with utf8StringSize

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -88,6 +88,16 @@ class DBHandle {
   static std::shared_ptr<DBHandle> getInstance();
 
   /**
+   * @brief Check the sanify of the database configuration options
+   *
+   * Create a handle to the backing store using the database configuration.
+   * Catch any instance creation exceptions and release the handle immediately.
+   *
+   * @return Success if a handle was created without error.
+   */
+  static bool checkDB();
+
+  /**
    * @brief Helper method which can be used to get a raw pointer to the
    * underlying RocksDB database handle
    *

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -88,7 +88,7 @@ class DBHandle {
   static std::shared_ptr<DBHandle> getInstance();
 
   /**
-   * @brief Check the sanify of the database configuration options
+   * @brief Check the sanity of the database configuration options
    *
    * Create a handle to the backing store using the database configuration.
    * Catch any instance creation exceptions and release the handle immediately.

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -48,14 +48,20 @@ class InternalRunnable : public apache::thrift::concurrency::Runnable {
   InternalRunnable() : run_(false) {}
 
  public:
+  /// The boost::thread entrypoint.
   void run() {
     run_ = true;
     enter();
   }
 
+  /// Check if the thread's entrypoint (run) executed, meaning thread context
+  /// was allocated.
   bool hasRun() { return run_; }
+  /// Sleep in a boost::thread interruptable state.
+  void interruptableSleep(size_t milli);
 
  protected:
+  /// Require the runnable thread define an entrypoint.
   virtual void enter() = 0;
 
  private:

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -149,34 +149,11 @@ Status remove(const boost::filesystem::path& path);
 Status isDirectory(const boost::filesystem::path& path);
 
 /**
- * @brief Parse the users out of a tomcat user config from disk
+ * @brief Return a vector of all home directories on the system
  *
- * @param path A string which represents the path of the tomcat user config
- * @param a vector of pairs which represent all of the users which were found
- * in the supplied file. pair.first is the username and pair.second is the
- * password.
- *
- * @return an instance of Status, indicating the success or failure
- * of the operation
+ * @return a vector of strings representing the path of all home directories
  */
-Status parseTomcatUserConfigFromDisk(
-    const boost::filesystem::path& path,
-    std::vector<std::pair<std::string, std::string> >& credentials);
-
-/**
- * @brief Parse the users out of a tomcat user config
- *
- * @param content A string which represents the content of the file to parse
- * @param a vector of pairs which represent all of the users which were found
- * in the supplied file. pair.first is the username and pair.second is the
- * password.
- *
- * @return an instance of Status, indicating the success or failure
- * of the operation
- */
-Status parseTomcatUserConfig(
-    const std::string& content,
-    std::vector<std::pair<std::string, std::string> >& credentials);
+std::vector<boost::filesystem::path> getHomeDirectories();
 
 #ifdef __APPLE__
 /**

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -23,11 +23,6 @@
 #include <osquery/database/results.h>
 #include <osquery/status.h>
 
-#ifndef FRIEND_TEST
-#define FRIEND_TEST(test_case_name, test_name) \
-  friend class test_case_name##_##test_name##_Test
-#endif
-
 namespace osquery {
 namespace tables {
 

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <set>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -199,7 +200,17 @@ struct ConstraintList {
    * @param op the ConstraintOperator.
    * @return A list of TEXT%-represented types matching the operator.
    */
-  std::vector<std::string> getAll(ConstraintOperator op);
+  std::set<std::string> getAll(ConstraintOperator op);
+
+  template<typename T>
+  std::set<T> getAll(ConstraintOperator op) {
+    std::set<T> literal_matches;
+    auto matches = getAll(op);
+    for (const auto& match : matches) {
+      literal_matches.insert(AS_LITERAL(T, match));
+    }
+    return literal_matches;
+  }
 
   /**
    * @brief Add a new Constraint to the list of constraints.

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -105,7 +105,7 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
   TARGET_OSQUERY_LINK_WHOLE(shell libosquery_additional)
   set_target_properties(shell PROPERTIES OUTPUT_NAME osqueryi)
 
-  add_executable(daemon main/daemon.cpp core/watcher.cpp)
+  add_executable(daemon main/daemon.cpp)
   TARGET_OSQUERY_LINK_WHOLE(daemon libosquery)
   TARGET_OSQUERY_LINK_WHOLE(daemon libosquery_additional)
   set_target_properties(daemon PROPERTIES OUTPUT_NAME osqueryd)

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -15,6 +15,7 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_core
   text.cpp
   flags.cpp
   hash.cpp
+  watcher.cpp
 )
 
 ADD_OSQUERY_LIBRARY(TRUE osquery_test_util

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -94,21 +94,6 @@ int getUnixTime() {
   return result;
 }
 
-std::vector<fs::path> getHomeDirectories() {
-  auto sql = SQL(
-      "SELECT DISTINCT directory FROM users WHERE directory != '/var/empty';");
-  std::vector<fs::path> results;
-  if (sql.ok()) {
-    for (const auto& row : sql.rows()) {
-      results.push_back(row.at("directory"));
-    }
-  } else {
-    LOG(ERROR)
-        << "Error executing query to return users: " << sql.getMessageString();
-  }
-  return results;
-}
-
 Status checkStalePid(const std::string& content) {
   int pid;
   try {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -144,7 +144,7 @@ Status checkStalePid(const std::string& content) {
       return Status(1, "osqueryd (" + content + ") is already running");
     } else {
       LOG(INFO) << "Found stale process for osqueryd (" << content
-                << ") removing pidfile.";
+                << ") removing pidfile";
     }
   }
 
@@ -173,7 +173,7 @@ Status createPidFile() {
     boost::filesystem::remove(FLAGS_pidfile);
   } catch (boost::filesystem::filesystem_error& e) {
     // Unable to remove old pidfile.
-    LOG(WARNING) << "Unable to remove the osqueryd pidfile.";
+    LOG(WARNING) << "Unable to remove the osqueryd pidfile";
   }
 
   // If no pidfile exists or the existing pid was stale, write, log, and run.

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -63,12 +63,12 @@ bool ConstraintList::literal_matches(const T& base_expr) {
   return true;
 }
 
-std::vector<std::string> ConstraintList::getAll(ConstraintOperator op) {
-  std::vector<std::string> set;
+std::set<std::string> ConstraintList::getAll(ConstraintOperator op) {
+  std::set<std::string> set;
   for (size_t i = 0; i < constraints_.size(); ++i) {
     if (constraints_[i].op == op) {
       // TODO: this does not apply a distinct.
-      set.push_back(constraints_[i].expr);
+      set.insert(constraints_[i].expr);
     }
   }
   return set;

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -14,32 +14,38 @@
 
 #include <unistd.h>
 
+#include <osquery/dispatcher.h>
+#include <osquery/flags.h>
+
 namespace osquery {
+
+DECLARE_bool(disable_watchdog);
 
 class Watcher {
  public:
   Watcher(int argc, char* argv[]) : worker_(0), argc_(argc), argv_(argv) {
     resetCounters();
+    last_respawn_time_ = 0;
   }
 
   void setWorkerName(const std::string& name) { name_ = name; }
   const std::string& getWorkerName() { return name_; }
 
+  /// Boilerplate function to sleep for some configured latency
   bool ok();
   /// Begin the worker-watcher process.
   bool watch();
   /// Fork a worker process.
-  bool createWorker();
+  void createWorker();
+  /// If the process is a worker, clean up identification.
+  void initWorker();
+  void resetCounters();
 
  private:
-  /// The entry point into a a worker child.
-  void initWorker();
   /// Inspect into the memory, CPU, and other worker process states.
   bool isWorkerSane();
   /// If a worker as otherwise gone insane, stop it.
   void stopWorker();
-  /// Reset the performance counting.
-  void resetCounters();
 
  private:
   size_t sustained_latency_;
@@ -57,6 +63,19 @@ class Watcher {
   /// When a worker child is spawned the process name will be changed.
   std::string name_;
 };
+
+/// The WatcherWatcher is spawned within the worker and watches the watcher.
+class WatcherWatcherRunner : public InternalRunnable {
+ public:
+  WatcherWatcherRunner(pid_t watcher) : watcher_(watcher) {}
+  void enter();
+
+ private:
+  pid_t watcher_;
+};
+
+/// Check if the current process is already a worker.
+bool isOsqueryWorker();
 
 /**
  * @brief Daemon tools may want to continually spawn worker processes

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -21,6 +21,15 @@ namespace osquery {
 
 DECLARE_bool(disable_watchdog);
 
+enum WatchdogLimitType {
+  MEMORY_LIMIT,
+  UTILIZATION_LIMIT,
+  RESPAWN_LIMIT,
+  RESPAWN_DELAY,
+  LATENCY_LIMIT,
+  INTERVAL,
+};
+
 class Watcher {
  public:
   Watcher(int argc, char* argv[]) : worker_(0), argc_(argc), argv_(argv) {
@@ -76,6 +85,9 @@ class WatcherWatcherRunner : public InternalRunnable {
 
 /// Check if the current process is already a worker.
 bool isOsqueryWorker();
+
+/// Get a performance limit by name and optional level.
+size_t getWorkerLimit(WatchdogLimitType limit, int level = -1);
 
 /**
  * @brief Daemon tools may want to continually spawn worker processes

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -88,6 +88,15 @@ std::shared_ptr<DBHandle> DBHandle::getInstance() {
   return getInstance(FLAGS_db_path, FLAGS_use_in_memory_database);
 }
 
+bool DBHandle::checkDB() {
+  try {
+    auto handle = DBHandle(FLAGS_db_path, FLAGS_use_in_memory_database);
+  } catch (const std::exception& e) {
+    return false;
+  }
+  return true;
+}
+
 std::shared_ptr<DBHandle> DBHandle::getInstanceInMemory() {
   return getInstance("", true);
 }

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <osquery/dispatcher.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -23,6 +25,10 @@ DEFINE_osquery_flag(int32,
                     worker_threads,
                     4,
                     "Number of work dispatch threads");
+
+void InternalRunnable::interruptableSleep(size_t milli) {
+  boost::this_thread::sleep(boost::posix_time::milliseconds(milli));
+}
 
 Dispatcher& Dispatcher::getInstance() {
   static Dispatcher d;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TSimpleServer.h>
 #include <thrift/transport/TServerSocket.h>
@@ -189,7 +187,7 @@ void ExtensionWatcher::enter() {
       transport->close();
       exitFatal();
     }
-    boost::this_thread::sleep(boost::posix_time::milliseconds(interval_));
+    interruptableSleep(interval_);
   }
 
   // Code will never reach this socket close.
@@ -240,7 +238,7 @@ Status startExtension(const std::string& manager_path,
   info.version = version;
   info.sdk_version = sdk_version;
 
-  // Register the extension's registery broadcast with the manager.
+  // Register the extension's registry broadcast with the manager.
   ExtensionManagerClient client(protocol);
   ExtensionStatus status;
   try {

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -25,6 +25,7 @@
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
+#include <osquery/sql.h>
 
 namespace pt = boost::property_tree;
 namespace fs = boost::filesystem;
@@ -468,5 +469,20 @@ Status isDirectory(const boost::filesystem::path& path) {
     return Status(0, "OK");
   }
   return Status(1, "Path is not a directory: " + path.string());
+}
+
+std::vector<fs::path> getHomeDirectories() {
+  auto sql = SQL(
+      "SELECT DISTINCT directory FROM users WHERE directory != '/var/empty';");
+  std::vector<fs::path> results;
+  if (sql.ok()) {
+    for (const auto& row : sql.rows()) {
+      results.push_back(row.at("directory"));
+    }
+  } else {
+    LOG(ERROR)
+        << "Error executing query to return users: " << sql.getMessageString();
+  }
+  return results;
 }
 }

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -21,6 +21,7 @@
 const std::string kShellTemp = "/tmp/osquery";
 
 int main(int argc, char *argv[]) {
+  // The shell is transient, rewrite config-loaded paths.
   if (osquery::pathExists(kShellTemp).ok() ||
       boost::filesystem::create_directory(kShellTemp)) {
     osquery::FLAGS_db_path = kShellTemp + "/shell.db";
@@ -32,6 +33,7 @@ int main(int argc, char *argv[]) {
   osquery::initOsquery(argc, argv, osquery::OSQUERY_TOOL_SHELL);
 
   // Start event threads.
+  osquery::attachEvents();
   osquery::EventFactory::delay();
   osquery::startExtensionManager();
 

--- a/osquery/sql/sql_tests.cpp
+++ b/osquery/sql/sql_tests.cpp
@@ -11,7 +11,9 @@
 #include <gtest/gtest.h>
 
 #include <osquery/core.h>
+#include <osquery/registry.h>
 #include <osquery/sql.h>
+#include <osquery/tables.h>
 
 namespace osquery {
 
@@ -26,6 +28,49 @@ TEST_F(SQLTests, test_simple_query_execution) {
 TEST_F(SQLTests, test_get_tables) {
   auto tables = SQL::getTableNames();
   EXPECT_TRUE(tables.size() > 0);
+}
+
+TEST_F(SQLTests, test_raw_access) {
+  auto results = SQL::selectAllFrom("time");
+  EXPECT_EQ(results.size(), 1);
+}
+
+class TestTable : public tables::TablePlugin {
+ private:
+  tables::TableColumns columns() {
+    return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
+  }
+
+  QueryData generate(tables::QueryContext& ctx) {
+    QueryData results;
+    if (ctx.constraints["test_int"].existsAndMatches("1")) {
+      results.push_back({{"test_int", "1"}, {"test_text", "0"}});
+    } else {
+      results.push_back({{"test_int", "0"}, {"test_text", "1"}});
+    }
+
+    auto ints = ctx.constraints["test_int"].getAll<int>(tables::EQUALS);
+    for (const auto& int_match : ints) {
+      results.push_back({{"test_int", INTEGER(int_match)}});
+    }
+
+    return results;
+  }
+};
+
+TEST_F(SQLTests, test_raw_access_context) {
+  REGISTER(TestTable, "table", "test_table");
+  auto results = SQL::selectAllFrom("test_table");
+
+  EXPECT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0]["test_text"], "1");
+
+  results = SQL::selectAllFrom("test_table", "test_int", tables::EQUALS, "1");
+  EXPECT_EQ(results.size(), 2);
+
+  results = SQL::selectAllFrom("test_table", "test_int", tables::EQUALS, "2");
+  EXPECT_EQ(results.size(), 2);
+  EXPECT_EQ(results[0]["test_int"], "0");
 }
 }
 

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -210,7 +210,17 @@ std::vector<std::string> getProcArgs(int pid, size_t argmax) {
 
 QueryData genProcesses(QueryContext &context) {
   QueryData results;
-  auto pidlist = getProcList();
+
+  std::set<int> pidlist;
+  if (context.constraints["pid"].exists()) {
+    pidlist = context.constraints["pid"].getAll<int>(EQUALS);
+  }
+
+  // No equality matches, get all pids.
+  if (pidlist.size() == 0) {
+    pidlist = getProcList();
+  }
+
   auto parent_pid = getParentMap(pidlist);
   int argmax = genMaxArgs();
 

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -278,8 +278,8 @@ QueryData genProcesses(QueryContext &context) {
       r["phys_footprint"] = TEXT(rusage_info_data.ri_phys_footprint);
 
       // time information
-      r["user_time"] = TEXT(rusage_info_data.ri_user_time);
-      r["system_time"] = TEXT(rusage_info_data.ri_system_time);
+      r["user_time"] = TEXT(rusage_info_data.ri_user_time / 1000000);
+      r["system_time"] = TEXT(rusage_info_data.ri_system_time / 1000000);
       r["start_time"] = TEXT(rusage_info_data.ri_proc_start_abstime);
     }
 

--- a/osquery/tables/system/darwin/startup_items.cpp
+++ b/osquery/tables/system/darwin/startup_items.cpp
@@ -10,6 +10,8 @@
 
 #include <signal.h>
 
+#include <boost/filesystem.hpp>
+
 #include <osquery/core.h>
 #include <osquery/tables.h>
 #include <osquery/filesystem.h>

--- a/osquery/tables/system/darwin/xattr.cpp
+++ b/osquery/tables/system/darwin/xattr.cpp
@@ -5,6 +5,8 @@
 
 #include <sys/xattr.h>
 
+#include <boost/filesystem.hpp>
+
 #include <osquery/logger.h>
 #include <osquery/core.h>
 #include <osquery/tables.h>

--- a/osquery/tables/system/linux/acpi_tables.cpp
+++ b/osquery/tables/system/linux/acpi_tables.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include <boost/filesystem.hpp>
+
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/hash.h>


### PR DESCRIPTION
* The watcher/worker model on OSX was flawed in that it forked without execing itself. 
* The worker now execs after setting an environment variable indicating the daemon should skip startup checks.
* `OSQUERYD_WORKER` indicates a worker should skip setting pid, checking DBInstance, and some logging.
* The performance monitoring of the worker was latent in most cases because of the implicit requirement to start an in-memory SQL database.
* This now skips the SQL and emits data directly from the processes table plugin using `Registry::call`. 
* On OSX CPU time is measured with different precision that Linux, the watcher now monitors utilization accordingly.
* The precision on OSX would cause an integer overflow in abort the watch (thus worker) within a reasonable amount of time.
* The worker now starts a "watcher watcher" process
* If the worker's parent changes (indicating it has become abandoned) it will crash itself.
* Processes table now select on pid more effectively.
* Some added functions to QueryContext.
* The DBInstance class has a new `checkDB` method that will release the instance after checking sanity.
*