### PR TITLE
[Implement #933] Add LUKS/dm-crypt disk_encryption support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ build/
 .idea/sqlDataSources.xml
 .idea/dynamic.xml
 .idea/dictionaries
+.idea/codeStyleSettings.xml
 
 # Doxygen Documentation
 doxygen/html

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -45,6 +45,7 @@ else()
   endif()
 
   ADD_OSQUERY_LINK(FALSE "blkid")
+  ADD_OSQUERY_LINK(FALSE "cryptsetup")
   ADD_OSQUERY_LINK(FALSE "udev")
   ADD_OSQUERY_LINK(FALSE "uuid")
 endif()

--- a/osquery/tables/specs/disk_encryption.table
+++ b/osquery/tables/specs/disk_encryption.table
@@ -4,7 +4,7 @@ schema([
     Column("name", TEXT),
     Column("uuid", TEXT),
     Column("encrypted", INTEGER, "1 if encrypted: true (disk is encrypted), else 0"),
-    Column("type", TEXT, "Description of cipher type if available"),
+    Column("type", TEXT, "Description of cipher type and mode if available"),
     ForeignKey(column="name", table="block_devices"),
     ForeignKey(column="uuid", table="block_devices"),
 ])

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -1,0 +1,84 @@
+#include <unistd.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <osquery/sql.h>
+
+extern "C" {
+#include <libcryptsetup.h>
+}
+
+namespace osquery {
+namespace tables {
+
+void genFDEStatusForBlockDevice(const std::string &name,
+                                const std::string &uuid,
+                                QueryData &results) {
+  Row r;
+  r["name"] = name;
+  r["uuid"] = uuid;
+
+  struct crypt_device *cd = nullptr;
+  const char *opt_header_device = nullptr;
+  struct crypt_active_device cad;
+  crypt_status_info ci;
+  std::string type;
+  std::string cipher;
+  std::string cipher_mode;
+
+  ci = crypt_status(cd, name.c_str());
+  switch (ci) {
+  case CRYPT_ACTIVE:
+  case CRYPT_BUSY:
+    r["encrypted"] = "1";
+
+    int crypt_init;
+#ifdef CENTOS_CENTOS6
+    crypt_init = crypt_init_by_name(&cd, name.c_str());
+#else
+    crypt_init =
+      crypt_init_by_name_and_header(&cd, name.c_str(), opt_header_device);
+#endif
+
+    if (crypt_init < 0) {
+      VLOG(1) << "Unable to initialize crypt device for " << name;
+      crypt_free(cd);
+      break;
+    }
+    
+    type = crypt_get_type(cd);
+    if (crypt_get_active_device(cd, name.c_str(), &cad) < 0) {
+      VLOG(1) << "Unable to get active device for " << name;
+      crypt_free(cd);
+      break;
+    }
+    cipher = crypt_get_cipher(cd);
+    cipher_mode = crypt_get_cipher_mode(cd);
+    r["type"] = type + "-" + cipher + "-" + cipher_mode;
+    break;
+  default:
+    r["encrypted"] = "0";
+  }
+
+  results.push_back(r);
+}
+
+QueryData genFDEStatus(QueryContext &context) {
+  QueryData results;
+
+  if (getuid() || geteuid()) {
+    VLOG(1) << "Not running as root, disk encryption status not available.";
+    return results;
+  }
+
+  auto block_devices = SQL::selectAllFrom("block_devices");
+  for (const auto &row : block_devices) {
+    const auto name = (row.count("name") > 0) ? row.at("name") : "";
+    const auto uuid = (row.count("uuid") > 0) ? row.at("uuid") : "";
+    genFDEStatusForBlockDevice(name, uuid, results);
+  }
+  return results;
+}
+}
+}

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -81,8 +81,10 @@ function main_centos() {
 
   if [[ $DISTRO = "centos6" ]]; then
     package libudev-devel
+    package cryptsetup-luks-devel
   elif [[ $DISTRO = "centos7" ]]; then
     package systemd-devel
+    package cryptsetup-devel
   fi
 
   install_gflags

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -89,6 +89,7 @@ function main_rhel() {
   package rpm-devel
   package rpm-build
   package libblkid-devel
+  package cryptsetup-devel
 
   install_cmake
   install_boost

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -51,6 +51,7 @@ function main_ubuntu() {
   package libapt-pkg-dev
   package libudev-dev
   package libblkid-dev
+  package libcryptsetup-dev
   package linux-headers-generic
   package ruby-dev
   package gcc


### PR DESCRIPTION
This implements #933

This change implements `disk_encryption` table for Linux. 
Note that this query has to be run as root since this reads headers on block devices.

```
+------------+----------------------------------------+-----------+-----------------------+
| name       | uuid                                   | encrypted | type                  |
+------------+----------------------------------------+-----------+-----------------------+
| /dev/sr0   |                                        | 0         |                       |
| /dev/sda   |                                        | 0         |                       |
| /dev/sda1  | 15d95ae5-5dee-4283-a49d-463188b4f7f9   | 0         |                       |
| /dev/sda2  |                                        | 0         |                       |
| /dev/sda5  | 482ef7ee-aff2-4c91-b273-9c3c510f4b72   | 0         |                       |
| /dev/loop0 |                                        | 0         |                       |
| /dev/loop1 |                                        | 0         |                       |
| /dev/loop2 |                                        | 0         |                       |
| /dev/loop3 |                                        | 0         |                       |
| /dev/loop4 |                                        | 0         |                       |
| /dev/loop5 |                                        | 0         |                       |
| /dev/loop6 |                                        | 0         |                       |
| /dev/loop7 |                                        | 0         |                       |
| /dev/ram0  |                                        | 0         |                       |
| /dev/ram1  |                                        | 0         |                       |
| /dev/ram10 |                                        | 0         |                       |
| /dev/ram11 |                                        | 0         |                       |
| /dev/ram12 |                                        | 0         |                       |
| /dev/ram13 |                                        | 0         |                       |
| /dev/ram14 |                                        | 0         |                       |
| /dev/ram15 |                                        | 0         |                       |
| /dev/ram2  |                                        | 0         |                       |
| /dev/ram3  |                                        | 0         |                       |
| /dev/ram4  |                                        | 0         |                       |
| /dev/ram5  |                                        | 0         |                       |
| /dev/ram6  |                                        | 0         |                       |
| /dev/ram7  |                                        | 0         |                       |
| /dev/ram8  |                                        | 0         |                       |
| /dev/ram9  |                                        | 0         |                       |
| /dev/dm-0  | al9yWk-y2Ah-DUnv-fLjY-ntc4-7aMc-UFTZaq | 1         | LUKS1-aes-xts-plain64 |
| /dev/dm-1  | 85dc6e5c-190f-4670-b3e3-9d173f3c0441   | 0         |                       |
| /dev/dm-2  | 50bcee27-5ccc-4bf5-b5e0-f9e271f7660f   | 0         |                       |
+------------+----------------------------------------+-----------+-----------------------+
```
