### PR TITLE
Remove cpp-netlib from make install

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -136,7 +136,11 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
 
   # Include the public API includes if make devel.
   install(TARGETS libosquery ARCHIVE DESTINATION lib COMPONENT devel OPTIONAL)
-  install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/" DESTINATION include COMPONENT devel OPTIONAL)
+  install(DIRECTORY "${CMAKE_SOURCE_DIR}/include"
+    DESTINATION include
+    COMPONENT devel OPTIONAL
+    PATTERN ".*" EXCLUDE
+  )
 
   # make install (executables)
   install(TARGETS shell RUNTIME DESTINATION bin COMPONENT main)


### PR DESCRIPTION
`make install` should:

```
cd build/darwin && cmake ../../ && \
		CTEST_OUTPUT_ON_FAILURE=1 make --no-print-directory install
-- Requested dependencies may have changed, run: make deps
-- Building for OS X
-- Found components for DL
-- Found readline library
-- Boost version: 1.57.0
-- Found the following Boost libraries:
--   unit_test_framework
--   system
--   regex
--   date_time
--   thread
--   filesystem
--   program_options
--   chrono
--   atomic
-- Found RocksDB
-- Thrift version 0.9.2
-- Found library dependency /usr/local/lib/libboost_thread-mt.a
-- Found library dependency /usr/local/lib/liblz4.a
-- Found library dependency /usr/local/lib/libboost_system.a
-- Found library dependency /usr/local/lib/libboost_filesystem.a
-- Found library dependency /usr/local/lib/libboost_regex.a
-- Found library dependency /usr/local/lib/libyara.a
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/reed/git/github/osquery/build/darwin
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib/libosquery.a
-- Up-to-date: /usr/local/include/include
-- Up-to-date: /usr/local/include/include/osquery
-- Up-to-date: /usr/local/include/include/osquery/config.h
-- Up-to-date: /usr/local/include/include/osquery/core.h
-- Up-to-date: /usr/local/include/include/osquery/database
-- Up-to-date: /usr/local/include/include/osquery/database/db_handle.h
-- Up-to-date: /usr/local/include/include/osquery/database/query.h
-- Up-to-date: /usr/local/include/include/osquery/database/results.h
-- Up-to-date: /usr/local/include/include/osquery/database.h
-- Up-to-date: /usr/local/include/include/osquery/enrollment.h
-- Up-to-date: /usr/local/include/include/osquery/events.h
-- Up-to-date: /usr/local/include/include/osquery/extensions.h
-- Up-to-date: /usr/local/include/include/osquery/filesystem.h
-- Up-to-date: /usr/local/include/include/osquery/flags.h
-- Up-to-date: /usr/local/include/include/osquery/hash.h
-- Up-to-date: /usr/local/include/include/osquery/logger.h
-- Up-to-date: /usr/local/include/include/osquery/registry.h
-- Up-to-date: /usr/local/include/include/osquery/sdk.h
-- Up-to-date: /usr/local/include/include/osquery/sql.h
-- Up-to-date: /usr/local/include/include/osquery/status.h
-- Up-to-date: /usr/local/include/include/osquery/tables.h
-- Up-to-date: /usr/local/bin/osqueryi
-- Up-to-date: /usr/local/bin/osqueryd
-- Up-to-date: /usr/local/share/osquery/osquery.example.conf
-- Up-to-date: /usr/local/share/osquery/com.facebook.osqueryd.plist
```