### PR TITLE
[#911] Implement FDE status

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -16,6 +16,7 @@ if(APPLE)
     system/darwin/ad_config.cpp
     system/darwin/apps.cpp
     system/darwin/block_devices.cpp
+    system/darwin/disk_encryption.cpp
     system/darwin/keychain_items.cpp
     system/darwin/keychain_utils.cpp
     system/darwin/firewall.h

--- a/osquery/tables/specs/x/disk_encryption.table
+++ b/osquery/tables/specs/x/disk_encryption.table
@@ -1,0 +1,11 @@
+table_name("disk_encryption")
+description("Disk Encryption")
+schema([
+    Column("name", TEXT),
+    Column("uuid", TEXT),
+    Column("encrypted", INTEGER, "1 if encrypted: true (disk is encrypted), else 0"),
+    Column("type", TEXT, "Description of cipher type if available"),
+    ForeignKey(column="name", table="block_devices"),
+    ForeignKey(column="uuid", table="block_devices"),
+])
+implementation("disk_encryption@genFDEStatus")

--- a/osquery/tables/system/darwin/disk_encryption.cpp
+++ b/osquery/tables/system/darwin/disk_encryption.cpp
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/sql.h>
+
+#include "osquery/tables/system/darwin/iokit_utils.h"
+
+namespace osquery {
+namespace tables {
+
+// AES-XTS is the only block algorithm supported by FileVault2
+// https://opensource.apple.com/source/xnu/xnu-2782.1.97/libkern/crypto/corecrypto_aesxts.c
+const std::string kEncryptionType = "AES-XTS";
+const std::string kDeviceNamePrefix = "/dev/";
+
+// kCoreStorageIsEncryptedKey is not publicly defined
+// or documented because CoreStorage is a private framework
+#define kCoreStorageIsEncryptedKey_ "CoreStorage Encrypted"
+
+void genFDEStatusForBSDName(const std::string& bsd_name,
+                            const std::string& uuid,
+                            QueryData& results) {
+
+  auto matching_dict =
+      IOBSDNameMatching(kIOMasterPortDefault, kNilOptions, bsd_name.c_str());
+  if (matching_dict == nullptr) {
+    CFRelease(matching_dict);
+    return;
+  }
+
+  auto service =
+      IOServiceGetMatchingService(kIOMasterPortDefault, matching_dict);
+  if (!service) {
+    IOObjectRelease(service);
+    return;
+  }
+
+  CFMutableDictionaryRef properties;
+  IORegistryEntryCreateCFProperties(
+      service, &properties, kCFAllocatorDefault, kNilOptions);
+
+  Row r;
+
+  r["name"] = kDeviceNamePrefix + bsd_name;
+  r["uuid"] = uuid;
+
+  auto encrypted = getIOKitProperty(properties, kCoreStorageIsEncryptedKey_);
+  r["encrypted"] = (encrypted.empty()) ? "0" : encrypted;
+  r["type"] = (r.at("encrypted") == "1") ? kEncryptionType : std::string();
+
+  results.push_back(r);
+  CFRelease(properties);
+  IOObjectRelease(service);
+}
+
+QueryData genFDEStatus(QueryContext& context) {
+  QueryData results;
+
+  auto block_devices = SQL::selectAllFrom("block_devices");
+
+  for (const auto& row : block_devices) {
+    const auto bsd_name = row.at("name").substr(kDeviceNamePrefix.size());
+    genFDEStatusForBSDName(bsd_name, row.at("uuid"), results);
+  }
+
+  return results;
+}
+}
+}


### PR DESCRIPTION

##### TODO:

- [x] ~~Implement `encrypted` column for OS X in `block_devices`~~
- [x] Move OS X is_encrypted to a separate virtual table

(These are now tracked in #933)
* ~~Linux implementation~~
* ~~Add/update Tests~~
* ~~Documentation~~
 
Hey @theopolis,

This change adds `encrypted` column to the `block_devices` table.

Turns out `CoreStorage` is sub-class of  `IOMedia` (not a surprise), so this is a straightforward change, since there is already a `DASession`.

```bash
❯ echo "select name, uuid, encrypted from block_devices where encrypted == 1;"  \
| ./osqueryi

+------------+--------------------------------------+-----------+
| name       | uuid                                 | encrypted |
+------------+--------------------------------------+-----------+
| /dev/disk1 | ABCF88F5-629A-4DE9-9D30-91EFA68149E8 | 1         |
+------------+--------------------------------------+-----------+
```

```bash
❯ echo "select name, uuid, encrypted from block_devices where encrypted == 1;" \
 | ./osqueryi

+--------------+--------------------------------------+-----------+
| name         | uuid                                 | encrypted |
+--------------+--------------------------------------+-----------+
| /dev/disk0   |                                      | 0         |
| /dev/disk0s1 | 9E103246-DCFF-4ED7-ACA0-60F81F0A3E2A | 0         |
| /dev/disk0s2 | 107602D7-927A-47D7-B59E-9A72C7E47742 | 0         |
| /dev/disk0s3 | A3BBDEE1-437A-4C52-93D4-CFB9D1F6B4F6 | 0         |
| /dev/disk2   |                                      | 0         |
+--------------+--------------------------------------+-----------+
```

##### Questions:

* The UUIDs are logical volume ones, and not the LVF one (see #911 discussion), does it matter here?
* Since sqlite doesn't have a BOOLEAN type, what is the standard for the boolean valued columns? INTEGER 1 (true) and 0 (false) or TEXT true or false? I saw both being used in the table specs, I went with the INTEGER.
* Do we want to another another table for encryption status if we add encryption type and recovery key information? Or just add columns to `block_devices`? Or is `block_devices` already getting too cluttered?
