### PR TITLE
HTTP Error due to git url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party"]
 	path = third-party
-	url = git://github.com/osquery/third-party.git
+	url = git+ssh://github.com/osquery/third-party.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party"]
 	path = third-party
-	url = https://github.com/osquery/third-party.git
+	url = git://github.com/osquery/third-party.git


### PR DESCRIPTION
I have seen few times this:

Cleaning up...
Submodule 'third-party' (https://github.com/osquery/third-party.git) registered for path 'third-party'
Initialized empty Git repository in /home/osquery/jenkins/workspace/osqueryPullRequestBuild/TargetSystem/centos6/third-party/.git/
error: RPC failed; result=6, HTTP code = 0

After some research, a way to mitigate this is to use git:// urls instead of https