### PR TITLE
Fix error in run when tables emit blank columns

### DIFF
--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -153,7 +153,9 @@ int queryDataCallback(void* argument, int argc, char* argv[], char* column[]) {
   QueryData* qData = (QueryData*)argument;
   Row r;
   for (int i = 0; i < argc; i++) {
-    r[column[i]] = argv[i];
+    if (column[i] != nullptr) {
+      r[column[i]] = (argv[i] != nullptr) ? argv[i] : "";
+    }
   }
   (*qData).push_back(r);
   return 0;


### PR DESCRIPTION
This check fixes a crash in the "run" testing and profiling binary when tables returns blank columns.