### PR TITLE
Add first wave of support for building on FreeBSD

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -15,7 +15,7 @@ endmacro(SET_OSQUERY_COMPILE)
 
 macro(ADD_OSQUERY_PYTHON_TEST TEST_NAME SOURCE)
   add_test(NAME python_${TEST_NAME}
-    COMMAND python "${CMAKE_SOURCE_DIR}/tools/tests/${SOURCE}" --build "${CMAKE_BINARY_DIR}"
+    COMMAND python2 "${CMAKE_SOURCE_DIR}/tools/tests/${SOURCE}" --build "${CMAKE_BINARY_DIR}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tools/tests/")
 endmacro(ADD_OSQUERY_PYTHON_TEST)
 
@@ -30,7 +30,7 @@ endmacro(ADD_OSQUERY_LINK)
 
 macro(ADD_OSQUERY_LINK_INTERNAL LINK LINK_PATHS LINK_SET)
   if(NOT "${LINK}" MATCHES "(^[-/].*)")
-    find_library("${LINK}_library" NAMES "lib${LINK}.a" "${LINK}" ${LINK_PATHS})
+      find_library("${LINK}_library" NAMES "${LINK}" "lib${LINK}" ${LINK_PATHS})
     message("-- Found library dependency ${${LINK}_library}")
     if("${${LINK}_library}" STREQUAL "${${LINK}_library}-NOTFOUND")
       string(ASCII 27 Esc)
@@ -182,7 +182,7 @@ macro(GENERATE_TABLE TABLE_FILE NAME BASE_PATH OUTPUT)
   GET_GENERATION_DEPS(${BASE_PATH})
   add_custom_command(
     OUTPUT "${TABLE_FILE_GEN}"
-    COMMAND python "${BASE_PATH}/tools/codegen/gentable.py"
+    COMMAND python2 "${BASE_PATH}/tools/codegen/gentable.py"
       "${TABLE_FILE}" "${TABLE_FILE_GEN}" "$ENV{DISABLE_BLACKLIST}"
     DEPENDS ${TABLE_FILE} ${GENERATION_DEPENDENCIES}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -207,7 +207,7 @@ macro(AMALGAMATE BASE_PATH NAME OUTPUT)
   # Append all of the code to a single amalgamation.
   add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/generated/${NAME}_amalgamation.cpp"
-    COMMAND python "${BASE_PATH}/tools/codegen/amalgamate.py"
+    COMMAND python2 "${BASE_PATH}/tools/codegen/amalgamate.py"
       "${BASE_PATH}/osquery/tables/" "${CMAKE_BINARY_DIR}/generated" "${NAME}"
     DEPENDS ${GENERATED_TARGETS} ${GENERATION_DEPENDENCIES}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/CMake/FindGlog.cmake
+++ b/CMake/FindGlog.cmake
@@ -6,20 +6,6 @@ endif()
 set(GLOG_ROOT_DIR "${CMAKE_BINARY_DIR}/third-party/glog")
 set(GLOG_SOURCE_DIR "${CMAKE_SOURCE_DIR}/third-party/glog")
 
-if(NOT APPLE)
-  include(CheckIncludeFiles)
-  unset(LIBUNWIND_FOUND CACHE)
-  check_include_files("libunwind.h;unwind.h" LIBUNWIND_FOUND)
-  if(LIBUNWIND_FOUND)
-    unset(libglog_FOUND CACHE)
-    execute_process(
-      COMMAND rm -rf "${GLOG_ROOT_DIR}" "${CMAKE_BINARY_DIR}/libglog-prefix"
-      ERROR_QUIET
-    )
-    message(WARNING "${Esc}[31mWarning: libunwind headers found [Issue #596], please: make deps\n${Esc}[m")
-  endif()
-endif()
-
 set(GLOG_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-unnamed-type-template-args -Wno-deprecated -Wno-error")
 
 INCLUDE(ExternalProject)
@@ -31,11 +17,11 @@ ExternalProject_Add(
     CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
     CXXFLAGS=${GLOG_CXX_FLAGS}
     --enable-frame-pointers --enable-shared=no --prefix=${GLOG_ROOT_DIR}
-  BUILD_COMMAND make
-  INSTALL_COMMAND make install
-  LOG_CONFIGURE ON
-  LOG_INSTALL ON
-  LOG_BUILD ON
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
+  INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+  LOG_CONFIGURE OFF
+  LOG_INSTALL OFF
+  LOG_BUILD OFF
 )
 
 set(GLOG_INCLUDE_DIR "${GLOG_ROOT_DIR}/include")

--- a/CMake/FindRocksDB.cmake
+++ b/CMake/FindRocksDB.cmake
@@ -73,6 +73,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   # On Linux
   set(ROCKSDB_LIBRARY_NAMES ${ROCKSDB_LIBRARY_NAMES} librocksdb.so)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(ROCKSDB_LIBRARY_NAMES ${ROCKSDB_LIBRARY_NAMES} librocksdb.so)
 else()
   set(ROCKSDB_LIBRARY_NAMES ${ROCKSDB_LIBRARY_NAMES} librocksdb.a)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(CMAKE_C_COMPILER "clang")
-set(CMAKE_CXX_COMPILER "clang++")
+#set(CMAKE_C_COMPILER "cc")
+#set(CMAKE_CXX_COMPILER "c++")
 add_compile_options(
   -Wall
   -Wextra
@@ -36,7 +36,8 @@ if(APPLE)
     "-x objective-c++ -fobjc-arc -Wno-c++11-extensions -mmacosx-version-min=${APPLE_MIN_ABI}")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(FREEBSD TRUE)
-  set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11 -stdlib=libc++")
+  set(LINUX FALSE)
+  set(CXX_COMPILE_FLAGS "${CXX_COMPILE_FLAGS} -std=c++11")
   set(OS_WHOLELINK_PRE "")
   set(OS_WHOLELINK_POST "")
 else()
@@ -139,7 +140,7 @@ execute_process(
 if(DEFINED ENV{SDK_VERSION})
   set(OSQUERY_BUILD_SDK_VERSION "${ENV{SDK_VERSION}}")
 else()
-  string(REPLACE "-" ";" OSQUERY_BUILD_SDK_VERSION ${OSQUERY_BUILD_VERSION})
+  string(REPLACE "-" ";" OSQUERY_BUILD_SDK_VERSION "1.4.5")
   list(GET OSQUERY_BUILD_SDK_VERSION 0 OSQUERY_BUILD_SDK_VERSION)
 endif()
 
@@ -164,7 +165,8 @@ elseif(OSQUERY_BUILD_PLATFORM STREQUAL "centos")
 elseif(OSQUERY_BUILD_PLATFORM STREQUAL "rhel")
   set(RHEL TRUE)
   message("-- Building for RHEL")
-elseif(FREEBSD)
+elseif(OSQUERY_BUILD_PLATFORM STREQUAL "freebsd")
+  set(FREEBSD TRUE)
   message("-- Building for FreeBSD")
 endif()
 
@@ -183,7 +185,7 @@ find_package(Dl REQUIRED)
 find_package(Readline REQUIRED)
 
 # Most dependent packages/libs we want static.
-set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dylib .so)
+set(CMAKE_FIND_LIBRARY_SUFFIXES .so .a .dylib)
 find_package(CppNetlib 0.11.0 REQUIRED)
 find_package(Gflags REQUIRED)
 find_package(Glog REQUIRED)
@@ -233,7 +235,7 @@ add_custom_target(
 # make format
 add_custom_target(
   format
-  python "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
+  python2 "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting code staged code changes with clang-format" VERBATIM
 )

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ PLATFORM := $(shell uname -s)
 VERSION := $(shell git describe --tags HEAD --always)
 MAKE = make
 
-SHELL := /bin/bash
+SHELL := $(shell which bash)
+ifeq ($(PLATFORM),FreeBSD)
+	MAKE = gmake
+endif
 
 DISTRO := $(shell . ./tools/lib.sh; _platform)
 DISTRO_VERSION := $(shell . ./tools/lib.sh; _distro $(DISTRO))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ These queries can be:
 
 For latest stable and nightly builds for OS X and Linux (deb/rpm), as well as yum and apt repository information visit [http://osquery.io/downloads](https://osquery.io/downloads/).
 
+##### FreeBSD
+
+The easiest way to install osquery on FreeBSD is via the ports tree.  Check [FreshPorts](http://www.freshports.org/sysutils/osquery) for the latest version information.
+
+```bash
+# from ports
+cd /usr/ports/sysutils/osquery && make install clean
+
+# from binary package
+pkg install osquery
+
+# using portmaster
+portmaster sysutils/osquery
+```
+
 ##### OS X (Homebrew)
 
 The easiest way to install osquery on OS X is via Homebrew. Check the [Homebrew](http://brew.sh/) homepage for installation instructions.

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -19,7 +19,11 @@
 
 #include <osquery/core.h>
 
+#ifdef FREEBSD
+#define GFLAGS_NAMESPACE gflags
+#else
 #define GFLAGS_NAMESPACE google
+#endif
 
 namespace boost {
 /// We define a lexical_cast template for boolean for Gflags boolean string

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -22,10 +22,13 @@ set(OSQUERY_LIBS
 
   readline
   pthread
-  dl
   bz2
   z
 )
+
+if(NOT FREEBSD)
+  ADD_OSQUERY_LINK(TRUE "dl")
+endif()
 
 # Add default linking details (the first argument means SDK + core).
 ADD_OSQUERY_LINK(TRUE "-rdynamic")

--- a/osquery/filesystem/CMakeLists.txt
+++ b/osquery/filesystem/CMakeLists.txt
@@ -4,7 +4,7 @@ if(APPLE)
   )
 
   ADD_OSQUERY_LINK(TRUE "-framework Foundation")
-elseif(LINUX)
+elif(LINUX)
   ADD_OSQUERY_LIBRARY(TRUE osquery_filesystem_linux
     linux/mem.cpp
     linux/proc.cpp

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -59,10 +59,12 @@ else()
   ADD_OSQUERY_LINK(FALSE "uuid")
 endif()
 
-file(GLOB OSQUERY_CROSS_TABLES "[!u]*/*.cpp")
-ADD_OSQUERY_LIBRARY(FALSE osquery_tables
-  ${OSQUERY_CROSS_TABLES}
-)
+if(NOT FREEBSD)
+  file(GLOB OSQUERY_CROSS_TABLES "[!u]*/*.cpp")
+  ADD_OSQUERY_LIBRARY(FALSE osquery_tables
+    ${OSQUERY_CROSS_TABLES}
+  )
+endif()
 
 file(GLOB OSQUERY_CROSS_TABLES_TESTS "[!u]*/tests/*.cpp")
 ADD_OSQUERY_TABLE_TEST(${OSQUERY_CROSS_TABLES_TESTS})

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -17,7 +17,7 @@
 /// The file change event publishers are slightly different in OS X and Linux.
 #ifdef __APPLE__
 #include "osquery/events/darwin/fsevents.h"
-#else
+#elif defined(LINUX)
 #include "osquery/events/linux/inotify.h"
 #endif
 

--- a/osquery/tables/system/freebsd/groups.cpp
+++ b/osquery/tables/system/freebsd/groups.cpp
@@ -8,6 +8,11 @@
  *
  */
 
+#include <set>
+#include <mutex>
+
+#include <grp.h>
+
 #include <osquery/core.h>
 #include <osquery/tables.h>
 
@@ -16,10 +21,26 @@ namespace tables {
 
 std::mutex grpEnumerationMutex;
 
-QueryData genGroups(QueryContext& context) {
+QueryData genGroups(QueryContext &context) {
+  std::lock_guard<std::mutex> lock(grpEnumerationMutex);
   QueryData results;
+  struct group *grp = nullptr;
+  std::set<long> groups_in;
 
-  throw std::domain_error("Table not implemented for FreeBSD");
+  setgrent();
+  while ((grp = getgrent()) != nullptr) {
+    if (std::find(groups_in.begin(), groups_in.end(), grp->gr_gid) ==
+        groups_in.end()) {
+      Row r;
+      r["gid"] = INTEGER(grp->gr_gid);
+      r["gid_signed"] = INTEGER((int32_t) grp->gr_gid);
+      r["groupname"] = TEXT(grp->gr_name);
+      results.push_back(r);
+      groups_in.insert(grp->gr_gid);
+    }
+  }
+  endgrent();
+  groups_in.clear();
 
   return results;
 }

--- a/osquery/tables/system/freebsd/users.cpp
+++ b/osquery/tables/system/freebsd/users.cpp
@@ -8,16 +8,45 @@
  *
  */
 
+#include <set>
+#include <mutex>
+#include <vector>
+#include <string>
+
+#include <pwd.h>
+
 #include <osquery/core.h>
 #include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
 
-QueryData genUsers(QueryContext& context) {
-  QueryData results;
+std::mutex pwdEnumerationMutex;
 
-  throw std::domain_error("Table not implemented for FreeBSD");
+QueryData genUsers(QueryContext& context) {
+  std::lock_guard<std::mutex> lock(pwdEnumerationMutex);
+  QueryData results;
+  struct passwd *pwd = nullptr;
+  std::set<long> users_in;
+
+  while ((pwd = getpwent()) != nullptr) {
+    if (std::find(users_in.begin(), users_in.end(), pwd->pw_uid) ==
+        users_in.end()) {
+      Row r;
+      r["uid"] = BIGINT(pwd->pw_uid);
+      r["gid"] = BIGINT(pwd->pw_gid);
+      r["uid_signed"] = BIGINT((int32_t) pwd->pw_uid);
+      r["gid_signed"] = BIGINT((int32_t) pwd->pw_gid);
+      r["username"] = TEXT(pwd->pw_name);
+      r["description"] = TEXT(pwd->pw_gecos);
+      r["directory"] = TEXT(pwd->pw_dir);
+      r["shell"] = TEXT(pwd->pw_shell);
+      results.push_back(r);
+      users_in.insert(pwd->pw_uid);
+    }
+  }
+  endpwent();
+  users_in.clear();
 
   return results;
 }

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -14,4 +14,6 @@ function main_freebsd() {
   package py27-pip
   package rocksdb
   package thrift-cpp
+  package thrift
+  package yara
 }

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -253,7 +253,7 @@ function package() {
       brew install --build-bottle $1 || brew upgrade $@
     fi
   elif [[ $OS = "freebsd" ]]; then
-    if [[ -z "$(pkg info -q $1)" ]]; then
+    if pkg info -q $1; then
       log "$1 is already installed. skipping."
     else
       log "installing $1"


### PR DESCRIPTION
This is an initial set of patches to get osquery to build under FreeBSD.  They still need some work:
- the python->python2 change should actually be $(PYTHON) instead.  CMake should check to see if $(PYTHON) is defined, if not, set it to python.
- CMAKE_CXX_COMPILER/CMAKE_C_COMPILER should be able to be overridden.  The FreeBSD ports framework wants to be able to choose the compiler it uses, given a set of requirements.
- Make the calls out to 'git' optional.  In these patches, I've just hardcoded the calls to return "unknown-version"
- If we don't need bash, it would be better to use /bin/sh.  I did not test to see what specifically required bash.  This would be one less dependency.
- The way I'm pulling in the third-party directory is kind of a hack, but it works.  If you guys have a better way to integrate these deps in the future, that would be ideal.  FreeBSD's ports tree has glog, gflags and a version of sqlite3 in it.  Perhaps we can investigate using these existing external dependencies to start work on eliminating the third-party directory wholesale.

My work so far on the port can be found here: https://people.freebsd.org/~zi/osquery.shar

Simply download it and run it to extract the port contents.  Then cd osquery && make
This will pull in all of the dependencies, apply the patches I have for 1.4.5 and get you to the point where linking fails for osqueryd due to libboost_regex/rocksdb issues.
Once we've got a successful build, I'll do some additional review and then commit the port to the FreeBSD ports repo.

Current Problems:
- third-party/glog requires these patches to build: https://svnweb.freebsd.org/ports/head/devel/glog/files/
- Linking fails with a bunch of 'undefined symbol' errors.  This affects libboost_regex and rocksdb.  Switching the linker to use the shared libraries seems to fix this.  This solution might be a good temporary fix, but I suspect we will want to statically link as much as possible, especially given the large dependency list for osquery.
- There might be others that will be discovered after the linking issue is resolved.  I'll continue work as soon as I've got a CMake-fix for it.