### PR TITLE
[Implements #1016] Disable tables runtime flag

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -127,6 +127,11 @@ Times to retry writing distributed query results.
 
 Disable osquery events pubsub.
 
+`--disable_tables=table_name1,table_name2`
+
+Comma-delimited list of table names to be disabled.
+This allows osquery to be launched without certain tables.
+
 `--events_expiry=86000`
 
 Timeout to expire event pubsub results.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -34,7 +34,7 @@ namespace osquery {
 
 #define DESCRIPTION \
   "osquery %s, your OS as a high-performance relational database\n"
-#define EPILOG "\nosquery project page <http://osquery.io>.\n"
+#define EPILOG "\nosquery project page <https://osquery.io>.\n"
 #define OPTIONS \
   "\nosquery configuration options (set by config or CLI flags):\n\n"
 #define OPTIONS_SHELL "\nosquery shell-only CLI flags:\n\n"
@@ -49,7 +49,8 @@ namespace osquery {
   "been created. Please consider explicitly defining those "                  \
   "options as a different \n"                                                 \
   "path. Additionally, review the \"using osqueryd\" wiki page:\n"            \
-  " - http://osquery.rtfd.org/introduction/using-osqueryd/\n\n";
+  " - https://osquery.readthedocs.org/en/latest/introduction/using-osqueryd/" \
+  "\n\n";
 
 CLI_FLAG(bool,
          config_check,

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -239,28 +239,16 @@ static int xFilter(sqlite3_vtab_cursor *pVtabCursor,
 Status attachTableInternal(const std::string &name,
                            const std::string &statement,
                            sqlite3 *db) {
+  if (SQLiteDBManager::isDisabled(name)) {
+    VLOG(0) << "Table " << name << " is disabled, not attaching";
+    return Status(0, getStringForSQLiteReturnCode(0));
+  }
+
   // A static module structure does not need specific logic per-table.
   static sqlite3_module module = {
-      0,
-      xCreate,
-      xCreate,
-      xBestIndex,
-      xDestroy,
-      xDestroy,
-      xOpen,
-      xClose,
-      xFilter,
-      xNext,
-      xEof,
-      xColumn,
-      xRowid,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
+      0,      xCreate, xCreate, xBestIndex, xDestroy, xDestroy, xOpen,
+      xClose, xFilter, xNext,   xEof,       xColumn,  xRowid,   0,
+      0,      0,       0,       0,          0,        0,
   };
 
   // Note, if the clientData API is used then this will save a registry call

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -36,6 +36,10 @@
     // and query results differentials. See also 'use_in_memory_database'.
     //"database_path": "/var/osquery/osquery.db",
 
+    // Comma-delimited list of table names to be disabled.
+    // This allows osquery to be launched without certain tables.
+    //"disable_tables": "foo_bar,time",
+
     // Enable debug or verbose debug output when logging.
     "debug": "false",
     "verbose_debug": "false",


### PR DESCRIPTION
This implements #1016.

Here's how it looks:

```bash
❯ ./build/darwin/osquery/osqueryi --verbose --disable_tables=time,foo_bar
I0430 01:07:36.459516 2054472448 init.cpp:148] osquery initialized [version=1.4.4-181-g4fa7083]
I0430 01:07:36.459674 2054472448 extensions.cpp:163] Modules autoload contains invalid paths: /etc/osquery/modules.load
I0430 01:07:36.459961 212852736 interface.cpp:249] Extension manager service starting: /Users/sbs/.osquery/shell.em
I0430 01:07:36.466197 217632768 events.cpp:422] Starting event publisher runloop: fsevents
I0430 01:07:36.466231 218169344 events.cpp:422] Starting event publisher runloop: iokit_hid
I0430 01:07:36.466241 218705920 events.cpp:422] Starting event publisher runloop: scnetwork
I0430 01:07:36.476591 2054472448 virtual_table.cpp:243] Table time is disabled, not attaching
osquery - being built, with love, at Facebook

Using a virtual database. Need help, type '.help'
osquery> select * from time;
Error: no such table: time
```

```bash
❯ ./build/darwin/osquery/osqueryi --help
<truncated output>
    --disable_tables VALUE            Comma-delimited list of table names to be disabled

```