### PR TITLE
Fix a broken link to the OS X install docs.

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -5,7 +5,7 @@ osquery exposes an operating system as a high-performance relational database. T
 
 ## Getting Started
 
-If you're interested in **installing osquery** check out the install guide for [OS X](installation/install-os-x) and [Linux](installation/install-linux).
+If you're interested in **installing osquery** check out the install guide for [OS X](installation/install-osx) and [Linux](installation/install-linux).
 
 If you're interested in **deploying osquery** to provide your organization with deeper insight into your Linux and OS X hosts check out the [using osqueryd guide](introduction/using-osqueryd).
 If you're interested in **performing ad-hoc queries**, check out [using osqueryi](introduction/using-osqueryi).


### PR DESCRIPTION
Just removing an extra `-` in the link.