### PR TITLE
add version of osquery to sync tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PLATFORM := $(shell uname -s)
+VERSION := $(shell git describe --tags HEAD --always)
 MAKE = make
 ifeq ($(PLATFORM),Darwin)
 	BUILD_DIR=darwin
@@ -86,8 +87,8 @@ sync:
 	python tools/codegen/gentargets.py -i $(SYNC_DIR)/code-analysis/compile_commands.json > $(SYNC_DIR)/osquery/TARGETS
 	@
 	@# wrap it up in a tarball
-	cd $(SYNC_DIR) && tar -zcf osquery-sync.tar.gz osquery
-	@echo "The output file is located at $(SYNC_DIR)/osquery-sync.tar.gz"
+	cd $(SYNC_DIR) && tar -zcf osquery-sync-$(VERSION).tar.gz osquery
+	@echo "The output file is located at $(SYNC_DIR)/osquery-sync-$(VERSION).tar.gz"
 
 %::
 	cd build/$(BUILD_DIR) && cmake ../.. && $(MAKE) --no-print-directory $@


### PR DESCRIPTION
```
[root@localhost vagrant]# make sync
mkdir -p build/sync
rm -rf build/sync/osquery*
cp -R osquery build/sync
cp -R include/osquery build/sync
cp -R build/centos6/sdk/generated/ build/sync/osquery
cp osquery.thrift build/sync/osquery/extensions
find build/sync -type f -name "CMakeLists.txt" -exec rm -f {} \;
mkdir -p build/sync/code-analysis
cd build/sync/code-analysis && SDK=True cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../../
CMake Warning at CMakeLists.txt:95 (message):
  Requested dependencies may have changed, run: make deps

-- Building for CentOS
-- Found components for DL
-- Found readline library
-- Looking for include files libunwind.h, unwind.h
-- Looking for include files libunwind.h, unwind.h - not found
-- Found RocksDB
-- Thrift version 0.9.1
-- Found library dependency /usr/lib/x86_64-linux-gnu/libboost_thread.a
-- Found library dependency /usr/lib/x86_64-linux-gnu/librt.a
-- Found library dependency /usr/lib/x86_64-linux-gnu/libboost_system.a
-- Found library dependency /usr/lib/x86_64-linux-gnu/libboost_filesystem.a
-- Configuring done
-- Generating done
-- Build files have been written to: /vagrant/build/sync/code-analysis
SDK=True
python tools/codegen/gentargets.py -i build/sync/code-analysis/compile_commands.json > build/sync/osquery/TARGETS
cd build/sync && tar -zcf osquery-sync-1.4.1-29-g472c605.tar.gz osquery
The output file is located at build/sync/osquery-sync-1.4.1-29-g472c605.tar.gz
```