### PR TITLE
Only support autoloading modules

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -73,30 +73,15 @@ Status getExtensions(const std::string& manager_path,
 Status pingExtension(const std::string& path);
 
 /**
- * @brief Request the extensions API to autoload any appropriate extensions.
- *
- * Extensions may be 'autoloaded' using the `extensions_autoload` command line
- * argument. loadExtensions should be called before any plugin or registry item
- * is used. This allows appropriate extensions to expose plugin requirements.
- *
- * An 'appropriate' extension is one within the `extensions_autoload` search
- * path with file ownership equivilent or greater (root) than the osquery
- * process requesting autoload.
- */
-void loadExtensions();
-
-/**
- * @brief Load extensions from a delimited search path string.
- *
- * @param paths A colon-delimited path variable, e.g: '/path1:/path2'.
- */
-Status loadExtensions(const std::string& paths);
-
-/**
  * @brief Request the extensions API to autoload any appropriate modules.
  *
- * Extension modules are shared libraries that add Plugins to the osquery
- * core's registry at runtime.
+ * Modules may be 'autoloaded' using the `modules_autoload` command line
+ * argument. loadModules should be called before any plugin or registry item
+ * is used. This allows appropriate modules to expose plugin requirements.
+ *
+ * An 'appropriate' module is one within the `modules_autoload` search
+ * path with file ownership equivilent or greater (root) than the osquery
+ * process requesting autoload.
  */
 void loadModules();
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -40,11 +40,6 @@ CLI_FLAG(string,
          "Path to the extensions UNIX domain socket")
 
 CLI_FLAG(string,
-         extensions_autoload,
-         "",
-         "An optional search path for autoloaded & managed extensions")
-
-CLI_FLAG(string,
          modules_autoload,
          "/usr/lib/osquery/modules",
          "Search path for autoloaded registry modules")
@@ -106,24 +101,11 @@ void ExtensionManagerWatcher::watch() {
   }
 }
 
-void loadExtensions() {
-  // Optionally autoload extensions
-  auto status = loadExtensions(FLAGS_extensions_autoload);
-  if (!status.ok()) {
-    LOG(WARNING) << "Could not autoload extensions: " << status.what();
-  }
-}
-
 void loadModules() {
   auto status = loadModules(FLAGS_modules_autoload);
   if (!status.ok()) {
     LOG(WARNING) << "Modules autoload contains invalid paths";
   }
-}
-
-Status loadExtensions(const std::string& paths) {
-  // Not implemented: Autoloading extensions given a search path.
-  return Status(0, "OK");
 }
 
 Status loadModulesFromDirectory(const std::string& dir) {


### PR DESCRIPTION
The current thought in #814, it to only support autoloading modules. Keep extensions as separate add-ons.