### PR TITLE
Ran clang-format across the codebase

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -115,7 +115,7 @@ class Config : private boost::noncopyable {
    * Config's constructor is private
    */
   Config() {}
-  ~Config(){}
+  ~Config() {}
   Config(Config const&);
   void operator=(Config const&);
 

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/database/db_handle.h
+++ b/include/osquery/database/db_handle.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/database/query.h
+++ b/include/osquery/database/query.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -269,7 +269,8 @@ bool addUniqueRowToQueryData(QueryData& q, const Row& r);
  * @param oldData the old QueryData to copy
  * @param newData the new escaped QueryData object
  */
-void escapeQueryData(const osquery::QueryData &oldData, osquery::QueryData &newData);
+void escapeQueryData(const osquery::QueryData& oldData,
+                     osquery::QueryData& newData);
 
 /**
  * @brief represents the relevant parameters of a scheduled query.

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -27,8 +27,10 @@
 namespace osquery {
 
 struct Subscription;
-template <class SC, class EC> class EventPublisher;
-template <class PUB> class EventSubscriber;
+template <class SC, class EC>
+class EventPublisher;
+template <class PUB>
+class EventSubscriber;
 class EventFactory;
 
 typedef const std::string EventPublisherID;
@@ -79,7 +81,8 @@ typedef std::shared_ptr<BaseEventPublisher> EventPublisherRef;
 typedef std::shared_ptr<SubscriptionContext> SubscriptionContextRef;
 typedef std::shared_ptr<EventContext> EventContextRef;
 typedef EventSubscriber<BaseEventPublisher> BaseEventSubscriber;
-typedef std::shared_ptr<EventSubscriber<BaseEventPublisher>> EventSubscriberRef;
+typedef std::shared_ptr<EventSubscriber<BaseEventPublisher> >
+    EventSubscriberRef;
 
 /**
  * @brief EventSubscriber%s may exist in various states.
@@ -254,7 +257,7 @@ class EventPublisherPlugin : public Plugin {
   size_t numEvents() const { return next_ec_id_; }
 
   /// Overriding the EventPublisher constructor is not recommended.
-  EventPublisherPlugin() : next_ec_id_(0), ending_(false), started_(false) {};
+  EventPublisherPlugin() : next_ec_id_(0), ending_(false), started_(false){};
   virtual ~EventPublisherPlugin() {}
 
   /// Return a string identifier associated with this EventPublisher.
@@ -467,7 +470,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return List of 'index.step' index strings.
    */
-  std::vector<std::string> getIndexes(EventTime start, 
+  std::vector<std::string> getIndexes(EventTime start,
                                       EventTime stop,
                                       int list_key = 0);
 

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/include/osquery/sdk.h
+++ b/include/osquery/sdk.h
@@ -80,10 +80,10 @@ REGISTER_INTERNAL(ExternalSQLPlugin, "sql", "sql");
  * The registry is again locked when the module load is complete and a well
  * known module-exported symbol is called.
  */
-#define CREATE_MODULE(name, version, min_sdk_version)         \
-  DECLARE_MODULE(name) {                                      \
-    Registry::declareModule(                                  \
-        name, version, min_sdk_version, OSQUERY_SDK_VERSION); \
+#define CREATE_MODULE(name, version, min_sdk_version)       \
+  DECLARE_MODULE(name) {                                    \
+    Registry::declareModule(name, version, min_sdk_version, \
+                            OSQUERY_SDK_VERSION);           \
   }
 
 /**
@@ -96,12 +96,12 @@ REGISTER_INTERNAL(ExternalSQLPlugin, "sql", "sql");
  * And example use includes checking if a process environment variable is
  * defined. If defined the module is declared.
  */
-#define CREATE_MODULE_IF(expr, name, version, min_sdk_version)  \
-  DECLARE_MODULE(name) {                                        \
-    if ((expr)) {                                               \
-      Registry::declareModule(                                  \
-          name, version, min_sdk_version, OSQUERY_SDK_VERSION); \
-    }                                                           \
+#define CREATE_MODULE_IF(expr, name, version, min_sdk_version) \
+  DECLARE_MODULE(name) {                                       \
+    if ((expr)) {                                              \
+      Registry::declareModule(name, version, min_sdk_version,  \
+                              OSQUERY_SDK_VERSION);            \
+    }                                                          \
   }
 
 /// Helper replacement for REGISTER, used within extension modules.

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -28,7 +28,7 @@
   do {                                                                    \
     _Pragma("clang diagnostic push")                                      \
         _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
-        expr;                                                             \
+            expr;                                                         \
     _Pragma("clang diagnostic pop")                                       \
   } while (0)
 
@@ -206,7 +206,7 @@ struct ConstraintList {
    */
   std::set<std::string> getAll(ConstraintOperator op) const;
 
-  template<typename T>
+  template <typename T>
   std::set<T> getAll(ConstraintOperator op) const {
     std::set<T> literal_matches;
     auto matches = getAll(op);

--- a/osquery/config/config_tests.cpp
+++ b/osquery/config/config_tests.cpp
@@ -149,7 +149,9 @@ TEST_F(ConfigTests, test_config_update) {
 
 class TestConfigParserPlugin : public ConfigParserPlugin {
  public:
-  std::vector<std::string> keys() { return {"dictionary", "dictionary2", "list"}; }
+  std::vector<std::string> keys() {
+    return {"dictionary", "dictionary2", "list"};
+  }
 
   Status update(const std::map<std::string, ConfigTree>& config) {
     // Set a simple boolean indicating the update callin occurred.

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -63,9 +63,9 @@ std::string base64Encode(const std::string& unencoded) {
     return std::string();
   }
 
-  unsigned int writePaddChars = (3-unencoded.length()%3)%3;
+  unsigned int writePaddChars = (3 - unencoded.length() % 3) % 3;
   std::string base64(it_base64(unencoded.begin()), it_base64(unencoded.end()));
-  base64.append(writePaddChars,'=');
+  base64.append(writePaddChars, '=');
   os << base64;
   return os.str();
 }

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -83,5 +83,4 @@ std::string stringFromCFNumber(const CFDataRef& cf_number, CFNumberType type);
 
 std::string stringFromCFData(const CFDataRef& cf_data);
 #endif
-
 }

--- a/osquery/core/conversions_tests.cpp
+++ b/osquery/core/conversions_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -20,8 +20,8 @@ std::string stringFromCFString(const CFStringRef& cf_string) {
   // Access, then convert the CFString. CFStringGetCStringPtr is less-safe.
   CFIndex length = CFStringGetLength(cf_string);
   char* buffer = (char*)malloc(length + 1);
-  if (!CFStringGetCString(
-          cf_string, buffer, length + 1, kCFStringEncodingASCII)) {
+  if (!CFStringGetCString(cf_string, buffer, length + 1,
+                          kCFStringEncodingASCII)) {
     free(buffer);
     return "";
   }

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -17,15 +17,15 @@
 namespace osquery {
 
 #ifdef __APPLE__
-  #import <CommonCrypto/CommonDigest.h>
-  #define __HASH_API(name) CC_##name
+#import <CommonCrypto/CommonDigest.h>
+#define __HASH_API(name) CC_##name
 #else
-  #include <openssl/sha.h>
-  #include <openssl/md5.h>
-  #define __HASH_API(name) name
+#include <openssl/sha.h>
+#include <openssl/md5.h>
+#define __HASH_API(name) name
 
-  #define SHA1_DIGEST_LENGTH SHA_DIGEST_LENGTH
-  #define SHA1_CTX SHA_CTX
+#define SHA1_DIGEST_LENGTH SHA_DIGEST_LENGTH
+#define SHA1_CTX SHA_CTX
 #endif
 
 #define HASH_CHUNK_SIZE 1024
@@ -84,7 +84,9 @@ std::string Hash::digest() {
   return digest.str();
 }
 
-std::string hashFromBuffer(HashType hash_type, const void* buffer, size_t size) {
+std::string hashFromBuffer(HashType hash_type,
+                           const void* buffer,
+                           size_t size) {
   Hash hash(hash_type);
   hash.update(buffer, size);
   return hash.digest();

--- a/osquery/core/status_tests.cpp
+++ b/osquery/core/status_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/core/text.cpp
+++ b/osquery/core/text.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/core/text_tests.cpp
+++ b/osquery/core/text_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -41,7 +41,8 @@ const std::map<WatchdogLimitType, std::vector<size_t> > kWatchdogLimits = {
     // Seconds of tolerable UTILIZATION_LIMIT sustained latency.
     {LATENCY_LIMIT, {12, 6, 3, 1}},
     // How often to poll for performance limit violations.
-    {INTERVAL, {3, 3, 3, 1}}, };
+    {INTERVAL, {3, 3, 3, 1}},
+};
 
 const std::string kExtensionExtension = ".ext";
 
@@ -298,8 +299,8 @@ void WatcherRunner::createWorker() {
   }
 
   // Get the path of the current process.
-  auto qd = SQL::selectAllFrom("processes", "pid", tables::EQUALS,
-    INTEGER(getpid()));
+  auto qd =
+      SQL::selectAllFrom("processes", "pid", tables::EQUALS, INTEGER(getpid()));
   if (qd.size() != 1 || qd[0].count("path") == 0 || qd[0]["path"].size() == 0) {
     LOG(ERROR) << "osquery watcher cannot determine process path";
     ::exit(EXIT_FAILURE);
@@ -346,8 +347,8 @@ bool WatcherRunner::createExtension(const std::string& extension) {
 
   // Check the path to the previously-discovered extension binary.
   auto exec_path = fs::system_complete(fs::path(extension));
-  if (!safePermissions(
-          exec_path.parent_path().string(), exec_path.string(), true)) {
+  if (!safePermissions(exec_path.parent_path().string(), exec_path.string(),
+                       true)) {
     // Extension binary has become unsafe.
     LOG(WARNING) << "Extension binary has unsafe permissions: " << extension;
     return false;
@@ -380,8 +381,8 @@ bool WatcherRunner::createExtension(const std::string& extension) {
 
   Watcher::setExtension(extension, ext_pid);
   Watcher::resetExtensionCounters(extension, getUnixTime());
-  VLOG(1) << "Created and monitoring extension child (" << ext_pid << "): "
-          << extension;
+  VLOG(1) << "Created and monitoring extension child (" << ext_pid
+          << "): " << extension;
   return true;
 }
 

--- a/osquery/database/db_handle_tests.cpp
+++ b/osquery/database/db_handle_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -50,8 +50,8 @@ TEST_F(DBHandleTests, test_get_handle_for_column_family) {
 }
 
 TEST_F(DBHandleTests, test_get) {
-  db->getDB()->Put(
-      rocksdb::WriteOptions(), cfh_queries, "test_query_123", "{}");
+  db->getDB()->Put(rocksdb::WriteOptions(), cfh_queries, "test_query_123",
+                   "{}");
   std::string r;
   std::string key = "test_query_123";
   auto s = db->Get(kQueries, key, r);

--- a/osquery/database/query_tests.cpp
+++ b/osquery/database/query_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/database/results_tests.cpp
+++ b/osquery/database/results_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/devtools/printer_tests.cpp
+++ b/osquery/devtools/printer_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -24,22 +24,22 @@ class PrinterTests : public testing::Test {
     order = {"name", "age", "food", "number"};
     q = {
         {
-         {"name", "Mike Jones"},
-         {"age", "39"},
-         {"food", "mac and cheese"},
-         {"number", "1"},
+            {"name", "Mike Jones"},
+            {"age", "39"},
+            {"food", "mac and cheese"},
+            {"number", "1"},
         },
         {
-         {"name", "John Smith"},
-         {"age", "44"},
-         {"food", "peanut butter and jelly"},
-         {"number", "2"},
+            {"name", "John Smith"},
+            {"age", "44"},
+            {"food", "peanut butter and jelly"},
+            {"number", "2"},
         },
         {
-         {"name", "Doctor Who"},
-         {"age", "2000"},
-         {"food", "fish sticks and custard"},
-         {"number", "11"},
+            {"name", "Doctor Who"},
+            {"age", "2000"},
+            {"food", "fish sticks and custard"},
+            {"number", "11"},
         },
     };
   }

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -324,15 +324,7 @@ struct callback_data {
 #define MODE_Pretty 9 /* Pretty print the SQL results */
 
 static const char *modeDescr[] = {
-    "line",
-    "column",
-    "list",
-    "semi",
-    "html",
-    "tcl",
-    "csv",
-    "explain",
-    "pretty",
+    "line", "column", "list", "semi", "html", "tcl", "csv", "explain", "pretty",
 };
 
 /*
@@ -404,7 +396,7 @@ static void output_html_string(FILE *out, const char *z) {
     z = "";
   while (*z) {
     for (i = 0; z[i] && z[i] != '<' && z[i] != '&' && z[i] != '>' &&
-                    z[i] != '\"' && z[i] != '\'';
+                z[i] != '\"' && z[i] != '\'';
          i++) {
     }
     if (i > 0) {
@@ -840,16 +832,16 @@ static int display_stats(sqlite3 *db, /* Database to query */
             iHiwtr);
     iHiwtr = iCur = -1;
     sqlite3_status(SQLITE_STATUS_MALLOC_SIZE, &iCur, &iHiwtr, bReset);
-    fprintf(
-        pArg->out, "Largest Allocation:                  %d bytes\n", iHiwtr);
+    fprintf(pArg->out, "Largest Allocation:                  %d bytes\n",
+            iHiwtr);
     iHiwtr = iCur = -1;
     sqlite3_status(SQLITE_STATUS_PAGECACHE_SIZE, &iCur, &iHiwtr, bReset);
-    fprintf(
-        pArg->out, "Largest Pcache Allocation:           %d bytes\n", iHiwtr);
+    fprintf(pArg->out, "Largest Pcache Allocation:           %d bytes\n",
+            iHiwtr);
     iHiwtr = iCur = -1;
     sqlite3_status(SQLITE_STATUS_SCRATCH_SIZE, &iCur, &iHiwtr, bReset);
-    fprintf(
-        pArg->out, "Largest Scratch Allocation:          %d bytes\n", iHiwtr);
+    fprintf(pArg->out, "Largest Scratch Allocation:          %d bytes\n",
+            iHiwtr);
 #ifdef YYTRACKMAXSTACKDEPTH
     iHiwtr = iCur = -1;
     sqlite3_status(SQLITE_STATUS_PARSER_STACK, &iCur, &iHiwtr, bReset);
@@ -862,20 +854,20 @@ static int display_stats(sqlite3 *db, /* Database to query */
 
   if (pArg && pArg->out && db) {
     iHiwtr = iCur = -1;
-    sqlite3_db_status(
-        db, SQLITE_DBSTATUS_LOOKASIDE_USED, &iCur, &iHiwtr, bReset);
+    sqlite3_db_status(db, SQLITE_DBSTATUS_LOOKASIDE_USED, &iCur, &iHiwtr,
+                      bReset);
     fprintf(pArg->out,
             "Lookaside Slots Used:                %d (max %d)\n",
             iCur,
             iHiwtr);
-    sqlite3_db_status(
-        db, SQLITE_DBSTATUS_LOOKASIDE_HIT, &iCur, &iHiwtr, bReset);
+    sqlite3_db_status(db, SQLITE_DBSTATUS_LOOKASIDE_HIT, &iCur, &iHiwtr,
+                      bReset);
     fprintf(pArg->out, "Successful lookaside attempts:       %d\n", iHiwtr);
-    sqlite3_db_status(
-        db, SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE, &iCur, &iHiwtr, bReset);
+    sqlite3_db_status(db, SQLITE_DBSTATUS_LOOKASIDE_MISS_SIZE, &iCur, &iHiwtr,
+                      bReset);
     fprintf(pArg->out, "Lookaside failures due to size:      %d\n", iHiwtr);
-    sqlite3_db_status(
-        db, SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL, &iCur, &iHiwtr, bReset);
+    sqlite3_db_status(db, SQLITE_DBSTATUS_LOOKASIDE_MISS_FULL, &iCur, &iHiwtr,
+                      bReset);
     fprintf(pArg->out, "Lookaside failures due to OOM:       %d\n", iHiwtr);
     iHiwtr = iCur = -1;
     sqlite3_db_status(db, SQLITE_DBSTATUS_CACHE_USED, &iCur, &iHiwtr, bReset);
@@ -898,8 +890,8 @@ static int display_stats(sqlite3 *db, /* Database to query */
   }
 
   if (pArg && pArg->out && db && pArg->pStmt) {
-    iCur = sqlite3_stmt_status(
-        pArg->pStmt, SQLITE_STMTSTATUS_FULLSCAN_STEP, bReset);
+    iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_FULLSCAN_STEP,
+                               bReset);
     fprintf(pArg->out, "Fullscan Steps:                      %d\n", iCur);
     iCur = sqlite3_stmt_status(pArg->pStmt, SQLITE_STMTSTATUS_SORT, bReset);
     fprintf(pArg->out, "Sort Operations:                     %d\n", iCur);
@@ -1205,7 +1197,6 @@ static int shell_exec(
   return rc;
 }
 
-
 /*
 ** Text of a help message
 */
@@ -1315,16 +1306,16 @@ static sqlite3_int64 integerValue(const char *zArg) {
     char *zSuffix;
     int iMult;
   } aMult[] = {
-        {(char *)"KiB", 1024},
-        {(char *)"MiB", 1024 * 1024},
-        {(char *)"GiB", 1024 * 1024 * 1024},
-        {(char *)"KB", 1000},
-        {(char *)"MB", 1000000},
-        {(char *)"GB", 1000000000},
-        {(char *)"K", 1000},
-        {(char *)"M", 1000000},
-        {(char *)"G", 1000000000},
-    };
+      {(char *)"KiB", 1024},
+      {(char *)"MiB", 1024 * 1024},
+      {(char *)"GiB", 1024 * 1024 * 1024},
+      {(char *)"KB", 1000},
+      {(char *)"MB", 1000000},
+      {(char *)"GB", 1000000000},
+      {(char *)"K", 1000},
+      {(char *)"M", 1000000},
+      {(char *)"G", 1000000000},
+  };
   int i;
   int isNeg = 0;
   if (zArg[0] == '-') {
@@ -1376,8 +1367,8 @@ static int booleanValue(char *zArg) {
   if (sqlite3_stricmp(zArg, "off") == 0 || sqlite3_stricmp(zArg, "no") == 0) {
     return 0;
   }
-  fprintf(
-      stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n", zArg);
+  fprintf(stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n",
+          zArg);
   return 0;
 }
 
@@ -1471,8 +1462,8 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
     return 0; /* no tokens, no error */
   n = strlen30(azArg[0]);
   c = azArg[0][0];
-  if (c == 'b' && n >= 3 && strncmp(azArg[0], "bail", n) == 0 &&
-             nArg > 1 && nArg < 3) {
+  if (c == 'b' && n >= 3 && strncmp(azArg[0], "bail", n) == 0 && nArg > 1 &&
+      nArg < 3) {
     bail_on_error = booleanValue(azArg[1]);
   } else if (c == 'e' && strncmp(azArg[0], "echo", n) == 0 && nArg > 1 &&
              nArg < 3) {
@@ -1705,8 +1696,8 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
     int i;
     fprintf(p->out, "%9.9s: %s\n", "echo", p->echoOn ? "on" : "off");
     fprintf(p->out, "%9.9s: %s\n", "eqp", p->autoEQP ? "on" : "off");
-    fprintf(
-        p->out, "%9.9s: %s\n", "explain", p->explainPrev.valid ? "on" : "off");
+    fprintf(p->out, "%9.9s: %s\n", "explain",
+            p->explainPrev.valid ? "on" : "off");
     fprintf(p->out, "%9.9s: %s\n", "headers", p->showHeader ? "on" : "off");
     fprintf(p->out, "%9.9s: %s\n", "mode", modeDescr[p->mode]);
     fprintf(p->out, "%9.9s: ", "nullvalue");
@@ -1845,7 +1836,7 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
     }
 #endif
   } else if (c == 'v' && strncmp(azArg[0], "version", n) == 0) {
-  	fprintf(p->out, "osquery %s\n", TEXT(OSQUERY_VERSION).c_str());
+    fprintf(p->out, "osquery %s\n", TEXT(OSQUERY_VERSION).c_str());
     fprintf(p->out,
             "SQLite %s %s\n" /*extra-version-info*/,
             sqlite3_libversion(),
@@ -2039,8 +2030,8 @@ static int process_input(struct callback_data *p, FILE *in) {
       if (rc || zErrMsg) {
         char zPrefix[100];
         if (in != 0 || !stdin_is_interactive) {
-          sqlite3_snprintf(
-              sizeof(zPrefix), zPrefix, "Error: near line %d:", startline);
+          sqlite3_snprintf(sizeof(zPrefix), zPrefix, "Error: near line %d:",
+                           startline);
         } else {
           sqlite3_snprintf(sizeof(zPrefix), zPrefix, "Error:");
         }
@@ -2103,8 +2094,8 @@ int launchIntoShell(int argc, char **argv) {
   data.db = db;
 
   // Add some shell-specific functions to the instance.
-  sqlite3_create_function(
-      db, "shellstatic", 0, SQLITE_UTF8, 0, shellstaticFunc, 0, 0);
+  sqlite3_create_function(db, "shellstatic", 0, SQLITE_UTF8, 0, shellstaticFunc,
+                          0, 0);
 
   Argv0 = argv[0];
   stdin_is_interactive = isatty(0);
@@ -2116,7 +2107,7 @@ int launchIntoShell(int argc, char **argv) {
     // SQLite: Need to check for batch mode here to so we can avoid printing
     // informational messages (like from process_sqliterc) before we do the
     // actual processing of arguments later in a second pass.
-      stdin_is_interactive = 0;
+    stdin_is_interactive = 0;
   }
 
   int warnInmemoryDb = 1;
@@ -2150,9 +2141,9 @@ int launchIntoShell(int argc, char **argv) {
   bail_on_error = (FLAGS_bail) ? 1 : 0;
 
   sqlite3_snprintf(sizeof(data.separator), data.separator, "%s",
-    FLAGS_separator.c_str());
+                   FLAGS_separator.c_str());
   sqlite3_snprintf(sizeof(data.nullvalue), data.nullvalue, "%s",
-    FLAGS_nullvalue.c_str());
+                   FLAGS_nullvalue.c_str());
 
   int rc = 0;
   if (argc > 1 && argv[1] != nullptr) {

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -34,7 +34,7 @@ Dispatcher& Dispatcher::getInstance() {
 
 Dispatcher::Dispatcher() {
   thread_manager_ = InternalThreadManager::newSimpleThreadManager(
-          (size_t)FLAGS_worker_threads, 0);
+      (size_t)FLAGS_worker_threads, 0);
   auto threadFactory = ThriftThreadFactory(new PosixThreadFactory());
   thread_manager_->threadFactory(threadFactory);
   thread_manager_->start();

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -31,7 +31,8 @@
 namespace osquery {
 
 typedef apache::thrift::concurrency::ThreadManager InternalThreadManager;
-typedef OSQUERY_THRIFT_POINTER::shared_ptr<InternalThreadManager> InternalThreadManagerRef;
+typedef OSQUERY_THRIFT_POINTER::shared_ptr<InternalThreadManager>
+    InternalThreadManagerRef;
 
 /**
  * @brief Default number of threads in the thread pool.
@@ -69,7 +70,8 @@ class InternalRunnable : public apache::thrift::concurrency::Runnable {
 typedef std::shared_ptr<InternalRunnable> InternalRunnableRef;
 typedef std::shared_ptr<boost::thread> InternalThreadRef;
 /// A thrift internal runnable with variable pointer wrapping.
-typedef OSQUERY_THRIFT_POINTER::shared_ptr<InternalRunnable> ThriftInternalRunnableRef;
+typedef OSQUERY_THRIFT_POINTER::shared_ptr<InternalRunnable>
+    ThriftInternalRunnableRef;
 typedef OSQUERY_THRIFT_POINTER::shared_ptr<
     apache::thrift::concurrency::PosixThreadFactory> ThriftThreadFactory;
 

--- a/osquery/dispatcher/dispatcher_tests.cpp
+++ b/osquery/dispatcher/dispatcher_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <ctime>
 
 #include <osquery/config.h>

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -38,8 +38,8 @@ Status MockDistributedProvider::getQueriesJSON(std::string& query_json) {
 }
 
 Status MockDistributedProvider::writeResultsJSON(const std::string& results) {
-    resultsJSON_ = results;
-    return Status();
+  resultsJSON_ = results;
+  return Status();
 }
 
 Status DistributedQueryHandler::parseQueriesJSON(
@@ -50,8 +50,7 @@ Status DistributedQueryHandler::parseQueriesJSON(
   try {
     std::istringstream query_stream(query_json);
     pt::read_json(query_stream, tree);
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     return Status(1, std::string("Error loading query JSON: ") + e.what());
   }
 
@@ -96,8 +95,7 @@ Status DistributedQueryHandler::serializeResults(
         return s;
       }
     }
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     return Status(1, std::string("Error serializing results: ") + e.what());
   }
   return Status();
@@ -146,8 +144,7 @@ Status DistributedQueryHandler::doQueries() {
     std::ostringstream ss;
     pt::write_json(ss, serialized_results, false);
     json = ss.str();
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     return Status(1, e.what());
   }
 

--- a/osquery/distributed/distributed.h
+++ b/osquery/distributed/distributed.h
@@ -29,7 +29,7 @@ namespace osquery {
  * file, querying a message queue, etc.)
  */
 class IDistributedProvider {
-public:
+ public:
   virtual ~IDistributedProvider() {}
 
   /*
@@ -58,8 +58,8 @@ public:
  * DistributedQueryHandler functionality.
  */
 class MockDistributedProvider : public IDistributedProvider {
-public:
- // These methods just read/write the corresponding public members
+ public:
+  // These methods just read/write the corresponding public members
   Status getQueriesJSON(std::string& query_json) override;
   Status writeResultsJSON(const std::string& results) override;
 
@@ -72,10 +72,10 @@ public:
  * distributed query
  */
 struct DistributedQueryRequest {
-public:
- explicit DistributedQueryRequest() {}
- explicit DistributedQueryRequest(const std::string& q, const std::string& i)
-     : query(q), id(i) {}
+ public:
+  explicit DistributedQueryRequest() {}
+  explicit DistributedQueryRequest(const std::string& q, const std::string& i)
+      : query(q), id(i) {}
   std::string query;
   std::string id;
 };
@@ -88,60 +88,61 @@ public:
  * the master, and executes queries.
  */
 class DistributedQueryHandler {
-public:
- /**
-  * @brief Construct a new handler with the given provider
-  *
-  * @param provider The provider used retrieving queries and writing results
-  */
- explicit DistributedQueryHandler(
-     std::unique_ptr<IDistributedProvider> provider)
-     : provider_(std::move(provider)) {}
+ public:
+  /**
+   * @brief Construct a new handler with the given provider
+   *
+   * @param provider The provider used retrieving queries and writing results
+   */
+  explicit DistributedQueryHandler(
+      std::unique_ptr<IDistributedProvider> provider)
+      : provider_(std::move(provider)) {}
 
- /**
-  * @brief Retrieve queries, run them, and write results
-  *
-  * This is the core method of DistributedQueryHandler, tying together all the
-  * other components to read the requests from the provider, execute the
-  * queries, and write the results back to the provider.
-  *
-  * @return osquery::Status indicating success or failure of the operation
-  */
- Status doQueries();
+  /**
+   * @brief Retrieve queries, run them, and write results
+   *
+   * This is the core method of DistributedQueryHandler, tying together all the
+   * other components to read the requests from the provider, execute the
+   * queries, and write the results back to the provider.
+   *
+   * @return osquery::Status indicating success or failure of the operation
+   */
+  Status doQueries();
 
- /**
-  * @brief Run and annotate an individual query
-  *
-  * @param query_string A string containing the query to be executed
-  *
-  * @return A SQL object containing the (annotated) query results
-  */
- static SQL handleQuery(const std::string& query_string);
+  /**
+   * @brief Run and annotate an individual query
+   *
+   * @param query_string A string containing the query to be executed
+   *
+   * @return A SQL object containing the (annotated) query results
+   */
+  static SQL handleQuery(const std::string& query_string);
 
- /**
-  * @brief Serialize the results of all requests into a ptree
-  *
-  * @param results The vector of requests and results
-  * @param tree The tree to serialize results into
-  *
-  * @return osquery::Status indicating success or failure of the operation
-  */
- static Status serializeResults(
-     const std::vector<std::pair<DistributedQueryRequest, SQL> >& results,
-     boost::property_tree::ptree& tree);
+  /**
+   * @brief Serialize the results of all requests into a ptree
+   *
+   * @param results The vector of requests and results
+   * @param tree The tree to serialize results into
+   *
+   * @return osquery::Status indicating success or failure of the operation
+   */
+  static Status serializeResults(
+      const std::vector<std::pair<DistributedQueryRequest, SQL> >& results,
+      boost::property_tree::ptree& tree);
 
- /**
-  * @brief Parse the query JSON into the individual query objects
-  *
-  * @param query_json The JSON string containing the queries
-  * @param requests A vector to fill with the query objects
-  *
-  * @return osquery::Status indicating success or failure of the parsing
-  */
-  static Status parseQueriesJSON(const std::string& query_json,
-                                 std::vector<DistributedQueryRequest>& requests);
+  /**
+   * @brief Parse the query JSON into the individual query objects
+   *
+   * @param query_json The JSON string containing the queries
+   * @param requests A vector to fill with the query objects
+   *
+   * @return osquery::Status indicating success or failure of the parsing
+   */
+  static Status parseQueriesJSON(
+      const std::string& query_json,
+      std::vector<DistributedQueryRequest>& requests);
 
-private:
+ private:
   // The provider used to read and write queries and results
   std::unique_ptr<IDistributedProvider> provider_;
 

--- a/osquery/distributed/distributed_tests.cpp
+++ b/osquery/distributed/distributed_tests.cpp
@@ -46,7 +46,9 @@ TEST_F(DistributedTests, test_test_distributed_provider) {
 }
 
 TEST_F(DistributedTests, test_parse_query_json) {
+  // clang-format off
   std::string request_json = R"([{"query": "foo", "id": "bar"}])";
+  // clang-format on
   std::vector<DistributedQueryRequest> requests;
   Status s = DistributedQueryHandler::parseQueriesJSON(request_json, requests);
   ASSERT_EQ(Status(), s);
@@ -54,7 +56,9 @@ TEST_F(DistributedTests, test_parse_query_json) {
   EXPECT_EQ("foo", requests[0].query);
   EXPECT_EQ("bar", requests[0].id);
 
+  // clang-format off
   std::string bad_json = R"([{"query": "foo", "id": "bar"}, {"query": "b"}])";
+  // clang-format on
   requests.clear();
   s = DistributedQueryHandler::parseQueriesJSON(bad_json, requests);
   ASSERT_FALSE(s.ok());
@@ -62,7 +66,7 @@ TEST_F(DistributedTests, test_parse_query_json) {
 }
 
 TEST_F(DistributedTests, test_handle_query) {
-// Access to the internal SQL implementation is only available in core.
+  // Access to the internal SQL implementation is only available in core.
   SQL query = DistributedQueryHandler::handleQuery("SELECT hour from time");
   ASSERT_TRUE(query.ok());
   QueryData rows = query.rows();
@@ -88,8 +92,10 @@ TEST_F(DistributedTests, test_serialize_results_empty) {
 
 TEST_F(DistributedTests, test_serialize_results_basic) {
   DistributedQueryRequest r0("foo", "foo_id");
-  QueryData rows0 = {{{"foo0", "foo0_val"}, {"bar0", "bar0_val"}},
-                     {{"foo1", "foo1_val"}, {"bar1", "bar1_val"}}, };
+  QueryData rows0 = {
+      {{"foo0", "foo0_val"}, {"bar0", "bar0_val"}},
+      {{"foo1", "foo1_val"}, {"bar1", "bar1_val"}},
+  };
   MockSQL q0 = MockSQL(rows0);
   pt::ptree tree;
 
@@ -110,8 +116,10 @@ TEST_F(DistributedTests, test_serialize_results_basic) {
 
 TEST_F(DistributedTests, test_serialize_results_multiple) {
   DistributedQueryRequest r0("foo", "foo_id");
-  QueryData rows0 = {{{"foo0", "foo0_val"}, {"bar0", "bar0_val"}},
-                     {{"foo1", "foo1_val"}, {"bar1", "bar1_val"}}, };
+  QueryData rows0 = {
+      {{"foo0", "foo0_val"}, {"bar0", "bar0_val"}},
+      {{"foo1", "foo1_val"}, {"bar1", "bar1_val"}},
+  };
   MockSQL q0 = MockSQL(rows0);
 
   DistributedQueryRequest r1("bar", "bar_id");
@@ -137,7 +145,7 @@ TEST_F(DistributedTests, test_serialize_results_multiple) {
 }
 
 TEST_F(DistributedTests, test_do_queries) {
-// Access to the internal SQL implementation is only available in core.
+  // Access to the internal SQL implementation is only available in core.
   auto provider_raw = new MockDistributedProvider();
   provider_raw->queriesJSON_ =
     R"([
@@ -185,7 +193,7 @@ TEST_F(DistributedTests, test_do_queries) {
 }
 
 TEST_F(DistributedTests, test_duplicate_request) {
-// Access to the internal SQL implementation is only available in core.
+  // Access to the internal SQL implementation is only available in core.
   auto provider_raw = new MockDistributedProvider();
   provider_raw->queriesJSON_ =
     R"([

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/darwin/fsevents_tests.cpp
+++ b/osquery/events/darwin/fsevents_tests.cpp
@@ -143,7 +143,10 @@ class TestFSEventsEventSubscriber
     : public EventSubscriber<FSEventsEventPublisher> {
  public:
   TestFSEventsEventSubscriber() { setName("TestFSEventsEventSubscriber"); }
-  Status init() { callback_count_ = 0; return Status(0, "OK"); }
+  Status init() {
+    callback_count_ = 0;
+    return Status(0, "OK");
+  }
   Status SimpleCallback(const FSEventsEventContextRef& ec,
                         const void* user_data) {
     callback_count_ += 1;
@@ -197,7 +200,8 @@ TEST_F(FSEventsTests, test_fsevents_run) {
   // Create a subscriptioning context
   auto mc = std::make_shared<FSEventsSubscriptionContext>();
   mc->path = kRealTestPath;
-  EventFactory::addSubscription("fsevents", Subscription::create("TestFSEventsEventSubscriber", mc));
+  EventFactory::addSubscription(
+      "fsevents", Subscription::create("TestFSEventsEventSubscriber", mc));
 
   // Create an event loop thread (similar to main)
   boost::thread temp_thread(EventFactory::run, "fsevents");

--- a/osquery/events/darwin/iokit_hid.cpp
+++ b/osquery/events/darwin/iokit_hid.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/darwin/iokit_hid.h
+++ b/osquery/events/darwin/iokit_hid.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/darwin/scnetwork.h
+++ b/osquery/events/darwin/scnetwork.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/events_database_tests.cpp
+++ b/osquery/events/events_database_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -48,14 +48,13 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
 TEST_F(EventsDatabaseTests, test_event_module_id) {
   auto sub = std::make_shared<FakeEventSubscriber>();
   sub->doNotExpire();
-  
+
   // Not normally available outside of EventSubscriber->Add().
   auto event_id1 = sub->getEventID();
   EXPECT_EQ(event_id1, "1");
   auto event_id2 = sub->getEventID();
   EXPECT_EQ(event_id2, "2");
 }
-
 
 TEST_F(EventsDatabaseTests, test_event_add) {
   auto sub = std::make_shared<FakeEventSubscriber>();

--- a/osquery/events/freebsd/fsevents.h
+++ b/osquery/events/freebsd/fsevents.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -63,13 +63,13 @@ void INotifyEventPublisher::tearDown() {
   inotify_handle_ = -1;
 }
 
-Status INotifyEventPublisher::restartMonitoring(){
+Status INotifyEventPublisher::restartMonitoring() {
   if (last_restart_ != 0 && getUnixTime() - last_restart_ < 10) {
     return Status(1, "Overflow");
   }
   last_restart_ = getUnixTime();
   VLOG(1) << "Got an overflow, trying to restart...";
-  for(const auto& desc : descriptors_){
+  for (const auto& desc : descriptors_) {
     removeMonitor(desc, 1);
   }
   path_descriptors_.clear();
@@ -108,7 +108,7 @@ Status INotifyEventPublisher::run() {
     if (event->mask & IN_Q_OVERFLOW) {
       // The inotify queue was overflown (remove all paths).
       Status stat = restartMonitoring();
-      if(!stat.ok()){
+      if (!stat.ok()) {
         return stat;
       }
     }
@@ -124,7 +124,7 @@ Status INotifyEventPublisher::run() {
       removeMonitor(event->wd, false);
     } else {
       auto ec = createEventContextFrom(event);
-      if(event->mask & IN_CREATE && isDirectory(ec->path).ok()){
+      if (event->mask & IN_CREATE && isDirectory(ec->path).ok()) {
         addMonitor(ec->path, 1);
       }
       fire(ec);

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/events/linux/inotify_tests.cpp
+++ b/osquery/events/linux/inotify_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -150,7 +150,10 @@ class TestINotifyEventSubscriber
     : public EventSubscriber<INotifyEventPublisher> {
  public:
   TestINotifyEventSubscriber() { setName("TestINotifyEventSubscriber"); }
-  Status init() { callback_count_ = 0; return Status(0, "OK"); }
+  Status init() {
+    callback_count_ = 0;
+    return Status(0, "OK");
+  }
   Status SimpleCallback(const INotifyEventContextRef& ec,
                         const void* user_data) {
     callback_count_ += 1;
@@ -205,7 +208,6 @@ TEST_F(INotifyTests, test_inotify_run) {
   // Create a temporary file to watch, open writeable
   FILE* fd = fopen(kRealTestPath.c_str(), "w");
 
-
   // Create a subscriber.
   auto sub = std::make_shared<TestINotifyEventSubscriber>();
   EventFactory::registerEventSubscriber(sub);
@@ -213,7 +215,8 @@ TEST_F(INotifyTests, test_inotify_run) {
   // Create a subscriptioning context
   auto mc = std::make_shared<INotifySubscriptionContext>();
   mc->path = kRealTestPath;
-  status = EventFactory::addSubscription("inotify", Subscription::create("TestINotifyEventSubscriber", mc));
+  status = EventFactory::addSubscription(
+      "inotify", Subscription::create("TestINotifyEventSubscriber", mc));
   EXPECT_TRUE(status.ok());
 
   // Create an event loop thread (similar to main)

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -65,7 +65,7 @@ Status UdevEventPublisher::run() {
     return Status(0, "Timeout");
   }
 
-  struct udev_device *device = udev_monitor_receive_device(monitor_);
+  struct udev_device* device = udev_monitor_receive_device(monitor_);
   if (device == nullptr) {
     LOG(ERROR) << "udev monitor returned invalid device.";
     return Status(1, "udev monitor failed.");

--- a/osquery/events/linux/udev.h
+++ b/osquery/events/linux/udev.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -107,8 +107,8 @@ class UdevEventPublisher
 
  private:
   /// udev handle (socket descriptor contained within).
-  struct udev *handle_;
-  struct udev_monitor *monitor_;
+  struct udev* handle_;
+  struct udev_monitor* monitor_;
 
  private:
   /// Check subscription details.

--- a/osquery/examples/example_test.cpp
+++ b/osquery/examples/example_test.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -477,8 +477,7 @@ Status callExtension(const std::string& extension_path,
   try {
     auto client = EXClient(extension_path);
     client.get()->call(ext_response, registry, item, request);
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
 

--- a/osquery/extensions/extensions_tests.cpp
+++ b/osquery/extensions/extensions_tests.cpp
@@ -185,8 +185,7 @@ TEST_F(ExtensionsTest, test_extension_broadcast) {
   RouteUUID uuid;
   try {
     uuid = (RouteUUID)stoi(status.getMessage(), nullptr, 0);
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     EXPECT_TRUE(false);
     return;
   }

--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/filesystem/darwin/plist_benchmark.cpp
+++ b/osquery/filesystem/darwin/plist_benchmark.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/filesystem/darwin/plist_tests.cpp
+++ b/osquery/filesystem/darwin/plist_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/filesystem/filesystem_tests.cpp
+++ b/osquery/filesystem/filesystem_tests.cpp
@@ -3,11 +3,10 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-
 
 #include <fstream>
 
@@ -63,9 +62,8 @@ TEST_F(FilesystemTests, test_wildcard_single_file_list) {
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(files.size(), 3);
   EXPECT_EQ(files.size(), files_flag.size());
-  EXPECT_NE(
-      std::find(files.begin(), files.end(), kFakeDirectory + "/roto.txt"),
-      files.end());
+  EXPECT_NE(std::find(files.begin(), files.end(), kFakeDirectory + "/roto.txt"),
+            files.end());
 }
 
 TEST_F(FilesystemTests, test_wildcard_dual) {
@@ -234,12 +232,11 @@ TEST_F(FilesystemTests, test_dotdot_relative) {
 
 TEST_F(FilesystemTests, test_no_wild) {
   std::vector<std::string> all;
-  auto status = resolveFilePattern(kFakeDirectory + "/roto.txt",
-                                   all, REC_LIST_FILES);
+  auto status =
+      resolveFilePattern(kFakeDirectory + "/roto.txt", all, REC_LIST_FILES);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(all.size(), 1);
-  EXPECT_NE(std::find(all.begin(), all.end(),
-                      kFakeDirectory + "/roto.txt"),
+  EXPECT_NE(std::find(all.begin(), all.end(), kFakeDirectory + "/roto.txt"),
             all.end());
 }
 

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/logger/logger_tests.cpp
+++ b/osquery/logger/logger_tests.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -66,9 +66,9 @@ Status FilesystemLoggerPlugin::logStatus(
     const std::vector<StatusLogLine>& log) {
   for (const auto& item : log) {
     // Emit this intermediate log to the glog filesystem logger.
-    google::LogMessage(item.filename.c_str(),
-                       item.line,
-                       (google::LogSeverity)item.severity).stream()
+    google::LogMessage(
+        item.filename.c_str(), item.line, (google::LogSeverity)item.severity)
+            .stream()
         << item.message;
   }
 

--- a/osquery/main/empty.cpp
+++ b/osquery/main/empty.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -3,11 +3,11 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <string>
 
 #include <osquery/core.h>

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -3,11 +3,10 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-
 
 #include <osquery/core.h>
 

--- a/osquery/registry/registry_tests.cpp
+++ b/osquery/registry/registry_tests.cpp
@@ -3,11 +3,11 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <gtest/gtest.h>
 
 #include <osquery/logger.h>

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -173,8 +173,8 @@ Status queryInternal(const std::string& q, QueryData& results, sqlite3* db) {
 }
 
 Status getQueryColumnsInternal(const std::string& q,
-                       tables::TableColumns& columns,
-                       sqlite3* db) {
+                               tables::TableColumns& columns,
+                               sqlite3* db) {
   int rc;
 
   // Will automatically handle calling sqlite3_finalize on the prepared stmt

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -241,26 +241,9 @@ Status attachTableInternal(const std::string &name,
                            sqlite3 *db) {
   // A static module structure does not need specific logic per-table.
   static sqlite3_module module = {
-      0,
-      xCreate,
-      xCreate,
-      xBestIndex,
-      xDestroy,
-      xDestroy,
-      xOpen,
-      xClose,
-      xFilter,
-      xNext,
-      xEof,
-      xColumn,
-      xRowid,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
+      0,      xCreate, xCreate, xBestIndex, xDestroy, xDestroy, xOpen,
+      xClose, xFilter, xNext,   xEof,       xColumn,  xRowid,   0,
+      0,      0,       0,       0,          0,        0,
   };
 
   // Note, if the clientData API is used then this will save a registry call

--- a/osquery/sql/virtual_table_tests.cpp
+++ b/osquery/sql/virtual_table_tests.cpp
@@ -39,8 +39,8 @@ TEST_F(VirtualTableTests, test_tableplugin_columndefinition) {
 TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto table = std::make_shared<sampleTablePlugin>();
   table->setName("sample");
-  //sqlite3* db = nullptr;
-  //sqlite3_open(":memory:", &db);
+  // sqlite3* db = nullptr;
+  // sqlite3_open(":memory:", &db);
   auto dbc = SQLiteDBManager::get();
 
   // Virtual tables require the registry/plugin API to query tables.

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -71,7 +71,8 @@ void genExtension(const std::string& path, QueryData& results) {
   results.push_back(r);
 }
 
-QueryData genChromeBasedExtensions(QueryContext& context, const fs::path sub_dir) {
+QueryData genChromeBasedExtensions(QueryContext& context,
+                                   const fs::path sub_dir) {
   QueryData results;
 
   auto homes = osquery::getHomeDirectories();

--- a/osquery/tables/applications/browser_utils.h
+++ b/osquery/tables/applications/browser_utils.h
@@ -18,7 +18,7 @@ namespace pt = boost::property_tree;
 namespace osquery {
 namespace tables {
 
-QueryData genChromeBasedExtensions(QueryContext& context, const fs::path sub_dir);
-
+QueryData genChromeBasedExtensions(QueryContext& context,
+                                   const fs::path sub_dir);
 }
 }

--- a/osquery/tables/events/darwin/hardware_events.cpp
+++ b/osquery/tables/events/darwin/hardware_events.cpp
@@ -3,11 +3,11 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <osquery/core.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>

--- a/osquery/tables/events/darwin/passwd_changes.cpp
+++ b/osquery/tables/events/darwin/passwd_changes.cpp
@@ -3,11 +3,11 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <vector>
 #include <string>
 

--- a/osquery/tables/events/freebsd/passwd_changes.cpp
+++ b/osquery/tables/events/freebsd/passwd_changes.cpp
@@ -3,11 +3,11 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
- 
+
 #include <osquery/core.h>
 #include <osquery/database.h>
 #include "osquery/events/freebsd/fsevents.h"

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -51,7 +51,7 @@ Status HardwareEventSubscriber::Callback(const UdevEventContextRef& ec,
     return Status(0, "Missing node and driver.");
   }
 
-  struct udev_device *device = ec->device;
+  struct udev_device* device = ec->device;
   r["action"] = ec->action_string;
   r["path"] = ec->devnode;
   r["type"] = ec->devtype;

--- a/osquery/tables/events/linux/passwd_changes.cpp
+++ b/osquery/tables/events/linux/passwd_changes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/events/yara_matches.cpp
+++ b/osquery/tables/events/yara_matches.cpp
@@ -38,8 +38,7 @@ typedef FSEventsEventContextRef FileEventContextRef;
 #else
 typedef EventSubscriber<INotifyEventPublisher> FileEventSubscriber;
 typedef INotifyEventContextRef FileEventContextRef;
-#define FILE_CHANGE_MASK \
-  IN_CREATE | IN_CLOSE_WRITE | IN_MODIFY
+#define FILE_CHANGE_MASK IN_CREATE | IN_CLOSE_WRITE | IN_MODIFY
 #endif
 
 /**
@@ -52,8 +51,7 @@ void YARACompilerCallback(int error_level,
                           void* user_data) {
   if (error_level == YARA_ERROR_LEVEL_ERROR) {
     VLOG(1) << file_name << "(" << line_number << "): error: " << message;
-  }
-  else {
+  } else {
     VLOG(1) << file_name << "(" << line_number << "): warning: " << message;
   }
 }
@@ -61,7 +59,7 @@ void YARACompilerCallback(int error_level,
 Status handleRuleFiles(const std::string& category,
                        const pt::ptree& rule_files,
                        std::map<std::string, YR_RULES*>* rules) {
-  YR_COMPILER *compiler = nullptr;
+  YR_COMPILER* compiler = nullptr;
   int result = yr_compiler_create(&compiler);
   if (result != ERROR_SUCCESS) {
     VLOG(1) << "Could not create compiler: " + std::to_string(result);
@@ -72,7 +70,7 @@ Status handleRuleFiles(const std::string& category,
 
   bool compiled = false;
   for (const auto& item : rule_files) {
-    YR_RULES *tmp_rules;
+    YR_RULES* tmp_rules;
     const auto rule = item.second.get("", "");
     VLOG(1) << "Loading " << rule;
 
@@ -104,17 +102,15 @@ Status handleRuleFiles(const std::string& category,
     } else {
       compiled = true;
       // Try to compile the rules.
-      FILE *rule_file = fopen(rule.c_str(), "r");
+      FILE* rule_file = fopen(rule.c_str(), "r");
 
       if (rule_file == nullptr) {
         yr_compiler_destroy(compiler);
         return Status(1, "Could not open file: " + rule);
       }
 
-      int errors = yr_compiler_add_file(compiler,
-                                        rule_file,
-                                        NULL,
-                                        rule.c_str());
+      int errors =
+          yr_compiler_add_file(compiler, rule_file, NULL, rule.c_str());
 
       fclose(rule_file);
       rule_file = nullptr;
@@ -149,10 +145,10 @@ Status handleRuleFiles(const std::string& category,
  * This is the YARA callback. Used to store matching rules in the row which is
  * passed in as user_data.
  */
-int YARACallback(int message, void *message_data, void *user_data) {
+int YARACallback(int message, void* message_data, void* user_data) {
   if (message == CALLBACK_MSG_RULE_MATCHING) {
-    Row *r = (Row *) user_data;
-    YR_RULE *rule = (YR_RULE *) message_data;
+    Row* r = (Row*)user_data;
+    YR_RULE* rule = (YR_RULE*)message_data;
     if ((*r)["matches"].length() > 0) {
       (*r)["matches"] += "," + std::string(rule->identifier);
     } else {
@@ -197,7 +193,7 @@ class YARAEventSubscriber : public FileEventSubscriber {
   Status init();
 
  private:
-  std::map<std::string, YR_RULES *> rules;
+  std::map<std::string, YR_RULES*> rules;
 
   /**
    * @brief This exports a single Callback for FSEventsEventPublisher events.

--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/etc_protocols.cpp
+++ b/osquery/tables/networking/etc_protocols.cpp
@@ -55,7 +55,8 @@ QueryData parseEtcProtocolsContent(const std::string& content) {
     // If there is a comment for the service.
     if (protocol_comment.size() > 1) {
       // Removes everything except the comment (parts of the comment).
-      protocol_comment.erase(protocol_comment.begin(), protocol_comment.begin() + 1);
+      protocol_comment.erase(protocol_comment.begin(),
+                             protocol_comment.begin() + 1);
       r["comment"] = TEXT(boost::algorithm::join(protocol_comment, " # "));
     }
     results.push_back(r);

--- a/osquery/tables/networking/etc_services.cpp
+++ b/osquery/tables/networking/etc_services.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -69,7 +69,8 @@ QueryData parseEtcServicesContent(const std::string& content) {
     // If there is a comment for the service.
     if (service_info_comment.size() > 1) {
       // Removes everything except the comment (parts of the comment).
-      service_info_comment.erase(service_info_comment.begin(), service_info_comment.begin() + 1);
+      service_info_comment.erase(service_info_comment.begin(),
+                                 service_info_comment.begin() + 1);
       r["comment"] = TEXT(boost::algorithm::join(service_info_comment, " # "));
     }
     results.push_back(r);

--- a/osquery/tables/networking/freebsd/routes.cpp
+++ b/osquery/tables/networking/freebsd/routes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -77,7 +77,7 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
     r["oerrors"] = BIGINT_FROM_UINT32(ifd->tx_errors);
 
     // Get Linux physical properties for the AF_PACKET entry.
-    int fd = socket(AF_INET, SOCK_DGRAM, 0); 
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd >= 0) {
       struct ifreq ifr;
       memcpy(ifr.ifr_name, addr->ifa_name, IFNAMSIZ);
@@ -86,11 +86,11 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
       }
 
       if (ioctl(fd, SIOCGIFMETRIC, &ifr) >= 0) {
-       r["metric"] = BIGINT_FROM_UINT32(ifr.ifr_metric);
+        r["metric"] = BIGINT_FROM_UINT32(ifr.ifr_metric);
       }
 
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) >= 0) {
-        r["type"] = INTEGER_FROM_UCHAR(ifr.ifr_hwaddr.sa_family); 
+        r["type"] = INTEGER_FROM_UCHAR(ifr.ifr_hwaddr.sa_family);
       }
     }
 
@@ -124,7 +124,8 @@ QueryData genInterfaceAddresses(QueryContext &context) {
   }
 
   for (if_addr = if_addrs; if_addr != nullptr; if_addr = if_addr->ifa_next) {
-    if (if_addr->ifa_addr->sa_family == AF_INET || if_addr->ifa_addr->sa_family == AF_INET6) {
+    if (if_addr->ifa_addr->sa_family == AF_INET ||
+        if_addr->ifa_addr->sa_family == AF_INET6) {
       genAddressesFromAddr(if_addr, results);
     }
   }

--- a/osquery/tables/networking/linux/arp_cache.cpp
+++ b/osquery/tables/networking/linux/arp_cache.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/linux/inet_diag.h
+++ b/osquery/tables/networking/linux/inet_diag.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -293,7 +293,7 @@ QueryData genOpenSockets(QueryContext &context) {
   for (const auto &process : pids) {
     std::map<std::string, std::string> descriptors;
     if (osquery::procDescriptors(process, descriptors).ok()) {
-      for (const auto& fd : descriptors) {
+      for (const auto &fd : descriptors) {
         if (fd.second.find("socket:") != std::string::npos) {
           // See #792: std::regex is incomplete until GCC 4.9
           auto inode = fd.second.substr(fd.second.find("socket:") + 8);

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/utils.cpp
+++ b/osquery/tables/networking/utils.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/networking/utils.h
+++ b/osquery/tables/networking/utils.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -28,20 +28,20 @@ typedef std::pair<std::string, RegisterBit_t> FeatureDef_t;
 std::map<int, std::vector<FeatureDef_t> > kCPUFeatures = {
     {1,
      {
-      FEATURE("pae", "edx", 6),
-      FEATURE("msr", "edx", 5),
-      FEATURE("mtrr", "edx", 12),
-      FEATURE("acpi", "edx", 22),
-      FEATURE("htt", "edx", 28),
-      FEATURE("ia64", "edx", 30),
-      FEATURE("vmx", "ecx", 5),
-      FEATURE("smx", "ecx", 6),
-      FEATURE("hypervisor", "ecx", 31),
-      FEATURE("aes", "ecx", 25),
+         FEATURE("pae", "edx", 6),
+         FEATURE("msr", "edx", 5),
+         FEATURE("mtrr", "edx", 12),
+         FEATURE("acpi", "edx", 22),
+         FEATURE("htt", "edx", 28),
+         FEATURE("ia64", "edx", 30),
+         FEATURE("vmx", "ecx", 5),
+         FEATURE("smx", "ecx", 6),
+         FEATURE("hypervisor", "ecx", 31),
+         FEATURE("aes", "ecx", 25),
      }},
     {7,
      {
-      FEATURE("mpx", "ebx", 14), FEATURE("sha", "ebx", 29),
+         FEATURE("mpx", "ebx", 14), FEATURE("sha", "ebx", 29),
      }},
 };
 

--- a/osquery/tables/system/crontab.cpp
+++ b/osquery/tables/system/crontab.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/acpi_tables.cpp
+++ b/osquery/tables/system/darwin/acpi_tables.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -36,7 +36,7 @@ void genACPITable(const void *key, const void *value, void *results) {
   ((QueryData *)results)->push_back(r);
 }
 
-QueryData genACPITables(QueryContext& context) {
+QueryData genACPITables(QueryContext &context) {
   QueryData results;
 
   auto matching = IOServiceMatching(kIOACPIClassName_);

--- a/osquery/tables/system/darwin/ad_config.cpp
+++ b/osquery/tables/system/darwin/ad_config.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -47,10 +47,8 @@ void genADConfig(const std::string& path, QueryData& results) {
     // Get references to common columns.
     const auto& key = row.at("key");
     const auto& subkey = row.at("subkey");
-    if (key == "trustoptions" ||
-        key == "trustkerberosprincipal" ||
-        key == "trustaccount" ||
-        key == "trusttype") {
+    if (key == "trustoptions" || key == "trustkerberosprincipal" ||
+        key == "trustaccount" || key == "trusttype") {
       r["option"] = key;
       r["value"] = row.at("value");
       results.push_back(r);

--- a/osquery/tables/system/darwin/apps.cpp
+++ b/osquery/tables/system/darwin/apps.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -34,7 +34,7 @@ void genCertificate(const SecCertificateRef& cert, QueryData& results) {
   Row r;
 
   // Iterate through each selected certificate property.
-  for (const auto &detail : kCertificateProperties) {
+  for (const auto& detail : kCertificateProperties) {
     auto property = CreatePropertyFromCertificate(cert, detail.second.type);
     if (property == nullptr) {
       r[detail.first] = "";
@@ -58,7 +58,7 @@ void genCertificate(const SecCertificateRef& cert, QueryData& results) {
   results.push_back(r);
 }
 
-QueryData genCerts(QueryContext &context) {
+QueryData genCerts(QueryContext& context) {
   QueryData results;
 
   // Allow the caller to set an explicit certificate (keychain) search path.

--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -213,7 +213,7 @@ void getFileData(QueryData &results,
 
       if (isPrintable(x_att.attribute_data)) {
         r["base64"] = INTEGER(0);
-        r["value"] = x_att.attribute_data;    
+        r["value"] = x_att.attribute_data;
       } else {
         r["base64"] = INTEGER(1);
         r["value"] = base64Encode(x_att.attribute_data);

--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/firewall.h
+++ b/osquery/tables/system/darwin/firewall.h
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/groups.mm
+++ b/osquery/tables/system/darwin/groups.mm
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -61,7 +61,7 @@ QueryData genGroups(QueryContext &context) {
       struct group *grp = getgrnam(r["groupname"].c_str());
       if (grp != nullptr) {
         r["gid"] = BIGINT(grp->gr_gid);
-        r["gid_signed"] = BIGINT((int32_t) grp->gr_gid);
+        r["gid_signed"] = BIGINT((int32_t)grp->gr_gid);
         results.push_back(r);
       }
     }

--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/kernel_extensions.cpp
+++ b/osquery/tables/system/darwin/kernel_extensions.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -59,11 +59,22 @@ std::string getCanonicalEfiDevicePath(const CFDataRef& data) {
         // Extract the device UUID to later join with block devices.
         auto uuid = ((const HARDDRIVE_DEVICE_PATH*)node)->Signature;
         boost::uuids::uuid hdd_signature = {{
-          uuid[3], uuid[2], uuid[1], uuid[0],
-          uuid[5], uuid[4],
-          uuid[7], uuid[6],
-          uuid[8], uuid[9],
-          uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15],
+            uuid[3],
+            uuid[2],
+            uuid[1],
+            uuid[0],
+            uuid[5],
+            uuid[4],
+            uuid[7],
+            uuid[6],
+            uuid[8],
+            uuid[9],
+            uuid[10],
+            uuid[11],
+            uuid[12],
+            uuid[13],
+            uuid[14],
+            uuid[15],
         }};
         path += boost::to_upper_copy(boost::uuids::to_string(hdd_signature));
       }
@@ -94,8 +105,8 @@ QueryData genKernelInfo(QueryContext& context) {
 
   // Parse the boot arguments, usually none.
   CFMutableDictionaryRef properties;
-  kr = IORegistryEntryCreateCFProperties(
-      chosen, &properties, kCFAllocatorDefault, 0);
+  kr = IORegistryEntryCreateCFProperties(chosen, &properties,
+                                         kCFAllocatorDefault, 0);
   IOObjectRelease(chosen);
 
   if (kr != KERN_SUCCESS) {
@@ -105,18 +116,18 @@ QueryData genKernelInfo(QueryContext& context) {
 
   Row r;
   CFTypeRef property;
-  if (CFDictionaryGetValueIfPresent(
-          properties, CFSTR("boot-args"), &property)) {
+  if (CFDictionaryGetValueIfPresent(properties, CFSTR("boot-args"),
+                                    &property)) {
     r["arguments"] = stringFromCFData((CFDataRef)property);
   }
 
-  if (CFDictionaryGetValueIfPresent(
-          properties, CFSTR("boot-device-path"), &property)) {
+  if (CFDictionaryGetValueIfPresent(properties, CFSTR("boot-device-path"),
+                                    &property)) {
     r["device"] = getCanonicalEfiDevicePath((CFDataRef)property);
   }
 
-  if (CFDictionaryGetValueIfPresent(
-          properties, CFSTR("boot-file"), &property)) {
+  if (CFDictionaryGetValueIfPresent(properties, CFSTR("boot-file"),
+                                    &property)) {
     r["path"] = stringFromCFData((CFDataRef)property);
     boost::trim(r["path"]);
   }

--- a/osquery/tables/system/darwin/mounts.cpp
+++ b/osquery/tables/system/darwin/mounts.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -19,7 +19,7 @@ namespace tables {
 QueryData genMounts(QueryContext& context) {
   QueryData results;
 
-  struct statfs *mnt;
+  struct statfs* mnt;
   int mnts = 0;
   int i;
   char real_path[PATH_MAX];

--- a/osquery/tables/system/darwin/packages.cpp
+++ b/osquery/tables/system/darwin/packages.cpp
@@ -212,7 +212,8 @@ void genPackageBOM(const std::string& path, QueryData& results) {
 
     size_t var_size;
     const char* var_data = bom.getPointer(var->index, &var_size);
-    if (var_data == nullptr || var_size < sizeof(BOMTree) || var_size < var->length) {
+    if (var_data == nullptr || var_size < sizeof(BOMTree) ||
+        var_size < var->length) {
       break;
     }
 

--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -30,8 +30,8 @@ void genPCIDevice(const io_service_t& device, QueryData& results) {
 
   // Get the device details
   CFMutableDictionaryRef details;
-  IORegistryEntryCreateCFProperties(
-      device, &details, kCFAllocatorDefault, kNilOptions);
+  IORegistryEntryCreateCFProperties(device, &details, kCFAllocatorDefault,
+                                    kNilOptions);
 
   r["pci_slot"] = getIOKitProperty(details, "pcidebug");
 

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -164,9 +164,8 @@ void genOSXDefaultPreferences(QueryContext& context, QueryData& results) {
     app_map = (CFArrayRef)CFArrayCreateMutable(
         kCFAllocatorDefault, domains.size(), &kCFTypeArrayCallBacks);
     for (const auto& domain : domains) {
-      auto cf_domain = CFStringCreateWithCString(kCFAllocatorDefault,
-                                                 domain.c_str(),
-                                                 kCFStringEncodingASCII);
+      auto cf_domain = CFStringCreateWithCString(
+          kCFAllocatorDefault, domain.c_str(), kCFStringEncodingASCII);
       CFArrayAppendValue((CFMutableArrayRef)app_map, cf_domain);
       CFRelease(cf_domain);
     }

--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -144,7 +144,7 @@ void genOpenDescriptors(int pid, descriptor_type type, QueryData &results) {
         fd_info.proc_fdtype == PROX_FDTYPE_VNODE) {
       genFileDescriptor(pid, fd_info.proc_fd, results);
     } else if (type == DESCRIPTORS_TYPE_SOCKET &&
-        fd_info.proc_fdtype == PROX_FDTYPE_SOCKET) {
+               fd_info.proc_fdtype == PROX_FDTYPE_SOCKET) {
       genSocketDescriptor(pid, fd_info.proc_fd, results);
     }
   }

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -550,7 +550,7 @@ void genProcessMemoryMap(int pid, QueryData &results) {
   }
 }
 
-QueryData genProcessMemoryMap(QueryContext& context) {
+QueryData genProcessMemoryMap(QueryContext &context) {
   QueryData results;
 
   auto pidlist = getProcList(context);

--- a/osquery/tables/system/darwin/startup_items.cpp
+++ b/osquery/tables/system/darwin/startup_items.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -62,8 +62,8 @@ Status parseAliasData(const std::string& data, std::string& result) {
     return Status(1, "Failed base64 decode");
   }
 
-  auto alias = CFDataCreate(
-      kCFAllocatorDefault, (const UInt8*)decoded.c_str(), decoded.size());
+  auto alias = CFDataCreate(kCFAllocatorDefault, (const UInt8*)decoded.c_str(),
+                            decoded.size());
   if (alias == nullptr) {
     // Failed to create CFData object.
     return Status(2, "CFData allocation failed");

--- a/osquery/tables/system/darwin/sysctl_utils.cpp
+++ b/osquery/tables/system/darwin/sysctl_utils.cpp
@@ -112,8 +112,9 @@ void genControlInfo(int* oid,
   results.push_back(r);
 }
 
-void genControlInfoFromName(const std::string& name, QueryData& results,
-                    const std::map<std::string, std::string>& config) {
+void genControlInfoFromName(const std::string& name,
+                            QueryData& results,
+                            const std::map<std::string, std::string>& config) {
   int request[CTL_DEBUG_MAXID + 2] = {0};
   size_t oid_size = CTL_DEBUG_MAXID;
   if (sysctlnametomib(name.c_str(), request, &oid_size) != 0) {

--- a/osquery/tables/system/darwin/tests/firewall_tests.cpp
+++ b/osquery/tables/system/darwin/tests/firewall_tests.cpp
@@ -38,13 +38,13 @@ TEST_F(FirewallTests, test_parse_alf_tree) {
   auto results = parseALFTree(tree);
   osquery::QueryData expected = {
       {
-       {"allow_signed_enabled", "1"},
-       {"firewall_unload", "0"},
-       {"global_state", "0"},
-       {"logging_enabled", "0"},
-       {"logging_option", "0"},
-       {"stealth_enabled", "0"},
-       {"version", "1.0a25"},
+          {"allow_signed_enabled", "1"},
+          {"firewall_unload", "0"},
+          {"global_state", "0"},
+          {"logging_enabled", "0"},
+          {"logging_option", "0"},
+          {"stealth_enabled", "0"},
+          {"version", "1.0a25"},
       },
   };
   EXPECT_EQ(results, expected);
@@ -86,37 +86,39 @@ TEST_F(FirewallTests, test_parse_alf_services_tree) {
   auto results = parseALFServicesTree(tree);
   osquery::QueryData expected = {
       {
-       {"service", "Apple Remote Desktop"},
-       {"process", "AppleVNCServer"},
-       {"state", "0"},
+          {"service", "Apple Remote Desktop"},
+          {"process", "AppleVNCServer"},
+          {"state", "0"},
       },
       {
-       {"service", "FTP"}, {"process", "ftpd"}, {"state", "0"},
+          {"service", "FTP"}, {"process", "ftpd"}, {"state", "0"},
       },
       {
-       {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
+          {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
       },
       {
-       {"service", "File Sharing"},
-       {"process", "AppleFileServer"},
-       {"state", "0"},
+          {"service", "File Sharing"},
+          {"process", "AppleFileServer"},
+          {"state", "0"},
       },
       {
-       {"service", "Web Sharing"}, {"process", "httpd"}, {"state", "0"},
+          {"service", "Web Sharing"}, {"process", "httpd"}, {"state", "0"},
       },
       {
-       {"service", "Printer Sharing"}, {"process", "cupsd"}, {"state", "0"},
+          {"service", "Printer Sharing"}, {"process", "cupsd"}, {"state", "0"},
       },
       {
-       {"service", "Remote Apple Events"},
-       {"process", "AEServer"},
-       {"state", "0"},
+          {"service", "Remote Apple Events"},
+          {"process", "AEServer"},
+          {"state", "0"},
       },
       {
-       {"service", "SSH"}, {"process", "sshd-keygen-wrapper"}, {"state", "0"},
+          {"service", "SSH"},
+          {"process", "sshd-keygen-wrapper"},
+          {"state", "0"},
       },
       {
-       {"service", "Samba Sharing"}, {"process", "smbd"}, {"state", "0"},
+          {"service", "Samba Sharing"}, {"process", "smbd"}, {"state", "0"},
       },
   };
   EXPECT_EQ(results, expected);

--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -24,7 +24,7 @@ std::string getUSBProperty(const CFMutableDictionaryRef& details,
                            const std::string& key) {
   // Get a property from the device.
   auto cfkey = CFStringCreateWithCString(kCFAllocatorDefault, key.c_str(),
-    kCFStringEncodingUTF8);
+                                         kCFStringEncodingUTF8);
   auto property = CFDictionaryGetValue(details, cfkey);
   CFRelease(cfkey);
   if (property) {
@@ -42,8 +42,8 @@ void genUSBDevice(const io_service_t& device, QueryData& results) {
 
   // Get the device details
   CFMutableDictionaryRef details;
-  IORegistryEntryCreateCFProperties(
-      device, &details, kCFAllocatorDefault, kNilOptions);
+  IORegistryEntryCreateCFProperties(device, &details, kCFAllocatorDefault,
+                                    kNilOptions);
 
   r["usb_address"] = getUSBProperty(details, "USB Address");
   r["usb_port"] = getUSBProperty(details, "PortNum");

--- a/osquery/tables/system/darwin/users.mm
+++ b/osquery/tables/system/darwin/users.mm
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -64,8 +64,8 @@ QueryData genUsers(QueryContext &context) {
       if (pwd != nullptr) {
         r["uid"] = BIGINT(pwd->pw_uid);
         r["gid"] = BIGINT(pwd->pw_gid);
-        r["uid_signed"] = BIGINT((int32_t) pwd->pw_uid);
-        r["gid_signed"] = BIGINT((int32_t) pwd->pw_gid);
+        r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
+        r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
         r["description"] = TEXT(pwd->pw_gecos);
         r["directory"] = TEXT(pwd->pw_dir);
         r["shell"] = TEXT(pwd->pw_shell);

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -27,7 +27,7 @@ namespace osquery {
 namespace tables {
 
 /// Path to XProtect.meta.plist and XProtect.plist
-const std::string kXProtectPath = 
+const std::string kXProtectPath =
     "/System/Library/CoreServices/"
     "CoreTypes.bundle/Contents/Resources/";
 
@@ -68,7 +68,7 @@ void genMatches(const pt::ptree& entry, std::vector<Row>& results) {
   }
 }
 
-void genXProtectEntry(const pt::ptree &entry, QueryData& results) {
+void genXProtectEntry(const pt::ptree& entry, QueryData& results) {
   // Entry is an XProtect dictionary of meta data about the item.
   auto name = entry.get("Description", "");
   auto launch_type = entry.get("LaunchServices.LSItemContentType", "");

--- a/osquery/tables/system/freebsd/groups.cpp
+++ b/osquery/tables/system/freebsd/groups.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/freebsd/processes.cpp
+++ b/osquery/tables/system/freebsd/processes.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/freebsd/users.cpp
+++ b/osquery/tables/system/freebsd/users.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/last.cpp
+++ b/osquery/tables/system/last.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -21,7 +21,7 @@ namespace tables {
 
 QueryData genLastAccess(QueryContext& context) {
   QueryData results;
-  struct utmpx *ut;
+  struct utmpx* ut;
 #ifdef __APPLE__
   setutxent_wtmp(0); // 0 = reverse chronological order
 

--- a/osquery/tables/system/linux/acpi_tables.cpp
+++ b/osquery/tables/system/linux/acpi_tables.cpp
@@ -48,8 +48,8 @@ void genACPITable(const std::string& table, QueryData& results) {
     r["size"] = INTEGER(-1);
   } else {
     r["size"] = INTEGER(table_content.size());
-    r["md5"] = osquery::hashFromBuffer(
-        HASH_TYPE_MD5, table_content.c_str(), table_content.length());
+    r["md5"] = osquery::hashFromBuffer(HASH_TYPE_MD5, table_content.c_str(),
+                                       table_content.length());
   }
 
   results.push_back(r);

--- a/osquery/tables/system/linux/block_devices.cpp
+++ b/osquery/tables/system/linux/block_devices.cpp
@@ -66,13 +66,13 @@ static void getBlockDevice(struct udev_device *dev, QueryData &results) {
     if (!blkid_do_safeprobe(pr)) {
       const char *blk_value = nullptr;
       if (!blkid_probe_lookup_value(pr, "TYPE", &blk_value, nullptr)) {
-	r["type"] = blk_value;
+        r["type"] = blk_value;
       }
       if (!blkid_probe_lookup_value(pr, "UUID", &blk_value, nullptr)) {
-	r["uuid"] = blk_value;
+        r["uuid"] = blk_value;
       }
       if (!blkid_probe_lookup_value(pr, "LABEL", &blk_value, nullptr)) {
-	r["label"] = blk_value;
+        r["label"] = blk_value;
       }
     }
     blkid_free_probe(pr);

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -38,7 +38,7 @@ void genFDEStatusForBlockDevice(const std::string &name,
     crypt_init = crypt_init_by_name(&cd, name.c_str());
 #else
     crypt_init =
-      crypt_init_by_name_and_header(&cd, name.c_str(), opt_header_device);
+        crypt_init_by_name_and_header(&cd, name.c_str(), opt_header_device);
 #endif
 
     if (crypt_init < 0) {
@@ -46,7 +46,7 @@ void genFDEStatusForBlockDevice(const std::string &name,
       crypt_free(cd);
       break;
     }
-    
+
     type = crypt_get_type(cd);
     if (crypt_get_active_device(cd, name.c_str(), &cad) < 0) {
       VLOG(1) << "Unable to get active device for " << name;

--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -33,7 +33,7 @@ QueryData genGroups(QueryContext &context) {
         groups_in.end()) {
       Row r;
       r["gid"] = INTEGER(grp->gr_gid);
-      r["gid_signed"] = INTEGER((int32_t) grp->gr_gid);
+      r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
       r["groupname"] = TEXT(grp->gr_name);
       results.push_back(r);
       groups_in.insert(grp->gr_gid);

--- a/osquery/tables/system/linux/kernel_integrity.cpp
+++ b/osquery/tables/system/linux/kernel_integrity.cpp
@@ -14,7 +14,8 @@
 namespace osquery {
 namespace tables {
 
-const std::string kKernelSyscallAddrModifiedPath = "/sys/kernel/camb/syscall_addr_modified";
+const std::string kKernelSyscallAddrModifiedPath =
+    "/sys/kernel/camb/syscall_addr_modified";
 const std::string kKernelTextHashPath = "/sys/kernel/camb/text_segment_hash";
 
 QueryData genKernelIntegrity(QueryContext &context) {
@@ -24,7 +25,8 @@ QueryData genKernelIntegrity(QueryContext &context) {
   std::string text_segment_hash;
   std::string syscall_addr_modified;
 
-  // Get an integral value, 0 or 1, for whether a syscall table pointer is modified. 
+  // Get an integral value, 0 or 1, for whether a syscall table pointer is
+  // modified.
   auto f1 = osquery::readFile(kKernelSyscallAddrModifiedPath, content);
   if (f1.ok()) {
     boost::trim(content);

--- a/osquery/tables/system/linux/kernel_modules.cpp
+++ b/osquery/tables/system/linux/kernel_modules.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -23,7 +23,8 @@
 namespace osquery {
 namespace tables {
 
-inline std::string getProcAttr(const std::string& attr, const std::string& pid) {
+inline std::string getProcAttr(const std::string& attr,
+                               const std::string& pid) {
   return "/proc/" + pid + "/" + attr;
 }
 
@@ -42,7 +43,8 @@ inline std::string readProcCMDLine(const std::string& pid) {
   return content;
 }
 
-inline std::string readProcLink(const std::string& attr, const std::string& pid) {
+inline std::string readProcLink(const std::string& attr,
+                                const std::string& pid) {
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
 
@@ -121,7 +123,7 @@ struct SimpleProcStat {
   std::string effective_gid; // Gid: - * - -
 
   std::string resident_size; // VmRSS:
-  std::string phys_footprint;  // VmSize:
+  std::string phys_footprint; // VmSize:
 
   // Output from sring parsing /proc/<pid>/stat.
   std::string user_time;

--- a/osquery/tables/system/linux/sysctl_utils.cpp
+++ b/osquery/tables/system/linux/sysctl_utils.cpp
@@ -24,7 +24,8 @@ namespace tables {
 
 const std::string kSystemControlPath = "/proc/sys/";
 
-void genControlInfo(const std::string& mib_path, QueryData& results,
+void genControlInfo(const std::string& mib_path,
+                    QueryData& results,
                     const std::map<std::string, std::string>& config) {
   if (isDirectory(mib_path).ok()) {
     // Iterate through the subitems and items.
@@ -72,12 +73,12 @@ void genControlInfo(int* oid,
   // Get control size
   size_t response_size = CTL_MAX_VALUE;
   char response[CTL_MAX_VALUE + 1] = {0};
-    if (sysctl(oid, oid_size, response, &response_size, 0, 0) != 0) {
-      // Cannot request MIB data.
-      return;
-    }
+  if (sysctl(oid, oid_size, response, &response_size, 0, 0) != 0) {
+    // Cannot request MIB data.
+    return;
+  }
 
-    // Data is output, but no way to determine type (long, int, string, struct).
+  // Data is output, but no way to determine type (long, int, string, struct).
   Row r;
   r["oid"] = stringFromMIB(oid, oid_size);
   r["current_value"] = std::string(response);
@@ -99,13 +100,14 @@ void genAllControls(QueryData& results,
         fs::path(sub).filename().string() != subsystem) {
       // Request is limiting subsystem.
       continue;
-    } 
+    }
     genControlInfo(sub, results, config);
   }
 }
 
-void genControlInfoFromName(const std::string& name, QueryData& results,
-                    const std::map<std::string, std::string>& config) {
+void genControlInfoFromName(const std::string& name,
+                            QueryData& results,
+                            const std::map<std::string, std::string>& config) {
   // Convert '.'-tokenized name to path.
   std::string name_path = name;
   std::replace(name_path.begin(), name_path.end(), '.', '/');

--- a/osquery/tables/system/linux/usb_devices.cpp
+++ b/osquery/tables/system/linux/usb_devices.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -26,7 +26,7 @@ std::mutex pwdEnumerationMutex;
 QueryData genUsers(QueryContext& context) {
   std::lock_guard<std::mutex> lock(pwdEnumerationMutex);
   QueryData results;
-  struct passwd *pwd = nullptr;
+  struct passwd* pwd = nullptr;
   std::set<long> users_in;
 
   while ((pwd = getpwent()) != nullptr) {
@@ -35,8 +35,8 @@ QueryData genUsers(QueryContext& context) {
       Row r;
       r["uid"] = BIGINT(pwd->pw_uid);
       r["gid"] = BIGINT(pwd->pw_gid);
-      r["uid_signed"] = BIGINT((int32_t) pwd->pw_uid);
-      r["gid_signed"] = BIGINT((int32_t) pwd->pw_gid);
+      r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
+      r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
       r["username"] = TEXT(pwd->pw_name);
       r["description"] = TEXT(pwd->pw_gecos);
       r["directory"] = TEXT(pwd->pw_dir);

--- a/osquery/tables/system/logged_in_users.cpp
+++ b/osquery/tables/system/logged_in_users.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -23,7 +23,7 @@ std::mutex utmpxEnumerationMutex;
 QueryData genLoggedInUsers(QueryContext& context) {
   std::lock_guard<std::mutex> lock(utmpxEnumerationMutex);
   QueryData results;
-  struct utmpx *entry = nullptr;
+  struct utmpx* entry = nullptr;
 
   while ((entry = getutxent()) != nullptr) {
     if (entry->ut_pid == 1) {

--- a/osquery/tables/system/shell_history.cpp
+++ b/osquery/tables/system/shell_history.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/system/suid_bin.cpp
+++ b/osquery/tables/system/suid_bin.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
@@ -24,13 +24,13 @@ namespace osquery {
 namespace tables {
 
 std::vector<std::string> kBinarySearchPaths = {
-  "/bin",
-  "/sbin",
-  "/usr/bin",
-  "/usr/sbin",
-  "/usr/local/bin",
-  "/usr/local/sbin",
-  "/tmp",
+    "/bin",
+    "/sbin",
+    "/usr/bin",
+    "/usr/sbin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    "/tmp",
 };
 
 Status genBin(const fs::path& path, int perms, QueryData& results) {
@@ -43,8 +43,8 @@ Status genBin(const fs::path& path, int perms, QueryData& results) {
   // store path
   Row r;
   r["path"] = path.string();
-  struct passwd *pw = getpwuid(info.st_uid);
-  struct group *gr = getgrgid(info.st_gid);
+  struct passwd* pw = getpwuid(info.st_uid);
+  struct group* gr = getgrgid(info.st_gid);
 
   // get user name + group
   std::string user;
@@ -115,7 +115,11 @@ void genSuidBinsFromPath(const std::string& path, QueryData& results) {
       VLOG(1) << "Cannot read binary from " << path;
       it.no_push();
       // Try to recover, otherwise break.
-      try { ++it; } catch(fs::filesystem_error& e) { break; }
+      try {
+        ++it;
+      } catch (fs::filesystem_error& e) {
+        break;
+      }
     }
   }
 }

--- a/osquery/tables/system/sysctl_utils.h
+++ b/osquery/tables/system/sysctl_utils.h
@@ -35,7 +35,8 @@ void genControlInfo(int* oid,
                     const std::map<std::string, std::string>& config);
 
 /// Must be implemented by the platform.
-void genControlInfoFromName(const std::string& name, QueryData& results,
-                    const std::map<std::string, std::string>& config);
+void genControlInfoFromName(const std::string& name,
+                            QueryData& results,
+                            const std::map<std::string, std::string>& config);
 }
 }

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/utility/hash.cpp
+++ b/osquery/tables/utility/hash.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */

--- a/tools/tests/test.cpp
+++ b/tools/tests/test.cpp
@@ -3,7 +3,7 @@
  *  All rights reserved.
  *
  *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant 
+ *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */


### PR DESCRIPTION
This is the result of a make format-all. This was pretty clean, only
required one set of `// clang-format off/on` in the raw strings in
distributed_tests.cpp