### PR TITLE
Fix URL for libtool

### DIFF
--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -189,7 +189,7 @@ function install_automake() {
 
 function install_libtool() {
   TARBALL=libtool-2.4.5.tar.gz
-  URL=https://osquery-packages.s3.amazonaws.com/deps/automake-2.4.5.tar.gz
+  URL=https://osquery-packages.s3.amazonaws.com/deps/libtool-2.4.5.tar.gz
   SOURCE=libtool-2.4.5
 
   if provision libtool /usr/bin/libtool; then


### PR DESCRIPTION
Looks like a simple typo: `automake` for `libtool`

Before this commit, this is the error you'd get when you ran `make deps`:

```
[+] libtool is not installed/provisioned. installing...
[+] libtool has not been downloaded. downloading...
--2015-05-11 06:01:38--  https://osquery-packages.s3.amazonaws.com/deps/automake-2.4.5.tar.gz
Resolving osquery-packages.s3.amazonaws.com... failed: Temporary failure in name resolution.
wget: unable to resolve host address “osquery-packages.s3.amazonaws.com”
[+] libtool has not been extracted. extracting...
tar (child): libtool-2.4.5.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
/vagrant/tools/provision/lib.sh: line 196: pushd: libtool-2.4.5: No such file or directory
make: *** [deps] Error 1
```