### PR TITLE
Build cmake with gcc to avoid gnu++1y

### DIFF
--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -64,9 +64,6 @@ function main_centos() {
   package clang
   package clang-devel
 
-  set_cc clang
-  set_cxx clang++
-
   package bzip2
   package bzip2-devel
   package openssl-devel
@@ -76,6 +73,10 @@ function main_centos() {
   package libblkid-devel
 
   install_cmake
+
+  set_cc clang
+  set_cxx clang++
+
   install_boost
 
   if [[ $DISTRO = "centos6" ]]; then

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -18,8 +18,9 @@ function install_cmake() {
       tar -xf cmake-3.2.1.tar.gz
     fi
     log "building cmake"
+
     pushd cmake-3.2.1
-    ./configure
+    ./bootstrap --prefix=/usr/local/
     make
     sudo make install
     popd


### PR DESCRIPTION
See #1025, this should build on a clean (unprovisioned) centos7 vagrant.