### PR TITLE
More thorough where_from parsing in extended_attributes

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -9,13 +9,14 @@ if(APPLE)
     ${OSQUERY_DARWIN_TABLES}
   )
 
-  file(GLOB OSQUERY_DARWIN_TABLES_TESTS "*/darwin/tests/*.cpp")
-  ADD_OSQUERY_TABLE_TEST(${OSQUERY_DARWIN_TABLES_TESTS})
-
   ADD_OSQUERY_LINK(FALSE "-framework CoreFoundation")
   ADD_OSQUERY_LINK(FALSE "-framework Security")
   ADD_OSQUERY_LINK(FALSE "-framework OpenDirectory")
   ADD_OSQUERY_LINK(FALSE "-framework DiskArbitration")
+  ADD_OSQUERY_LINK(FALSE "-framework CoreServices")
+
+  file(GLOB OSQUERY_DARWIN_TABLES_TESTS "*/darwin/tests/*.cpp")
+  ADD_OSQUERY_TABLE_TEST(${OSQUERY_DARWIN_TABLES_TESTS})
 elseif(FREEBSD)
   file(GLOB OSQUERY_FREEBSD_TABLES "*/freebsd/*.cpp")
   ADD_OSQUERY_LIBRARY(FALSE osquery_tables_freebsd


### PR DESCRIPTION
Currently where_from parsing in extended_attributes is too browser centric and misses other information for files sent through airdrop/bluetooth/etc.

```
❯ echo "select key,value,base64 from extended_attributes where path = \"/Users/sbs/Downloads/foobar.jpg\";" | osqueryi
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
| key                                                    | value                                                                        | base64 |
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
| where_from_download_url                                |                                                                              | 0      |
| where_from_download_page                               |                                                                              | 0      |
| com.apple.metadata:kMDLabel_2y5wx3qeq6lyq7mbnojxxubaty | 8q6G9yfQ8/uXLgtBwDJKgH4uzRQe5UxI7O/NCa9b7efKAm7gQEXUfjxA+t99Nj24k0SO4ZJRzcXm | 1      |
| quarantine_creator                                     | sharingd                                                                     | 0      |
| quarantine_state                                       | 0000                                                                         | 0      |
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
```

**This change:** 
* uses the Metadata API in CoreServices for more robust parsing
* Gets additional non-browser where_from attributes

```
❯ echo "select key,value,base64 from extended_attributes where path = \"/Users/sbs/Downloads/foobar.jpg\";" | ./build/darwin/osquery/osqueryi
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
| key                                                    | value                                                                        | base64 |
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
| where_from                                             | iPhone                                                                       | 0      |
| com.apple.metadata:kMDLabel_2y5wx3qeq6lyq7mbnojxxubaty | 8q6G9yfQ8/uXLgtBwDJKgH4uzRQe5UxI7O/NCa9b7efKAm7gQEXUfjxA+t99Nj24k0SO4ZJRzcXm | 1      |
| quarantine_creator                                     | sharingd                                                                     | 0      |
| quarantine_state                                       | 0000                                                                         | 0      |
+--------------------------------------------------------+------------------------------------------------------------------------------+--------+
```

The keys `where_from_download_url` and `where_from_download_page` do not accurately describe the data they hold so I have renamed them to `where_from`

```
❯ echo "select key,value,base64 from extended_attributes where path = \"/Users/sbs/Downloads/googlechrome.dmg\";" | ./build/darwin/osquery/osqueryi
+----------------------------------+-----------------------------------------------------------------------------------+--------+
| key                              | value                                                                             | base64 |
+----------------------------------+-----------------------------------------------------------------------------------+--------+
| com.apple.diskimages.fsck        | OP++fu++J8B7AGyIsqFQTRZwbHo=                                                      | 1      |
| com.apple.diskimages.recentcksum | i:30488735 on D13C8AE1-84A5-3C9E-9C8B-64FB89B03AE8 @ 1430867427 - CRC32:$CB826D8D | 0      |
| where_from                       | https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg                     | 0      |
| where_from                       | https://www.google.com/chrome/browser/thankyou.html?platform=mac                  | 0      |
| quarantine_creator               | Google\x20Chrome                                                                  | 0      |
| quarantine_state                 | 0001                                                                              | 0      |
+----------------------------------+-----------------------------------------------------------------------------------+--------+
```

While researching this, noticed that there is Quarantine API in CoreServices, so there is potential to improve that in future too.