### PR TITLE
Use all available CPUs when provisioning a Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,11 @@
 Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |v|
+    if ENV['OSQUERY_BUILD_CPUS']
+      v.cpus = ENV['OSQUERY_BUILD_CPUS'].to_i
+    else
+      v.cpus = 2
+    end
     v.memory = 4096
-    v.cpus = 2
   end
  [
    %w{centos6.5 chef/centos-6.5},

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -47,6 +47,13 @@ $ vagrant up ubuntu14
 $ vagrant ssh ubuntu14
 ```
 
+By default vagrant will allocate 2 virtual CPUs to the virtual machine instance. You can override this by setting `OSQUERY_BUILD_CPUS` environment variable before spinning up an instance. To allocate the maximum number of CPUs `OSQUERY_BUILD_CPUS` can be set as:
+
+```sh
+OSQUERY_BUILD_CPUS=`nproc`             # for Linux
+OSQUERY_BUILD_CPUS=`sysctl -n hw.ncpu` # for OS X
+```
+
 Once you have logged into the vagrant box, run the following to create a package:
 
 ```sh


### PR DESCRIPTION
As much of a fan I am of sword-fighting, I would still like my code to be compiled faster.

![compiling](https://sslimgs.xkcd.com/comics/compiling.png)