### PR TITLE
Use CMake find_package for python, fix ifaddrs on FreeBSD

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -15,7 +15,8 @@ endmacro(SET_OSQUERY_COMPILE)
 
 macro(ADD_OSQUERY_PYTHON_TEST TEST_NAME SOURCE)
   add_test(NAME python_${TEST_NAME}
-    COMMAND python "${CMAKE_SOURCE_DIR}/tools/tests/${SOURCE}" --build "${CMAKE_BINARY_DIR}"
+    COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/tests/${SOURCE}"
+      --build "${CMAKE_BINARY_DIR}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tools/tests/")
 endmacro(ADD_OSQUERY_PYTHON_TEST)
 
@@ -184,7 +185,7 @@ macro(GENERATE_TABLE TABLE_FILE NAME BASE_PATH OUTPUT)
   GET_GENERATION_DEPS(${BASE_PATH})
   add_custom_command(
     OUTPUT "${TABLE_FILE_GEN}"
-    COMMAND python "${BASE_PATH}/tools/codegen/gentable.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${BASE_PATH}/tools/codegen/gentable.py"
       "${TABLE_FILE}" "${TABLE_FILE_GEN}" "$ENV{DISABLE_BLACKLIST}"
     DEPENDS ${TABLE_FILE} ${GENERATION_DEPENDENCIES}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -209,7 +210,7 @@ macro(AMALGAMATE BASE_PATH NAME OUTPUT)
   # Append all of the code to a single amalgamation.
   add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/generated/${NAME}_amalgamation.cpp"
-    COMMAND python "${BASE_PATH}/tools/codegen/amalgamate.py"
+    COMMAND ${PYTHON_EXECUTABLE} "${BASE_PATH}/tools/codegen/amalgamate.py"
       "${BASE_PATH}/osquery/tables/" "${CMAKE_BINARY_DIR}/generated" "${NAME}"
     DEPENDS ${GENERATED_TARGETS} ${GENERATION_DEPENDENCIES}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,9 @@ find_package(Snappy REQUIRED)
 find_package(Sqlite3 REQUIRED)
 find_package(Thrift 0.9.1 REQUIRED)
 
+# Python is used for table spec generation and formating.
+find_package(PythonInterp 2 REQUIRED)
+
 enable_testing()
 
 include(CMakeLibs)
@@ -254,7 +257,7 @@ add_custom_target(
 # make format
 add_custom_target(
   format
-  python "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
+  ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting code staged code changes with clang-format" VERBATIM
 )

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -28,6 +28,8 @@ set(OSQUERY_LIBS
 
 if(NOT FREEBSD)
   set(OSQUERY_LIBS ${OSQUERY_LIBS} dl)
+else()
+  ADD_OSQUERY_LINK("icuuc")
 endif()
 
 # Add default linking details (the first argument means SDK + core).

--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -11,8 +11,9 @@
 #include <sstream>
 #include <iomanip>
 
-#include <ifaddrs.h>
+// Maintain the order of includes (ifaddrs after if).
 #include <net/if.h>
+#include <ifaddrs.h>
 #include <sys/socket.h>
 
 #ifdef __linux__

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -31,9 +31,9 @@ TEMPLATES = {}
 RESERVED = ["n", "index"]
 
 # Set the platform in osquery-language
-if sys.platform in ["freebsd10"]:
+if sys.platform.find("freebsd") == 0:
     PLATFORM = "freebsd"
-elif sys.platform in ["linux", "linux2"]:
+elif sys.platform.find("linux") == 0:
     PLATFORM = "linux"
 else:
     PLATFORM = sys.platform


### PR DESCRIPTION
1. Require a python2 interpreter for thrift:py generation.
2. Move ifaddrs after net/if include: https://www.freebsd.org/cgi/man.cgi?query=getifaddrs