### PR TITLE
Towards safer and shuffled unittests

### DIFF
--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -78,7 +78,7 @@ TEST_F(ConfigTests, test_watched_files) {
 
   // From the new, recommended top-level "file_paths" collection.
   EXPECT_EQ(config.files().at("downloads2").size(), 1);
-  EXPECT_EQ(config.files().at("system_binaries").size(), 2);
+  EXPECT_EQ(config.files().at("system_binaries").size(), 1);
 }
 
 TEST_F(ConfigTests, test_locking) {

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -23,14 +23,6 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
-const std::string kTestQuery = "SELECT * FROM test_table";
-
-#ifndef OSQUERY_BUILD_SDK
-const std::string kTestDataPath = "../../../tools/tests/";
-#else
-const std::string kTestDataPath = "../../../../tools/tests/";
-#endif
-
 QueryData getTestDBExpectedResults() {
   QueryData d;
   Row row1;

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -23,13 +23,26 @@
 
 namespace osquery {
 
-// kTestQuery is a test query that can be executed against the database
-// returned from createTestDB() to result in the dataset returned from
-// getTestDBExpectedResults()
-extern const std::string kTestQuery;
-extern const std::string kTestDataPath;
+/// Any SQL-dependent tests should use kTestQuery for a pre-populated example.
+const std::string kTestQuery = "SELECT * FROM test_table";
 
-const std::string kFakeDirectory = "/tmp/osquery-fstests-pattern";
+/// Most tests will use binary or disk-backed content for parsing tests.
+#ifndef OSQUERY_BUILD_SDK
+const std::string kTestDataPath = "../../../tools/tests/";
+#else
+const std::string kTestDataPath = "../../../../tools/tests/";
+#endif
+
+/// Tests should limit intermediate input/output to a working directory.
+/// Config data, logging results, and intermediate database/caching usage.
+#ifdef DARWIN
+const std::string kTestWorkingDirectory = "/private/tmp/osquery-tests/";
+#else
+const std::string kTestWorkingDirectory = "/tmp/osquery-tests/";
+#endif
+
+/// A fake directory tree should be used for filesystem iterator testing.
+const std::string kFakeDirectory = kTestWorkingDirectory + "fstree";
 
 // getTestDBExpectedResults returns the results of kTestQuery of the table that
 // initially gets returned from createTestDB()

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -21,10 +21,11 @@
 #include <osquery/tables.h>
 
 #include "osquery/events/darwin/fsevents.h"
+#include "osquery/core/test_util.h"
 
 namespace osquery {
 
-const std::string kRealTestPath = "/private/tmp/osquery-fsevents-trigger";
+const std::string kRealTestPath = kTestWorkingDirectory + "fsevents_trigger";
 int kMaxEventLatency = 3000;
 
 class FSEventsTests : public testing::Test {
@@ -142,7 +143,10 @@ TEST_F(FSEventsTests, test_fsevents_add_subscription_success) {
 class TestFSEventsEventSubscriber
     : public EventSubscriber<FSEventsEventPublisher> {
  public:
-  TestFSEventsEventSubscriber() { setName("TestFSEventsEventSubscriber"); }
+  TestFSEventsEventSubscriber() : callback_count_(0) {
+    setName("TestFSEventsEventSubscriber");
+  }
+
   Status init() {
     callback_count_ = 0;
     return Status(0, "OK");

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -12,7 +12,6 @@
 
 #include <linux/limits.h>
 
-#include <osquery/events.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
@@ -43,7 +42,7 @@ Status INotifyEventPublisher::setUp() {
   inotify_handle_ = ::inotify_init();
   // If this does not work throw an exception.
   if (inotify_handle_ == -1) {
-    return Status(1, "Could not init inotify.");
+    return Status(1, "Could not init inotify");
   }
   return Status(0, "OK");
 }
@@ -68,7 +67,7 @@ Status INotifyEventPublisher::restartMonitoring(){
     return Status(1, "Overflow");
   }
   last_restart_ = getUnixTime();
-  VLOG(1) << "Got an overflow, trying to restart...";
+  VLOG(1) << "inotify was overflown, attempting to restart handle";
   for(const auto& desc : descriptors_){
     removeMonitor(desc, 1);
   }
@@ -183,7 +182,7 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
   if (!isPathMonitored(path)) {
     int watch = ::inotify_add_watch(getHandle(), path.c_str(), IN_ALL_EVENTS);
     if (watch == -1) {
-      LOG(ERROR) << "Could not add inotfy watch on: " << path;
+      LOG(ERROR) << "Could not add inotify watch on: " << path;
       return false;
     }
 
@@ -232,7 +231,7 @@ bool INotifyEventPublisher::removeMonitor(int watch, bool force) {
     return false;
   }
 
-  std::string path = descriptor_paths_[watch];
+  auto path = descriptor_paths_[watch];
   return removeMonitor(path, force);
 }
 

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -17,7 +17,6 @@
 #include <sys/stat.h>
 
 #include <osquery/events.h>
-#include <osquery/status.h>
 
 namespace osquery {
 

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -21,14 +21,15 @@
 #include <osquery/tables.h>
 
 #include "osquery/events/linux/inotify.h"
+#include "osquery/core/test_util.h"
 
 namespace osquery {
 
-const std::string kRealTestPath = "/tmp/osquery-inotify-trigger";
-const std::string kRealTestDir = "/tmp/osquery-inotify-triggers";
-const std::string kRealTestDirPath = "/tmp/osquery-inotify-triggers/1";
-const std::string kRealTestSubDir = "/tmp/osquery-inotify-triggers/2";
-const std::string kRealTestSubDirPath = "/tmp/osquery-inotify-triggers/2/1";
+const std::string kRealTestPath = kTestWorkingDirectory + "inotify-trigger";
+const std::string kRealTestDir = kTestWorkingDirectory + "inotify-triggers";
+const std::string kRealTestDirPath = kRealTestDir + "/1";
+const std::string kRealTestSubDir = kRealTestDir + "/2";
+const std::string kRealTestSubDirPath = kRealTestSubDir + "/1";
 
 int kMaxEventLatency = 3000;
 
@@ -149,11 +150,15 @@ TEST_F(INotifyTests, test_inotify_add_subscription_success) {
 class TestINotifyEventSubscriber
     : public EventSubscriber<INotifyEventPublisher> {
  public:
-  TestINotifyEventSubscriber() { setName("TestINotifyEventSubscriber"); }
+  TestINotifyEventSubscriber() : callback_count_(0) {
+    setName("TestINotifyEventSubscriber");
+  }
+
   Status init() {
     callback_count_ = 0;
     return Status(0, "OK");
   }
+
   Status SimpleCallback(const INotifyEventContextRef& ec,
                         const void* user_data) {
     callback_count_ += 1;

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -25,7 +25,7 @@ namespace osquery {
 
 const int kDelayUS = 200;
 const int kTimeoutUS = 10000;
-const std::string kTestManagerSocket = "/tmp/osquery-em.socket";
+const std::string kTestManagerSocket = kTestWorkingDirectory + "test.em";
 
 class ExtensionsTest : public testing::Test {
  protected:

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -33,17 +33,17 @@ class FilesystemTests : public testing::Test {
 };
 
 TEST_F(FilesystemTests, test_plugin) {
-  std::ofstream test_file("/tmp/osquery-fstests-file");
+  std::ofstream test_file(kTestWorkingDirectory + "fstests-file");
   test_file.write("test123\n", sizeof("test123"));
   test_file.close();
 
   std::string content;
-  auto s = readFile("/tmp/osquery-fstests-file", content);
+  auto s = readFile(kTestWorkingDirectory + "fstests-file", content);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(content, "test123\n");
 
-  remove("/tmp/osquery-fstests-file");
+  remove(kTestWorkingDirectory + "fstests-file");
 }
 
 TEST_F(FilesystemTests, test_list_files_in_directory_not_found) {

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -20,14 +20,17 @@ DECLARE_string(logger_plugin);
 
 class LoggerTests : public testing::Test {
  public:
-  LoggerTests() {}
-
   void SetUp() {
+    logging_status_ = FLAGS_disable_logging;
+    FLAGS_disable_logging = false;
+
     log_lines.clear();
     status_messages.clear();
     statuses_logged = 0;
     last_status = {O_INFO, "", -1, ""};
   }
+
+  void TearDown() { FLAGS_disable_logging = logging_status_; }
 
   // Track lines emitted to logString
   static std::vector<std::string> log_lines;
@@ -38,6 +41,10 @@ class LoggerTests : public testing::Test {
 
   // Count calls to logStatus
   static int statuses_logged;
+
+ private:
+  /// Save the status of logging before running tests, restore afterward.
+  bool logging_status_;
 };
 
 std::vector<std::string> LoggerTests::log_lines;

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -12,10 +12,46 @@
 
 #include <time.h>
 
+#include <boost/filesystem.hpp>
+
 #include <gtest/gtest.h>
 
+#include <osquery/database.h>
+
+#include "osquery/core/test_util.h"
+
+namespace osquery {
+DECLARE_string(database_path);
+DECLARE_string(extensions_socket);
+DECLARE_string(modules_autoload);
+DECLARE_string(extensions_autoload);
+DECLARE_bool(disable_logging);
+
+void initTesting() {
+  // Seed the random number generator, some tests generate temporary files
+  // ports, sockets, etc using random numbers.
+  std::chrono::milliseconds ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          std::chrono::system_clock::now().time_since_epoch());
+  srand(ms.count());
+
+  // Set safe default values for path-based flags.
+  // Specific unittests may edit flags temporarily.
+  boost::filesystem::remove_all(kTestWorkingDirectory);
+  boost::filesystem::create_directories(kTestWorkingDirectory);
+  FLAGS_database_path = kTestWorkingDirectory + "unittests.db";
+  FLAGS_extensions_socket = kTestWorkingDirectory + "unittests.em";
+  FLAGS_extensions_autoload = kTestWorkingDirectory + "unittests-ext.load";
+  FLAGS_modules_autoload = kTestWorkingDirectory + "unittests-mod.load";
+  FLAGS_disable_logging = true;
+
+  // Create a default DBHandle instance before unittests.
+  (void)DBHandle::getInstance();
+}
+}
+
 int main(int argc, char* argv[]) {
-  srand(time(nullptr));
+  osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging
   // google::InitGoogleLogging(argv[0]);


### PR DESCRIPTION
Jenkins recently broke all unittests because of false assumptions about filesystem state. We did some patching and left files on disk, subsequently the unittests assumed a blank state.