### PR TITLE
Request template classes

### DIFF
--- a/CMake/FindCppNetlib.cmake
+++ b/CMake/FindCppNetlib.cmake
@@ -1,0 +1,10 @@
+SET(CPP-NETLIB_BUILD_TESTS false)
+ADD_DEFINITIONS(-DBOOST_NETWORK_ENABLE_HTTPS)
+ADD_SUBDIRECTORY("${CMAKE_SOURCE_DIR}/third-party/cpp-netlib")
+INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/third-party/cpp-netlib")
+SET(CPP-NETLIB_LINK_DIR "${PROJECT_BINARY_DIR}/third-party/cpp-netlib/libs/network/src")
+SET(CPP-NETLIB_LIBRARY
+  "${CPP-NETLIB_LINK_DIR}/libcppnetlib-uri.a"
+  "${CPP-NETLIB_LINK_DIR}/libcppnetlib-client-connections.a"
+  "${CPP-NETLIB_LINK_DIR}/libcppnetlib-server-parsers.a"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ find_package(Readline REQUIRED)
 
 # Most dependent packages/libs we want static.
 set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dylib .so)
+find_package(CppNetlib 0.11.0 REQUIRED)
 find_package(Gflags REQUIRED)
 find_package(Glog REQUIRED)
 find_package(Gtest REQUIRED)
@@ -188,8 +189,8 @@ find_package(Doxygen)
 if(DOXYGEN_FOUND)
   add_custom_target(
     docs
-    echo "PROJECT_NUMBER=${OSQUERY_BUILD_VERSION}" | 
-      cat ${CMAKE_SOURCE_DIR}/docs/Doxyfile - | 
+    echo "PROJECT_NUMBER=${OSQUERY_BUILD_VERSION}" |
+      cat ${CMAKE_SOURCE_DIR}/docs/Doxyfile - |
       "${DOXYGEN_EXECUTABLE}" -
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Generating API documentation with Doxygen" VERBATIM
@@ -199,7 +200,7 @@ endif(DOXYGEN_FOUND)
 # make format-all
 add_custom_target(
   format-all
-  find osquery include tools \( -name "*.h" -o -name "*.cpp" -o -name "*.mm" \) 
+  find osquery include tools \( -name "*.h" -o -name "*.cpp" -o -name "*.mm" \)
     -exec clang-format -i {} +
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting all osquery code with clang-format" VERBATIM

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -18,6 +18,7 @@ set(OSQUERY_LIBS
   ${GFLAGS_LIBRARY}
   ${OPENSSL_CRYPTO_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}
+  ${CPP-NETLIB_LIBRARY}
 
   readline
   pthread
@@ -62,6 +63,7 @@ add_subdirectory(extensions)
 add_subdirectory(filesystem)
 add_subdirectory(logger)
 add_subdirectory(registry)
+add_subdirectory(remote)
 add_subdirectory(sql)
 add_subdirectory(tables)
 

--- a/osquery/remote/CMakeLists.txt
+++ b/osquery/remote/CMakeLists.txt
@@ -1,0 +1,11 @@
+ADD_OSQUERY_LIBRARY(TRUE osquery_requests
+  requests.h
+  transports/http.h
+  transports/http.cpp
+  serializers/json.h
+  serializers/json.cpp
+)
+
+ADD_OSQUERY_TEST(TRUE requests_tests requests_tests.cpp)
+ADD_OSQUERY_TEST(TRUE json_tests serializers/json_tests.cpp)
+ADD_OSQUERY_TEST(TRUE http_tests transports/http_tests.cpp)

--- a/osquery/remote/requests.h
+++ b/osquery/remote/requests.h
@@ -1,0 +1,248 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <string>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/logger.h>
+#include <osquery/status.h>
+
+namespace osquery {
+
+class Serializer;
+
+/**
+ * @brief Abstract base class for remote transport implementations
+ *
+ * To define a new transport mechanism (HTTP, WebSockets, etc) for use with
+ * remote connections, subclass osquery::Transport and implement the pure
+ * virtual methods (as well as any base methods you may want to implement
+ * custom behavior for).
+ */
+class Transport {
+ public:
+  /**
+   * @brief Set the destination URI
+   *
+   * @param A string representing the destination
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+  */
+  virtual void setDestination(std::string destination) {
+    destination_ = destination;
+  }
+
+  /**
+   * @brief Set the serializer
+   *
+   * @param A serializer object
+   */
+  virtual void setSerializer(std::shared_ptr<Serializer> serializer) {
+    serializer_ = serializer;
+  }
+
+  /**
+   * @brief Send a simple request to the destination with no parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  virtual Status sendRequest() = 0;
+
+  /**
+   * @brief Send a simple request to the destination with parameters
+   *
+   * @param params A string representing the serialized parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  virtual Status sendRequest(const std::string& params) = 0;
+
+  /**
+   * @brief Get the status of the response
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status getResponseStatus() const { return response_status_; }
+
+  /**
+   * @brief Get the parameters of the response
+   *
+   * @return The parameters
+   */
+  const boost::property_tree::ptree& getResponseParams() const {
+    return response_params_;
+  }
+
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~Transport() {}
+
+ protected:
+  /// storage for the transport destination
+  std::string destination_;
+
+  /// storage for the serializer reference
+  std::shared_ptr<Serializer> serializer_;
+
+  /// storage for response status
+  Status response_status_;
+
+  /// storage for response parameters
+  boost::property_tree::ptree response_params_;
+};
+
+/**
+ * @brief Abstract base class for serialization implementations
+ *
+ * To define a new serialization mechanism (JSON, XML, etc) for use with
+ * remote connections, subclass osquery::Serializer and implement the pure
+ * virtual methods (as well as any base methods you may want to implement
+ * custom behavior for).
+ */
+class Serializer {
+ public:
+  /**
+   * @brief Set the transport
+   *
+   * @param A transport object
+   */
+  virtual void setTransport(std::shared_ptr<Transport> transport) {
+    transport_ = transport;
+  }
+
+  /**
+   * @brief Returns the HTTP content type, for HTTP/TLS transport
+   *
+   * If a serializer is going to be used for HTTP/TLS, it probably needs to
+   * set it's own content type. Return a string with the appropriate content
+   * type for serializer.
+   *
+   * @return The content type
+   */
+  virtual std::string getContentType() const = 0;
+
+  /**
+   * @brief Serialize a property tree into a string
+   *
+   * @param params A property tree of parameters
+   *
+   * @param serialized The string to populate the final serialized params into
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  virtual Status serialize(const boost::property_tree::ptree& params,
+                           std::string& serialized) = 0;
+
+  /**
+   * @brief Deerialize a property tree into a property tree
+   *
+   * @param params A string of serialized parameters
+   *
+   * @param serialized The property tree to populate the final serialized
+   * params into
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  virtual Status deserialize(const std::string& serialized,
+                             boost::property_tree::ptree& params) = 0;
+
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~Serializer() {}
+
+ protected:
+  /// storage for the transport reference
+  std::shared_ptr<Transport> transport_;
+};
+
+/**
+ * @brief Request class for making flexible remote network requests
+ */
+template <class TTransport, class TSerializer>
+class Request {
+ public:
+  /**
+   * @brief This is the constructor that you should use to instantiate Request
+   *
+   * @param destination A string of the remote URI destination
+   */
+  Request(const std::string& destination) : destination_(destination) {
+    transport_ = std::make_shared<TTransport>();
+    transport_->setDestination(destination_);
+    serializer_ = std::make_shared<TSerializer>();
+
+    transport_->setSerializer(serializer_);
+    serializer_->setTransport(transport_);
+  }
+
+  /**
+   * @brief Class destructor
+   */
+  virtual ~Request() {}
+
+  /**
+   * @brief Send a simple request to the destination with no parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status call() { return transport_->sendRequest(); }
+
+  /**
+   * @brief Send a simple request to the destination with parameters
+   *
+   * @param params A property tree representing the parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status call(const boost::property_tree::ptree& params) {
+    std::string serialized;
+    auto s = serializer_->serialize(params, serialized);
+    if (!s.ok()) {
+      return s;
+    }
+    return transport_->sendRequest(serialized);
+  }
+
+  /**
+   * @brief Get the request response
+   *
+   * @return A pair of a Status and a property tree of response params
+   */
+  Status getResponse(boost::property_tree::ptree& params) {
+    params = transport_->getResponseParams();
+    return transport_->getResponseStatus();
+  }
+
+ private:
+  /// storage for the resource destination
+  std::string destination_;
+
+  /// storage for the serializer to be used
+  std::shared_ptr<TSerializer> serializer_;
+
+  /// storage for the transport to be used
+  std::shared_ptr<TTransport> transport_;
+};
+}

--- a/osquery/remote/requests_tests.cpp
+++ b/osquery/remote/requests_tests.cpp
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "osquery/remote/requests.h"
+#include "osquery/remote/transports/http.h"
+#include "osquery/remote/serializers/json.h"
+
+namespace osquery {
+
+class RequestsTests : public testing::Test {
+ public:
+  void SetUp() {}
+};
+
+class MockTransport : public Transport {
+ public:
+  Status sendRequest() {
+    response_status_ = Status(0, "OK");
+    return response_status_;
+  }
+
+  Status sendRequest(const std::string& params) {
+    response_params_.put<std::string>("foo", "baz");
+    response_status_ = Status(0, "OK");
+    return response_status_;
+  }
+};
+
+class MockSerializer : public Serializer {
+ public:
+  std::string getContentType() const { return "mock"; }
+
+  Status serialize(const boost::property_tree::ptree& params,
+                   std::string& serialized) {
+    return Status(0, "OK");
+  }
+
+  Status deserialize(const std::string& serialized,
+                     boost::property_tree::ptree& params) {
+    return Status(0, "OK");
+  }
+};
+
+TEST_F(RequestsTests, testCall) {
+  auto req = Request<MockTransport, MockSerializer>("foobar");
+  auto s1 = req.call();
+  EXPECT_TRUE(s1.ok());
+
+  boost::property_tree::ptree params;
+  auto s2 = req.getResponse(params);
+  EXPECT_TRUE(s2.ok());
+  boost::property_tree::ptree empty_ptree;
+  EXPECT_EQ(params, empty_ptree);
+}
+
+TEST_F(RequestsTests, testCallWithParams) {
+  auto req = Request<MockTransport, MockSerializer>("foobar");
+  boost::property_tree::ptree params;
+  params.put<std::string>("foo", "bar");
+  auto s1 = req.call(params);
+  EXPECT_TRUE(s1.ok());
+
+  boost::property_tree::ptree recv;
+  auto s2 = req.getResponse(recv);
+  EXPECT_TRUE(s2.ok());
+
+  boost::property_tree::ptree expected;
+  expected.put<std::string>("foo", "baz");
+  EXPECT_EQ(recv, expected);
+}
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}

--- a/osquery/remote/serializers/json.cpp
+++ b/osquery/remote/serializers/json.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include "osquery/remote/serializers/json.h"
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+Status JSONSerializer::serialize(const pt::ptree& params,
+                                 std::string& serialized) {
+  std::ostringstream ss;
+  try {
+    pt::write_json(ss, params, false);
+  } catch (const std::exception& e) {
+    return Status(1, e.what());
+  }
+  serialized = ss.str();
+  return Status(0, "OK");
+}
+
+Status JSONSerializer::deserialize(const std::string& serialized,
+                                   pt::ptree& params) {
+  std::stringstream j;
+  j << serialized;
+  try {
+    pt::read_json(j, params);
+  } catch (const std::exception& e) {
+    return Status(1, e.what());
+  }
+  return Status(0, "OK");
+}
+}

--- a/osquery/remote/serializers/json.h
+++ b/osquery/remote/serializers/json.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include "osquery/remote/requests.h"
+
+namespace osquery {
+
+/**
+ * @brief JSON Serializer
+ */
+class JSONSerializer : public Serializer {
+ public:
+  /**
+   * @brief Serialize a property tree into a string
+   *
+   * @param params A property tree of parameters
+   *
+   * @param serialized The string to populate the final serialized params into
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status serialize(const boost::property_tree::ptree& params,
+                   std::string& serialized);
+
+  /**
+   * @brief Deerialize a property tree into a property tree
+   *
+   * @param params A string of serialized parameters
+   *
+   * @param serialized The property tree to populate the final serialized
+   * params into
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status deserialize(const std::string& serialized,
+                     boost::property_tree::ptree& params);
+
+  /**
+   * @brief Returns the HTTP content type, for HTTP/TLS transport
+   *
+   * @return The content type
+   */
+  std::string getContentType() const { return "application/json"; }
+};
+}

--- a/osquery/remote/serializers/json_tests.cpp
+++ b/osquery/remote/serializers/json_tests.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "osquery/remote/serializers/json.h"
+
+namespace osquery {
+
+class JSONTests : public testing::Test {};
+
+TEST_F(JSONTests, testSerialize) {
+  auto json = JSONSerializer();
+  boost::property_tree::ptree params;
+  params.put<std::string>("foo", "bar");
+
+  std::string serialized;
+  auto s = json.serialize(params, serialized);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(serialized, "{\"foo\":\"bar\"}\n");
+}
+
+TEST_F(JSONTests, testDeserialize) {
+  auto json = JSONSerializer();
+  boost::property_tree::ptree params;
+  std::string serialized = "{\"foo\":\"bar\"}\n";
+  auto s = json.deserialize(serialized, params);
+
+  boost::property_tree::ptree expected;
+  expected.put<std::string>("foo", "bar");
+
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(params, expected);
+}
+}
+
+int main(int argc, char* argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+  return RUN_ALL_TESTS();
+}

--- a/osquery/remote/transports/http.cpp
+++ b/osquery/remote/transports/http.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/network/protocol/http/client.hpp>
+
+#include "osquery/remote/transports/http.h"
+
+using namespace boost::network;
+
+namespace osquery {
+
+void HTTPTransport::decorateRequest(http::client::request& r) {
+  r << header("Connection", "close");
+  r << header("Content-Type", serializer_->getContentType());
+}
+
+Status HTTPTransport::sendRequest() {
+  http::client client;
+  http::client::request r(destination_);
+  decorateRequest(r);
+  response_ = client.get(r);
+  response_status_ =
+      serializer_->deserialize(body(response_), response_params_);
+  return response_status_;
+}
+
+Status HTTPTransport::sendRequest(const std::string& params) {
+  http::client client;
+  http::client::request r(destination_);
+  decorateRequest(r);
+  response_ = client.post(r, params);
+  response_status_ =
+      serializer_->deserialize(body(response_), response_params_);
+  return response_status_;
+}
+}

--- a/osquery/remote/transports/http.h
+++ b/osquery/remote/transports/http.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <boost/network/protocol/http/client.hpp>
+
+#include "osquery/remote/requests.h"
+
+namespace osquery {
+
+/**
+ * @brief HTTP transport
+ */
+class HTTPTransport : public Transport {
+ public:
+  /**
+   * @brief Send a simple request to the destination with no parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status sendRequest();
+
+  /**
+   * @brief Send a simple request to the destination with parameters
+   *
+   * @param params A string representing the serialized parameters
+   *
+   * @return An instance of osquery::Status indicating the success or failure
+   * of the operation
+   */
+  Status sendRequest(const std::string& params);
+
+  /**
+   * @brief Class destructor
+  */
+  ~HTTPTransport() {}
+
+ protected:
+  /**
+    * @brief Modify a request object with base modifications
+    *
+    * @param The request object, to be modified
+    */
+  void decorateRequest(boost::network::http::client::request& r);
+
+ protected:
+  /// Storage for the HTTP response object
+  boost::network::http::client::response response_;
+};
+}

--- a/osquery/remote/transports/http_tests.cpp
+++ b/osquery/remote/transports/http_tests.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <thread>
+
+#include <boost/network/protocol/http/server.hpp>
+#include <gtest/gtest.h>
+
+#include "osquery/remote/requests.h"
+#include "osquery/remote/serializers/json.h"
+#include "osquery/remote/transports/http.h"
+
+namespace http = boost::network::http;
+
+namespace osquery {
+
+struct FooBarHTTPHandler;
+typedef http::server<FooBarHTTPHandler> Server;
+
+struct FooBarHTTPHandler {
+  void operator()(Server::request const &request, Server::response &response) {
+    response = Server::response::stock_reply(Server::response::ok,
+                                             std::string("{\"foo\":\"bar\"}"));
+  }
+
+  void log(...) {}
+};
+
+class HTTPTests : public testing::Test {};
+
+TEST_F(HTTPTests, testCall) {
+  auto r = Request<HTTPTransport, JSONSerializer>("http://127.0.0.1:8237");
+  auto s1 = r.call();
+  EXPECT_TRUE(s1.ok());
+  boost::property_tree::ptree params;
+  auto s2 = r.getResponse(params);
+  EXPECT_TRUE(s2.ok());
+}
+
+TEST_F(HTTPTests, testCallWithParams) {
+  auto r = Request<HTTPTransport, JSONSerializer>("http://127.0.0.1:8237");
+  boost::property_tree::ptree params;
+  params.put<std::string>("foo", "bar");
+  auto s1 = r.call(params);
+  EXPECT_TRUE(s1.ok());
+  boost::property_tree::ptree recv;
+  auto s2 = r.getResponse(recv);
+  EXPECT_TRUE(s2.ok());
+  EXPECT_EQ(params, recv);
+}
+}
+
+int main(int argc, char *argv[]) {
+  testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+
+  osquery::FooBarHTTPHandler handler;
+  osquery::Server::options options(handler);
+  osquery::Server server(options.address("127.0.0.1").port("8237"));
+  boost::thread t(boost::bind(&osquery::Server::run, &server));
+  auto ret = RUN_ALL_TESTS();
+  server.stop();
+  t.join();
+  return ret;
+}


### PR DESCRIPTION
As discussed in the comments of #961. Included is an HTTP transport
(which works for HTTPS also) and a JSON serializer.

I've already updated `third-party`, this PR will update the pinned hash.