### PR TITLE
Fix Ubuntu os_version regex

### DIFF
--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -31,7 +31,7 @@ const std::string kLinuxOSRegex =
 const std::string kLinuxOSRelease = "/etc/os-release";
 const std::string kLinuxOSRegex =
     "VERSION=\"(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)[\\.]{0,1}(?P<patch>[0-9]+)"
-    "?, (?P<name>[\\w ]*)\"$";
+    "?.*, (?P<name>[\\w ]*)\"$";
 #endif
 
 QueryData genOSVersion(QueryContext& context) {


### PR DESCRIPTION
@marpaia I think this should do it. The "LTS" string wasn't set in the version I tested with. :(