### PR TITLE
Fix for centos7 targets

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -492,6 +492,7 @@ function main() {
     package readline-devel
     package procps-devel
     package rpm-devel
+    package rpm-build
     package libblkid-devel
 
     if [[ $DISTRO = "centos6" ]]; then


### PR DESCRIPTION
rpmbuild was missing in the provision script and was making centos7 targets to fail