### PR TITLE
[Fix #1121] Minify shell table/schema, add meta tests

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -339,7 +339,12 @@ class Tester(object):
 
         # Write config
         random.seed(time.time())
-        shutil.rmtree(CONFIG_DIR)
+
+        try:
+            shutil.rmtree(CONFIG_DIR)
+        except:
+            # Allow the tester to fail
+            pass
         os.makedirs(CONFIG_DIR)
         CONFIG = read_config(ARGS.config) if ARGS.config else DEFAULT_CONFIG
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -30,6 +30,51 @@ class OsqueryiTest(unittest.TestCase):
         self.assertRaises(test_base.OsqueryException,
             self.osqueryi.run_query, 'foo')
 
+    def test_meta_commands(self):
+        '''Test the supported meta shell/help/info commands'''
+        commands = [
+            '.help',
+            '.all',
+            '.all osquery_info',
+            '.all this_table_does_not_exist',
+            '.echo',
+            '.echo on',
+            '.echo off',
+            '.header',
+            '.header off',
+            '.header on',
+            '.mode',
+            '.mode csv',
+            '.mode column',
+            '.mode line',
+            '.mode list',
+            '.mode pretty',
+            '.mode this_mode_does_not_exists',
+            '.nullvalue',
+            '.nullvalue ""',
+            '.print',
+            '.print hello',
+            '.schema osquery_info',
+            '.schema this_table_does_not_exist',
+            '.schema',
+            '.separator',
+            '.separator ,',
+            '.show',
+            '.tables osquery',
+            '.tables osquery_info',
+            '.tables this_table_does_not_exist',
+            '.tables',
+            '.trace',
+            '.width',
+            '.width 80',
+            '.timer',
+            '.timer on',
+            '.timer off'
+        ]
+        for command in commands:
+            result = self.osqueryi.run_command(command)
+        pass
+
     def test_time(self):
         '''Demonstrating basic usage of OsqueryWrapper with the time table'''
         self.osqueryi.run_command(' ')  # flush error output


### PR DESCRIPTION
1. Fix an array-out-of bounds error in .show (regression from removing mode names).
2. Use the registry for table names and schema
3. Add meta command integration tests for the shell to prevent #1121-style regressions.
