### PR TITLE
[Fix #877] Removing an extra escape

### DIFF
--- a/osquery/database/query.cpp
+++ b/osquery/database/query.cpp
@@ -101,15 +101,11 @@ osquery::Status Query::addNewResults(const osquery::QueryData& qd,
     return hqr_status;
   }
 
-  QueryData escaped_qd;
-  // remove all non-ascii characters from the string
-  escapeQueryData(qd, escaped_qd);
-
   if (calculate_diff) {
-    dr = diff(hQR.mostRecentResults.second, escaped_qd);
+    dr = diff(hQR.mostRecentResults.second, qd);
   }
   hQR.mostRecentResults.first = unix_time;
-  hQR.mostRecentResults.second = escaped_qd;
+  hQR.mostRecentResults.second = qd;
   std::string json;
   auto serialize_status = serializeHistoricalQueryResultsJSON(hQR, json);
   if (!serialize_status.ok()) {

--- a/osquery/database/query.cpp
+++ b/osquery/database/query.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -101,11 +101,15 @@ osquery::Status Query::addNewResults(const osquery::QueryData& qd,
     return hqr_status;
   }
 
+  QueryData escaped_qd;
+  // remove all non-ascii characters from the string
+  escapeQueryData(qd, escaped_qd);
+
   if (calculate_diff) {
-    dr = diff(hQR.mostRecentResults.second, qd);
+    dr = diff(hQR.mostRecentResults.second, escaped_qd);
   }
   hQR.mostRecentResults.first = unix_time;
-  hQR.mostRecentResults.second = qd;
+  hQR.mostRecentResults.second = escaped_qd;
   std::string json;
   auto serialize_status = serializeHistoricalQueryResultsJSON(hQR, json);
   if (!serialize_status.ok()) {

--- a/osquery/database/results_tests.cpp
+++ b/osquery/database/results_tests.cpp
@@ -24,6 +24,7 @@ namespace pt = boost::property_tree;
 namespace osquery {
 
 class ResultsTests : public testing::Test {};
+std::string escapeNonPrintableBytes(const std::string& data);
 
 TEST_F(ResultsTests, test_simple_diff) {
   QueryData o;
@@ -128,6 +129,33 @@ TEST_F(ResultsTests, test_serialize_scheduled_query_log_item_json) {
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first, json);
+}
+
+TEST_F(ResultsTests, test_unicode_to_ascii_conversion) {
+  EXPECT_EQ(escapeNonPrintableBytes("しかたがない"),
+            "\\xE3\\x81\\x97\\xE3\\x81\\x8B\\xE3\\x81\\x9F\\xE3\\x81\\x8C\\xE3"
+            "\\x81\\xAA\\xE3\\x81\\x84");
+  EXPECT_EQ(escapeNonPrintableBytes("悪因悪果"),
+            "\\xE6\\x82\\xAA\\xE5\\x9B\\xA0\\xE6\\x82\\xAA\\xE6\\x9E\\x9C");
+  EXPECT_EQ(escapeNonPrintableBytes("モンスターハンター"),
+            "\\xE3\\x83\\xA2\\xE3\\x83\\xB3\\xE3\\x82\\xB9\\xE3\\x82\\xBF\\xE3"
+            "\\x83\\xBC\\xE3\\x83\\x8F\\xE3\\x83\\xB3\\xE3\\x82\\xBF\\xE3\\x83"
+            "\\xBC");
+  EXPECT_EQ(
+      escapeNonPrintableBytes(
+          "съешь же ещё этих мягких французских булок, да выпей чаю"),
+      "\\xD1\\x81\\xD1\\x8A\\xD0\\xB5\\xD1\\x88\\xD1\\x8C \\xD0\\xB6\\xD0\\xB5 "
+      "\\xD0\\xB5\\xD1\\x89\\xD1\\x91 \\xD1\\x8D\\xD1\\x82\\xD0\\xB8\\xD1\\x85 "
+      "\\xD0\\xBC\\xD1\\x8F\\xD0\\xB3\\xD0\\xBA\\xD0\\xB8\\xD1\\x85 "
+      "\\xD1\\x84\\xD1\\x80\\xD0\\xB0\\xD0\\xBD\\xD1\\x86\\xD1\\x83\\xD0\\xB7\\"
+      "xD1\\x81\\xD0\\xBA\\xD0\\xB8\\xD1\\x85 "
+      "\\xD0\\xB1\\xD1\\x83\\xD0\\xBB\\xD0\\xBE\\xD0\\xBA, "
+      "\\xD0\\xB4\\xD0\\xB0 \\xD0\\xB2\\xD1\\x8B\\xD0\\xBF\\xD0\\xB5\\xD0\\xB9 "
+      "\\xD1\\x87\\xD0\\xB0\\xD1\\x8E");
+
+  EXPECT_EQ(
+      escapeNonPrintableBytes("The quick brown fox jumps over the lazy dog."),
+      "The quick brown fox jumps over the lazy dog.");
 }
 
 TEST_F(ResultsTests, test_adding_duplicate_rows_to_query_data) {


### PR DESCRIPTION
I believe the cause of the problem was that an extraneous escape was happening
in the `addNewResults` function in query.cpp.

I believe this can be safely removed because it's purpose is only to make things
JSON safe. However, I don't think this function is ever called with out a JSON
serialization later, making this unnecessary.