### PR TITLE
[Fix #1017] Use a fs glob in chrome-extensions searching

### DIFF
--- a/osquery/tables/applications/browser_chrome.cpp
+++ b/osquery/tables/applications/browser_chrome.cpp
@@ -18,9 +18,9 @@ namespace tables {
 
 /// Each home directory will include custom extensions.
 #ifdef __APPLE__
-#define kChromePath "/Library/Application Support/Google/Chrome/Default/"
+#define kChromePath "/Library/Application Support/Google/Chrome/%/"
 #else
-#define kChromePath "/.config/google-chrome/Default/"
+#define kChromePath "/.config/google-chrome/%/"
 #endif
 #define kChromeExtensionsPath "Extensions/"
 

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -76,24 +76,28 @@ QueryData genChromeBasedExtensions(QueryContext& context, const fs::path sub_dir
 
   auto homes = osquery::getHomeDirectories();
   for (const auto& home : homes) {
-    // For each user, enumerate all of their opera profiles.
-    std::vector<std::string> extensions;
-    fs::path extension_path = home.string() + sub_dir.string();
-    if (!listDirectoriesInDirectory(extension_path, extensions).ok()) {
+    // For each user, enumerate all of their chrome profiles.
+    std::vector<std::string> profiles;
+    fs::path extension_path = home / sub_dir;
+    if (!resolveFilePattern(extension_path, profiles, REC_LIST_FOLDERS).ok()) {
       continue;
     }
 
-    // Generate an addons list from their extensions JSON.
-    for (const auto& extension : extensions) {
-      std::vector<std::string> versions;
-      if (!listDirectoriesInDirectory(extension, versions).ok()) {
-        continue;
-      }
+    // For each profile list each extension in the Extensions directory.
+    std::vector<std::string> extensions;
+    for (const auto& profile : profiles) {
+      listDirectoriesInDirectory(profile, extensions);
+    }
 
-      // Extensions use /<ID>/<VERSION>/manifest.json.
-      for (const auto& version : versions) {
-        genExtension(version, results);
-      }
+    // Generate an addons list from their extensions JSON.
+    std::vector<std::string> versions;
+    for (const auto& extension : extensions) {
+      listDirectoriesInDirectory(extension, versions);
+    }
+
+    // Extensions use /<EXTENSION>/<VERSION>/manifest.json.
+    for (const auto& version : versions) {
+      genExtension(version, results);
     }
   }
 


### PR DESCRIPTION
Chrome (non-Opera) may use multiple profiles before the
extensions dir. Use a glob before searching for extensions/versions.