### PR TITLE
Add keychain_items to include basic item details

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -17,7 +17,8 @@ if(APPLE)
     system/darwin/acpi_tables.cpp
     system/darwin/apps.cpp
     system/darwin/block_devices.cpp
-    system/darwin/certificates_utils.cpp
+    system/darwin/keychain_items.cpp
+    system/darwin/keychain_utils.cpp
     system/darwin/firewall.h
     system/darwin/firewall.cpp
     system/darwin/homebrew_packages.cpp

--- a/osquery/tables/specs/darwin/keychain_items.table
+++ b/osquery/tables/specs/darwin/keychain_items.table
@@ -1,0 +1,12 @@
+table_name("keychain_items")
+description("Generic details about keychain items")
+schema([
+    Column("label", TEXT, "Generic item name"),
+    Column("description", TEXT, "Optional item description"),
+    Column("comment", TEXT, "Optional keychain comment"),
+    Column("created", TEXT, "Data item was created"),
+    Column("modified", TEXT, "Date of last modification"),
+    Column("type", TEXT, "Keychain item type (class)"),
+    Column("path", TEXT, "Path to keychain containing item"),
+])
+implementation("keychain_items@genKeychainItems")

--- a/osquery/tables/system/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/certificates_tests.cpp
@@ -8,26 +8,16 @@
  *
  */
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <Security/Security.h>
-
 #include <gtest/gtest.h>
 
 #include <osquery/database.h>
 #include <osquery/logger.h>
 
-#include "osquery/core/conversions.h"
+#include "osquery/tables/system/darwin/keychain.h"
 #include "osquery/core/test_util.h"
 
 namespace osquery {
 namespace tables {
-
-CFDataRef CreatePropertyFromCertificate(const SecCertificateRef&,
-                                        const CFTypeRef&);
-std::string genSHA1ForCertificate(const SecCertificateRef&);
-std::string genCommonNameProperty(const CFDataRef&);
-std::string genKIDProperty(const CFDataRef&);
-std::string genCAProperty(const CFDataRef& constraints);
 
 class CACertsTests : public ::testing::Test {
  protected:

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -21,13 +21,21 @@ namespace tables {
 
 typedef std::string (*PropGenerator)(const CFDataRef&);
 
+/// A helper data structure to apply a decode generator to property.
 struct CertProperty {
+  /// Property key.
   CFTypeRef type;
+  /// Generator function.
   PropGenerator generate;
 };
 
-extern const std::map<std::string, CertProperty> kCertificateProperties;
+extern const std::vector<std::string> kSystemKeychainPaths;
+extern const std::vector<std::string> kUserKeychainPaths;
 
+void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
+std::string getKeychainPath(const SecKeychainItemRef& item);
+
+/// Certificate property parsing functions.
 std::string genKIDProperty(const CFDataRef& kid);
 std::string genCommonNameProperty(const CFDataRef& constraints);
 std::string genAlgProperty(const CFDataRef& alg);
@@ -39,6 +47,10 @@ std::string genSHA1ForCertificate(const SecCertificateRef& ca);
 CFDataRef CreatePropertyFromCertificate(const SecCertificateRef& cert,
                                         const CFTypeRef& oid);
 bool CertificateIsCA(const SecCertificateRef& cert);
+
+/// Generate a list of keychain items for a given item type.
+CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
+                               const CFTypeRef& item_type);
 
 // From SecCertificatePriv.h
 typedef uint32_t SecKeyUsage;

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+#include <osquery/tables.h>
+
+#include "osquery/tables/system/darwin/keychain.h"
+
+namespace osquery {
+namespace tables {
+
+const std::vector<CFTypeRef> kKeychainItemTypes = {
+    kSecClassGenericPassword,
+    kSecClassCertificate,
+    kSecClassKey,
+    kSecClassIdentity,
+};
+
+const std::map<SecItemAttr, std::string> kKeychainItemAttrs = {
+    {kSecLabelItemAttr, "label"},
+    {kSecDescriptionItemAttr, "description"},
+    {kSecCommentItemAttr, "comment"},
+    {kSecCreationDateItemAttr, "created"},
+    {kSecModDateItemAttr, "modified"},
+};
+
+const std::map<SecItemClass, std::string> kKeychainItemClasses = {
+    {kSecGenericPasswordItemClass, "password"},
+    {kSecCertificateItemClass, "certificate"},
+    {kSecPublicKeyItemClass, "public key"},
+    {kSecPrivateKeyItemClass, "private key"},
+    {kSecSymmetricKeyItemClass, "symmetric key"}};
+
+void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
+  Row r;
+
+  // Create an info structure with 1 tag, then iterate over setting the tag
+  // type to assure maximum compatibility with the various Keychain items.
+  SecKeychainAttributeInfo info;
+  UInt32 tags[1];
+  info.count = sizeof(tags) / sizeof(UInt32);
+  info.tag = tags;
+  info.format = nullptr;
+
+  SecItemClass item_class = 0;
+  SecKeychainAttributeList* attr_list = nullptr;
+
+  // Any tag that does not exist for the item will prevent the entire result.
+  for (const auto& attr_tag : kKeychainItemAttrs) {
+    tags[0] = attr_tag.first;
+    SecKeychainItemCopyAttributesAndData(
+        item, &info, &item_class, &attr_list, 0, nullptr);
+
+    if (attr_list != nullptr) {
+      // Expect each specific tag to return string data.
+      for (int i = 0; i < attr_list->count; ++i) {
+        SecKeychainAttribute* attr = &attr_list->attr[i];
+        if (attr->length > 0) {
+          r[attr_tag.second] = std::string((char*)attr->data, attr->length);
+        }
+      }
+      SecKeychainItemFreeAttributesAndData(attr_list, nullptr);
+      attr_list = nullptr;
+    }
+  }
+
+  // The keychain item class is obtained each time and will be consistent.
+  if (kKeychainItemClasses.count(item_class) > 0) {
+    r["type"] = kKeychainItemClasses.at(item_class);
+  }
+
+  r["path"] = getKeychainPath(item);
+  results.push_back(r);
+}
+
+QueryData genKeychainItems(QueryContext& context) {
+  QueryData results;
+
+  // Allow the caller to set an explicit certificate (keychain) search path.
+  std::set<std::string> keychain_paths;
+  if (context.constraints["path"].exists()) {
+    keychain_paths = context.constraints["path"].getAll(EQUALS);
+  } else {
+    // Otherwise limit ONLY to system keychains.
+    for (const auto& path : kSystemKeychainPaths) {
+      keychain_paths.insert(path);
+    }
+  }
+
+  for (const auto& item_type : kKeychainItemTypes) {
+    CFArrayRef items = CreateKeychainItems(keychain_paths, item_type);
+    auto count = CFArrayGetCount(items);
+    for (CFIndex i = 0; i < count; i++) {
+      genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),
+                      results);
+    }
+
+    CFRelease(items);
+  }
+
+  return results;
+}
+}
+}


### PR DESCRIPTION
The final part of #786, simple data about all keychain items for system-keychains or a keychain of your choosing via `WHERE path = '/path/to/non-system/keychain.keychain'`.