### PR TITLE
[Fix #713] Do not abort if EM fails

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -139,9 +139,15 @@ void ExtensionRunner::enter() {
       new TBinaryProtocolFactory());
 
   // Start the Thrift server's run loop.
-  TSimpleServer server(
-      processor, serverTransport, transportFactory, protocolFactory);
-  server.serve();
+  try {
+    TSimpleServer server(
+        processor, serverTransport, transportFactory, protocolFactory);
+    server.serve();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Cannot start extension handler (" << socket_path << ") ("
+               << e.what() << ")";
+    throw e;
+  }
 }
 
 ExtensionManagerRunner::~ExtensionManagerRunner() {
@@ -166,9 +172,14 @@ void ExtensionManagerRunner::enter() {
       new TBinaryProtocolFactory());
 
   // Start the Thrift server's run loop.
-  TSimpleServer server(
-      processor, serverTransport, transportFactory, protocolFactory);
-  server.serve();
+  try {
+    TSimpleServer server(
+        processor, serverTransport, transportFactory, protocolFactory);
+    server.serve();
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "Extensions disabled: cannot start extension manager ("
+                 << socket_path << ") (" << e.what() << ")";
+  }
 }
 
 void ExtensionWatcher::enter() {


### PR DESCRIPTION
Extensions will fail (SIGABRT) since they ONLY expose a thrift service. osqueryd/osqueryi, the extension manager, is optional. 