### PR TITLE
Testing CentOS7 clang 3.5 without fortify

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -31,32 +31,27 @@ elseif(LINUX)
     endif()
   elseif(CENTOS)
     set(PACKAGE_TYPE "rpm")
+    set(PACKAGE_DEPENDENCIES
+      "glibc >= 2.12"
+      "openssl >= 1.0"
+      "bzip2-libs"
+      "readline"
+      "zlib"
+      "snappy"
+      "rpm-libs"
+    )
     if(OSQUERY_BUILD_DISTRO STREQUAL "CENTOS6")
       set(PACKAGE_DEPENDENCIES
-        "glibc >= 2.12"
-        "openssl >= 1.0"
-        "readline"
-        "zlib"
-        "snappy"
-        "bzip2-libs"
+        "${PACKAGE_DEPENDENCIES}"
         "procps"
         "libudev"
-        "rpm-libs"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "CENTOS7")
       set(PACKAGE_DEPENDENCIES
-        "glibc >= 2.12"
-        "openssl >= 1.0"
-        "readline"
-        "zlib"
-        "snappy"
-        "bzip2-libs"
+        "${PACKAGE_DEPENDENCIES}"
         "procps-ng"
         "systemd-devel"
-        "rpm-libs"
-        "epel-release"
-        "thrift"
-        "thrift-devel"
+	"epel-release"
       )
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,26 @@ cmake_minimum_required(VERSION 2.8.8)
 
 set(CMAKE_C_COMPILER "/usr/bin/clang")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
-set(CXX_COMPILE_FLAGS
+set(C_COMPILE_FLAGS
   -Wall
   -Wextra
   -Wstrict-aliasing
   -Wno-unused-parameter
+  -Wno-unused-result
   -Wno-missing-field-initializers
   -Wno-sign-compare
+  -Wnon-virtual-dtor
+  -Wchar-subscripts
+  -Wpointer-arith
+  -Woverloaded-virtual
   -Wformat
   -Wformat-security
   -Werror=format-security
   -fstack-protector-all
-  -D_FORTIFY_SOURCE=2
   -fPIE
 )
-string(REPLACE ";" " " CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS}")
+string(REPLACE ";" " " C_COMPILE_FLAGS "${C_COMPILE_FLAGS}")
+set(CXX_COMPILE_FLAGS "")
 set(CMAKE_SHARED_LINKER_FLAGS "-z relro -z now")
 
 if(APPLE)
@@ -28,47 +33,17 @@ if(APPLE)
   # Special compile flags for Objective-C++
   set(OBJCXX_COMPILE_FLAGS
     "-x objective-c++ -fobjc-arc -Wno-c++11-extensions -mmacosx-version-min=${APPLE_MIN_ABI}")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(FREEBSD TRUE)
+  set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11 -stdlib=libc++")
+  set(OS_WHOLELINK_PRE "")
+  set(OS_WHOLELINK_POST "")
 else()
-  if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(FREEBSD TRUE)
-    set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11 -stdlib=libc++")
-    set(OS_WHOLELINK_PRE "")
-    set(OS_WHOLELINK_POST "")
-  else()
-    set(LINUX TRUE)
-    set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11")
-    set(OS_WHOLELINK_PRE "-Wl,-whole-archive")
-    set(OS_WHOLELINK_POST "-Wl,-no-whole-archive")
-  endif()
+  set(LINUX TRUE)
+  set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11")
+  set(OS_WHOLELINK_PRE "-Wl,-whole-archive")
+  set(OS_WHOLELINK_POST "-Wl,-no-whole-archive")
 endif()
-
-# make debug (environment variable from Makefile)
-if(DEFINED ENV{DEBUG})
-  set(CMAKE_BUILD_TYPE "Debug")
-  set(C_COMPILE_FLAGS "${CMAKE_C_FLAGS} -g -DDEBUG -O0 -pg")
-else()
-  set(C_COMPILE_FLAGS "${CMAKE_C_FLAGS} -O2")
-endif()
-
-# make analyze (environment variable from Makefile)
-if(DEFINED ENV{ANALYZE})
-  set(CMAKE_CXX_COMPILER "${CMAKE_SOURCE_DIR}/tools/analysis/clang-analyze.sh")
-endif()
-
-# make sanitize (environment variable from Makefile)
-if(DEFINED ENV{SANITIZE})
-  set(CXX_COMPILE_FLAGS "-g -O0 -fno-omit-frame-pointer")
-  set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -fsanitize=leak -fsanitize=address")
-  if(LINUX)
-    set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -fsanitize=memory")
-  endif()
-endif()
-
-# Finished setting compiler/compiler flags.
-set(CMAKE_CXX_FLAGS "${C_COMPILE_FLAGS} ${CXX_COMPILE_FLAGS}"
-  CACHE STRING "compile flags" FORCE)
-
-project(OSQUERY)
 
 # Use osquery language to set platform/os
 execute_process(
@@ -81,6 +56,31 @@ string(REPLACE "." "_" PLATFORM "${PLATFORM}")
 string(TOUPPER "${PLATFORM}" PLATFORM)
 list(GET PLATFORM 0 OSQUERY_BUILD_OS)
 list(GET PLATFORM 1 OSQUERY_BUILD_DISTRO)
+
+# make debug (environment variable from Makefile)
+if(DEFINED ENV{DEBUG})
+  set(CMAKE_BUILD_TYPE "Debug")
+  set(C_COMPILE_FLAGS "${C_COMPILE_FLAGS} -g -DDEBUG -O0 -pg")
+elseif(DEFINED ENV{SANITIZE})
+  # make santifize (cannot make debug sanitize)
+  set(C_COMPILE_FLAGS "-g -O0 -fno-omit-frame-pointer")
+  set(C_COMPILE_FLAGS "${C_COMPILE_FLAGS} -fsanitize=leak -fsanitize=address")
+else()
+  set(C_COMPILE_FLAGS "${C_COMPILE_FLAGS} -O2")
+  # Do not enable fortify with clang: http://llvm.org/bugs/show_bug.cgi?id=16821
+  #set(C_COMPILE_FLAGS "${C_COMPILE_FLAGS} -D_FORTIFY_SOURCE=2")
+endif()
+
+# make analyze (environment variable from Makefile)
+if(DEFINED ENV{ANALYZE})
+  set(CMAKE_CXX_COMPILER "${CMAKE_SOURCE_DIR}/tools/analysis/clang-analyze.sh")
+endif()
+
+# Finished setting compiler/compiler flags.
+set(CMAKE_CXX_FLAGS "${C_COMPILE_FLAGS} ${CXX_COMPILE_FLAGS}"
+  CACHE STRING "compile flags" FORCE)
+
+project(OSQUERY)
 
 # Make sure deps were built before compiling (else show warning)
 execute_process(

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -150,6 +150,7 @@ class RegistryHelperCore {
 
  public:
   RegistryHelperCore(bool auto_setup = true) : auto_setup_(auto_setup) {}
+  virtual ~RegistryHelperCore() {}
 
   /**
    * @brief Remove a registry item by its identifier.

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -39,7 +39,6 @@ endif()
 # The remaining boost libraries are discovered with find_library.
 ADD_OSQUERY_LINK(TRUE "boost_system")
 ADD_OSQUERY_LINK(TRUE "boost_filesystem")
-ADD_OSQUERY_LINK(TRUE "boost_regex")
 
 # Construct a set of all object files, starting with third-party and all
 # of the osquery core objects (sources from ADD_CORE_LIBRARY macros).

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -8,11 +8,12 @@
  *
  */
 
+#include <regex>
+
 #include <arpa/inet.h>
 #include <linux/netlink.h>
 
 #include <boost/algorithm/string/split.hpp>
-#include <boost/regex.hpp>
 
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
@@ -285,15 +286,15 @@ QueryData genOpenSockets(QueryContext &context) {
   }
 
   // Generate a map of socket inode to process tid.
-  boost::regex inode_regex("[0-9]+");
+  std::regex inode_regex("[0-9]+", std::regex_constants::extended);
   std::map<std::string, std::string> socket_inodes;
   for (const auto& process : processes) {
     std::map<std::string, std::string> descriptors;
     if (osquery::procDescriptors(process, descriptors).ok()) {
       for (const auto& fd : descriptors) {
         if (fd.second.find("socket:") != std::string::npos) {
-          boost::smatch inode;
-          boost::regex_search(fd.second, inode, inode_regex);
+          std::smatch inode;
+          std::regex_search(fd.second, inode, inode_regex);
           if (inode[0].str().length() > 0) {
             socket_inodes[inode[0].str()] = process;
           }

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -64,18 +64,15 @@ inline std::string readProcCMDLine(const proc_t* proc_info) {
 inline std::string readProcLink(const proc_t* proc_info,
     const std::string& attr) {
   // The exe is a symlink to the binary on-disk.
-  auto attr_path = getProcAttr(attr, proc_info);
-  long path_max = pathconf(attr_path.c_str(), _PC_PATH_MAX);
-  auto link_path = (char*)malloc(path_max);
-  memset(link_path, 0, path_max);
+  auto attr_path = getProcAttr("exe", proc_info);
 
   std::string result;
-  int bytes = readlink(attr_path.c_str(), link_path, path_max);
+  char link_path[PATH_MAX] = {0};
+  auto bytes = readlink(attr_path.c_str(), link_path, sizeof(link_path) - 1);
   if (bytes >= 0) {
     result = std::string(link_path);
   }
 
-  free(link_path);
   return result;
 }
 

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -415,7 +415,8 @@ function main() {
       if [[ $DISTRO = "centos6" ]]; then
         sudo rpm -iv ftp://rpmfind.net/linux/centos/7.0.1406/updates/x86_64/Packages/kernel-headers-3.10.0-123.9.3.el7.x86_64.rpm
       elif [[ $DISTRO = "centos7" ]]; then
-        package kernel-headers
+        #package kernel-headers
+        true
       fi
     fi
 
@@ -487,7 +488,7 @@ function main() {
       install_boost
       package libudev-devel
     elif [[ $DISTRO = "centos7" ]]; then
-      package boost
+      install_boost
       package systemd-devel
     fi
 
@@ -510,8 +511,7 @@ function main() {
       package autoconf
       package automake
       package libtool
-      package thrift
-      package thrift-devel
+      install_thrift
     fi
 
     install_rocksdb


### PR DESCRIPTION
A working test of CentOS7 without fortify, which causes NL socket reads to hang.