### PR TITLE
Specify dependency on libcryptsetup in CentOS/RHEL

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -47,12 +47,14 @@ elseif(LINUX)
       set(PACKAGE_ITERATION "1.el6_6.5")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
+        "cryptsetup-luks-libs"
         "libudev"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "centos7")
       set(PACKAGE_ITERATION "1.el7_7.0")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
+        "cryptsetup-libs"
       )
     endif()
   elseif(RHEL)
@@ -70,12 +72,14 @@ elseif(LINUX)
       set(PACKAGE_ITERATION "1.el6_6.5")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
+        "cryptsetup-luks-libs"
         "libudev"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel7")
       set(PACKAGE_ITERATION "1.el7_7.0")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
+        "cryptsetup-libs"
       )
     endif()
   endif()


### PR DESCRIPTION
`libcryptsetup` is a required runtime dependency.

Corresponding sections of provision files:

- [CentOS provision file](https://github.com/facebook/osquery/blob/8235fd155f25334e8edf21218491cc511853c17e/tools/provision/centos.sh#L73-L78)
- [RHEL provision file](https://github.com/facebook/osquery/blob/8235fd155f25334e8edf21218491cc511853c17e/tools/provision/rhel.sh#L94-L99)

CentOS 6
--------

[Demonstration of problem and work around.](https://gist.github.com/brandt/e32af345b63c339ddbdb#file-centos-6-log-L81)

Error message:

```
[root@b1a7318dbf3c /]# osqueryi
osqueryi: error while loading shared libraries: libcryptsetup.so.1: cannot open shared object file: No such file or directory
```

CentOS 7
--------

[Demonstration of problem and work around.](https://gist.github.com/brandt/e32af345b63c339ddbdb#file-centos-7-log-L314)

Error message:

```
[root@be01c8b1bb18 /]# osqueryi
osqueryi: error while loading shared libraries: libcryptsetup.so.4: cannot open shared object file: No such file or directory
```