### PR TITLE
[Fix #953] Check sqlite predicate expression passing

### DIFF
--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -194,6 +194,10 @@ static int xFilter(sqlite3_vtab_cursor *pVtabCursor,
 
   for (size_t i = 0; i < argc; ++i) {
     auto expr = (const char *)sqlite3_value_text(argv[i]);
+    if (expr == nullptr) {
+      // SQLite did not expose the expression value.
+      continue;
+    }
     // Set the expression from SQLite's now-populated argv.
     pVtab->content->constraints[i].second.expr = std::string(expr);
     // Add the constraint to the column-sorted query request map.


### PR DESCRIPTION
A subquery may optionally include a where clause (predicate) constraint expression when an operator+constraint is specified.

The best value optimization phase will increase the count for a missing expression and include an `argv` item to filter, however this value will return null when fetching the string value.