### PR TITLE
[Fix #1125 #1126] Flag padding checks, config_check tests

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -115,7 +115,7 @@ class Config : private boost::noncopyable {
    * Since instances of Config should only be created via getInstance(),
    * Config's constructor is private
    */
-  Config() {}
+  Config() : force_merge_success_(false) {}
   ~Config(){}
   Config(Config const&);
   void operator=(Config const&);
@@ -134,7 +134,7 @@ class Config : private boost::noncopyable {
   static Status genConfig();
 
   /// Merge a retrieved config source JSON into a working ConfigData.
-  static void mergeConfig(const std::string& source, ConfigData& conf);
+  static Status mergeConfig(const std::string& source, ConfigData& conf);
 
  public:
   /**
@@ -171,6 +171,9 @@ class Config : private boost::noncopyable {
 
   /// The reader/writer config data mutex.
   boost::shared_mutex mutex_;
+
+  /// Enforce merge success.
+  bool force_merge_success_;
 
  private:
   static const pt::ptree& getParsedData(const std::string& parser);

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -20,6 +20,7 @@ DECLARE_int32(worker_threads);
 DECLARE_string(extensions_socket);
 DECLARE_string(extensions_autoload);
 DECLARE_string(extensions_timeout);
+DECLARE_bool(disable_extensions);
 
 /// A millisecond internal applied to extension initialization.
 extern const int kExtensionInitializeMLatency;

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -122,17 +122,17 @@ std::map<std::string, FlagInfo> Flag::flags() {
 void Flag::printFlags(bool shell, bool external, bool cli) {
   std::vector<GFLAGS_NAMESPACE::CommandLineFlagInfo> info;
   GFLAGS_NAMESPACE::GetAllFlags(&info);
+  auto& details = instance().flags_;
 
   // Determine max indent needed for all flag names.
   size_t max = 0;
-  for (const auto& flag : info) {
-    max = (max > flag.name.size()) ? max : flag.name.size();
+  for (const auto& flag : details) {
+    max = (max > flag.first.size()) ? max : flag.first.size();
   }
   // Additional index for flag values.
-  max += 5;
+  max += 6;
 
   auto& aliases = instance().aliases_;
-  auto& details = instance().flags_;
   for (const auto& flag : info) {
     if (details.count(flag.name) > 0) {
       const auto& detail = details.at(flag.name);
@@ -155,14 +155,18 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
 
     fprintf(stdout, "    --%s", flag.name.c_str());
 
-    size_t pad = max;
+    int pad = max;
     if (flag.type != "bool") {
       fprintf(stdout, " VALUE");
       pad -= 6;
     }
+    pad -= flag.name.size();
 
-    fprintf(stdout, "%s", std::string(pad - flag.name.size(), ' ').c_str());
-    fprintf(stdout, "%s\n", getDescription(flag.name).c_str());
+    if (pad > 0 && pad < 80) {
+      // Never pad more than 80 characters.
+      fprintf(stdout, "%s", std::string(pad, ' ').c_str());
+    }
+    fprintf(stdout, "  %s\n", getDescription(flag.name).c_str());
   }
 }
 }

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -263,6 +263,11 @@ void Initializer::start() {
   // Load registry/extension modules before extensions.
   osquery::loadModules();
 
+  // Pre-extension manager initialization options checking.
+  if (FLAGS_config_check && !Watcher::hasManagedExtensions()) {
+    FLAGS_disable_extensions = true;
+  }
+
   // Bind to an extensions socket and wait for registry additions.
   osquery::startExtensionManager();
 

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -11,7 +11,9 @@
 #include <stdio.h>
 
 #include <osquery/core.h>
+#include <osquery/extensions.h>
 
+#include "osquery/core/watcher.h"
 #include "osquery/devtools/devtools.h"
 
 int main(int argc, char *argv[]) {
@@ -21,6 +23,10 @@ int main(int argc, char *argv[]) {
       osquery::FLAGS_L) {
     // A query was set as a positional argument for via stdin.
     osquery::FLAGS_disable_events = true;
+    // The shell may have loaded table extensions, if not, disable the manager.
+    if (!osquery::Watcher::hasManagedExtensions()) {
+      osquery::FLAGS_disable_extensions = true;
+    }
   }
 
   runner.start();

--- a/tools/tests/test.badconfig
+++ b/tools/tests/test.badconfig
@@ -1,0 +1,38 @@
+{
+  // Deprecated query schedule
+  "scheduledQueries": [
+    {
+      "name": "time",
+      "query": "select * from time;",
+      "interval": 1
+    }
+  ],
+
+  // New, recommended query schedule
+  "schedule": {
+    "time2": {"query": "select * from time;", "interval": 1}
+  },
+
+  // Deprecated collection for file monitoring
+  "additional_monitoring" : {
+    "file_paths": {
+      "downloads": [
+        "/tmp/osquery-fstests-pattern/%%"
+      ]
+    }
+  },
+
+  // New, recommended file monitoring (top-level)
+  "file_paths": {
+    "downloads2": [
+      "/tmp/osquery-fstests-pattern/%%"
+    ],
+    "system_binaries": [
+      "/tmp/osquery-fstests-pattern/%",
+      "/tmp/osquery-fstests-pattern/deep11/%"
+    ]
+  }
+}
+
+// The horror!!!
+,

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -310,6 +310,20 @@ class Autoloader(object):
         except:
             pass
 
+class TimeoutRunner(object):
+    def __init__(self, cmd=[], timeout_sec=1):
+        self.stdout = None
+        self.stderr = None
+        self.proc = subprocess.Popen(" ".join(cmd),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        kill_proc = lambda p: p.kill()
+        timer = threading.Timer(timeout_sec, kill_proc, [self.proc])
+        timer.start()
+        self.stdout, self.stderr = self.proc.communicate()
+        timer.cancel()
+
 class Tester(object):
     def __init__(self):
         global ARGS, CONFIG, CONFIG_DIR

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -30,6 +30,44 @@ class OsqueryiTest(unittest.TestCase):
         self.assertRaises(test_base.OsqueryException,
             self.osqueryi.run_query, 'foo')
 
+    def test_config_check_success(self):
+        '''Test that a 0-config passes'''
+        proc = test_base.TimeoutRunner([
+            self.binary,
+            "--config_check",
+            "--config_path=test.config"], 2)
+        self.assertEqual(proc.stdout, "")
+        print (proc.stdout)
+        print (proc.stderr)
+        self.assertEqual(proc.proc.poll(), 0)
+
+    def test_config_check_failure(self):
+        '''Test that a missing config fails'''
+        proc = test_base.TimeoutRunner([
+            self.binary,
+            "--config_check",
+            "--config_path=/this/path/does/not/exist"], 2)
+        self.assertNotEqual(proc.stderr, "")
+        print (proc.stdout)
+        print (proc.stderr)
+        self.assertEqual(proc.proc.poll(), 1)
+
+        # Now with a valid path, but invalid content.
+        proc = test_base.TimeoutRunner([
+            self.binary,
+            "--config_check",
+            "--config_path=test.badconfig"], 2)
+        self.assertNotEqual(proc.stderr, "")
+        self.assertEqual(proc.proc.poll(), 1)
+
+        # Finally with a missing config plugin
+        proc = test_base.TimeoutRunner([
+            self.binary,
+            "--config_check",
+            "--config_plugin=does_not_exist"], 2)
+        self.assertNotEqual(proc.stderr, "")
+        self.assertNotEqual(proc.proc.poll(), 0)
+
     def test_meta_commands(self):
         '''Test the supported meta shell/help/info commands'''
         commands = [
@@ -91,7 +129,6 @@ class OsqueryiTest(unittest.TestCase):
             args={"config_path": "/"})
         result = self.osqueryi.run_query('SELECT * FROM time;')
         self.assertEqual(len(result), 1)
-
 
 if __name__ == '__main__':
     test_base.Tester().run()


### PR DESCRIPTION
1. Make the flag help padding checks more robust. Also use only the flag values from osquery, not gflags.
2. Fix `--config_check` always returning (0, OK).
3. Add `--config_check` tests to osqueryi's integration testing.