### PR TITLE
[Fix #1080] Remove netlink, support raw sockets

### DIFF
--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <arpa/inet.h>
-#include <linux/netlink.h>
 
 #include <boost/algorithm/string/split.hpp>
 
@@ -18,116 +17,17 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-// From uapi/linux/sock_diag.h
-// From linux/sock_diag.h (<= 3.6)
-#ifndef SOCK_DIAG_BY_FAMILY
-#define SOCK_DIAG_BY_FAMILY 20
-#endif
-
-#include "inet_diag.h"
-
 namespace osquery {
 namespace tables {
 
-// heavily influenced by github.com/kristrev/inet-diag-example
-enum {
-  TCP_ESTABLISHED = 1,
-  TCP_SYN_SENT,
-  TCP_SYN_RECV,
-  TCP_FIN_WAIT1,
-  TCP_FIN_WAIT2,
-  TCP_TIME_WAIT,
-  TCP_CLOSE,
-  TCP_CLOSE_WAIT,
-  TCP_LAST_ACK,
-  TCP_LISTEN,
-  TCP_CLOSING
+// Linux proc protocol define to net stats file name.
+const std::map<int, std::string> kLinuxProtocolNames = {
+    {IPPROTO_ICMP, "icmp"},
+    {IPPROTO_TCP, "tcp"},
+    {IPPROTO_UDP, "udp"},
+    {IPPROTO_UDPLITE, "udplite"},
+    {IPPROTO_RAW, "raw"},
 };
-
-#define TCPF_ALL 0xFFF
-#define SOCKET_BUFFER_SIZE (getpagesize() < 8192L ? getpagesize() : 8192L)
-
-int sendNLDiagMessage(int sockfd, int protocol, int family) {
-  struct sockaddr_nl sa;
-  memset(&sa, 0, sizeof(sa));
-  sa.nl_family = AF_NETLINK;
-
-  // Only interested in network sockets currently.
-  struct inet_diag_req_v2 conn_req;
-  memset(&conn_req, 0, sizeof(conn_req));
-  conn_req.sdiag_family = family;
-  conn_req.sdiag_protocol = protocol;
-  if (protocol == IPPROTO_TCP) {
-    conn_req.idiag_states =
-        TCPF_ALL &
-        ~((1 << TCP_SYN_RECV) | (1 << TCP_TIME_WAIT) | (1 << TCP_CLOSE));
-    // Request additional TCP information.
-    conn_req.idiag_ext |= (1 << (INET_DIAG_INFO - 1));
-  } else {
-    conn_req.idiag_states = -1;
-  }
-
-  struct nlmsghdr nlh;
-  memset(&nlh, 0, sizeof(nlh));
-  nlh.nlmsg_len = NLMSG_LENGTH(sizeof(conn_req));
-  nlh.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
-  nlh.nlmsg_type = SOCK_DIAG_BY_FAMILY;
-
-  struct iovec iov[4];
-  iov[0].iov_base = (void *)&nlh;
-  iov[0].iov_len = sizeof(nlh);
-  iov[1].iov_base = (void *)&conn_req;
-  iov[1].iov_len = sizeof(conn_req);
-
-  struct msghdr msg;
-  memset(&msg, 0, sizeof(msg));
-  msg.msg_name = (void *)&sa;
-  msg.msg_namelen = sizeof(sa);
-  msg.msg_iov = iov;
-  msg.msg_iovlen = 2;
-
-  int retval = sendmsg(sockfd, &msg, 0);
-  return retval;
-}
-
-Row getNLDiagMessage(const struct inet_diag_msg *diag_msg,
-                     int protocol,
-                     int family) {
-  char local_addr_buf[INET6_ADDRSTRLEN] = {0};
-  char remote_addr_buf[INET6_ADDRSTRLEN] = {0};
-
-  // set up data structures depending on idiag_family type
-  if (diag_msg->idiag_family == AF_INET) {
-    inet_ntop(AF_INET,
-              (struct in_addr *)&(diag_msg->id.idiag_src),
-              local_addr_buf,
-              INET_ADDRSTRLEN);
-    inet_ntop(AF_INET,
-              (struct in_addr *)&(diag_msg->id.idiag_dst),
-              remote_addr_buf,
-              INET_ADDRSTRLEN);
-  } else if (diag_msg->idiag_family == AF_INET6) {
-    inet_ntop(AF_INET6,
-              (struct in_addr6 *)&(diag_msg->id.idiag_src),
-              local_addr_buf,
-              INET6_ADDRSTRLEN);
-    inet_ntop(AF_INET6,
-              (struct in_addr6 *)&(diag_msg->id.idiag_dst),
-              remote_addr_buf,
-              INET6_ADDRSTRLEN);
-  }
-
-  // populate the Row from diag_msg fields
-  Row row;
-  row["socket"] = INTEGER(diag_msg->idiag_inode);
-  row["family"] = INTEGER(family);
-  row["protocol"] = INTEGER(protocol);
-  row["local_address"] = TEXT(local_addr_buf);
-  row["remote_address"] = TEXT(remote_addr_buf);
-  row["local_port"] = INTEGER(ntohs(diag_msg->id.idiag_sport));
-  row["remote_port"] = INTEGER(ntohs(diag_msg->id.idiag_dport));
-  return row;
-}
 
 std::string addressFromHex(const std::string &encoded_address, int family) {
   char addr_buffer[INET6_ADDRSTRLEN] = {0};
@@ -161,13 +61,12 @@ unsigned short portFromHex(const std::string &encoded_port) {
   return decoded;
 }
 
-/// A fallback method for generating socket information from /proc/net
 void genSocketsFromProc(const std::map<std::string, std::string> &socket_inodes,
                         int protocol,
                         int family,
                         QueryData &results) {
   std::string path = "/proc/net/";
-  path += (protocol == IPPROTO_UDP) ? "udp" : "tcp";
+  path += kLinuxProtocolNames.at(protocol);
   path += (family == AF_INET6) ? "6" : "";
 
   std::string content;
@@ -223,60 +122,6 @@ void genSocketsFromProc(const std::map<std::string, std::string> &socket_inodes,
   }
 }
 
-void genSocketsForFamily(
-    const std::map<std::string, std::string> &socket_inodes,
-    int protocol,
-    int family,
-    QueryData &results) {
-  // set up the socket
-  int nl_sock = 0;
-  if ((nl_sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_INET_DIAG)) == -1) {
-    return;
-  }
-
-  // send the inet_diag message
-  if (sendNLDiagMessage(nl_sock, protocol, family) < 0) {
-    close(nl_sock);
-    return;
-  }
-
-  // recieve netlink messages
-  uint8_t recv_buf[SOCKET_BUFFER_SIZE];
-  int numbytes = recv(nl_sock, recv_buf, sizeof(recv_buf), 0);
-  if (numbytes <= 0) {
-    VLOG(1) << "NETLINK receive failed";
-    return;
-  }
-
-  auto nlh = (struct nlmsghdr *)recv_buf;
-  while (NLMSG_OK(nlh, numbytes)) {
-    if (nlh->nlmsg_type == NLMSG_DONE) {
-      break;
-    }
-
-    if (nlh->nlmsg_type == NLMSG_ERROR) {
-      genSocketsFromProc(socket_inodes, protocol, family, results);
-      break;
-    }
-
-    // parse and process netlink message
-    auto diag_msg = (struct inet_diag_msg *)NLMSG_DATA(nlh);
-    auto row = getNLDiagMessage(diag_msg, protocol, family);
-
-    if (socket_inodes.count(row["socket"]) > 0) {
-      row["pid"] = socket_inodes.at(row["socket"]);
-    } else {
-      row["pid"] = "-1";
-    }
-
-    results.push_back(row);
-    nlh = NLMSG_NEXT(nlh, numbytes);
-  }
-
-  close(nl_sock);
-  return;
-}
-
 QueryData genOpenSockets(QueryContext &context) {
   QueryData results;
 
@@ -303,11 +148,13 @@ QueryData genOpenSockets(QueryContext &context) {
     }
   }
 
-  // Use netlink messages to query socket information.
-  genSocketsForFamily(socket_inodes, IPPROTO_TCP, AF_INET, results);
-  genSocketsForFamily(socket_inodes, IPPROTO_UDP, AF_INET, results);
-  genSocketsForFamily(socket_inodes, IPPROTO_TCP, AF_INET6, results);
-  genSocketsForFamily(socket_inodes, IPPROTO_UDP, AF_INET6, results);
+  // This used to use netlink (Ref: #1094) to request socket information.
+  // Use proc messages to query socket information.
+  for (const auto &protocol : kLinuxProtocolNames) {
+    genSocketsFromProc(socket_inodes, protocol.first, AF_INET, results);
+    genSocketsFromProc(socket_inodes, protocol.first, AF_INET6, results);
+  }
+
   return results;
 }
 }

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -10,15 +10,6 @@
 function main_centos() {
   sudo yum update -y
 
-  if [[ -z $(rpm -qa | grep 'kernel-headers-3') ]]; then
-    if [[ $DISTRO = "centos6" ]]; then
-      sudo rpm -iv https://osquery-packages.s3.amazonaws.com/deps/kernel-headers-3.10.0-123.9.3.el7.x86_64.rpm
-    elif [[ $DISTRO = "centos7" ]]; then
-      #package kernel-headers
-      true
-    fi
-  fi
-
   package texinfo
   package wget
   package git-all


### PR DESCRIPTION
See the reference-tagged issue #1094 about removing netlink for the time being.

This adds the common, proc-accessible protocol lists to processes_open_sockets aside from just TCP/UDP.