### PR TITLE
[Fix #948] Absolute paths in wildcard resolution

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -281,7 +281,8 @@ Status resolveLastPathComponent(const fs::path& fs_path,
 
   try {
     // Is the path a file
-    if (setting == REC_LIST_FILES && fs::is_regular_file(fs_path)) {
+    if ((setting & (REC_EVENT_OPT | REC_LIST_FILES)) > 0  &&
+          fs::is_regular_file(fs_path)) {
       results.push_back(fs_path.string());
       return Status(0, "OK");
     }

--- a/osquery/filesystem/filesystem_tests.cpp
+++ b/osquery/filesystem/filesystem_tests.cpp
@@ -232,6 +232,17 @@ TEST_F(FilesystemTests, test_dotdot_relative) {
   EXPECT_TRUE(found);
 }
 
+TEST_F(FilesystemTests, test_no_wild) {
+  std::vector<std::string> all;
+  auto status = resolveFilePattern(kFakeDirectory + "/roto.txt",
+                                   all, REC_LIST_FILES);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(all.size(), 1);
+  EXPECT_NE(std::find(all.begin(), all.end(),
+                      kFakeDirectory + "/roto.txt"),
+            all.end());
+}
+
 TEST_F(FilesystemTests, test_safe_permissions) {
   // For testing we can request a different directory path.
   EXPECT_TRUE(safePermissions("/", kFakeDirectory + "/door.txt"));


### PR DESCRIPTION
There was a bug in the logic that prevented absolute paths from being passed through the wildcard resolution function unscathed. It should be fixed now.