### PR TITLE
Cross compile with LLVM 3.4 using gcc 4.9 on RHEL6.5

### DIFF
--- a/CMake/FindGlog.cmake
+++ b/CMake/FindGlog.cmake
@@ -20,7 +20,7 @@ if(NOT APPLE)
   endif()
 endif()
 
-set(GLOG_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-unnamed-type-template-args -Wno-deprecated -Wno-error -DHAVE_PREAD")
+set(GLOG_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-unnamed-type-template-args -Wno-deprecated -Wno-error")
 
 INCLUDE(ExternalProject)
 ExternalProject_Add(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(OS_WHOLELINK_POST "")
 else()
   set(LINUX TRUE)
-  # Do not used the shared linker flags for modules.
+  # Do not use the shared linker flags for modules.
   set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11")
   set(OS_WHOLELINK_PRE "-Wl,-whole-archive")
   set(OS_WHOLELINK_POST "-Wl,-no-whole-archive")
@@ -59,9 +59,11 @@ string(TOUPPER "${PLATFORM}" PLATFORM)
 list(GET PLATFORM 0 OSQUERY_BUILD_OS)
 list(GET PLATFORM 1 OSQUERY_BUILD_DISTRO)
 
+# RHEL6 uses a different gcc 4.9 runtime
 if(${OSQUERY_BUILD_DISTRO} STREQUAL "RHEL6")
-  set(CMAKE_C_COMPILER "gcc")
-  set(CMAKE_CXX_COMPILER "g++")
+  set(GCC_RUNTIME "/opt/rh/devtoolset-3/root/usr/")
+  message("-- Setting RHEL6 GCC runtime: ${GCC_RUNTIME}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_RUNTIME}")
 endif()
 
 # make debug (environment variable from Makefile)
@@ -116,7 +118,7 @@ else()
   list(GET OSQUERY_BUILD_SDK_VERSION 0 OSQUERY_BUILD_SDK_VERSION)
 endif()
 
-# make extensions (tests building SDK-based extensions)
+# make sdk (tests building SDK-based extensions)
 if(DEFINED ENV{SDK})
   set(OSQUERY_BUILD_SDK_ONLY TRUE)
 endif()

--- a/tools/analysis/clang-analyze.sh
+++ b/tools/analysis/clang-analyze.sh
@@ -4,8 +4,8 @@
 # All rights reserved.
 
 declare -a BLACKLIST=(
-    "osquery/devtools/shell.cpp"
-    "virtual_table.cpp"
+    "logging.cc"
+    "logging_unittest.cc"
   )
 
 for BL_ITEM in ${BLACKLIST[@]}; do

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -73,11 +73,11 @@ function main_rhel() {
   package clang-devel
 
   if [[ $DISTRO = "rhel6" ]]; then
-    # GCC is needed for glib/libstdc++ 4.9+
+    # GCC is needed for glib/libstdc++/gcc4.9+
+    # osquery code will use the 4.9+ toolchain
     set_cc gcc
     set_cxx g++
   elif [[ $DISTRO = "rhel7" ]]; then
-    # Clang was built with a newer libstdc++
     set_cc clang
     set_cxx clang++
   fi


### PR DESCRIPTION
The clang in yum is built with gcc 4.4 and the standard loader. We need to compile our dependencies with the devtoolkit3 version of gcc (4.9) as well as our source. The only way to use clang is to build LLVM/clang ourselves since it is not included alongside the updated gcc in devtoolkit.

Reference: #926

Update (4/13): Instead of building another LLVM/clang using the updated gcc toolchain we can use the existing compiler and set the new gcc toolchain for the osquery build. The downside is the static analyzer may not work as intended.