### PR TITLE
[Fix #919] Fixing segfault for non-existent path in keychain_items

### DIFF
--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -99,6 +99,9 @@ QueryData genKeychainItems(QueryContext& context) {
 
   for (const auto& item_type : kKeychainItemTypes) {
     CFArrayRef items = CreateKeychainItems(keychain_paths, item_type);
+    if (items == nullptr) {
+      continue;
+    }
     auto count = CFArrayGetCount(items);
     for (CFIndex i = 0; i < count; i++) {
       genKeychainItem((SecKeychainItemRef)CFArrayGetValueAtIndex(items, i),


### PR DESCRIPTION
There was a bug where when passing a path to a file that doesn't exist to keychain_items causes a crash because a check for null was not present.