### PR TITLE
Add a CMake variable for packages

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -5,6 +5,7 @@ if(APPLE)
     "${CMAKE_SOURCE_DIR}/tools/deployment/make_osx_package.sh"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Building default OS X package (no custom config)" VERBATIM
+    DEPENDS daemon shell
   )
 elseif(LINUX)
   if(UBUNTU)
@@ -91,5 +92,6 @@ elseif(LINUX)
       -d "${PACKAGE_DEPENDENCIES}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Building linux packages (no custom config)" VERBATIM
+    DEPENDS daemon shell
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 
 # make debug (environment variable from Makefile)
 if(DEFINED ENV{DEBUG})
+  set(DEBUG TRUE)
   set(CMAKE_BUILD_TYPE "Debug")
   add_compile_options(-g -O0 -pg)
   add_definitions(-DDEBUG)
@@ -87,6 +88,7 @@ elseif(DEFINED ENV{SANITIZE})
   set(SANITIZE_BLACKLIST "${CMAKE_SOURCE_DIR}/tools/tests/sanitize_blacklist.txt")
   add_compile_options(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
 else()
+  set(DEBUG FALSE)
   add_compile_options(-O2)
   add_definitions(-DNDEBUG)
   # Do not enable fortify with clang: http://llvm.org/bugs/show_bug.cgi?id=16821
@@ -96,6 +98,19 @@ endif()
 # make analyze (environment variable from Makefile)
 if(DEFINED ENV{ANALYZE})
   set(CMAKE_CXX_COMPILER "${CMAKE_SOURCE_DIR}/tools/analysis/clang-analyze.sh")
+endif()
+
+# make sdk (tests building SDK-based extensions)
+if(DEFINED ENV{SDK})
+  set(OSQUERY_BUILD_SDK_ONLY TRUE)
+endif()
+
+# make packages will set release to true and blacklist development features,
+# development plugins, etc.
+if(DEFINED ENV{PACKAGE})
+  set(OSQUERY_BUILD_RELEASE TRUE)
+else()
+  set(OSQUERY_BUILD_RELEASE FALSE)
 endif()
 
 # Finished setting compiler/compiler flags.
@@ -126,11 +141,6 @@ if(DEFINED ENV{SDK_VERSION})
 else()
   string(REPLACE "-" ";" OSQUERY_BUILD_SDK_VERSION ${OSQUERY_BUILD_VERSION})
   list(GET OSQUERY_BUILD_SDK_VERSION 0 OSQUERY_BUILD_SDK_VERSION)
-endif()
-
-# make sdk (tests building SDK-based extensions)
-if(DEFINED ENV{SDK})
-  set(OSQUERY_BUILD_SDK_ONLY TRUE)
 endif()
 
 # Set various platform/platform-version/build version/etc defines.

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,13 @@ ifeq ($(PLATFORM),Linux)
 		@ln -snf debug_$(BUILD_DIR) build/debug_linux
 endif
 
-package:
+package: .setup
 	# Alias for packages (do not use CPack)
-	cd build/$(BUILD_DIR) && cmake ../../ && \
+	cd build/$(BUILD_DIR) && PACKAGE=True cmake ../../ && \
+		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
+
+packages: .setup
+	cd build/$(BUILD_DIR) && PACKAGE=True cmake ../../ && \
 		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
 
 %::

--- a/osquery/config/CMakeLists.txt
+++ b/osquery/config/CMakeLists.txt
@@ -2,10 +2,20 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_config
   config.cpp
 )
 
-ADD_OSQUERY_LIBRARY(FALSE osquery_config_plugins
-  update.cpp
+set(OSQUERY_CONFIG_PLUGINS
   plugins/filesystem.cpp
-  plugins/http.cpp
+  update.cpp
+)
+
+if(NOT OSQUERY_BUILD_RELEASE)
+  set(OSQUERY_CONFIG_PLUGINS
+    ${OSQUERY_CONFIG_PLUGINS}
+    plugins/http.cpp
+  )
+endif()
+
+ADD_OSQUERY_LIBRARY(FALSE osquery_config_plugins
+  ${OSQUERY_CONFIG_PLUGINS}
 )
 
 file(GLOB OSQUERY_CONFIG_TESTS "tests/*.cpp")

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -216,6 +216,7 @@ void Initializer::initWatcher() {
 
 void Initializer::initWorker(const std::string& name) {
   // Clear worker's arguments.
+  size_t name_size = strlen((*argv_)[0]);
   for (int i = 0; i < *argc_; i++) {
     if ((*argv_)[i] != nullptr) {
       memset((*argv_)[i], 0, strlen((*argv_)[i]));
@@ -223,7 +224,6 @@ void Initializer::initWorker(const std::string& name) {
   }
 
   // Set the worker's process name.
-  size_t name_size = strlen((*argv_)[0]);
   if (name.size() <= name_size) {
     std::copy(name.begin(), name.end(), (*argv_)[0]);
   }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -26,7 +26,7 @@ FLAG(string,
      "hostname",
      "Field used to identify the host running osquery (hostname, uuid)");
 
-FLAG(bool, disable_monitor, false, "Disable the schedule monitor");
+FLAG(bool, enable_monitor, false, "Enable the schedule monitor");
 
 CLI_FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit")
 
@@ -94,7 +94,7 @@ inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
 void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // Execute the scheduled query and create a named query object.
   VLOG(1) << "Executing query: " << query.query;
-  auto sql = (!FLAGS_disable_monitor) ? monitor(name, query) : SQL(query.query);
+  auto sql = (FLAGS_enable_monitor) ? monitor(name, query) : SQL(query.query);
 
   if (!sql.ok()) {
     LOG(ERROR) << "Error executing query (" << query.query

--- a/osquery/remote/CMakeLists.txt
+++ b/osquery/remote/CMakeLists.txt
@@ -4,9 +4,11 @@ ADD_OSQUERY_LIBRARY(FALSE osquery_remote
   transports/http.cpp
 )
 
-ADD_OSQUERY_LIBRARY(FALSE osquery_enrollment_plugins
-  enrollment/plugins/http.cpp
-)
+if(NOT OSQUERY_BUILD_RELEASE)
+  ADD_OSQUERY_LIBRARY(FALSE osquery_enrollment_plugins
+    enrollment/plugins/http.cpp
+  )
+endif()
 
 file(GLOB OSQUERY_ENROLLMENT_PLUGIN_TESTS "enrollment/plugins/tests/*.cpp")
 ADD_OSQUERY_TEST(FALSE ${OSQUERY_ENROLLMENT_PLUGIN_TESTS})

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -29,7 +29,7 @@ from gentable import Column, ForeignKey, \
 LOG_FORMAT = "%(levelname)s [Line %(lineno)d]: %(message)s"
 
 CANONICAL_PLATFORMS = {
-    "x": "All Platforms",
+    "specs": "All Platforms",
     "darwin": "Darwin (Apple OS X)",
     "linux": "Ubuntu, CentOS",
     "centos": "CentOS",


### PR DESCRIPTION
While cutting 1.4.5 I noticed enrollment and http-based config retrieval plugins were included. Instead of a note to not use these features I'd rather support a release-package boolean to remove in-progress features.