### PR TITLE
Changing read the docs URL to be https

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The tools make low-level operating system analytics and monitoring both performa
 CentOS 6.5   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/) | | **Homepage:** | https://osquery.io
 CentOS 7.0   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/) | | **Downloads:** | https://osquery.io/downloads
 Ubuntu 12.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/) | |**Tables:** | https://osquery.io/tables
-Ubuntu 14.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/) | | **Guide:** | http://osquery.rtfd.org
+Ubuntu 14.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/) | | **Guide:** | https://osquery.readthedocs.org
 OS X 10.10   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/) | | **Homebrew:** | `brew install osquery`
 
 #### What is osquery?


### PR DESCRIPTION
I figured this was using the shortened URL because it was shorter / looked better, so I threw it up on my fork (https://github.com/marpaia/osquery/tree/readme) and I think it looks pretty good. Plus, it looks awesome when our README has all TLS links.