### PR TITLE
Fix osquery_extensions listing .0 for the core

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -54,7 +54,11 @@ typedef std::map<RouteUUID, ExtensionInfo> ExtensionList;
 
 inline std::string getExtensionSocket(
     RouteUUID uuid, const std::string& path = FLAGS_extensions_socket) {
-  return path + "." + std::to_string(uuid);
+  if (uuid == 0) {
+    return path;
+  } else {
+    return path + "." + std::to_string(uuid);
+  }
 }
 
 namespace extensions {


### PR DESCRIPTION
Fixing a silly inconsistency with reporting socket locations for the core extension manager.