### PR TITLE
Nit, prefer boolean columns to not use 'is_'

### DIFF
--- a/osquery/tables/specs/linux/process_memory_map.table
+++ b/osquery/tables/specs/linux/process_memory_map.table
@@ -9,6 +9,6 @@ schema([
     Column("device", TEXT, "MA:MI Major/minor device ID"),
     Column("inode", INTEGER, "Mapped path inode, 0 means uninitialized (BSS)"),
     Column("path", TEXT, "Path to mapped file or mapped type"),
-    Column("is_pseudo", INTEGER, "1 if path is a pseudo path, else 0"),
+    Column("pseudo", INTEGER, "1 if path is a pseudo path, else 0"),
 ])
 implementation("processes@genProcessMemoryMap")

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -128,7 +128,7 @@ void genProcessMap(const proc_t* proc_info, QueryData& results) {
     }
 
     // BSS with name in pathname.
-    r["is_pseudo"] = (fields[4] == "0" && r["path"].size() > 0) ? "1" : "0";
+    r["pseudo"] = (fields[4] == "0" && r["path"].size() > 0) ? "1" : "0";
     results.push_back(r);
   }
 }


### PR DESCRIPTION
Save for 'file', it's nicer to remove 'is_' for boolean fields. When selecting you would write "SELECT * FROM xyz WHERE condition is expression", not "true condition is true".