### PR TITLE
Adding new table to display iptables filters, chains and rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,11 @@ include_directories("${CMAKE_SOURCE_DIR}")
 include_directories("/usr/local/include")
 link_directories("/usr/local/lib")
 
+# Add sysroot overrides for each platform/distro.
+if(LINUX)
+  include_directories("${CMAKE_SOURCE_DIR}/sysroots/linux")
+endif()
+
 add_subdirectory(osquery)
 add_subdirectory(tools/tests)
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
   ADD_OSQUERY_LINK(FALSE "cryptsetup")
   ADD_OSQUERY_LINK(FALSE "udev")
   ADD_OSQUERY_LINK(FALSE "uuid")
+  ADD_OSQUERY_LINK(FALSE "ip4tc")
 endif()
 
 file(GLOB OSQUERY_CROSS_TABLES "[!ue]*/*.cpp")

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <sstream>
+
+#include <arpa/inet.h>
+#include <libiptc/libiptc.h>
+
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/tables.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+
+namespace osquery {
+namespace tables {
+
+const std::string kLinuxIpTablesNames = "/proc/net/ip_tables_names";
+const char MAP[] = {'0','1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+const int HIGH_BITS = 4;
+const int LOW_BITS = 15;
+
+void parseIpEntry(ipt_ip *ip, Row &r) {
+  r["protocol"] = INTEGER(ip->proto);
+  if (strlen(ip->iniface)) {
+    r["iniface"] = TEXT(ip->iniface);
+  } else {
+    r["iniface"] = "all";
+  }
+  if (strlen(ip->outiface)) {
+    r["outiface"] = TEXT(ip->outiface);
+  } else {
+   r["outiface"] = "all";
+  }
+  char src_ip_string[INET6_ADDRSTRLEN] = {0};
+  if (inet_ntop(AF_INET, (struct in_addr *)&ip->src, src_ip_string, INET6_ADDRSTRLEN) != NULL) {
+   r["src_ip"] = TEXT(src_ip_string);
+  }
+  char dst_ip_string[INET6_ADDRSTRLEN] = {0};
+  if (inet_ntop(AF_INET, (struct in_addr *)&ip->dst, dst_ip_string, INET6_ADDRSTRLEN) != NULL) {
+   r["dst_ip"] = TEXT(dst_ip_string);
+  }
+  char src_ip_mask[INET6_ADDRSTRLEN] = {0};
+  if (inet_ntop(AF_INET, (struct in_addr *)&ip->smsk, src_ip_mask, INET6_ADDRSTRLEN) != NULL) {
+   r["src_mask"] = TEXT(src_ip_mask);
+  }
+  char dst_ip_mask[INET6_ADDRSTRLEN] = {0};
+  if (inet_ntop(AF_INET, (struct in_addr *)&ip->dmsk, dst_ip_mask, INET6_ADDRSTRLEN) != NULL) {
+   r["dst_mask"] = TEXT(dst_ip_mask);
+  }
+
+  char aux_char[2];
+  std::string iniface_mask = "";
+  for (int i = 0; ip->iniface_mask[i] != 0x00 && i<IFNAMSIZ; i++) {
+    aux_char[0] = MAP[(int) ip->iniface_mask[i] >> HIGH_BITS];
+    aux_char[1] = MAP[(int) ip->iniface_mask[i] & LOW_BITS];
+    iniface_mask += aux_char[0];
+    iniface_mask += aux_char[1];
+  }
+
+  r["iniface_mask"] = TEXT(iniface_mask);
+  std::string outiface_mask = "";
+  for (int i = 0; ip->outiface_mask[i] != 0x00 && i<IFNAMSIZ; i++) {
+    aux_char[0] = MAP[(int) ip->outiface_mask[i] >> HIGH_BITS];
+    aux_char[1] = MAP[(int) ip->outiface_mask[i] & LOW_BITS];
+    outiface_mask += aux_char[0];
+    outiface_mask += aux_char[1];
+  }
+  r["outiface_mask"] = TEXT(outiface_mask);
+}
+
+QueryData getIptablesRules(const std::string& content) {
+  QueryData results;
+
+  for (auto& line : split(content, "\n")) {
+    if (line.size() == 0) {
+      continue;
+    }
+
+    // Inline trim each line.
+    boost::trim(line);
+
+    Row r;
+
+    r["filter_name"] = TEXT(line);
+
+    // Initialize the access to iptc
+    auto handle = (struct iptc_handle*) iptc_init(line.c_str());
+
+    if (handle) {
+      // Iterate through chains
+      for (auto chain = iptc_first_chain((struct iptc_handle*)handle); chain; chain = iptc_next_chain((struct iptc_handle*)handle))  {
+        r["chain"] = TEXT(chain);
+
+        struct ipt_counters counters;
+        const char* policy;
+
+        if ((policy = iptc_get_policy(chain, &counters, (struct iptc_handle*)handle))) {
+          r["policy"] = TEXT(policy);
+          r["packets"] = INTEGER(counters.pcnt);
+          r["bytes"] = INTEGER(counters.bcnt);
+        }
+
+        struct ipt_entry *prev_rule;
+
+        // Iterating through all the rules per chain
+        for (auto chain_rule = iptc_first_rule(chain, (struct iptc_handle*)handle); chain_rule; chain_rule = iptc_next_rule(prev_rule, (struct iptc_handle*)handle))  {
+          prev_rule = (struct ipt_entry*)chain_rule;
+
+          auto target = iptc_get_target(chain_rule, (struct iptc_handle*)handle);
+          if (target) {
+            r["target"] = TEXT(target);
+          }
+
+          if (chain_rule->target_offset) {
+            r["match"] = "yes";
+          } else {
+            r["match"] = "no";
+          }
+
+          struct ipt_ip *ip = (struct ipt_ip*)&chain_rule->ip;
+          parseIpEntry(ip, r);
+
+          results.push_back(r);
+        } // Rule iteration
+        results.push_back(r);
+      } // Chain iteration
+
+      iptc_free((struct iptc_handle*) handle);
+
+    }
+  } // Filter table iteration
+
+  return results;
+}
+
+QueryData genIptables(QueryContext& context) {
+  std::string content;
+  QueryData results;
+
+  auto s = osquery::readFile(kLinuxIpTablesNames, content);
+
+  if (s.ok()) {
+    return getIptablesRules(content);
+  } else {
+    LOG(ERROR) << "Error reading " << kLinuxIpTablesNames << " : " << s.toString();
+    return {};
+  }
+}
+}
+}

--- a/osquery/tables/networking/linux/tests/iptables_tests.cpp
+++ b/osquery/tables/networking/linux/tests/iptables_tests.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/logger.h>
+#include <osquery/database.h>
+
+#include <libiptc/libiptc.h>
+#include <arpa/inet.h>
+
+#include "osquery/core/test_util.h"
+
+namespace osquery {
+namespace tables {
+
+void parseIpEntry(ipt_ip *ip, Row &row);
+
+ipt_ip* getIpEntryContent() {
+  static ipt_ip ip_entry;
+
+  ip_entry.proto = 6;
+  memset(ip_entry.iniface, 0, IFNAMSIZ);
+  strcpy(ip_entry.outiface, "eth0");
+  inet_aton("123.123.123.123", &ip_entry.src);
+  inet_aton("45.45.45.45", &ip_entry.dst);
+  inet_aton("250.251.252.253", &ip_entry.smsk);
+  inet_aton("253.252.251.250", &ip_entry.dmsk);
+  memset(ip_entry.iniface_mask, 0xfe, IFNAMSIZ );
+  memset(ip_entry.outiface_mask, 0xfa, IFNAMSIZ );
+
+  return &ip_entry;
+}
+
+Row getIpEntryExpectedResults() {
+  Row row;
+
+  row["protocol"] = "6";
+  row["iniface"] = "all";
+  row["outiface"] = "eth0";
+  row["src_ip"] = "123.123.123.123";
+  row["dst_ip"] = "45.45.45.45";
+  row["src_mask"] = "250.251.252.253";
+  row["dst_mask"] = "253.252.251.250";
+  row["iniface_mask"] = "FEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFE";
+  row["outiface_mask"] = "FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFA";
+
+  return row;
+}
+
+class IptablesTests : public testing::Test {};
+
+TEST_F(IptablesTests, test_iptables_ip_entry) {
+  Row row;
+  parseIpEntry(getIpEntryContent(), row);
+  EXPECT_EQ(row, getIpEntryExpectedResults());
+}
+}
+}

--- a/osquery/tables/specs/linux/iptables.table
+++ b/osquery/tables/specs/linux/iptables.table
@@ -1,0 +1,21 @@
+table_name("iptables")
+description("Linux IP packet filtering and NAT tool.")
+schema([
+    Column("filter_name", TEXT, "Packet matching filter table name."),
+    Column("chain", TEXT, "Size of module content."),
+    Column("policy", TEXT, "Policy that applies for this rule."),
+    Column("target", TEXT, "Target that applies for this rule."),
+    Column("protocol", INTEGER, "Protocol number identification."),
+    Column("src_ip", TEXT, "Source IP address."),
+    Column("src_mask", TEXT, "Source IP address mask."),
+    Column("iniface", TEXT, "Input interface for the rule."),
+    Column("iniface_mask", TEXT, "Input interface mask for the rule."),
+    Column("dst_ip", TEXT, "Destination IP address."),
+    Column("dst_mask", TEXT, "Destination IP address mask."),
+    Column("outiface", TEXT, "Output interface for the rule."),
+    Column("outiface_mask", TEXT, "Output interface mask for the rule."),
+    Column("match", TEXT, "Matching rule that applies."),
+    Column("packets", INTEGER, "Number of matching packets for this rule."),
+    Column("bytes", INTEGER, "Number of matching bytes for this rule."),
+])
+implementation("iptables@genIptables")

--- a/sysroots/linux/linux/netfilter_ipv4/ip_tables.h
+++ b/sysroots/linux/linux/netfilter_ipv4/ip_tables.h
@@ -1,0 +1,227 @@
+/*
+ * 25-Jul-1998 Major changes to allow for ip chain table
+ *
+ * 3-Jan-2000 Named tables to allow packet selection for different uses.
+ */
+
+/*
+ * 	Format of an IP firewall descriptor
+ *
+ * 	src, dst, src_mask, dst_mask are always stored in network byte order.
+ * 	flags are stored in host byte order (of course).
+ * 	Port numbers are stored in HOST byte order.
+ */
+
+#ifndef _IPTABLES_H
+#define _IPTABLES_H
+
+#include <linux/types.h>
+
+#include <linux/netfilter_ipv4.h>
+
+#include <linux/netfilter/x_tables.h>
+
+#define IPT_FUNCTION_MAXNAMELEN XT_FUNCTION_MAXNAMELEN
+#define IPT_TABLE_MAXNAMELEN XT_TABLE_MAXNAMELEN
+#define ipt_match xt_match
+#define ipt_target xt_target
+#define ipt_table xt_table
+#define ipt_get_revision xt_get_revision
+#define ipt_entry_match xt_entry_match
+#define ipt_entry_target xt_entry_target
+#define ipt_standard_target xt_standard_target
+#define ipt_error_target xt_error_target
+#define ipt_counters xt_counters
+#define IPT_CONTINUE XT_CONTINUE
+#define IPT_RETURN XT_RETURN
+
+/* This group is older than old (iptables < v1.4.0-rc1~89) */
+#include <linux/netfilter/xt_tcpudp.h>
+#define ipt_udp xt_udp
+#define ipt_tcp xt_tcp
+#define IPT_TCP_INV_SRCPT	XT_TCP_INV_SRCPT
+#define IPT_TCP_INV_DSTPT	XT_TCP_INV_DSTPT
+#define IPT_TCP_INV_FLAGS	XT_TCP_INV_FLAGS
+#define IPT_TCP_INV_OPTION	XT_TCP_INV_OPTION
+#define IPT_TCP_INV_MASK	XT_TCP_INV_MASK
+#define IPT_UDP_INV_SRCPT	XT_UDP_INV_SRCPT
+#define IPT_UDP_INV_DSTPT	XT_UDP_INV_DSTPT
+#define IPT_UDP_INV_MASK	XT_UDP_INV_MASK
+
+/* The argument to IPT_SO_ADD_COUNTERS. */
+#define ipt_counters_info xt_counters_info
+/* Standard return verdict, or do jump. */
+#define IPT_STANDARD_TARGET XT_STANDARD_TARGET
+/* Error verdict. */
+#define IPT_ERROR_TARGET XT_ERROR_TARGET
+
+/* fn returns 0 to continue iteration */
+#define IPT_MATCH_ITERATE(e, fn, args...) \
+	XT_MATCH_ITERATE(struct ipt_entry, e, fn, ## args)
+
+/* fn returns 0 to continue iteration */
+#define IPT_ENTRY_ITERATE(entries, size, fn, args...) \
+	XT_ENTRY_ITERATE(struct ipt_entry, entries, size, fn, ## args)
+
+/* Yes, Virginia, you have to zero the padding. */
+struct ipt_ip {
+	/* Source and destination IP addr */
+	struct in_addr src, dst;
+	/* Mask for src and dest IP addr */
+	struct in_addr smsk, dmsk;
+	char iniface[IFNAMSIZ], outiface[IFNAMSIZ];
+	unsigned char iniface_mask[IFNAMSIZ], outiface_mask[IFNAMSIZ];
+
+	/* Protocol, 0 = ANY */
+	__u16 proto;
+
+	/* Flags word */
+	__u8 flags;
+	/* Inverse flags */
+	__u8 invflags;
+};
+
+/* Values for "flag" field in struct ipt_ip (general ip structure). */
+#define IPT_F_FRAG		0x01	/* Set if rule is a fragment rule */
+#define IPT_F_GOTO		0x02	/* Set if jump is a goto */
+#define IPT_F_MASK		0x03	/* All possible flag bits mask. */
+
+/* Values for "inv" field in struct ipt_ip. */
+#define IPT_INV_VIA_IN		0x01	/* Invert the sense of IN IFACE. */
+#define IPT_INV_VIA_OUT		0x02	/* Invert the sense of OUT IFACE */
+#define IPT_INV_TOS		0x04	/* Invert the sense of TOS. */
+#define IPT_INV_SRCIP		0x08	/* Invert the sense of SRC IP. */
+#define IPT_INV_DSTIP		0x10	/* Invert the sense of DST OP. */
+#define IPT_INV_FRAG		0x20	/* Invert the sense of FRAG. */
+#define IPT_INV_PROTO		XT_INV_PROTO
+#define IPT_INV_MASK		0x7F	/* All possible flag bits mask. */
+
+/* This structure defines each of the firewall rules.  Consists of 3
+   parts which are 1) general IP header stuff 2) match specific
+   stuff 3) the target to perform if the rule matches */
+struct ipt_entry {
+	struct ipt_ip ip;
+
+	/* Mark with fields that we care about. */
+	unsigned int nfcache;
+
+	/* Size of ipt_entry + matches */
+	__u16 target_offset;
+	/* Size of ipt_entry + matches + target */
+	__u16 next_offset;
+
+	/* Back pointer */
+	unsigned int comefrom;
+
+	/* Packet and byte counters. */
+	struct xt_counters counters;
+
+	/* The matches (if any), then the target. */
+	unsigned char elems[0];
+};
+
+/*
+ * New IP firewall options for [gs]etsockopt at the RAW IP level.
+ * Unlike BSD Linux inherits IP options so you don't have to use a raw
+ * socket for this. Instead we check rights in the calls.
+ *
+ * ATTENTION: check linux/in.h before adding new number here.
+ */
+#define IPT_BASE_CTL		64
+
+#define IPT_SO_SET_REPLACE	(IPT_BASE_CTL)
+#define IPT_SO_SET_ADD_COUNTERS	(IPT_BASE_CTL + 1)
+#define IPT_SO_SET_MAX		IPT_SO_SET_ADD_COUNTERS
+
+#define IPT_SO_GET_INFO			(IPT_BASE_CTL)
+#define IPT_SO_GET_ENTRIES		(IPT_BASE_CTL + 1)
+#define IPT_SO_GET_REVISION_MATCH	(IPT_BASE_CTL + 2)
+#define IPT_SO_GET_REVISION_TARGET	(IPT_BASE_CTL + 3)
+#define IPT_SO_GET_MAX			IPT_SO_GET_REVISION_TARGET
+
+/* ICMP matching stuff */
+struct ipt_icmp {
+	__u8 type;				/* type to match */
+	__u8 code[2];				/* range of code */
+	__u8 invflags;				/* Inverse flags */
+};
+
+/* Values for "inv" field for struct ipt_icmp. */
+#define IPT_ICMP_INV	0x01	/* Invert the sense of type/code test */
+
+/* The argument to IPT_SO_GET_INFO */
+struct ipt_getinfo {
+	/* Which table: caller fills this in. */
+	char name[XT_TABLE_MAXNAMELEN];
+
+	/* Kernel fills these in. */
+	/* Which hook entry points are valid: bitmask */
+	unsigned int valid_hooks;
+
+	/* Hook entry points: one per netfilter hook. */
+	unsigned int hook_entry[NF_INET_NUMHOOKS];
+
+	/* Underflow points. */
+	unsigned int underflow[NF_INET_NUMHOOKS];
+
+	/* Number of entries */
+	unsigned int num_entries;
+
+	/* Size of entries. */
+	unsigned int size;
+};
+
+/* The argument to IPT_SO_SET_REPLACE. */
+struct ipt_replace {
+	/* Which table. */
+	char name[XT_TABLE_MAXNAMELEN];
+
+	/* Which hook entry points are valid: bitmask.  You can't
+           change this. */
+	unsigned int valid_hooks;
+
+	/* Number of entries */
+	unsigned int num_entries;
+
+	/* Total size of new entries */
+	unsigned int size;
+
+	/* Hook entry points. */
+	unsigned int hook_entry[NF_INET_NUMHOOKS];
+
+	/* Underflow points. */
+	unsigned int underflow[NF_INET_NUMHOOKS];
+
+	/* Information about old entries: */
+	/* Number of counters (must be equal to current number of entries). */
+	unsigned int num_counters;
+	/* The old entries' counters. */
+	struct xt_counters *counters;
+
+	/* The entries (hang off end: not really an array). */
+	struct ipt_entry entries[0];
+};
+
+/* The argument to IPT_SO_GET_ENTRIES. */
+struct ipt_get_entries {
+	/* Which table: user fills this in. */
+	char name[XT_TABLE_MAXNAMELEN];
+
+	/* User fills this in: total entry size. */
+	unsigned int size;
+
+	/* The entries. */
+	struct ipt_entry entrytable[0];
+};
+
+/* Helper functions */
+static __inline__ struct xt_entry_target *
+ipt_get_target(struct ipt_entry *e)
+{
+	return (struct ipt_entry_target *)((char *)e + e->target_offset);
+}
+
+/*
+ *	Main firewall chains definitions and global var's definitions.
+ */
+#endif /* _IPTABLES_H */

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -64,7 +64,6 @@ function main_centos() {
   package libblkid-devel
   package iptables
   package iptables-devel
-  patch_iptables_headers
 
   install_cmake
 

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -62,6 +62,9 @@ function main_centos() {
   package rpm-devel
   package rpm-build
   package libblkid-devel
+  package iptables
+  package iptables-devel
+  patch_iptables_headers
 
   install_cmake
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -151,6 +151,38 @@ function install_boost() {
   fi
 }
 
+function patch_iptables_headers() {
+  IPV4FILE="/usr/include/linux/netfilter_ipv4/ip_tables.h"
+  IPV6FILE="/usr/include/linux/netfilter_ipv6/ip6_tables.h"
+  CODE_TO_PATCH="return (void \*)e + e->target_offset;"
+  if [[ -f "$IPV4FILE" ]]; then
+    if [[ -n `grep "$CODE_TO_PATCH" "$IPV4FILE"` ]]; then
+      log "IPv4 code to patch found, backing up first"
+      sudo cp "$IPV4FILE" "$IPV4FILE.osquery"
+      PATCH="return (struct ipt_entry_target *)((char *)e + e->target_offset);"
+      cat "$IPV4FILE" | sudo bash -c "sed \"s/$CODE_TO_PATCH/$PATCH/g\" > \"$IPV4FILE\""
+      log "IPv4 headers patched succesfully"
+    else
+      log "IPv4 code to patch not found, skipping."
+    fi
+  else
+    log "IPv4 iptables headers not found, skipping."
+  fi
+  if [[ -f "$IPV6FILE" ]]; then
+    if [[ -n `grep "$CODE_TO_PATCH" "$IPV6FILE"` ]]; then
+      log "IPv6 code to patch found, backing up first"
+      sudo cp "$IPV6FILE" "$IPV6FILE.osquery"
+      PATCH="return (struct ip6t_entry_target *)((char *)e + e->target_offset);"
+      cat "$IPV6FILE" | sudo bash -c "sed \"s/$CODE_TO_PATCH/$PATCH/g\" > \"$IPV6FILE\""
+      log "IPv6 headers patched succesfully"
+    else
+      log "IPv6 code to patch not found, skipping."
+    fi
+  else
+    log "IPv6 iptables headers not found, skipping."
+  fi
+}
+
 function install_gflags() {
   if [[ ! -f /usr/local/lib/libgflags.a ]]; then
     if [[ ! -f v2.1.1.tar.gz ]]; then

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -151,38 +151,6 @@ function install_boost() {
   fi
 }
 
-function patch_iptables_headers() {
-  IPV4FILE="/usr/include/linux/netfilter_ipv4/ip_tables.h"
-  IPV6FILE="/usr/include/linux/netfilter_ipv6/ip6_tables.h"
-  CODE_TO_PATCH="return (void \*)e + e->target_offset;"
-  if [[ -f "$IPV4FILE" ]]; then
-    if [[ -n `grep "$CODE_TO_PATCH" "$IPV4FILE"` ]]; then
-      log "IPv4 code to patch found, backing up first"
-      sudo cp "$IPV4FILE" "$IPV4FILE.osquery"
-      PATCH="return (struct ipt_entry_target *)((char *)e + e->target_offset);"
-      cat "$IPV4FILE" | sudo bash -c "sed \"s/$CODE_TO_PATCH/$PATCH/g\" > \"$IPV4FILE\""
-      log "IPv4 headers patched succesfully"
-    else
-      log "IPv4 code to patch not found, skipping."
-    fi
-  else
-    log "IPv4 iptables headers not found, skipping."
-  fi
-  if [[ -f "$IPV6FILE" ]]; then
-    if [[ -n `grep "$CODE_TO_PATCH" "$IPV6FILE"` ]]; then
-      log "IPv6 code to patch found, backing up first"
-      sudo cp "$IPV6FILE" "$IPV6FILE.osquery"
-      PATCH="return (struct ip6t_entry_target *)((char *)e + e->target_offset);"
-      cat "$IPV6FILE" | sudo bash -c "sed \"s/$CODE_TO_PATCH/$PATCH/g\" > \"$IPV6FILE\""
-      log "IPv6 headers patched succesfully"
-    else
-      log "IPv6 code to patch not found, skipping."
-    fi
-  else
-    log "IPv6 iptables headers not found, skipping."
-  fi
-}
-
 function install_gflags() {
   if [[ ! -f /usr/local/lib/libgflags.a ]]; then
     if [[ ! -f v2.1.1.tar.gz ]]; then

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -43,7 +43,6 @@ function main_rhel() {
   package subscription-manager
   package iptables
   package iptables-devel
-  patch_iptables_headers
 
   if [[ -z `rpm -qa epel-release` ]]; then
     if [[ $DISTRO = "rhel6" ]]; then

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -41,6 +41,9 @@ function main_rhel() {
   package xz
   package xz-devel
   package subscription-manager
+  package iptables
+  package iptables-devel
+  patch_iptables_headers
 
   if [[ -z `rpm -qa epel-release` ]]; then
     if [[ $DISTRO = "rhel6" ]]; then

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -32,6 +32,9 @@ function main_ubuntu() {
   package libbz2-dev
   package devscripts
   package debhelper
+  package iptables
+  package iptables-dev
+  patch_iptables_headers
 
   if [[ $DISTRO = "precise" ]]; then
     package clang-3.4

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -34,7 +34,6 @@ function main_ubuntu() {
   package debhelper
   package iptables
   package iptables-dev
-  patch_iptables_headers
 
   if [[ $DISTRO = "precise" ]]; then
     package clang-3.4


### PR DESCRIPTION
This code gives osquery visibility over iptables filter, chains and rules. Also the headers that are patched to make osquery to compile with a C++ compiler but the returns has a void pointer. More info: https://bugzilla.netfilter.org/show_bug.cgi?id=536