### PR TITLE
Fix dameon flags loading from options

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -112,11 +112,15 @@ Status Config::genConfig() {
 }
 
 inline void mergeOption(const tree_node& option, ConfigData& conf) {
-  conf.options[option.first.data()] = option.second.data();
+  std::string key = option.first.data();
+  std::string value = option.second.data();
+
+  Flag::updateValue(key, value);
+  conf.options[key] = value;
   if (conf.all_data.count("options") > 0) {
-    conf.all_data.get_child("options").erase(option.first);
+    conf.all_data.get_child("options").erase(key);
   }
-  conf.all_data.add_child("options." + option.first, option.second);
+  conf.all_data.add_child("options." + key, option.second);
 }
 
 // inline void mergeScheduledQuery(const tree_node& node, ConfigData& conf) {

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -67,13 +67,17 @@ TEST_F(ConfigTests, test_plugin) {
 
 TEST_F(ConfigTests, test_queries_execute) {
   ConfigDataInstance config;
-  EXPECT_EQ(config.schedule().size(), 2);
+  EXPECT_EQ(config.schedule().size(), 3);
 }
 
 TEST_F(ConfigTests, test_watched_files) {
   ConfigDataInstance config;
-  EXPECT_EQ(config.files().size(), 2);
+  ASSERT_EQ(config.files().size(), 3);
+  // From the deprecated "additional_monitoring" collection.
   EXPECT_EQ(config.files().at("downloads").size(), 1);
+
+  // From the new, recommended top-level "file_paths" collection.
+  EXPECT_EQ(config.files().at("downloads2").size(), 1);
   EXPECT_EQ(config.files().at("system_binaries").size(), 2);
 }
 

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -84,8 +84,11 @@ std::string Flag::getDescription(const std::string& name) {
 }
 
 Status Flag::updateValue(const std::string& name, const std::string& value) {
-  GFLAGS_NAMESPACE::SetCommandLineOption(name.c_str(), value.c_str());
-  return Status(0, "OK");
+  if (instance().flags_.count(name) > 0) {
+    GFLAGS_NAMESPACE::SetCommandLineOption(name.c_str(), value.c_str());
+    return Status(0, "OK");
+  }
+  return Status(1, "Flag not found");
 }
 
 std::map<std::string, FlagInfo> Flag::flags() {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -28,6 +28,8 @@
 
 #include "osquery/core/watcher.h"
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 
 #define DESCRIPTION \
@@ -59,8 +61,6 @@ CLI_FLAG(bool,
 #ifndef __APPLE__
 CLI_FLAG(bool, daemonize, false, "Run as daemon (osqueryd only)");
 #endif
-
-namespace fs = boost::filesystem;
 
 void printUsage(const std::string& binary, int tool) {
   // Parse help options before gflags. Only display osquery-related options.
@@ -176,8 +176,8 @@ void Initializer::initDaemon() {
   syslog(
       LOG_NOTICE, "%s started [version=%s]", binary_.c_str(), OSQUERY_VERSION);
 
-  // check if /var/osquery exists
-  if ((Flag::isDefault("pidfile") || Flag::isDefault("db_path")) &&
+  // Check if /var/osquery exists
+  if ((Flag::isDefault("pidfile") || Flag::isDefault("database_path")) &&
       !isDirectory("/var/osquery")) {
     std::cerr << CONFIG_ERROR
   }
@@ -192,7 +192,7 @@ void Initializer::initDaemon() {
 
 void Initializer::initWatcher() {
   // The watcher takes a list of paths to autoload extensions from.
-  loadExtensions();
+  osquery::loadExtensions();
 
   // Add a watcher service thread to start/watch an optional worker and set
   // of optional extensions in the autoload paths.
@@ -306,7 +306,7 @@ void Initializer::start() {
 
   // Start event threads.
   osquery::attachEvents();
-  osquery::EventFactory::delay();
+  EventFactory::delay();
 }
 
 void Initializer::shutdown() {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -131,7 +131,13 @@ class Watcher : private boost::noncopyable {
   /// Reset pid and performance counters for a worker or extension process.
   static void reset(pid_t child);
 
-  /// Return the number of autoloadable extensions.
+  /**
+   * @brief Return the state of autoloadable extensions.
+   *
+   * Some initialization decisions are made based on waiting for plugins to
+   * broadcast from potentially-loaded extensions. If no extensions are loaded
+   * and an active (selected at comand line) plugin is missing, fail quickly.
+   */
   static bool hasManagedExtensions();
 
  private:
@@ -152,7 +158,7 @@ class Watcher : private boost::noncopyable {
   pid_t worker_;
   /// Keep a list of resolved extension paths and their managed pids.
   std::map<std::string, pid_t> extensions_;
-  /// Path to autoload extensions from.
+  /// Paths to autoload extensions.
   std::vector<std::string> extensions_paths_;
 
  private:
@@ -180,9 +186,9 @@ class WatcherLocker {
 /**
  * @brief The watchdog thread responsible for spawning/monitoring children.
  *
- * The WatcherRunner thread will spawn any autoloaded modules or optional
+ * The WatcherRunner thread will spawn any autoloaded extensions or optional
  * osquery daemon worker processes. It will then poll for their performance
- * state and kill/respawn osquery child processes.
+ * state and kill/respawn osquery child processes if they violate limits.
  */
 class WatcherRunner : public InternalRunnable {
  public:
@@ -199,6 +205,7 @@ class WatcherRunner : public InternalRunnable {
   }
 
  private:
+  /// Dispatcher (this service thread's) entry point.
   void enter();
   /// Boilerplate function to sleep for some configured latency
   bool ok();
@@ -208,7 +215,7 @@ class WatcherRunner : public InternalRunnable {
   bool isChildSane(pid_t child);
 
  private:
-  /// Fork a worker process.
+  /// Fork and execute a worker process.
   void createWorker();
   /// Fork an extension process.
   bool createExtension(const std::string& extension);

--- a/tools/tests/test.config
+++ b/tools/tests/test.config
@@ -1,4 +1,5 @@
 {
+  // Deprecated query schedule
   "scheduledQueries": [
     {
       "name": "time",
@@ -6,15 +7,29 @@
       "interval": 1
     }
   ],
+
+  // New, recommended query schedule
+  "schedule": {
+    "time2": {"query": "select * from time;", "interval": 1}
+  },
+
+  // Deprecated collection for file monitoring
   "additional_monitoring" : {
     "file_paths": {
       "downloads": [
         "/tmp/osquery-fstests-pattern/%%"
-      ],
-      "system_binaries": [
-        "/tmp/osquery-fstests-pattern/%",
-        "/tmp/osquery-fstests-pattern/deep11/%"
       ]
     }
+  },
+
+  // New, recommended file monitoring (top-level)
+  "file_paths": {
+    "downloads2": [
+      "/tmp/osquery-fstests-pattern/%%"
+    ],
+    "system_binaries": [
+      "/tmp/osquery-fstests-pattern/%",
+      "/tmp/osquery-fstests-pattern/deep11/%"
+    ]
   }
 }

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -4,7 +4,7 @@
 #  All rights reserved.
 #
 #  This source code is licensed under the BSD-style license found in the
-#  LICENSE file in the root directory of this source tree. An additional grant 
+#  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 from __future__ import absolute_import
@@ -69,33 +69,6 @@ class EXClient:
         return Extension.Client(self.protocol)
 
 
-def expect(functional, expected, interval=0.2, timeout=2):
-    """Helper function to run a function with expected latency"""
-    delay = 0
-    result = None
-    while result is None or len(result) != expected:
-        try:
-            result = functional()
-            if len(result) == expected: break
-        except: pass
-        if delay >= timeout:
-            return None
-        time.sleep(interval)
-        delay += interval
-    return result
-
-
-def expectTrue(functional, interval=0.2, timeout=2): 
-    """Helper function to run a function with expected latency"""
-    delay = 0
-    while delay < timeout:
-        if functional():
-            return True
-        time.sleep(interval)
-        delay += interval
-    return False
-
-
 class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
     def tearDown(self):
         stale_sockets = glob.glob("/tmp/osquery-test.em*")
@@ -123,13 +96,13 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # List the number of extensions
         print (em.ping())
-        result = expect(em.extensions, 0)
+        result = test_base.expect(em.extensions, 0)
         self.assertEqual(len(result), 0)
 
         # Try the basic ping API
@@ -152,15 +125,15 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
     def test_3_example_extension(self):
         daemon = self._run_daemon({"disable_watchdog": True})
         self.assertTrue(daemon.isAlive())
-        
+
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # Make sure there are no extensions registered
-        result = expect(em.extensions, 0)
+        result = test_base.expect(em.extensions, 0)
         self.assertEqual(len(result), 0)
 
         # Make sure the extension process starts
@@ -168,7 +141,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(extension.isAlive())
 
         # Now that an extension has started, check extension list
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
         ex_uuid = result.keys()[0]
         ex_data = result[ex_uuid]
@@ -213,15 +186,15 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
     def test_4_extension_dies(self):
         daemon = self._run_daemon({"disable_watchdog": True})
         self.assertTrue(daemon.isAlive())
-        
+
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # Make sure there are no extensions registered
-        result = expect(em.extensions, 0)
+        result = test_base.expect(em.extensions, 0)
         self.assertEqual(len(result), 0)
 
         # Make sure the extension process starts
@@ -229,14 +202,14 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(extension.isAlive())
 
         # Now that an extension has started, check extension list
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
 
         # Kill the extension
         extension.kill()
 
         # Make sure the daemon detects the change
-        result = expect(em.extensions, 0, timeout=5)
+        result = test_base.expect(em.extensions, 0, timeout=5)
         self.assertEqual(len(result), 0)
 
         # Make sure the extension restarts
@@ -244,7 +217,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(extension.isAlive())
 
         # With the reset there should be 1 extension again
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
         print (em.query("select * from example"))
 
@@ -266,12 +239,12 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # The waiting extension should have connected to the daemon.
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
 
         client.close()
@@ -289,12 +262,12 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # The waiting extension should have connected to the daemon.
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
 
         client.close()
@@ -308,12 +281,12 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # The waiting extension should have connected to the daemon.
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
 
         client.close()
@@ -330,13 +303,13 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = EXClient()
-        expectTrue(client.open)
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open())
         em = client.getEM()
 
         # The waiting extension should have connected to the daemon.
         # If there are no extensions the daemon may have exited (in error).
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertEqual(len(result), 1)
 
         client.close()
@@ -356,7 +329,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.open()
         em = client.getEM()
         # Need the manager to request the extension's UUID.
-        result = expect(em.extensions, 1)
+        result = test_base.expect(em.extensions, 1)
         self.assertTrue(result is not None)
         ex_uuid = result.keys()[0]
         client2 = EXClient(uuid=ex_uuid)
@@ -383,6 +356,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
 
 if __name__ == "__main__":
+    test_base.assertPermissions()
     module = test_base.Tester()
 
     # Find and import the thrift-generated python interface

--- a/tools/tests/test_modules.py
+++ b/tools/tests/test_modules.py
@@ -19,6 +19,7 @@ import unittest
 
 # osquery-specific testing utils
 import test_base
+import utils
 
 class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
     def setUp(self):
@@ -70,4 +71,5 @@ class ModuleTests(test_base.ProcessGenerator, unittest.TestCase):
 
 
 if __name__ == "__main__":
+    test_base.assertPermissions()
     module = test_base.Tester().run()

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -20,6 +20,10 @@ def red(msg):
     return "\033[41m\033[1;30m %s \033[0m" % str(msg)
 
 
+def lightred(msg):
+    return "\033[1;31m %s \033[0m" % str(msg)
+
+
 def yellow(msg):
     return "\033[43m\033[1;30m %s \033[0m" % str(msg)
 


### PR DESCRIPTION
Flags loaded from options was removed during a refactor of config merging. This fixes the ignored options regression.