### PR TITLE
Relaxing iptables, EL-deps

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -53,8 +53,6 @@ elseif(LINUX)
       set(PACKAGE_ITERATION "1.el7_7.0")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "systemd-devel"
-        "epel-release"
       )
     endif()
   elseif(RHEL)
@@ -78,8 +76,6 @@ elseif(LINUX)
       set(PACKAGE_ITERATION "1.el7_7.0")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "systemd-devel"
-        "epel-release"
       )
     endif()
   endif()

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -16,9 +16,11 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-#include <osquery/tables.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/tables/networking/utils.h"
 
 namespace osquery {
 namespace tables {
@@ -35,30 +37,20 @@ void parseIpEntry(ipt_ip *ip, Row &r) {
   } else {
     r["iniface"] = "all";
   }
+
   if (strlen(ip->outiface)) {
     r["outiface"] = TEXT(ip->outiface);
   } else {
    r["outiface"] = "all";
   }
-  char src_ip_string[INET6_ADDRSTRLEN] = {0};
-  if (inet_ntop(AF_INET, (struct in_addr *)&ip->src, src_ip_string, INET6_ADDRSTRLEN) != NULL) {
-   r["src_ip"] = TEXT(src_ip_string);
-  }
-  char dst_ip_string[INET6_ADDRSTRLEN] = {0};
-  if (inet_ntop(AF_INET, (struct in_addr *)&ip->dst, dst_ip_string, INET6_ADDRSTRLEN) != NULL) {
-   r["dst_ip"] = TEXT(dst_ip_string);
-  }
-  char src_ip_mask[INET6_ADDRSTRLEN] = {0};
-  if (inet_ntop(AF_INET, (struct in_addr *)&ip->smsk, src_ip_mask, INET6_ADDRSTRLEN) != NULL) {
-   r["src_mask"] = TEXT(src_ip_mask);
-  }
-  char dst_ip_mask[INET6_ADDRSTRLEN] = {0};
-  if (inet_ntop(AF_INET, (struct in_addr *)&ip->dmsk, dst_ip_mask, INET6_ADDRSTRLEN) != NULL) {
-   r["dst_mask"] = TEXT(dst_ip_mask);
-  }
 
-  char aux_char[2];
-  std::string iniface_mask = "";
+  r["src_ip"] = ipAsString((struct in_addr *)&ip->src);
+  r["dst_ip"] = ipAsString((struct in_addr *)&ip->dst);
+  r["src_mask"] = ipAsString((struct in_addr *)&ip->smsk);
+  r["dst_mask"] = ipAsString((struct in_addr *)&ip->dmsk);
+
+  char aux_char[2] = {0};
+  std::string iniface_mask;
   for (int i = 0; ip->iniface_mask[i] != 0x00 && i<IFNAMSIZ; i++) {
     aux_char[0] = MAP[(int) ip->iniface_mask[i] >> HIGH_BITS];
     aux_char[1] = MAP[(int) ip->iniface_mask[i] & LOW_BITS];
@@ -77,83 +69,83 @@ void parseIpEntry(ipt_ip *ip, Row &r) {
   r["outiface_mask"] = TEXT(outiface_mask);
 }
 
-QueryData getIptablesRules(const std::string& content) {
-  QueryData results;
+void genIPTablesRules(const std::string &filter, QueryData &results) {
+  Row r;
+  r["filter_name"] = filter;
 
-  for (auto& line : split(content, "\n")) {
-    if (line.size() == 0) {
-      continue;
+  // Initialize the access to iptc
+  auto handle = (struct iptc_handle *)iptc_init(filter.c_str());
+  if (handle == nullptr) {
+    return;
+  }
+
+  // Iterate through chains
+  for (auto chain = iptc_first_chain(handle); chain != nullptr;
+       chain = iptc_next_chain(handle)) {
+    r["chain"] = TEXT(chain);
+
+    struct ipt_counters counters;
+    auto policy = iptc_get_policy(chain, &counters, handle);
+
+    if (policy != nullptr) {
+      r["policy"] = TEXT(policy);
+      r["packets"] = INTEGER(counters.pcnt);
+      r["bytes"] = INTEGER(counters.bcnt);
+    } else {
+      r["policy"] = "";
+      r["packets"] = "0";
+      r["bytes"] = "0";
     }
 
-    // Inline trim each line.
-    boost::trim(line);
+    struct ipt_entry *prev_rule = nullptr;
+    // Iterating through all the rules per chain
+    for (auto chain_rule = iptc_first_rule(chain, handle); chain_rule;
+         chain_rule = iptc_next_rule(prev_rule, handle)) {
+      prev_rule = (struct ipt_entry *)chain_rule;
 
-    Row r;
+      auto target = iptc_get_target(chain_rule, handle);
+      if (target != nullptr) {
+        r["target"] = TEXT(target);
+      } else {
+        r["target"] = "";
+      }
 
-    r["filter_name"] = TEXT(line);
+      if (chain_rule->target_offset) {
+        r["match"] = "yes";
+      } else {
+        r["match"] = "no";
+      }
 
-    // Initialize the access to iptc
-    auto handle = (struct iptc_handle*) iptc_init(line.c_str());
+      struct ipt_ip *ip = (struct ipt_ip *)&chain_rule->ip;
+      parseIpEntry(ip, r);
 
-    if (handle) {
-      // Iterate through chains
-      for (auto chain = iptc_first_chain((struct iptc_handle*)handle); chain; chain = iptc_next_chain((struct iptc_handle*)handle))  {
-        r["chain"] = TEXT(chain);
+      results.push_back(r);
+    } // Rule iteration
+    results.push_back(r);
+  } // Chain iteration
 
-        struct ipt_counters counters;
-        const char* policy;
-
-        if ((policy = iptc_get_policy(chain, &counters, (struct iptc_handle*)handle))) {
-          r["policy"] = TEXT(policy);
-          r["packets"] = INTEGER(counters.pcnt);
-          r["bytes"] = INTEGER(counters.bcnt);
-        }
-
-        struct ipt_entry *prev_rule;
-
-        // Iterating through all the rules per chain
-        for (auto chain_rule = iptc_first_rule(chain, (struct iptc_handle*)handle); chain_rule; chain_rule = iptc_next_rule(prev_rule, (struct iptc_handle*)handle))  {
-          prev_rule = (struct ipt_entry*)chain_rule;
-
-          auto target = iptc_get_target(chain_rule, (struct iptc_handle*)handle);
-          if (target) {
-            r["target"] = TEXT(target);
-          }
-
-          if (chain_rule->target_offset) {
-            r["match"] = "yes";
-          } else {
-            r["match"] = "no";
-          }
-
-          struct ipt_ip *ip = (struct ipt_ip*)&chain_rule->ip;
-          parseIpEntry(ip, r);
-
-          results.push_back(r);
-        } // Rule iteration
-        results.push_back(r);
-      } // Chain iteration
-
-      iptc_free((struct iptc_handle*) handle);
-
-    }
-  } // Filter table iteration
-
-  return results;
+  iptc_free(handle);
 }
 
 QueryData genIptables(QueryContext& context) {
-  std::string content;
   QueryData results;
 
+  // Read in table names
+  std::string content;
   auto s = osquery::readFile(kLinuxIpTablesNames, content);
-
   if (s.ok()) {
-    return getIptablesRules(content);
+    for (auto &line : split(content, "\n")) {
+      boost::trim(line);
+      if (line.size() > 0) {
+        genIPTablesRules(line, results);
+      }
+    }
   } else {
-    LOG(ERROR) << "Error reading " << kLinuxIpTablesNames << " : " << s.toString();
-    return {};
+    // Permissions issue or iptables modules are not loaded.
+    TLOG << "Error reading " << kLinuxIpTablesNames << " : " << s.toString();
   }
+
+  return results;
 }
 }
 }

--- a/osquery/tables/networking/utils.cpp
+++ b/osquery/tables/networking/utils.cpp
@@ -35,9 +35,9 @@ namespace osquery {
 namespace tables {
 
 std::string ipAsString(const struct sockaddr *in) {
-  char dst[INET6_ADDRSTRLEN];
-  memset(dst, 0, sizeof(dst));
-  void *in_addr;
+  char dst[INET6_ADDRSTRLEN] = {0};
+  // memset(dst, 0, sizeof(dst));
+  void *in_addr = nullptr;
 
   if (in->sa_family == AF_INET) {
     in_addr = (void *)&(((struct sockaddr_in *)in)->sin_addr);
@@ -50,7 +50,15 @@ std::string ipAsString(const struct sockaddr *in) {
   inet_ntop(in->sa_family, in_addr, dst, sizeof(dst));
   std::string address(dst);
   boost::trim(address);
+  return address;
+}
 
+std::string ipAsString(const struct in_addr *in) {
+  char dst[INET6_ADDRSTRLEN] = {0};
+
+  inet_ntop(AF_INET, in, dst, sizeof(dst));
+  std::string address(dst);
+  boost::trim(address);
   return address;
 }
 
@@ -124,7 +132,7 @@ std::string macAsString(const struct ifaddrs *addr) {
     }
   }
 #else
-  struct sockaddr_dl *sdl;
+  struct sockaddr_dl *sdl = nullptr;
 
   sdl = (struct sockaddr_dl *)addr->ifa_addr;
   if (sdl->sdl_alen != 6) {

--- a/osquery/tables/networking/utils.h
+++ b/osquery/tables/networking/utils.h
@@ -27,6 +27,7 @@ namespace tables {
 
 // Return a string representation for an IPv4/IPv6 struct.
 std::string ipAsString(const struct sockaddr *in);
+std::string ipAsString(const struct in_addr *in);
 std::string macAsString(const struct ifaddrs *addr);
 std::string macAsString(const char *addr);
 int netmaskFromIP(const struct sockaddr *in);

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -90,4 +90,3 @@ function contains_element() {
   for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
   return 1
 }
-

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/provision/lib.sh"
 function main() {
   platform OS
   distro $OS DISTRO
+  threads THREADS
 
   if [[ $1 = "get_platform" ]]; then
     echo "$OS;$DISTRO"

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -62,8 +62,6 @@ function main_centos() {
   package rpm-devel
   package rpm-build
   package libblkid-devel
-  package iptables
-  package iptables-devel
 
   install_cmake
 
@@ -76,18 +74,16 @@ function main_centos() {
     package libudev-devel
     package cryptsetup-luks-devel
   elif [[ $DISTRO = "centos7" ]]; then
-    package systemd-devel
     package cryptsetup-devel
   fi
 
   install_gflags
+  install_iptables_dev
 
   package doxygen
   package byacc
   package flex
   package bison
-
-  remove_package libunwind-devel
 
   if [[ $DISTRO = "centos6" ]]; then
     install_autoconf

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -41,8 +41,6 @@ function main_rhel() {
   package xz
   package xz-devel
   package subscription-manager
-  package iptables
-  package iptables-devel
 
   if [[ -z `rpm -qa epel-release` ]]; then
     if [[ $DISTRO = "rhel6" ]]; then
@@ -98,17 +96,15 @@ function main_rhel() {
     package libudev-devel
   elif [[ $DISTRO = "rhel7" ]]; then
     package cryptsetup-devel
-    package systemd-devel
   fi
 
   install_gflags
+  install_iptables_dev
 
   package doxygen
   package byacc
   package flex
   package bison
-
-  remove_package libunwind-devel
 
   if [[ $DISTRO = "rhel6" ]]; then
     install_autoconf

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -32,8 +32,6 @@ function main_ubuntu() {
   package libbz2-dev
   package devscripts
   package debhelper
-  package iptables
-  package iptables-dev
 
   if [[ $DISTRO = "precise" ]]; then
     package clang-3.4
@@ -72,12 +70,7 @@ function main_ubuntu() {
 
   install_cmake
   install_gflags
-
-  if [[ $DISTRO = "precise" ]]; then
-    remove_package libunwind7-dev
-  else
-    remove_package libunwind8-dev
-  fi
+  install_iptables_dev
 
   package libsnappy-dev
   package libbz2-dev


### PR DESCRIPTION
1. Remove epel-release and systemd-devel from EL-based distro package requirements.
2. Build the libip4tc iptables-table requirement inline and install the static lib.
3. Add some helpful provision lib macros
4. Remove the remove-package of unwind, since we've removed the checking from glog.
5. Speed up deps/provisioning installs.