### PR TITLE
Add a missing Page attribute to fix broken mkdocs build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ theme: readthedocs
 docs_dir: docs/wiki
 site_dir: build/wiki
 pages:
-- ['index.md', 'Introduction']
+- ['index.md', 'Introduction', 'Welcome to osquery']
 
 - ['introduction/overview.md', 'Introduction', 'Features Overview']
 - ['introduction/using-osqueryi.md', 'Introduction', 'osqueryi (shell)']


### PR DESCRIPTION
mkdocs v0.12.2 fails to build and serve without this page attribute.  Adding a "Welcome to osquery" title to fix the build and for the navigation object to render correctly.

Before:
```
$ mkdocs serve
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 9, in <module>
    load_entry_point('mkdocs==0.12.2', 'console_scripts', 'mkdocs')()
  File "/usr/local/lib/python2.7/site-packages/mkdocs/main.py", line 77, in run_main
    main(cmd, args=sys.argv[2:], options=dict(opts))
  File "/usr/local/lib/python2.7/site-packages/mkdocs/main.py", line 49, in main
    serve(config, options=options)
  File "/usr/local/lib/python2.7/site-packages/mkdocs/serve.py", line 22, in serve
    builder()
  File "/usr/local/lib/python2.7/site-packages/mkdocs/serve.py", line 19, in builder
    build(config, live_server=True)
  File "/usr/local/lib/python2.7/site-packages/mkdocs/build.py", line 252, in build
    build_pages(config)
  File "/usr/local/lib/python2.7/site-packages/mkdocs/build.py", line 209, in build_pages
    site_navigation = nav.SiteNavigation(config['pages'], config['use_directory_urls'])
  File "/usr/local/lib/python2.7/site-packages/mkdocs/nav.py", line 37, in __init__
    _generate_site_navigation(pages_config, self.url_context, use_directory_urls)
  File "/usr/local/lib/python2.7/site-packages/mkdocs/nav.py", line 250, in _generate_site_navigation
    header.children.append(page)
AttributeError: 'Page' object has no attribute 'children'
```

After: it runs correctly