### PR TITLE
Move YARA initialization to setUp().

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -309,7 +309,7 @@ class ConfigParserPlugin : public Plugin {
   pt::ptree data_;
 
  private:
-  Status setUp() final;
+  Status setUp();
 
  private:
   /// Config::update will call all appropriate parser updates.

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -75,13 +75,6 @@ REGISTER(YARAEventSubscriber, "event_subscriber", "yara_events");
 Status YARAEventSubscriber::init() {
   Status status;
 
-  // XXX: Move into config parser update?
-  int result = yr_initialize();
-  if (result != ERROR_SUCCESS) {
-    LOG(WARNING) << "Unable to initialize YARA (" << result << ")";
-    return Status(1, "Unable to initialize YARA");
-  }
-
   ConfigDataInstance config;
   const auto& yara_config = config.getParsedData("yara");
   if (yara_config.count("file_paths") == 0)

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -217,6 +217,16 @@ int YARACallback(int message, void *message_data, void *user_data) {
   return CALLBACK_CONTINUE;
 }
 
+Status YARAConfigParserPlugin::setUp() {
+  int result = yr_initialize();
+  if (result != ERROR_SUCCESS) {
+    LOG(WARNING) << "Unable to initialize YARA (" << result << ")";
+    return Status(1, "Unable to initialize YARA");
+  }
+
+  return Status(0, "OK");
+}
+
 Status YARAConfigParserPlugin::update(const std::map<std::string, ConfigTree>& config) {
   Status status;
   const auto& yara_config = config.at("yara");

--- a/osquery/tables/utils/yara_utils.h
+++ b/osquery/tables/utils/yara_utils.h
@@ -52,6 +52,8 @@ class YARAConfigParserPlugin : public ConfigParserPlugin {
   // Retrieve compiled rules.
   std::map<std::string, YR_RULES *> rules() { return rules_; }
 
+  Status setUp();
+
  private:
   // Store compiled rules in a map (group => rules).
   std::map<std::string, YR_RULES *> rules_;


### PR DESCRIPTION
This was causing a crash when executing a query using the yara table
from the command line, because YARA was never initialized properly, so
the thread index was whatever was left on the stack. Eventually YARA
would attempt to set a rule that matches using this thread index and
would explode in flames.

Fix it by moving the initialization to a place that is always called.