### PR TITLE
[Fix #945] Fix crashes from bad JSON

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -46,9 +46,9 @@ Status Config::update(const std::map<std::string, std::string>& config) {
   if (Registry::external()) {
     for (const auto& source : config) {
       PluginRequest request = {
-        {"action", "update"},
-        {"source", source.first},
-        {"data", source.second},
+          {"action", "update"},
+          {"source", source.first},
+          {"data", source.second},
       };
       // A "update" registry item within core should call the core's update
       // method. The config plugin call action handling must also know to
@@ -123,7 +123,7 @@ inline void mergeAdditional(const tree_node& node, ConfigData& conf) {
       }
       for (const auto& file : category.second) {
         conf.yara[category.first].push_back(
-          file.second.get_value<std::string>());
+            file.second.get_value<std::string>());
       }
     }
   } else {
@@ -163,7 +163,13 @@ void Config::mergeConfig(const std::string& source, ConfigData& conf) {
   json_data << source;
 
   pt::ptree tree;
-  pt::read_json(json_data, tree);
+  try {
+    pt::read_json(json_data, tree);
+  } catch (const pt::ptree_error& e) {
+    VLOG(1)
+        << "There was an error parsing the JSON read from a file: " << e.what();
+    return;
+  }
 
   // Legacy query schedule vector support.
   if (tree.count("scheduledQueries") > 0) {

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -35,7 +35,8 @@ REGISTER(FilesystemConfigPlugin, "config", "filesystem");
 
 Status FilesystemConfigPlugin::genConfig(
     std::map<std::string, std::string>& config) {
-  if (!fs::exists(FLAGS_config_path)) {
+  if (!fs::is_regular_file(FLAGS_config_path)) {
+    VLOG(1) << "Was not given a file to load config from";
     return Status(1, "config file does not exist");
   }
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -21,8 +21,8 @@ import test_base
 
 class OsqueryiTest(unittest.TestCase):
     def setUp(self):
-        binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
-        self.osqueryi = test_base.OsqueryWrapper(binary)
+        self.binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
+        self.osqueryi = test_base.OsqueryWrapper(self.binary)
 
     def test_error(self):
         '''Test that we throw an error on bad query'''
@@ -40,6 +40,12 @@ class OsqueryiTest(unittest.TestCase):
         self.assertTrue(0 <= int(row['hour']) <= 24)
         self.assertTrue(0 <= int(row['minutes']) <= 60)
         self.assertTrue(0 <= int(row['seconds']) <= 60)
+
+    def test_config_bad_json(self):
+        self.osqueryi = test_base.OsqueryWrapper(self.binary,
+            args={"config_path": "/"})
+        result = self.osqueryi.run_query('SELECT * FROM time;')
+        self.assertEqual(len(result), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are a couple places where this was an issue.

The first place was in the filesystem plugin where it was only checked that it
existed, and not that it was an actual file.

The second was a lack of try and catch on the parse call in config.cpp.

Both of those issues are addressed in this diff.