### PR TITLE
Extensions helpers, API additions

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -226,6 +226,23 @@ class RegistryHelperCore {
   /// Allow the registry to introspect into the registered name (for logging).
   void setName(const std::string& name);
 
+  /// Allow others to introspect into the registered name (for reporting).
+  const std::string& getName() const { return name_; }
+
+  /// Check if a given plugin name is considered internal.
+  bool isInternal(const std::string& item_name) const;
+
+  /// Allow others to introspect into the routes from extensions.
+  const std::map<std::string, RouteUUID>& getExternal() const {
+    return external_;
+  }
+
+  /// Set an 'active' plugin to receive registry calls when no item name given.
+  Status setActive(const std::string& item_name);
+
+  /// Get the 'active' plugin, return success with the active plugin name.
+  Status getActive() const;
+
  protected:
   /// The identifier for this registry, used to register items.
   std::string name_;
@@ -244,6 +261,9 @@ class RegistryHelperCore {
   std::map<std::string, PluginResponse> routes_;
   /// Keep a lookup of registry items that are blacklisted from broadcast.
   std::vector<std::string> internal_;
+  /// Support an 'active' mode where calls without a specific item name will
+  /// be directed to the 'active' plugin.
+  std::string active_;
 };
 
 /**
@@ -497,6 +517,19 @@ class RegistryFactory : private boost::noncopyable {
                      const std::string& item_name,
                      const PluginRequest& request);
 
+  /// A helper call that uses the active plugin (if the registry has one).
+  static Status call(const std::string& registry_name,
+                     const PluginRequest& request,
+                     PluginResponse& response);
+
+  /// A helper call that uses the active plugin (if the registry has one).
+  static Status call(const std::string& registry_name,
+                     const PluginRequest& request);
+
+  /// Set a registry's active plugin.
+  static Status setActive(const std::string& registry_name,
+                          const std::string& item_name);
+
   /// Run `setUp` on every registry that is not marked 'lazy'.
   static void setUp();
 
@@ -504,6 +537,9 @@ class RegistryFactory : private boost::noncopyable {
   static bool exists(const std::string& registry_name,
                      const std::string& item_name,
                      bool local = false);
+
+  /// Get a list of the registry names.
+  static std::vector<std::string> names();
 
   /// Get a list of the registry item names for a given registry.
   static std::vector<std::string> names(const std::string& registry_name);

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -34,8 +34,8 @@ int Flag::create(const std::string& name, const FlagDetail& flag) {
   return 0;
 }
 
-int Flag::createAlias(const std::string& alias, const std::string& name) {
-  instance().aliases_.insert(std::make_pair(alias, name));
+int Flag::createAlias(const std::string& alias, const FlagAliasDetail& flag) {
+  instance().aliases_.insert(std::make_pair(alias, flag));
   return 0;
 }
 
@@ -70,6 +70,17 @@ std::string Flag::getType(const std::string& name) {
     return "";
   }
   return info.type;
+}
+
+std::string Flag::getDescription(const std::string& name) {
+  if (instance().flags_.count(name)) {
+    return instance().flags_.at(name).description;
+  }
+
+  if (instance().aliases_.count(name)) {
+    return getDescription(instance().aliases_.at(name).name);
+  }
+  return "";
 }
 
 Status Flag::updateValue(const std::string& name, const std::string& value) {
@@ -110,19 +121,24 @@ void Flag::printFlags(bool shell, bool external) {
   }
   max += 7;
 
+  auto& aliases = instance().aliases_;
   auto& details = instance().flags_;
   for (const auto& flag : info) {
-    if (details.count(flag.name) == 0) {
-      // This flag was not defined within osquery code, skip.
-      continue;
-    }
-
-    const auto& detail = details.at(flag.name);
-    if ((shell && !detail.shell) || (!shell && detail.shell)) {
-      continue;
-    }
-
-    if ((external && !detail.external) || (!external && detail.external)) {
+    if (details.count(flag.name) > 0) {
+      const auto& detail = details.at(flag.name);
+      if ((shell && !detail.shell) || (!shell && detail.shell) ||
+          (external && !detail.external) || (!external && detail.external)) {
+        continue;
+      }
+    } else if (aliases.count(flag.name) > 0) {
+      const auto& alias = aliases.at(flag.name);
+      // Aliases are only printed if this is an external tool and the alias
+      // is external.
+      if (!alias.external || !external) {
+        continue;
+      }
+    } else {
+      // This flag was not defined as an osquery flag or flag alias.
       continue;
     }
 
@@ -135,7 +151,7 @@ void Flag::printFlags(bool shell, bool external) {
     }
 
     fprintf(stdout, "%s", std::string(pad - flag.name.size(), ' ').c_str());
-    fprintf(stdout, "%s\n", detail.description.c_str());
+    fprintf(stdout, "%s\n", getDescription(flag.name).c_str());
   }
 }
 }

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -46,10 +46,19 @@ void printUsage(const std::string& binary, int tool) {
   } else {
     fprintf(stdout, "Usage: %s [OPTION]...\n\n", binary.c_str());
   }
-  fprintf(stdout, "The following options control osquery.\n\n");
 
-  // Print only the core/internal flags.
-  Flag::printFlags();
+  fprintf(stdout, "The following options control osquery");
+  if (tool == OSQUERY_EXTENSION) {
+    fprintf(stdout, " extensions");
+  }
+  fprintf(stdout, ".\n\n");
+
+  // Print only the core/internal or extension flags.
+  if (tool == OSQUERY_EXTENSION) {
+    Flag::printFlags(false, true);
+  } else {
+    Flag::printFlags();
+  }
 
   if (tool == OSQUERY_TOOL_SHELL) {
     // Print shell flags.

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -31,6 +31,10 @@ FLAG(string,
      "/var/osquery/osquery.em",
      "Path to the extensions UNIX domain socket")
 
+/// Alias the extensions_socket (used by core) to an alternate name reserved
+/// for extension binaries
+EXTENSION_FLAG_ALIAS(std::string, socket, extensions_socket);
+
 void ExtensionWatcher::enter() {
   // Watch the manager, if the socket is removed then the extension will die.
   while (true) {

--- a/osquery/tables/specs/x/osquery_registry.table
+++ b/osquery/tables/specs/x/osquery_registry.table
@@ -1,0 +1,11 @@
+table_name("osquery_registry")
+description("List the osquery registry plugins.")
+schema([
+    Column("registry", TEXT, "Name of the osquery registry"),
+    Column("name", TEXT, "Name of the plugin item"),
+    Column("owner_uuid", INTEGER, "Extension route UUID (0 for core)"),
+    Column("internal", INTEGER, "1 if the plugin is internal else 0"),
+    Column("active", INTEGER, "1 if this plugin is active else 0"),
+])
+attributes(utility=True)
+implementation("osquery@genOsqueryRegistry")


### PR DESCRIPTION
#797 Use --socket for extensions, limit help
#796 Add an 'active' concept to registries, support a blank item call
#798 Add osquery_registry to list the internal/external plugin details