### PR TITLE
Building example extension with SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,14 @@ test_sdk: .setup
 	cd build/$(BUILD_DIR)/sdk && SDK=True cmake ../../../ && \
 	  $(MAKE) test --no-print-directory $(MAKEFLAGS)
 
+debug_sdk: .setup
+	cd build/$(BUILD_DIR)/sdk && SDK=True DEBUG=True cmake ../../../ && \
+	  $(MAKE) --no-print-directory $(MAKEFLAGS)
+
+test_debug_sdk: .setup
+	cd build/$(BUILD_DIR)/sdk && SDK=True DEBUG=True cmake ../../../ && \
+	  $(MAKE) test --no-print-directory $(MAKEFLAGS)
+
 deps: .setup
 	./tools/provision.sh build build/$(BUILD_DIR)
 

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -31,9 +31,11 @@ namespace osquery {
  * @brief The version of osquery
  */
 extern const std::string kVersion;
+extern const std::string kSDKVersion;
 
 /// Use a macro for the version literal, set the kVersion symbol in the library.
 #define OSQUERY_VERSION STR(OSQUERY_BUILD_VERSION)
+#define OSQUERY_SDK_VERSION STR(OSQUERY_BUILD_SDK_VERSION)
 
 /**
  * @brief A helpful tool type to report when logging, print help, or debugging.
@@ -42,7 +44,7 @@ enum osqueryTool {
   OSQUERY_TOOL_SHELL,
   OSQUERY_TOOL_DAEMON,
   OSQUERY_TOOL_TEST,
-  OSQUERY_TOOL_EXTENSION,
+  OSQUERY_EXTENSION,
 };
 
 /**

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -28,8 +28,11 @@
 #endif
 
 #include <osquery/status.h>
+#include <osquery/flags.h>
 
 namespace osquery {
+
+DECLARE_int32(worker_threads);
 
 typedef apache::thrift::concurrency::ThreadManager InternalThreadManager;
 typedef std::shared_ptr<InternalThreadManager> InternalThreadManagerRef;
@@ -152,7 +155,7 @@ class Dispatcher {
   void join();
 
   /// See `join`, but applied to osquery services.
-  void joinServices();
+  static void joinServices();
 
   /// Destroy and stop all osquery service threads and service objects.
   void removeServices();

--- a/include/osquery/sdk.h
+++ b/include/osquery/sdk.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#ifndef OSQUERY_BUILD_SDK
+#define OSQUERY_BUILD_SDK
+#endif
+
+#include <osquery/config.h>
+#include <osquery/core.h>
+#include <osquery/database.h>
+#include <osquery/events.h>
+#include <osquery/extensions.h>
+#include <osquery/filesystem.h>
+#include <osquery/flags.h>
+#include <osquery/hash.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+#include <osquery/sql.h>
+#include <osquery/status.h>
+#include <osquery/tables.h>

--- a/osquery.thrift
+++ b/osquery.thrift
@@ -9,6 +9,7 @@ struct InternalExtensionInfo {
   1:string name,
   2:string version,
   3:string sdk_version,
+  4:string min_sdk_version,
 }
 
 /// Unique ID for each extension.
@@ -73,6 +74,10 @@ service ExtensionManager extends Extension {
   ),
   /// Allow an extension to query using an SQL string.
   ExtensionResponse query(
+    1:string sql,
+  ),
+  /// Allow an extension to introspect into SQL used in a parsed query.
+  ExtensionResponse getQueryColumns(
     1:string sql,
   ),
 }

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -94,19 +94,21 @@ void initOsquery(int argc, char* argv[], int tool) {
 
   // Initialize the status and results logger.
   initStatusLogger(binary);
-  VLOG(1) << "osquery initializing [version=" OSQUERY_VERSION "]";
+  if (tool != OSQUERY_EXTENSION) {
+    VLOG(1) << "osquery initializing [version=" OSQUERY_VERSION "]";
 
-  // Load the osquery config using the default/active config plugin.
-  Config::getInstance().load();
+    // Load the osquery config using the default/active config plugin.
+    Config::getInstance().load();
 
-  if (FLAGS_config_check) {
-    // The initiator requested an initialization and config check.
-    auto s = Config::checkConfig();
-    if (!s.ok()) {
-      std::cerr << "Error reading config: " << s.toString() << "\n";
+    if (FLAGS_config_check) {
+      // The initiator requested an initialization and config check.
+      auto s = Config::checkConfig();
+      if (!s.ok()) {
+        std::cerr << "Error reading config: " << s.toString() << "\n";
+      }
+      // A configuration check exits the application.
+      ::exit(s.getCode());
     }
-    // A configuration check exits the application.
-    ::exit(s.getCode());
   }
 
   // Run the setup for all non-lazy registries.

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -24,7 +24,12 @@ namespace pt = boost::property_tree;
 namespace osquery {
 
 const std::string kTestQuery = "SELECT * FROM test_table";
+
+#ifndef OSQUERY_BUILD_SDK
 const std::string kTestDataPath = "../../../../tools/tests/";
+#else
+const std::string kTestDataPath = "../../../../../tools/tests/";
+#endif
 
 QueryData getTestDBExpectedResults() {
   QueryData d;

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -81,7 +81,7 @@ InternalThreadManagerRef Dispatcher::getThreadManager() {
 void Dispatcher::join() { thread_manager_->join(); }
 
 void Dispatcher::joinServices() {
-  for (auto& thread : service_threads_) {
+  for (auto& thread : getInstance().service_threads_) {
     thread->join();
   }
 }

--- a/osquery/distributed/distributed_tests.cpp
+++ b/osquery/distributed/distributed_tests.cpp
@@ -58,6 +58,8 @@ TEST_F(DistributedTests, test_parse_query_json) {
 }
 
 TEST_F(DistributedTests, test_handle_query) {
+// Access to the internal SQL implementation is only available in core.
+#ifndef OSQUERY_BUILD_SDK
   SQL query = DistributedQueryHandler::handleQuery("SELECT hour from time");
   ASSERT_TRUE(query.ok());
   QueryData rows = query.rows();
@@ -68,6 +70,7 @@ TEST_F(DistributedTests, test_handle_query) {
   ASSERT_FALSE(query.ok());
   rows = query.rows();
   ASSERT_EQ(0, rows.size());
+#endif
 }
 
 TEST_F(DistributedTests, test_serialize_results_empty) {
@@ -132,6 +135,8 @@ TEST_F(DistributedTests, test_serialize_results_multiple) {
 }
 
 TEST_F(DistributedTests, test_do_queries) {
+// Access to the internal SQL implementation is only available in core.
+#ifndef OSQUERY_BUILD_SDK
   auto provider_raw = new MockDistributedProvider();
   provider_raw->queriesJSON_ =
     R"([
@@ -176,9 +181,12 @@ TEST_F(DistributedTests, test_do_queries) {
     EXPECT_LE(row->second.get<int>("minutes"), 60);
     EXPECT_EQ(getHostname(), row->second.get<std::string>("_source_host"));
   }
+#endif
 }
 
 TEST_F(DistributedTests, test_duplicate_request) {
+// Access to the internal SQL implementation is only available in core.
+#ifndef OSQUERY_BUILD_SDK
   auto provider_raw = new MockDistributedProvider();
   provider_raw->queriesJSON_ =
     R"([
@@ -209,6 +217,7 @@ TEST_F(DistributedTests, test_duplicate_request) {
   json_stream.str(provider_raw->resultsJSON_);
   ASSERT_NO_THROW(pt::read_json(json_stream, tree));
   EXPECT_EQ(0, tree.get_child("results").size());
+#endif
 }
 }
 

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -8,9 +8,9 @@
  *
  */
 
-#include <osquery/tables.h>
+#include <osquery/sdk.h>
 
-namespace osquery {
+using namespace osquery;
 
 class ExampleTable : public tables::TablePlugin {
  private:
@@ -31,9 +31,16 @@ class ExampleTable : public tables::TablePlugin {
 };
 
 REGISTER(ExampleTable, "table", "example");
-}
 
 int main(int argc, char* argv[]) {
-  // Do some broadcast of the registry.
-  auto example = std::make_shared<osquery::ExampleTable>();
+  initOsquery(argc, argv, OSQUERY_EXTENSION);
+
+  auto status = startExtension("example", "0.0.1");
+  if (!status.ok()) {
+    LOG(ERROR) << status.getMessage();
+  }
+
+  // Finally shutdown.
+  shutdownOsquery();
+  return 0;
 }

--- a/osquery/filesystem/darwin/plist_tests.cpp
+++ b/osquery/filesystem/darwin/plist_tests.cpp
@@ -79,11 +79,9 @@ TEST_F(PlistTests, test_parse_plist_array) {
 
 TEST_F(PlistTests, test_parse_plist_content_with_blobs) {
   pt::ptree tree;
-  fs::path bin_path(argv0);
+  fs::path test_root(kTestDataPath);
 
-  auto s = parsePlist((bin_path.parent_path() /
-                       "../../../../tools/tests/test_binary.plist").string(),
-                      tree);
+  auto s = parsePlist((test_root / "test_binary.plist").string(), tree);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_THROW(tree.get<bool>("foobar"), pt::ptree_bad_path);

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -15,4 +15,5 @@
 namespace osquery {
 
 const std::string kVersion = OSQUERY_VERSION;
+const std::string kSDKVersion = OSQUERY_SDK_VERSION;
 }

--- a/osquery/sql/sql_tests.cpp
+++ b/osquery/sql/sql_tests.cpp
@@ -20,17 +20,25 @@ namespace osquery {
 class SQLTests : public testing::Test {};
 
 TEST_F(SQLTests, test_simple_query_execution) {
+// Access to the internal SQL implementation is only available in core.
+#ifndef OSQUERY_BUILD_SDK
   auto sql = SQL("SELECT * FROM time");
   EXPECT_TRUE(sql.ok());
   EXPECT_EQ(sql.rows().size(), 1);
+#endif
 }
 
 TEST_F(SQLTests, test_get_tables) {
+// Access to the internal SQL implementation is only available in core.
+#ifndef OSQUERY_BUILD_SDK
   auto tables = SQL::getTableNames();
   EXPECT_TRUE(tables.size() > 0);
+#endif
 }
 
 TEST_F(SQLTests, test_raw_access) {
+  // Access to the table plugins (no SQL parsing required) works in both
+  // extensions and core, though with limitations on available tables.
   auto results = SQL::selectAllFrom("time");
   EXPECT_EQ(results.size(), 1);
 }

--- a/osquery/tables/specs/x/file.table
+++ b/osquery/tables/specs/x/file.table
@@ -21,4 +21,5 @@ schema([
     Column("is_char", INTEGER, "1 if a character special device else 0"),
     Column("is_block", INTEGER, "1 if a block special device else 0"),
 ])
+attributes(utility=True)
 implementation("utility/file@genFile")

--- a/osquery/tables/specs/x/hash.table
+++ b/osquery/tables/specs/x/hash.table
@@ -7,4 +7,5 @@ schema([
     Column("sha1", TEXT, "SHA1 hash of provided filesystem data"),
     Column("sha256", TEXT, "SHA256 hash of provided filesystem data"),
 ])
+attributes(utility=True)
 implementation("utility/hash@genHash")

--- a/osquery/tables/specs/x/osquery_extensions.table
+++ b/osquery/tables/specs/x/osquery_extensions.table
@@ -7,4 +7,5 @@ schema([
     Column("sdk_version", TEXT),
     Column("socket", TEXT),
 ])
+attributes(utility=True)
 implementation("osquery@genOsqueryExtensions")

--- a/osquery/tables/specs/x/osquery_flags.table
+++ b/osquery/tables/specs/x/osquery_flags.table
@@ -8,4 +8,5 @@ schema([
     Column("value", TEXT),
     Column("shell_only", INTEGER),
 ])
+attributes(utility=True)
 implementation("osquery@genOsqueryFlags")

--- a/osquery/tables/specs/x/osquery_info.table
+++ b/osquery/tables/specs/x/osquery_info.table
@@ -7,4 +7,5 @@ schema([
     Column("pid", INTEGER, "Process (or thread) ID"),
     Column("extensions", TEXT),
 ])
+attributes(utility=True)
 implementation("osquery@genOsqueryInfo")

--- a/osquery/tables/specs/x/time.table
+++ b/osquery/tables/specs/x/time.table
@@ -5,4 +5,5 @@ schema([
     Column("minutes", INTEGER),
     Column("seconds", INTEGER),
 ])
+attributes(utility=True)
 implementation("time@genTime")

--- a/osquery/tables/templates/default.cpp.in
+++ b/osquery/tables/templates/default.cpp.in
@@ -48,7 +48,11 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
   }
 };
 
+{% if attributes.utility %}
+REGISTER_INTERNAL({{table_name_cc}}TablePlugin, "table", "{{table_name}}");
+{% else %}
 REGISTER({{table_name_cc}}TablePlugin, "table", "{{table_name}}");
+{% endif %}
 /// END[GENTABLE]
 
 }}

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -150,6 +150,7 @@ class TableState(Singleton):
             impl=self.impl,
             function=self.function,
             class_name=self.class_name,
+            attributes=self.attributes,
         )
 
         # Check for reserved column names


### PR DESCRIPTION
Many things extensions-related.

An extension is made with the `sdk` make target. By default the example_extension is built that registers an example table. Running example_extension will check for an active osquery process, attempt to register, and on success enter a Thrift blocking server join. It will not end until the osquery core process is shutdown or something interrupts the process.

There's one removed unit test that only existed because extensions would broadcast the duplicate "utility" tables includes in libosquery. We've added a "internal" flag to registry items (plugins), which are not broadcasted. The "utility" tables are marked as such and the table generation code flags these tables as internal registry items.

There are a couple final SQL implementation abstractions brought into the Thrift API since extensions do NOT have access to SQLite.