### PR TITLE
Make YARA rule compiling handle relative paths.

### DIFF
--- a/osquery/tables/utils/yara.cpp
+++ b/osquery/tables/utils/yara.cpp
@@ -120,7 +120,7 @@ QueryData genYara(QueryContext& context) {
 
     std::string full_path;
     if (file[0] != '/') {
-      full_path = std::string("/var/osquery/") + file;
+      full_path = std::string("/etc/osquery/yara/") + file;
     } else {
       full_path = file;
     }

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -131,7 +131,7 @@ Status handleRuleFiles(const std::string& category,
 
     std::string full_path;
     if (rule[0] != '/') {
-      full_path = std::string("/var/osquery/") + rule;
+      full_path = std::string("/etc/osquery/yara/") + rule;
     } else {
       full_path = rule;
     }

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -129,6 +129,13 @@ Status handleRuleFiles(const std::string& category,
     const auto rule = item.second.get("", "");
     VLOG(1) << "Loading " << rule;
 
+    std::string full_path;
+    if (rule[0] != '/') {
+      full_path = std::string("/var/osquery/") + rule;
+    } else {
+      full_path = rule;
+    }
+
     // First attempt to load the file, in case it is saved (pre-compiled)
     // rules. Sadly there is no way to load multiple compiled rules in
     // succession. This means that:
@@ -144,7 +151,7 @@ Status handleRuleFiles(const std::string& category,
     //
     // If you want to use saved rule files you must have them all in a single
     // file. This is easy to accomplish with yarac(1).
-    result = yr_rules_load(rule.c_str(), &tmp_rules);
+    result = yr_rules_load(full_path.c_str(), &tmp_rules);
     if (result != ERROR_SUCCESS && result != ERROR_INVALID_FILE) {
       yr_compiler_destroy(compiler);
       return Status(1, "Error loading YARA rules: " + std::to_string(result));
@@ -157,17 +164,17 @@ Status handleRuleFiles(const std::string& category,
     } else {
       compiled = true;
       // Try to compile the rules.
-      FILE *rule_file = fopen(rule.c_str(), "r");
+      FILE *rule_file = fopen(full_path.c_str(), "r");
 
       if (rule_file == nullptr) {
         yr_compiler_destroy(compiler);
-        return Status(1, "Could not open file: " + rule);
+        return Status(1, "Could not open file: " + full_path);
       }
 
       int errors = yr_compiler_add_file(compiler,
                                         rule_file,
                                         NULL,
-                                        rule.c_str());
+                                        full_path.c_str());
 
       fclose(rule_file);
       rule_file = nullptr;


### PR DESCRIPTION
Previously this only existed in the yara table, but it now exists in the
yara config parser land, which will compile signature groups upon
update. Now your signature groups can reference signature files using
paths relative to /var/osquery.