### PR TITLE
Adding osquery_scheduled table

### DIFF
--- a/osquery/tables/specs/utility/osquery_schedule.table
+++ b/osquery/tables/specs/utility/osquery_schedule.table
@@ -1,0 +1,9 @@
+table_name("osquery_schedule")
+description("Information about the current queries that are scheduled in osquery.")
+schema([
+    Column("interval", INTEGER, "The interval in seconds to run this query, not an exact interval."),
+    Column("name", TEXT, "The given name for this query."),
+    Column("query", TEXT, "The exact query to run."),
+])
+attributes(utility=True)
+implementation("osquery@genOsquerySchedule")

--- a/osquery/tables/specs/utility/osquery_scheduled.table
+++ b/osquery/tables/specs/utility/osquery_scheduled.table
@@ -1,9 +1,0 @@
-table_name("osquery_scheduled")
-description("Information about the current queries that are scheduled in osquery.")
-schema([
-    Column("interval", INTEGER, "The interval in seconds to run this query, not an exact interval."),
-    Column("name", TEXT, "The given name for this query."),
-    Column("query", TEXT, "The exact query to run."),
-])
-attributes(utility=True)
-implementation("osquery@genOsqueryScheduled")

--- a/osquery/tables/specs/utility/osquery_scheduled.table
+++ b/osquery/tables/specs/utility/osquery_scheduled.table
@@ -1,0 +1,9 @@
+table_name("osquery_scheduled")
+description("Information about the current queries that are scheduled in osquery.")
+schema([
+    Column("interval", INTEGER, "The interval in seconds to run this query, not an exact interval."),
+    Column("name", TEXT, "The given name for this query."),
+    Column("query", TEXT, "The exact query to run."),
+])
+attributes(utility=True)
+implementation("osquery@genOsqueryScheduled")

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -133,5 +133,20 @@ QueryData genOsqueryInfo(QueryContext& context) {
 
   return results;
 }
+
+QueryData genOsqueryScheduled(QueryContext& context) {
+  QueryData results;
+
+  ConfigDataInstance config;
+  for (const auto& query : config.schedule()) {
+    Row r;
+    r["name"] = TEXT(query.first);
+    r["query"] = TEXT(query.second.query);
+    r["interval"] = INTEGER(query.second.interval);
+    results.push_back(r);
+  }
+
+  return results;
+}
 }
 }

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -134,7 +134,7 @@ QueryData genOsqueryInfo(QueryContext& context) {
   return results;
 }
 
-QueryData genOsqueryScheduled(QueryContext& context) {
+QueryData genOsquerySchedule(QueryContext& context) {
   QueryData results;
 
   ConfigDataInstance config;


### PR DESCRIPTION
Code for the table and specs to add the new table osquery_scheduled that will track all the current scheduled queries