### PR TITLE
Move YARA initialization to config parser.

### DIFF
--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -75,13 +75,6 @@ REGISTER(YARAEventSubscriber, "event_subscriber", "yara_events");
 Status YARAEventSubscriber::init() {
   Status status;
 
-  // XXX: Move into config parser update?
-  int result = yr_initialize();
-  if (result != ERROR_SUCCESS) {
-    LOG(WARNING) << "Unable to initialize YARA (" << result << ")";
-    return Status(1, "Unable to initialize YARA");
-  }
-
   ConfigDataInstance config;
   const auto& yara_config = config.getParsedData("yara");
   if (yara_config.count("file_paths") == 0)

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -219,6 +219,13 @@ int YARACallback(int message, void *message_data, void *user_data) {
 
 Status YARAConfigParserPlugin::update(const std::map<std::string, ConfigTree>& config) {
   Status status;
+
+  int result = yr_initialize();
+  if (result != ERROR_SUCCESS) {
+    LOG(WARNING) << "Unable to initialize YARA (" << result << ")";
+    return Status(1, "Unable to initialize YARA");
+  }
+
   const auto& yara_config = config.at("yara");
   if (yara_config.count("signatures") > 0) {
     const auto& signatures = yara_config.get_child("signatures");


### PR DESCRIPTION
This was causing a crash when executing a query using the yara table
from the command line, because YARA was never initialized properly, so
the thread index was whatever was left on the stack. Eventually YARA
would attempt to set a rule that matches using this thread index and
would explode in flames.

Fix it by moving the initialization to a place that is always called.