### PR TITLE
Fix missing command: force_provision

### DIFF
--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -160,7 +160,7 @@ function install_autoconf() {
   if provision autoconf /usr/bin/autoconf; then
     PROVISION_AUTOCONF=true
   elif [[ `autoconf -V | head -1 | awk '{print $4}' | sed 's/\.//g'` -lt "269" ]]; then
-    force_provision autoconf
+    provision autoconf
     PROVISION_AUTOCONF=true
   fi
 


### PR DESCRIPTION
Prior to this commit, you'd get this error when running `make deps` with a version of autoconf that belongs in a museum (e.g. the one that's in CentOS 6 Base):

```
[+] autoconf is already installed. skipping provision.
/home/brandt/osquery/tools/provision/lib.sh: line 163: force_provision: command not found
make: *** [deps] Error 127
```

I couldn't find a `force_provision` in the codebase. Plain old `provision` should do the job.