### PR TITLE
Use a .load file instead of delimited dirs

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -95,7 +95,7 @@ void loadExtensions();
  *
  * @param paths A colon-delimited path variable, e.g: '/path1:/path2'.
  */
-Status loadExtensions(const std::string& paths);
+Status loadExtensions(const std::string& loadfile);
 
 /**
  * @brief Request the extensions API to autoload any appropriate modules.
@@ -110,10 +110,10 @@ void loadModules();
  *
  * @param paths A colon-delimited path variable, e.g: '/path1:/path2'.
  */
-Status loadModules(const std::string& paths);
+Status loadModules(const std::string& loadfile);
 
 /// Load all modules in a direcotry.
-Status loadModulesFromDirectory(const std::string& dir);
+Status loadModuleFile(const std::string& path);
 
 /**
  * @brief Call a Plugin exposed by an Extension Registry route.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -187,11 +187,7 @@ void Initializer::initDaemon() {
 
 void Initializer::initWatcher() {
   // The watcher takes a list of paths to autoload extensions from.
-  auto autoload_paths = osquery::split(FLAGS_extensions_autoload, ":");
-  for (auto& path : autoload_paths) {
-    boost::trim(path);
-    Watcher::addExtensionPath(path);
-  }
+  loadExtensions();
 
   // Add a watcher service thread to start/watch an optional worker and set
   // of optional extensions in the autoload paths.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -133,28 +133,20 @@ void Watcher::reset(pid_t child) {
 
 void Watcher::addExtensionPath(const std::string& path) {
   // Resolve acceptable extension binaries from autoload paths.
-  if (!isDirectory(path).ok()) {
-    VLOG(1) << "Cannot autoload extensions from non-directory: " << path;
+  if (isDirectory(path).ok()) {
+    VLOG(1) << "Cannot autoload extension from directory: " << path;
     return;
   }
 
-  // Get all potentially-safe/appropriate extension binaries in path.
-  std::vector<std::string> extensions;
-  if (!listFilesInDirectory(path, extensions).ok()) {
-    VLOG(1) << "Cannot autoload extensions from: " << path;
-    return;
-  }
-
-  for (const auto& extension : extensions) {
-    // Only autoload extensions which were safe at the time of discovery.
-    // If the extension binary later becomes unsafe (permissions change) then
-    // it will fail to reload if a reload is ever needed.
-    if (safePermissions(path, extension, true)) {
-      if (fs::path(extension).extension().string() == kExtensionExtension) {
-        setExtension(extension, 0);
-        resetExtensionCounters(extension, 0);
-        VLOG(1) << "Found autoloadable extension: " << extension;
-      }
+  // Only autoload extensions which were safe at the time of discovery.
+  // If the extension binary later becomes unsafe (permissions change) then
+  // it will fail to reload if a reload is ever needed.
+  fs::path extension(path);
+  if (safePermissions(extension.parent_path().string(), path, true)) {
+    if (extension.extension().string() == kExtensionExtension) {
+      setExtension(extension.string(), 0);
+      resetExtensionCounters(extension.string(), 0);
+      VLOG(1) << "Found autoloadable extension: " << extension.string();
     }
   }
 }

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -280,6 +280,19 @@ class ProcessGenerator(object):
                     pass
 
 
+class Autoloader(object):
+    '''Helper class to write a module or extension autoload file.'''
+    def __init__(self, path, autoloads=[]):
+        self.path = path
+        with open(path, "w") as fh:
+            fh.write("\n".join(autoloads))
+
+    def __del__(self):
+        try:
+            os.unlink(self.path)
+        except:
+            pass
+
 class Tester(object):
     def __init__(self):
         global ARGS, CONFIG

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -286,9 +286,11 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         extension.kill()
 
     def test_6_extensions_autoload(self):
+        loader = test_base.Autoloader("/tmp/osqueryd-temp-ext.load",
+            [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
             "disable_watchdog": True,
-            "extensions_autoload": test_base.ARGS.build + "/osquery",
+            "extensions_autoload": loader.path,
         })
         self.assertTrue(daemon.isAlive())
 
@@ -306,8 +308,10 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         daemon.kill(True)
 
     def test_7_extensions_autoload_watchdog(self):
+        loader = test_base.Autoloader("/tmp/osqueryd-temp-ext.load",
+            [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
-            "extensions_autoload": test_base.ARGS.build + "/osquery",
+            "extensions_autoload": loader.path,
         })
         self.assertTrue(daemon.isAlive())
 
@@ -325,9 +329,11 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         daemon.kill(True)
 
     def test_8_external_config(self):
+        loader = test_base.Autoloader("/tmp/osqueryd-temp-ext.load",
+            [test_base.ARGS.build + "/osquery/example_extension.ext"])
         daemon = self._run_daemon({
             "disable_watchdog": True,
-            "extensions_autoload": test_base.ARGS.build + "/osquery",
+            "extensions_autoload": loader.path,
             "config_plugin": "example",
         })
         self.assertTrue(daemon.isAlive())

--- a/tools/tests/test_modules.py
+++ b/tools/tests/test_modules.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 #from __future__ import unicode_literals
 
 import os
+import sys
 import unittest
 
 # osquery-specific testing utils
@@ -22,9 +23,11 @@ import test_base
 class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
     def setUp(self):
         self.binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
-        self.modules_path = os.path.join(test_base.ARGS.build, "osquery")
+        ext = "dylib" if sys.platform == "darwin" else "so"
+        self.modules_loader = test_base.Autoloader("/tmp/osqueryi-mod.load",
+            [test_base.ARGS.build + "/osquery/libmodexample.%s" % ext])
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
-            {"modules_autoload": self.modules_path})
+            {"modules_autoload": self.modules_loader.path})
 
     def test_1_shell_with_module(self):
         '''Test the shell loads the compiled shared library.'''
@@ -46,7 +49,7 @@ class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
         module built as part of the default SDK build.
         '''
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
-            {"modules_autoload": self.modules_path}, {"TESTFAIL1": "1"})
+            {"modules_autoload": self.modules_loader.path}, {"TESTFAIL1": "1"})
         result = self.osqueryi.run_query(
             'SELECT * from time;')
         # Make sure the environment variable did not introduce any unexpected
@@ -60,7 +63,7 @@ class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
         '''Test a failed module initialize (we interrupt the registry call).
         '''
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
-            {"modules_autoload": self.modules_path}, {"TESTFAIL2": "1"})
+            {"modules_autoload": self.modules_loader.path}, {"TESTFAIL2": "1"})
         # The environment variable should have prevented the module load.
         self.assertRaises(test_base.OsqueryException,
             self.osqueryi.run_query, 'SELECT * from example;')


### PR DESCRIPTION
Instead of using a parameter filled with delimited paths, use a .load.