### PR TITLE
Add example newsyslog conf for OS X

### DIFF
--- a/tools/deployment/com.facebook.osqueryd.conf
+++ b/tools/deployment/com.facebook.osqueryd.conf
@@ -1,0 +1,3 @@
+# logfilename                         [owner:group]  mode count size   when  flags [/pid_file] [sig_num]
+/var/log/osquery/osqueryd.results.log root:wheel     600  2     10000  *     NZ
+

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -32,6 +32,8 @@ CLEAN=false
 # Config files
 LAUNCHD_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.plist"
 LAUNCHD_DST="/private/var/osquery/$LD_IDENTIFIER.plist"
+NEWSYSLOG_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.conf"
+NEWSYSLOG_DST="/private/var/osquery/$LD_IDENTIFIER.conf"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/private/var/osquery/osquery.example.conf"
 OSQUERY_CONFIG_SRC=""
@@ -156,6 +158,7 @@ function main() {
   log "copying osquery configurations"
   mkdir -p `dirname $INSTALL_PREFIX$LAUNCHD_DST`
   cp $LAUNCHD_SRC $INSTALL_PREFIX$LAUNCHD_DST
+  cp $NEWSYSLOG_SRC $INSTALL_PREFIX$NEWSYSLOG_DST
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
 
   log "finalizing preinstall and postinstall scripts"


### PR DESCRIPTION
The old issue: #302 was left a bit dangling in suggestions for log rotation. We should do a little better and include an example newsyslog config in our deployment directory.

We also mention how this is installed with Chef here: http://osquery.readthedocs.org/en/latest/deployment/configuration/