### PR TITLE
[Fix #955] Fix etc_hosts hostname parsing so that inline comments are now ignored

### DIFF
--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -232,6 +232,8 @@ QueryData getEtcHostsExpectedResults() {
   Row row2;
   Row row3;
   Row row4;
+  Row row5;
+  Row row6;
 
   row1["address"] = "127.0.0.1";
   row1["hostnames"] = "localhost";
@@ -241,7 +243,11 @@ QueryData getEtcHostsExpectedResults() {
   row3["hostnames"] = "localhost";
   row4["address"] = "fe80::1%lo0";
   row4["hostnames"] = "localhost";
-  return {row1, row2, row3, row4};
+  row5["address"] = "127.0.0.1";
+  row5["hostnames"] = "example.com example";
+  row6["address"] = "127.0.0.1";
+  row6["hostnames"] = "example.net";
+  return {row1, row2, row3, row4, row5, row6};
 }
 
 ::std::ostream& operator<<(::std::ostream& os, const Status& s) {

--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -35,6 +35,9 @@ QueryData parseEtcHostsContent(const std::string& content) {
     if (line.size() > 1) {
       std::vector<std::string> hostnames;
       for (int i = 1; i < line.size(); ++i) {
+        if (boost::starts_with(line[i], "#")) {
+          break;
+        }
         hostnames.push_back(line[i]);
       }
       r["hostnames"] = boost::algorithm::join(hostnames, " ");

--- a/tools/tests/test_hosts.txt
+++ b/tools/tests/test_hosts.txt
@@ -8,3 +8,5 @@
 255.255.255.255 broadcasthost
 ::1             localhost
 fe80::1%lo0     localhost
+127.0.0.1       example.com example
+127.0.0.1       example.net # This is a comment


### PR DESCRIPTION
This fixes #955.

Inline comments are now ignored. Updated tests.

Now querying doesn't output inline comments:
```
+-------------------------------------------------------+
| hostnames                                             |
+-------------------------------------------------------+
| localhost                                             |
| localhost.localdomain                                 |
| broadcasthost                                         |
| localhost                                             |
| local                                                 |
| bad_domain.com                                        |
+-------------------------------------------------------+
```

Ran the Intruments wrapper script:

```
❯ echo "select count(*) from etc_hosts;" | ./build/darwin/osquery/osqueryi --line
count(*) = 10833

❯ sudo -E python ./tools/profile.py --leaks --query "select * from etc_hosts;"
Analyzing leaks in query: select * from etc_hosts;
  definitely: 0 leaks for 0 total leaked bytes.
```


 
