### PR TITLE
[Fix #962] Add OS name and friendly version

### DIFF
--- a/osquery/tables/specs/x/os_version.table
+++ b/osquery/tables/specs/x/os_version.table
@@ -1,8 +1,10 @@
 table_name("os_version")
-description("A single row containing the operating system version.")
+description("A single row containing the operating system name and version.")
 schema([
-  Column("major", INTEGER),
-  Column("minor", INTEGER),
-  Column("patch", INTEGER),
+  Column("name", TEXT, "Distribution or product name"),
+  Column("major", INTEGER, "Major release version"),
+  Column("minor", INTEGER, "Minor release version"),
+  Column("patch", INTEGER, "Optional patch release"),
+  Column("build", TEXT, "Optional build-specific or variant string"),
 ])
 implementation("system/os_version@genOSVersion")

--- a/osquery/tables/system/darwin/ad_config.cpp
+++ b/osquery/tables/system/darwin/ad_config.cpp
@@ -13,11 +13,12 @@
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 
-const std::string kADConfigPath = "/Library/Preferences/OpenDirectory/"
-                                  "Configurations/Active Directory/";
-
 namespace osquery {
 namespace tables {
+
+const std::string kADConfigPath =
+    "/Library/Preferences/OpenDirectory/"
+    "Configurations/Active Directory/";
 
 void genADConfig(const std::string& path, QueryData& results) {
   auto config = SQL::selectAllFrom("preferences", "path", EQUALS, path);


### PR DESCRIPTION
Instead of returning the kernel version for OS X, we should return the 10.VERSION string.