### PR TITLE
[Docs] Fix 404s and https mixed content warning

### DIFF
--- a/docs/wiki/deployment/anomaly-detection.md
+++ b/docs/wiki/deployment/anomaly-detection.md
@@ -2,7 +2,7 @@
 
 An osquery deployment can help you establish an infrastructural baseline, allowing you to detect malicious activity using scheduled queries.
 
-This approach will help you catch known malware ([WireLurker](http://bits.blogs.nytimes.com/2014/11/05/malicious-software-campaign-targets-apple-users-in-china/), IceFog, Imuler, etc), and more importantly, unknown malware. Let's look at Mac OS X startup items for a given laptop using [osqueryi](../introduction/using-osqueryi):
+This approach will help you catch known malware ([WireLurker](http://bits.blogs.nytimes.com/2014/11/05/malicious-software-campaign-targets-apple-users-in-china/), IceFog, Imuler, etc), and more importantly, unknown malware. Let's look at Mac OS X startup items for a given laptop using [osqueryi](../introduction/using-osqueryi.md):
 
 ```sh
 $ osqueryi
@@ -25,7 +25,7 @@ We can use osquery's log aggregation capabilities to easily pinpoint when the at
 
 ## Looking at the logs
 
-Using the [log aggregation guide](log-aggregation), you will receive log lines like the following in your datastore (ElasticSearch, Splunk, etc):
+Using the [log aggregation guide](log-aggregation.md), you will receive log lines like the following in your datastore (ElasticSearch, Splunk, etc):
 
 ```json
 {

--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -1,9 +1,9 @@
 An osquery deployment consists of:
 
-* Installing the tools for [OS X](../installation/install-osx) or [Linux](../installation/install-linux)
-* Reviewing the [osqueryd](../introduction/using-osqueryd) introduction
+* Installing the tools for [OS X](../installation/install-osx.md) or [Linux](../installation/install-linux.md)
+* Reviewing the [osqueryd](../introduction/using-osqueryd.md) introduction
 * Configuring and starting the osqueryd service (this page)
-* Managing and [collecting](log-aggregation) the query results
+* Managing and [collecting](log-aggregation.md) the query results
 
 In the future, osquery tools may allow for **ad-hoc** or distributed queries
 that are not part of the configured query schedule and return results
@@ -25,7 +25,7 @@ There are several components to a configuration:
 
 There are also "initialization" parameters that control how osqueryd is launched.
 These parameters only make sense as command-line arguments since they are used
-before a configuration plugin is selected. See the [command line flags](../installation/cli-flags)
+before a configuration plugin is selected. See the [command line flags](../installation/cli-flags.md)
 overview for a complete list of these parameters.
 
 The default config plugin, **filesystem**, reads from a file and optional directory ".d" based on the filename.
@@ -61,7 +61,7 @@ This config tells osqueryd to schedule two queries, **macosx_kextstat** and **fo
 * the schedule keys must be unique
 * the "interval" specifies query frequency, in seconds
 
-The first query will document changes to an OS X host's kernel extensions, with a query interval of 10 seconds. Consider using osquery's [performance tooling](performance-safety) to understand the performance impact for each query.
+The first query will document changes to an OS X host's kernel extensions, with a query interval of 10 seconds. Consider using osquery's [performance tooling](performance-safety.md) to understand the performance impact for each query.
 
 The results of your query are cached on disk via [RocksDB](http://rocksdb.org/). On first query run, all of the results are stored in RocksDB. On subsequent runs, only result-set changes are logged to RocksDB.
 

--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -5,7 +5,7 @@ selected files in the `file_events` table.
 
 To get started with FIM (file integrity monitoring), you must first identify
 which files and directories you wish to monitor.
-Following the [wildcard rules](../development/wildcard-rules/), you can specify
+Following the [wildcard rules](../development/wildcard-rules.md), you can specify
 a directory or filename filter to limit the selection of files to monitor.
 
 For example, you may want to monitor `/etc` along with other files on a linux

--- a/docs/wiki/deployment/log-aggregation.md
+++ b/docs/wiki/deployment/log-aggregation.md
@@ -90,7 +90,7 @@ Kibana has a default logstash dashboard and automatically field-extracts all log
 
 An example Kibana log entry:
 
-![](http://i.imgur.com/thivGYc.png)
+![](https://i.imgur.com/thivGYc.png)
 
 ### Splunk
 
@@ -98,7 +98,7 @@ If you're forwarding logs with the [Splunk Universal Forwarder](http://docs.splu
 
 Splunk will automatically extract the relevant fields for analytics, as shown below:
 
-![](http://i.imgur.com/tWCPx51.png)
+![](https://i.imgur.com/tWCPx51.png)
 
 ### Rsyslog, Fluentd, Scribe, etc
 

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -103,7 +103,7 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
 }
 ```
 
-Most of the time the **Event format** is the most appropriate. The next section in the deployment guide describes [log aggregation](log-aggregation) methods. The aggregation methods describe collecting, searching, and alerting on the results from a query schedule.
+Most of the time the **Event format** is the most appropriate. The next section in the deployment guide describes [log aggregation](log-aggregation.md) methods. The aggregation methods describe collecting, searching, and alerting on the results from a query schedule.
 
 ## Unique host identification
 

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -35,7 +35,7 @@ The configuration for osquery is simple. Here is an example config:
 }
 ```
 
-The first thing to notice is the *file_paths* section, which is used to describe which paths to monitor for changes. Each key is an arbitrary category name and the value is a list of paths. The syntax used is documented [here](http://osquery.readthedocs.org/en/latest/development/wildcard-rules/index.html). The paths, when expanded out by osquery, are monitored for changes and processed by the [file_events](https://osquery.io/docs/tables/#file_events) table.
+The first thing to notice is the *file_paths* section, which is used to describe which paths to monitor for changes. Each key is an arbitrary category name and the value is a list of paths. The syntax used is documented [here](https://osquery.readthedocs.org/en/latest/development/wildcard-rules/index.html). The paths, when expanded out by osquery, are monitored for changes and processed by the [file_events](https://osquery.io/docs/tables/#file_events) table.
 
 The second thing to notice is the *yara* section, which contains the configuration to use for YARA within osquery. The *yara* section contains two keys: *signatures* and *file_paths*. The *signatures* key contains a set of arbitrary key names, called "signature groups". The value for each of these groups are the paths to the signature files that will be compiled and stored within osquery. The paths to the signature files can be absolute or relative to ```/etc/osquery/yara/```. The *file_paths* key maps the category name for an event described in the global *file_paths* section to a signature grouping to use when scanning.
 
@@ -82,7 +82,7 @@ As you can see, even though no matches were found an row is still created and st
 
 The **yara** table is used for on-demand scanning. With this table you can arbitrarily YARA scan any available file on the filesystem with any available signature files or signature group from the configuration. In order to scan the table must be given a constraint which says where to scan and what to scan with.
 
-In order to determine where to scan the table accepts either a *path* or a *pattern* constraint. The *path* constraint must be a full path to a single file. There is no expansion or recursion with this constraint. The *pattern* constraint follows the same [wildcard rules](http://osquery.readthedocs.org/en/latest/development/wildcard-rules/index.html) mentioned before.
+In order to determine where to scan the table accepts either a *path* or a *pattern* constraint. The *path* constraint must be a full path to a single file. There is no expansion or recursion with this constraint. The *pattern* constraint follows the same [wildcard rules](https://osquery.readthedocs.org/en/latest/development/wildcard-rules/index.html) mentioned before.
 
 Once the "where" is out of the way you must specify the "what" part. This is done through either the *sigfile* or *sig_group* constraints. The *sigfile* constraint can be either an absolute path to a signature file on disk or a path relative to */var/osquery/*. The signature file will be compiled only for the execution of this one query and removed afterwards. The *sig_group* constraint must consist of a named signature grouping from your configuration file.
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -73,7 +73,7 @@ $ ls -la ./build/linux/osquery/
 
 Building osquery on OS X or Linux requires a significant number of dependencies, which
 are not needed when deploying. It does not make sense to install osquery on
-your build hosts. See the [Custom Packages](../installation/custom-packages) guide
+your build hosts. See the [Custom Packages](../installation/custom-packages.md) guide
 for generating pkgs, debs or rpms.
 
 ## Notes and FAQ

--- a/docs/wiki/development/config-plugins.md
+++ b/docs/wiki/development/config-plugins.md
@@ -1,4 +1,4 @@
-For details on how osqueryd schedules queries and loads information from a config, see the [configuration](../deployment/configuration) deployment guide.
+For details on how osqueryd schedules queries and loads information from a config, see the [configuration](../deployment/configuration.md) deployment guide.
 
 You may distribute configurations in your environment differently than Facebook. To support all environments, the way that osqueryd goes about retrieving configurations is completely pluggable and configurable.
 

--- a/docs/wiki/development/creating-tables.md
+++ b/docs/wiki/development/creating-tables.md
@@ -147,6 +147,6 @@ If your code compiled properly, launch the interactive query console by executin
 
 ### Getting your query ready for use in osqueryd
 
-You don't have to do anything to make your query work in the osqueryd daemon. All osquery queries work in osqueryd. It's worth noting, however, that osqueryd is a long-running process. If your table leaks memory or uses a lot of systems resources, you will notice poor performance from osqueryd. For more information on ensuring a performant table, see [performance overview](../deployment/performance-safety).
+You don't have to do anything to make your query work in the osqueryd daemon. All osquery queries work in osqueryd. It's worth noting, however, that osqueryd is a long-running process. If your table leaks memory or uses a lot of systems resources, you will notice poor performance from osqueryd. For more information on ensuring a performant table, see [performance overview](../deployment/performance-safety.md).
 
 When in doubt, use existing open source tables to guide your development.

--- a/docs/wiki/development/logger-plugins.md
+++ b/docs/wiki/development/logger-plugins.md
@@ -1,4 +1,4 @@
-For details on how osqueryd schedules queries and loads information from a config, see the [configuration](../deployment/configuration) deployment guide.
+For details on how osqueryd schedules queries and loads information from a config, see the [configuration](../deployment/configuration.md) deployment guide.
 
 If you would like to use services like [scribe](https://github.com/facebookarchive/scribe) or [flume](http://flume.apache.org/), you need to write a C++ function that consumes/handles a string argument.
 

--- a/docs/wiki/development/pubsub-framework.md
+++ b/docs/wiki/development/pubsub-framework.md
@@ -18,7 +18,7 @@ There's an array of yet-to-be-implemented uses of the inotify publisher, but a s
 
 ## Event Subscribers
 
-Let's continue to use the inotify event publisher as an example. And let's implement a table that reports new files created in "/etc/`" The first thing we need is a [table spec](creating-tables):
+Let's continue to use the inotify event publisher as an example. And let's implement a table that reports new files created in "/etc/`" The first thing we need is a [table spec](creating-tables.md):
 
 ```python
 table_name("new_etc_files")

--- a/docs/wiki/development/unit-tests.md
+++ b/docs/wiki/development/unit-tests.md
@@ -6,7 +6,7 @@ All commits to osquery should be well unit-tested. Having tests is useful for ma
 
 This guide is going to take you through the process of creating and building a new unit test in the osquery project.
 
-Ensure that you can properly build the code by running `make` at the root of the osquery repository. If your build fails, refer to the ["building the code"](building) guide.
+Ensure that you can properly build the code by running `make` at the root of the osquery repository. If your build fails, refer to the ["building the code"](building.md) guide.
 
 Before you modify osquery code (or any code for that matter), make sure that you can successfully execute all tests. Run `make test` to run all tests.
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -5,14 +5,14 @@ osquery exposes an operating system as a high-performance relational database. T
 
 ## Getting Started
 
-If you're interested in **installing osquery** check out the install guide for [OS X](installation/install-osx) and [Linux](installation/install-linux).
+If you're interested in **installing osquery** check out the install guide for [OS X](installation/install-osx.md) and [Linux](installation/install-linux.md).
 
-If you're interested in **deploying osquery** to provide your organization with deeper insight into your Linux and OS X hosts check out the [using osqueryd guide](introduction/using-osqueryd).
-If you're interested in **performing ad-hoc queries**, check out [using osqueryi](introduction/using-osqueryi).
+If you're interested in **deploying osquery** to provide your organization with deeper insight into your Linux and OS X hosts check out the [using osqueryd guide](introduction/using-osqueryd.md).
+If you're interested in **performing ad-hoc queries**, check out [using osqueryi](introduction/using-osqueryi.md).
 
-If you're interested in **extending one of the existing osquery products** or improving core libraries read the developer documentation pages. You should start with "[building the code](development/building)" and "[contributing code](development/contributing-code)".
+If you're interested in **extending one of the existing osquery products** or improving core libraries read the developer documentation pages. You should start with "[building the code](development/building.md)" and "[contributing code](development/contributing-code.md)".
 
-If you're interested in **using osquery's functionality in your own tool**, check out the [osquery SDK](development/osquery-sdk).
+If you're interested in **using osquery's functionality in your own tool**, check out the [osquery SDK](development/osquery-sdk.md).
 
 ## Getting help
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -2,7 +2,7 @@ The osquery shell and daemon use optional command line (CLI) flags to control
 initialization, disable/enable features, and select plugins.
 
 Most of these flag-based parameters apply to both tools. Flags that do not
-control startup settings may be included as "options" to the daemon within its [configuration](../deployment/configuration).
+control startup settings may be included as "options" to the daemon within its [configuration](../deployment/configuration.md).
 
 ## CLI-only (initialization) flags
 

--- a/docs/wiki/installation/custom-packages.md
+++ b/docs/wiki/installation/custom-packages.md
@@ -4,11 +4,11 @@ We support building custom deployment packages (pkg/deb/rpm) for less common use
 - Proprietary modifications to "core" features that aren't simple additional plugins
 - Custom dependency modifications (patched versions of glog, thrift, etc)
 
-The first step to creating custom packages is having [built](../development/building) and tested osquery. This means reading the development guides and in most cases having a dedicated "build host".
+The first step to creating custom packages is having [built](../development/building.md) and tested osquery. This means reading the development guides and in most cases having a dedicated "build host".
 
 ## Linux
 
-In your cloned osquery repository, once you have [built the code](../development/building) (hopefully a tagged release):
+In your cloned osquery repository, once you have [built the code](../development/building.md) (hopefully a tagged release):
 
 ```sh
 $ make packages
@@ -18,7 +18,7 @@ This will use CMake and *fpm*, installed as an osquery build dependency, to gene
 
 ## OS X
 
-In your cloned osquery repository, once you have [built the code](../development/building) (hopefully a tagged release):
+In your cloned osquery repository, once you have [built the code](../development/building.md) (hopefully a tagged release):
 
 ```sh
 $ make packages

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -71,7 +71,7 @@ osquery does not require a kernel driver currently.
 There are medium priority plans to extend table data collection into the kernel
 as well as use kernel frameworks to protect the daemon and log data.
 
-We include an optional [kernel driver](../deployment/kernel-linux) that implements an example osquery table.
+We include an optional [kernel driver](../deployment/kernel-linux.md) that implements an example osquery table.
 
 \* You may also set a different config plugin using `/etc/osquery/osquery.flags`.<br />
 \** We do not recommend using the latest/unstable package as it is built

--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -22,7 +22,7 @@ If you plan to manage an enterprise osquery deployment, the easiest installation
 an OS X package installer. You will have to manage and deploy updates.
 
 Each osquery tag (release) builds an OS X package:
-[osquery.io/downloads](http://osquery.io/downloads/).
+[osquery.io/downloads](https://osquery.io/downloads/).
 There are no package or library dependencies.
 
 The default package creates the following structure:

--- a/docs/wiki/introduction/using-osqueryd.md
+++ b/docs/wiki/introduction/using-osqueryd.md
@@ -4,7 +4,7 @@ The installation and deployment guides are mostly focused on the osquery daemon 
 
 ## Configuration and query schedule
 
-The primary daemon feature is executing a query schedule. This schedule is defined in an [osquery configuration](../deployment/configuration) and includes a list of semi-broad queries and their interval. The interval is an approximate time to run the query.
+The primary daemon feature is executing a query schedule. This schedule is defined in an [osquery configuration](../deployment/configuration.md) and includes a list of semi-broad queries and their interval. The interval is an approximate time to run the query.
 
 ```json
 {
@@ -41,4 +41,4 @@ If there are no USB devices added or removed to the laptop this query would neve
 ]
 ```
 
-Each line in the results is decorated with a bit more information as described in the [logging](../deployment/logging) guide. This includes time, hostname, added or removed action, etc.
+Each line in the results is decorated with a bit more information as described in the [logging](../deployment/logging.md) guide. This includes time, hostname, added or removed action, etc.

--- a/docs/wiki/introduction/using-osqueryi.md
+++ b/docs/wiki/introduction/using-osqueryi.md
@@ -3,7 +3,7 @@ not need to run as an administrator. Use the shell to prototype queries and expl
 
 ## Executing SQL queries
 
-osqueryi lets you run commands and query osquery tables. See the [table API](http://osquery.io/tables/) for a complete list of tables, types, and column descriptions. For SQL syntax help, see [SQL as understood by SQLite](http://www.sqlite.org/lang.html).
+osqueryi lets you run commands and query osquery tables. See the [table API](https://osquery.io/tables/) for a complete list of tables, types, and column descriptions. For SQL syntax help, see [SQL as understood by SQLite](http://www.sqlite.org/lang.html).
 
 Here is an example query:
 
@@ -104,4 +104,4 @@ $
 ```
 
 The shell does not keep much state or connect to a osqueryd daemon.
-If you would like to run queries and log changes to the output or log operating system events consider deploying a query **schedule** using [osqueryd](using-osqueryd).
+If you would like to run queries and log changes to the output or log operating system events consider deploying a query **schedule** using [osqueryd](using-osqueryd.md).


### PR DESCRIPTION
Noticed that the linked screenshot images were loaded over http resulting in mixed content warning. This updates links to https.

Also noticed that most of the internal hyperlinks were broken. According to [Mkdocs RTD](https://mkdocs.readthedocs.org/en/latest/user-guide/writing-your-docs/#linking-documents) these require the `.md` extension.

I think I got most of those, but my grep/regex could have certainly missed some.