### PR TITLE
Fix build on FreeBSD.

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -29,7 +29,7 @@ set(OSQUERY_LIBS
 if(NOT FREEBSD)
   set(OSQUERY_LIBS ${OSQUERY_LIBS} dl)
 else()
-  ADD_OSQUERY_LINK("icuuc")
+  ADD_OSQUERY_LINK(TRUE "icuuc")
 endif()
 
 # Add default linking details (the first argument means SDK + core).


### PR DESCRIPTION
Missing an argument to OSQUERY_ADD_LINK here, which was causing the build to fail on FreeBSD.