### PR TITLE
Ability to configure osquery from multiple files

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -14,10 +14,15 @@
 #include <memory>
 #include <vector>
 
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 #include <osquery/flags.h>
 #include <osquery/registry.h>
 #include <osquery/scheduler.h>
 #include <osquery/status.h>
+
+namespace pt = boost::property_tree;
 
 namespace osquery {
 
@@ -35,6 +40,7 @@ struct OsqueryConfig {
   std::vector<OsqueryScheduledQuery> scheduledQueries;
   std::map<std::string, std::string> options;
   std::map<std::string, std::vector<std::string> > eventFiles;
+  pt::ptree all_data;
 };
 
 /**
@@ -106,6 +112,15 @@ class Config {
    * @return A map all the files in the JSON blob organized by category
    */
   static std::map<std::string, std::vector<std::string> >& getWatchedFiles();
+
+  /**
+   * @brief Return the configuration ptree
+   *
+   *
+   *
+   * @return Returns the unparsed, ptree representation of the given config
+   */
+  static pt::ptree& getEntireConfiguration();
 
   /**
    * @brief Calculate the has of the osquery config

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -111,7 +111,7 @@ class Config {
    *
    * @return A map all the files in the JSON blob organized by category
    */
-  static std::map<std::string, std::vector<std::string> >& getWatchedFiles();
+  static std::map<std::string, std::vector<std::string> > getWatchedFiles();
 
   /**
    * @brief Return the configuration ptree
@@ -120,7 +120,7 @@ class Config {
    *
    * @return Returns the unparsed, ptree representation of the given config
    */
-  static pt::ptree& getEntireConfiguration();
+  static pt::ptree getEntireConfiguration();
 
   /**
    * @brief Calculate the has of the osquery config
@@ -239,7 +239,7 @@ class ConfigPlugin : public Plugin {
    * indicates that config retrieval was successful, then the config data
    * should be returned in pair.second.
    */
-  virtual Status genConfig(std::map<std::string, std::string>&) = 0;
+  virtual Status genConfig(std::map<std::string, std::string>& config) = 0;
   Status call(const PluginRequest& request, PluginResponse& response);
 };
 

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -187,7 +187,7 @@ class Config {
    * @return an instance of osquery::Status, indicating the success or failure
    * of the operation.
    */
-  static osquery::Status genConfig(std::string& conf);
+  static osquery::Status genConfig(std::vector<std::string>& conf);
 
   /// Prevent ConfigPlugins from implementing setUp.
   osquery::Status setUp() { return Status(0, "Not used"); }
@@ -239,7 +239,7 @@ class ConfigPlugin : public Plugin {
    * indicates that config retrieval was successful, then the config data
    * should be returned in pair.second.
    */
-  virtual std::pair<osquery::Status, std::string> genConfig() = 0;
+  virtual Status genConfig(std::map<std::string, std::string>&) = 0;
   Status call(const PluginRequest& request, PluginResponse& response);
 };
 

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -94,7 +94,8 @@ Status pathExists(const boost::filesystem::path& path);
  * of the operation.
  */
 Status listFilesInDirectory(const boost::filesystem::path& path,
-                            std::vector<std::string>& results);
+                            std::vector<std::string>& results,
+                            bool ignore_error = 0);
 
 /**
  * @brief List all of the directories in a specific directory, non-recursively.
@@ -108,7 +109,8 @@ Status listFilesInDirectory(const boost::filesystem::path& path,
  * of the operation.
  */
 Status listDirectoriesInDirectory(const boost::filesystem::path& path,
-                                  std::vector<std::string>& results);
+                                  std::vector<std::string>& results,
+                                  bool ignore_error = 0);
 
 /**
  * @brief Given a wildcard filesystem patten, resolve all possible paths

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -95,7 +95,7 @@ Status pathExists(const boost::filesystem::path& path);
  */
 Status listFilesInDirectory(const boost::filesystem::path& path,
                             std::vector<std::string>& results,
-                            bool ignore_error = 0);
+                            bool ignore_error = 1);
 
 /**
  * @brief List all of the directories in a specific directory, non-recursively.
@@ -110,7 +110,7 @@ Status listFilesInDirectory(const boost::filesystem::path& path,
  */
 Status listDirectoriesInDirectory(const boost::filesystem::path& path,
                                   std::vector<std::string>& results,
-                                  bool ignore_error = 0);
+                                  bool ignore_error = 1);
 
 /**
  * @brief Given a wildcard filesystem patten, resolve all possible paths

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -11,8 +11,6 @@
 #include <mutex>
 #include <sstream>
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
 #include <osquery/config.h>
@@ -88,6 +86,7 @@ Status Config::genConfig(OsqueryConfig& conf) {
   try {
     json << config_string;
     pt::read_json(json, tree);
+    conf.all_data = tree;
     // Parse each scheduled query from the config.
     for (const pt::ptree::value_type& v : tree.get_child("scheduledQueries")) {
       osquery::OsqueryScheduledQuery q;
@@ -135,6 +134,11 @@ std::vector<OsqueryScheduledQuery> Config::getScheduledQueries() {
 std::map<std::string, std::vector<std::string> >& Config::getWatchedFiles() {
   boost::shared_lock<boost::shared_mutex> lock(rw_lock);
   return getInstance().cfg_.eventFiles;
+}
+
+pt::ptree& Config::getEntireConfiguration() {
+  boost::shared_lock<boost::shared_mutex> lock(rw_lock);
+  return getInstance().cfg_.all_data;
 }
 
 Status Config::getMD5(std::string& hash_string) {

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -71,10 +71,10 @@ Status Config::genConfig(std::vector<std::string>& conf) {
     return status;
   }
 
-  for (std::map<std::string, std::string>::iterator it = response[0].begin();
-       it != response[0].end();
-       ++it) {
-    conf.push_back(it->second);
+  if (response.size() > 0) {
+    for (const auto& it : response[0]) {
+      conf.push_back(it.second);
+    }
   }
   return Status(0, "OK");
 }
@@ -151,12 +151,12 @@ std::vector<OsqueryScheduledQuery> Config::getScheduledQueries() {
   return getInstance().cfg_.scheduledQueries;
 }
 
-std::map<std::string, std::vector<std::string> >& Config::getWatchedFiles() {
+std::map<std::string, std::vector<std::string> > Config::getWatchedFiles() {
   boost::shared_lock<boost::shared_mutex> lock(rw_lock);
   return getInstance().cfg_.eventFiles;
 }
 
-pt::ptree& Config::getEntireConfiguration() {
+pt::ptree Config::getEntireConfiguration() {
   boost::shared_lock<boost::shared_mutex> lock(rw_lock);
   return getInstance().cfg_.all_data;
 }
@@ -168,7 +168,7 @@ Status Config::getMD5(std::string& hash_string) {
   hash_string = osquery::hashFromBuffer(
       HASH_TYPE_MD5, (void*)out.str().c_str(), out.str().length());
 
-  return Status(1, "NI");
+  return Status(0, "OK");
 }
 
 Status Config::checkConfig() {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -66,7 +66,7 @@ TEST_F(ConfigTests, test_plugin) {
 
 TEST_F(ConfigTests, test_queries_execute) {
   auto queries = Config::getInstance().getScheduledQueries();
-  EXPECT_EQ(queries.size(), 1);
+  EXPECT_EQ(queries.size(), 2);
 }
 
 TEST_F(ConfigTests, test_threatfiles_execute) {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -22,12 +22,15 @@ namespace osquery {
 
 // The config_path flag is defined in the filesystem config plugin.
 DECLARE_string(config_path);
+// The config_extra_files flag is defined in the filesystem config plugin.
+DECLARE_string(config_extra_files);
 
 class ConfigTests : public testing::Test {
  public:
   ConfigTests() {
     FLAGS_config_plugin = "filesystem";
     FLAGS_config_path = kTestDataPath + "test.config";
+    FLAGS_config_extra_files = kTestDataPath + "/notreal/";
   }
 
  protected:

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -46,8 +46,7 @@ class TestConfigPlugin : public ConfigPlugin {
  public:
   TestConfigPlugin() {}
   Status genConfig(std::map<std::string, std::string>& config) {
-    std::vector<std::string> test;
-    test.push_back("foobar");
+    config["data"] = "foobar";
     return Status(0, "OK");
     ;
   }
@@ -62,8 +61,7 @@ TEST_F(ConfigTests, test_plugin) {
 
   EXPECT_EQ(status.ok(), true);
   EXPECT_EQ(status.toString(), "OK");
-  // std::vector<std::string> result = response[0].at("data");
-  // EXPECT_EQ(response[0].at("data").at(0), "foobar");
+  EXPECT_EQ(response[0].at("data"), "foobar");
 }
 
 TEST_F(ConfigTests, test_queries_execute) {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -44,9 +45,11 @@ class ConfigTests : public testing::Test {
 class TestConfigPlugin : public ConfigPlugin {
  public:
   TestConfigPlugin() {}
-
-  std::pair<Status, std::string> genConfig() {
-    return std::make_pair(Status(0, "OK"), "foobar");
+  Status genConfig(std::map<std::string, std::string>& config) {
+    std::vector<std::string> test;
+    test.push_back("foobar");
+    return Status(0, "OK");
+    ;
   }
 };
 
@@ -59,7 +62,8 @@ TEST_F(ConfigTests, test_plugin) {
 
   EXPECT_EQ(status.ok(), true);
   EXPECT_EQ(status.toString(), "OK");
-  EXPECT_EQ(response[0].at("data"), "foobar");
+  // std::vector<std::string> result = response[0].at("data");
+  // EXPECT_EQ(response[0].at("data").at(0), "foobar");
 }
 
 TEST_F(ConfigTests, test_queries_execute) {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -22,15 +22,12 @@ namespace osquery {
 
 // The config_path flag is defined in the filesystem config plugin.
 DECLARE_string(config_path);
-// The config_extra_files flag is defined in the filesystem config plugin.
-DECLARE_string(config_extra_files);
 
 class ConfigTests : public testing::Test {
  public:
   ConfigTests() {
     FLAGS_config_plugin = "filesystem";
     FLAGS_config_path = kTestDataPath + "test.config";
-    FLAGS_config_extra_files = kTestDataPath + "/notreal/";
   }
 
  protected:

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -27,10 +27,6 @@ using osquery::Status;
 namespace osquery {
 
 FLAG(string, config_path, "/var/osquery/osquery.conf", "Path to config file");
-FLAG(string,
-     config_extra_files,
-     "/var/osquery/osquery.conf.d/%.conf",
-     "Path to extra config files");
 
 class FilesystemConfigPlugin : public ConfigPlugin {
  public:
@@ -45,7 +41,7 @@ std::pair<osquery::Status, std::string> FilesystemConfigPlugin::genConfig() {
     return std::make_pair(Status(1, "config file does not exist"), "");
   }
   std::vector<std::string> conf_files;
-  Status stat = resolveFilePattern(FLAGS_config_extra_files, conf_files);
+  Status stat = resolveFilePattern(FLAGS_config_path + ".d/%.conf", conf_files);
   if (!stat.ok()) {
     VLOG(1) << "Error is resolving extra configuration files: "
             << stat.getMessage();

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -9,19 +9,28 @@
  */
 
 #include <fstream>
+#include <iostream>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #include <osquery/config.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
+#include <osquery/filesystem.h>
 
 namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
 using osquery::Status;
 
 namespace osquery {
 
 FLAG(string, config_path, "/var/osquery/osquery.conf", "Path to config file");
+FLAG(string,
+     config_extra_files,
+     "/var/osquery/osquery.conf.d/%.conf",
+     "Path to extra config files");
 
 class FilesystemConfigPlugin : public ConfigPlugin {
  public:
@@ -32,19 +41,40 @@ REGISTER(FilesystemConfigPlugin, "config", "filesystem");
 
 std::pair<osquery::Status, std::string> FilesystemConfigPlugin::genConfig() {
   std::string config;
-  if (!fs::exists(FLAGS_config_path)) {
-    return std::make_pair(Status(1, "config file does not exist"), config);
+  std::vector<std::string> conf_files;
+  Status stat = resolveFilePattern(FLAGS_config_extra_files, conf_files);
+  if (!stat.ok()) {
+    VLOG(1) << "Error is resolving extra configuration files: "
+            << stat.getMessage();
   }
+  VLOG(1) << "Finished resolving, merging " << conf_files.size()
+          << " additional JSONs";
 
-  VLOG(1) << "Filesystem ConfigPlugin reading: " << FLAGS_config_path;
-  std::ifstream config_stream(FLAGS_config_path);
+  conf_files.push_back(FLAGS_config_path);
 
-  config_stream.seekg(0, std::ios::end);
-  config.reserve(config_stream.tellg());
-  config_stream.seekg(0, std::ios::beg);
+  pt::ptree merged;
 
-  config.assign((std::istreambuf_iterator<char>(config_stream)),
-                std::istreambuf_iterator<char>());
-  return std::make_pair(Status(0, "OK"), config);
+  for (const auto& conf_file : conf_files) {
+    VLOG(1) << "Filesystem ConfigPlugin reading: " << conf_file;
+    std::ifstream config_stream(conf_file);
+
+    config_stream.seekg(0, std::ios::end);
+    config.reserve(config_stream.tellg());
+    config_stream.seekg(0, std::ios::beg);
+
+    config.assign((std::istreambuf_iterator<char>(config_stream)),
+                  std::istreambuf_iterator<char>());
+
+    std::stringstream json(config);
+    pt::ptree tree;
+    pt::read_json(json, tree);
+
+    for (const auto& elem : tree) {
+      merged.push_back(elem);
+    }
+  }
+  std::stringstream complete;
+  write_json(complete, merged);
+  return std::make_pair(Status(0, "OK"), complete.str());
 }
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -287,9 +287,9 @@ Status resolveLastPathComponent(const boost::filesystem::path& fs_path,
 
   std::vector<std::string> files;
   std::vector<std::string> folders;
-  Status stat_file = listFilesInDirectory(fs_path.parent_path(), files, 1);
+  Status stat_file = listFilesInDirectory(fs_path.parent_path(), files);
   Status stat_fold =
-      listDirectoriesInDirectory(fs_path.parent_path(), folders, 1);
+      listDirectoriesInDirectory(fs_path.parent_path(), folders);
 
   // Is the last component a wildcard?
   if (components[components.size() - 1] == kWildcardCharacter) {

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -290,14 +290,7 @@ Status resolveLastPathComponent(const boost::filesystem::path& fs_path,
   Status stat_file = listFilesInDirectory(fs_path.parent_path(), files, 1);
   Status stat_fold =
       listDirectoriesInDirectory(fs_path.parent_path(), folders, 1);
-  if (!stat_file.ok()) {
-    VLOG(1) << "FILE LIST ERROR: " << stat_file.getMessage();
-    return stat_file;
-  }
-  if (!stat_fold.ok()) {
-    VLOG(1) << "FOLD LIST ERROR: " << stat_fold.getMessage();
-    return stat_fold;
-  }
+
   // Is the last component a wildcard?
   if (components[components.size() - 1] == kWildcardCharacter) {
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -126,8 +126,9 @@ Status remove(const boost::filesystem::path& path) {
 }
 
 Status listFilesInDirectory(const boost::filesystem::path& path,
-                            std::vector<std::string>& results) {
-  try {
+                            std::vector<std::string>& results,
+                            bool ignore_error) {
+
     if (!boost::filesystem::exists(path)) {
       return Status(1, "Directory not found: " + path.string());
     }
@@ -139,20 +140,23 @@ Status listFilesInDirectory(const boost::filesystem::path& path,
     boost::filesystem::directory_iterator begin_iter(path);
     boost::filesystem::directory_iterator end_iter;
     for (; begin_iter != end_iter; begin_iter++) {
-      if (!boost::filesystem::is_directory(begin_iter->path())) {
-        results.push_back(begin_iter->path().string());
+      try {
+        if (boost::filesystem::is_regular_file(begin_iter->path())) {
+          results.push_back(begin_iter->path().string());
+        }
+      } catch (const boost::filesystem::filesystem_error& e) {
+        if (ignore_error == 0) {
+          return Status(1, e.what());
+        }
       }
     }
 
     return Status(0, "OK");
-  } catch (const boost::filesystem::filesystem_error& e) {
-    return Status(1, e.what());
-  }
 }
 
 Status listDirectoriesInDirectory(const boost::filesystem::path& path,
-                                  std::vector<std::string>& results) {
-  try {
+                                  std::vector<std::string>& results,
+                                  bool ignore_error) {
     if (!boost::filesystem::exists(path)) {
       return Status(1, "Directory not found");
     }
@@ -170,15 +174,18 @@ Status listDirectoriesInDirectory(const boost::filesystem::path& path,
     boost::filesystem::directory_iterator begin_iter(path);
     boost::filesystem::directory_iterator end_iter;
     for (; begin_iter != end_iter; begin_iter++) {
-      if (boost::filesystem::is_directory(begin_iter->path())) {
-        results.push_back(begin_iter->path().string());
+      try {
+        if (boost::filesystem::is_directory(begin_iter->path())) {
+          results.push_back(begin_iter->path().string());
+        }
+      } catch (const boost::filesystem::filesystem_error& e) {
+        if (ignore_error == 0) {
+          return Status(1, e.what());
+        }
       }
     }
 
     return Status(0, "OK");
-  } catch (const boost::filesystem::filesystem_error& e) {
-    return Status(1, e.what());
-  }
 }
 
 /**
@@ -253,6 +260,7 @@ Status resolveLastPathComponent(const boost::filesystem::path& fs_path,
                                 ReturnSetting setting,
                                 const std::vector<std::string>& components,
                                 unsigned int rec_depth) {
+
   // Is the last component a double star?
   if (components[components.size() - 1] == kWildcardCharacterRecursive) {
     if (setting & REC_EVENT_OPT) {
@@ -279,18 +287,20 @@ Status resolveLastPathComponent(const boost::filesystem::path& fs_path,
 
   std::vector<std::string> files;
   std::vector<std::string> folders;
-  Status stat_file = listFilesInDirectory(fs_path.parent_path(), files);
-  Status stat_fold = listDirectoriesInDirectory(fs_path.parent_path(), folders);
-
+  Status stat_file = listFilesInDirectory(fs_path.parent_path(), files, 1);
+  Status stat_fold =
+      listDirectoriesInDirectory(fs_path.parent_path(), folders, 1);
   if (!stat_file.ok()) {
+    VLOG(1) << "FILE LIST ERROR: " << stat_file.getMessage();
     return stat_file;
   }
   if (!stat_fold.ok()) {
+    VLOG(1) << "FOLD LIST ERROR: " << stat_fold.getMessage();
     return stat_fold;
   }
-
   // Is the last component a wildcard?
   if (components[components.size() - 1] == kWildcardCharacter) {
+
     if (setting & REC_EVENT_OPT) {
       results.push_back(fs_path.parent_path().string());
       return Status(0, "OK");

--- a/tools/tests/test.config.d/extra_options.conf
+++ b/tools/tests/test.config.d/extra_options.conf
@@ -1,0 +1,6 @@
+{
+  "options":{
+    "optionC" : "optionc-val",
+    "optionD" : "optiond-val"
+  }
+}

--- a/tools/tests/test.config.d/osquery.conf
+++ b/tools/tests/test.config.d/osquery.conf
@@ -1,0 +1,16 @@
+{
+  "scheduledQueries": [
+    {
+      "name": "time_again",
+      "query": "select * from time;",
+      "interval": 1
+    }
+  ],
+  "options":{
+    "optionA" : "optiona-val",
+    "optionB" : "optionb-val"
+  },
+  "additional_monitoring" : {
+    "other_thing" : {"element" : "key"}
+  }
+}


### PR DESCRIPTION
This pull request will allow us to pull in multiple configuration files, merge them together, then pass that as the configuration.

I am looking for comments on how this merging should go. Should we append everything, try and remove duplicates? What do we think?

Right now, this just appends them together and relies on config to understand what to do with multiple top level entities of the same type.