### PR TITLE
Detect TLS version from OpenSSL/CMake FIND_LIBRARY

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -20,6 +20,16 @@ macro(ADD_OSQUERY_PYTHON_TEST TEST_NAME SOURCE)
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tools/tests/")
 endmacro(ADD_OSQUERY_PYTHON_TEST)
 
+# Add a static or dynamic link to libosquery.a (the core library)
+macro(ADD_OSQUERY_LINK_CORE LINK)
+  ADD_OSQUERY_LINK(TRUE ${LINK} ${ARGN})
+endmacro(ADD_OSQUERY_LINK_CORE)
+
+# Add a static or dynamic link to libosquery_additional.a (the non-sdk library)
+macro(ADD_OSQUERY_LINK_ADDITIONAL LINK)
+  ADD_OSQUERY_LINK(FALSE ${LINK} ${ARGN})
+endmacro(ADD_OSQUERY_LINK_ADDITIONAL)
+
 # Core/non core link helping macros (tell the build to link ALL).
 macro(ADD_OSQUERY_LINK IS_CORE LINK)
   if(${IS_CORE})
@@ -48,6 +58,17 @@ macro(ADD_OSQUERY_LINK_INTERNAL LINK LINK_PATHS LINK_SET)
   set(${LINK_SET} "${${LINK_SET}}" PARENT_SCOPE)
 endmacro(ADD_OSQUERY_LINK_INTERNAL)
 
+# Add a test and sources for components in libosquery.a (the core library)
+macro(ADD_OSQUERY_TEST_CORE)
+  ADD_OSQUERY_TEST(TRUE ${ARGN})
+endmacro(ADD_OSQUERY_TEST_CORE)
+
+# Add a test and sources for components in libosquery_additional.a (the non-sdk library)
+macro(ADD_OSQUERY_TEST_ADDITIONAL)
+  ADD_OSQUERY_TEST(FALSE ${ARGN})
+endmacro(ADD_OSQUERY_TEST_ADDITIONAL)
+
+# Core/non core test names and sources macros.
 macro(ADD_OSQUERY_TEST IS_CORE)
   if(NOT DEFINED ENV{SKIP_TESTS} AND (${IS_CORE} OR NOT OSQUERY_BUILD_SDK_ONLY))
     if(${IS_CORE})
@@ -67,6 +88,16 @@ macro(ADD_OSQUERY_TABLE_TEST)
   endif()
 endmacro(ADD_OSQUERY_TABLE_TEST)
 
+# Add sources to libosquery.a (the core library)
+macro(ADD_OSQUERY_LIBRARY_CORE TARGET)
+  ADD_OSQUERY_LIBRARY(TRUE ${TARGET} ${ARGN})
+endmacro(ADD_OSQUERY_LIBRARY_CORE)
+
+# Add sources to libosquery_additional.a (the non-sdk library)
+macro(ADD_OSQUERY_LIBRARY_ADDITIONAL TARGET)
+  ADD_OSQUERY_LIBRARY(FALSE ${TARGET} ${ARGN})
+endmacro(ADD_OSQUERY_LIBRARY_ADDITIONAL)
+
 # Core/non core lists of target source files.
 macro(ADD_OSQUERY_LIBRARY IS_CORE TARGET)
   if(${IS_CORE} OR NOT OSQUERY_BUILD_SDK_ONLY)
@@ -82,6 +113,16 @@ macro(ADD_OSQUERY_LIBRARY IS_CORE TARGET)
     endif()
   endif()
 endmacro(ADD_OSQUERY_LIBRARY TARGET)
+
+# Add sources to libosquery.a (the core library)
+macro(ADD_OSQUERY_OBJCXX_LIBRARY_CORE TARGET)
+  ADD_OSQUERY_OBJCXX_LIBRARY(TRUE TARGET ${ARGN})
+endmacro(ADD_OSQUERY_OBJCXX_LIBRARY_CORE)
+
+# Add sources to libosquery_additional.a (the non-sdk library)
+macro(ADD_OSQUERY_OBJCXX_LIBRARY_ADDITIONAL TARGET)
+  ADD_OSQUERY_OBJCXX_LIBRARY(FALSE TARGET ${ARGN})
+endmacro(ADD_OSQUERY_OBJCXX_LIBRARY_ADDITIONAL)
 
 # Core/non core lists of target source files compiled as ObjC++.
 macro(ADD_OSQUERY_OBJCXX_LIBRARY IS_CORE TARGET)
@@ -225,12 +266,3 @@ function(JOIN VALUES GLUE OUTPUT)
   string(REPLACE ";" "${GLUE}" _TMP_STR "${VALUES}")
   set(${OUTPUT} "${_TMP_STR}" PARENT_SCOPE)
 endfunction(JOIN)
-
-macro(WARNING_LOG MESSAGE)
-  string(ASCII 27 Esc)
-  message("-- ${Esc}[31m${MESSAGE}${Esc}[m")
-endmacro(WARNING_LOG)
-
-macro(LOG MESSAGE)
-  message("-- ${MESSAGE}")
-endmacro(LOG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" "${CMAKE_MODULE_PATH}")
-include(CMakeLibs)
+macro(WARNING_LOG MESSAGE)
+  string(ASCII 27 Esc)
+  message("-- ${Esc}[31m${MESSAGE}${Esc}[m")
+endmacro(WARNING_LOG)
+
+macro(LOG MESSAGE)
+  message("-- ${MESSAGE}")
+endmacro(LOG)
 
 if(NOT DEFINED ENV{CC})
   set(CMAKE_C_COMPILER "clang")
@@ -116,7 +122,7 @@ elseif(DEFINED ENV{SANITIZE})
   add_compile_options(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
 else()
   set(DEBUG FALSE)
-  add_compile_options(-O2)
+  add_compile_options(-O3)
   add_definitions(-DNDEBUG)
   # Do not enable fortify with clang: http://llvm.org/bugs/show_bug.cgi?id=16821
   #set(C_COMPILE_FLAGS "${C_COMPILE_FLAGS} -D_FORTIFY_SOURCE=2")
@@ -143,6 +149,8 @@ endif()
 # Finished setting compiler/compiler flags.
 project(OSQUERY)
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" "${CMAKE_MODULE_PATH}")
+include(CMakeLibs)
 
 # Make sure deps were built before compiling (else show warning).
 execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ endif()
 if(${OSQUERY_BUILD_DISTRO} STREQUAL "rhel6")
   set(GCC_RUNTIME "/opt/rh/devtoolset-3/root/usr/")
   WARNING_LOG("Setting RHEL6 GCC runtime: ${GCC_RUNTIME}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --gcc-toolchain=${GCC_RUNTIME}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC_RUNTIME}")
 endif()
 
@@ -240,6 +241,24 @@ find_package(BZip2 REQUIRED)
 find_package(Dl REQUIRED)
 find_package(Readline REQUIRED)
 
+# Make sure the OpenSSL/ssl library has a TLS client method.
+# Prefer the highest version of TLS, but accept 1.2, 1.1, or 1.0.
+include(CheckLibraryExists)
+CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_2_client_method" "" OPENSSL_TLSV12)
+CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_1_client_method" "" OPENSSL_TLSV11)
+CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_client_method" "" OPENSSL_TLSV10)
+
+# Add a define based on the highest TLS version found. Fatal if no TLS client.
+if(OPENSSL_TLSV12)
+  add_definitions(-DSSL_TXT_TLSV1_2)
+elseif(OPENSSL_TLSV11)
+  add_definitions(-DSSL_TXT_TLSV1_1)
+elseif(OPENSSL_TLSV10)
+  add_definitions(-DSSL_TXT_TLSV1)
+else()
+  message(FATAL "Cannot find any TLS client methods")
+endif()
+
 # Most dependent packages/libs we want static.
 set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dylib .so)
 find_package(CppNetlib 0.11.0 REQUIRED)
@@ -252,7 +271,6 @@ find_package(Sqlite3 REQUIRED)
 find_package(Thrift 0.9.1 REQUIRED)
 
 # Python is used for table spec generation and formating.
-find_package(PythonInterp 2 REQUIRED)
 if(PYTHON_VERSION_MAJOR STREQUAL "2" AND PYTHON_VERSION_MINOR STREQUAL "4")
   WARNING_LOG("Found python 2.4, overriding to /usr/bin/python2.6")
   set(PYTHON_EXECUTABLE "/usr/bin/python2.6")

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -100,22 +100,24 @@ class Config : private boost::noncopyable {
   static Status getMD5(std::string& hashString);
 
   /**
-   * @brief Adds a new query to the schedule queries
+   * @brief Adds a new query to the scheduled queries.
    *
    */
-  static void addScheduledQuery(const std::string name, const std::string query, const int interval);
+  static void addScheduledQuery(const std::string& name,
+                                const std::string& query,
+                                int interval);
 
   /**
-   * @brief Checks if the query is already added to the schedule
+   * @brief Checks if a query exists in the query schedule.
    *
    */
-  static bool checkScheduledQuery(const std::string query);
+  static bool checkScheduledQuery(const std::string& query);
 
   /**
-   * @brief Checks if the query name is already added to the schedule
+   * @brief Checks if the query name exists in the query schedule.
    *
    */
-  static bool checkScheduledQueryName(const std::string query_name);
+  static bool checkScheduledQueryName(const std::string& query_name);
 
   /**
    * @brief Check to ensure that the config is accessible and properly

--- a/include/osquery/database/results.h
+++ b/include/osquery/database/results.h
@@ -47,7 +47,7 @@ typedef std::map<std::string, RowData> Row;
  *
  * @return Status indicating the success or failure of the operation
  */
-Status serializeRow(const Row& r, boost::property_tree::ptree& tree);
+Status serializeRow(const Row& r, pt::ptree& tree);
 
 /**
  * @brief Serialize a Row object into a JSON string
@@ -67,7 +67,7 @@ Status serializeRowJSON(const Row& r, std::string& json);
  *
  * @return Status indicating the success or failure of the operation
  */
-Status deserializeRow(const boost::property_tree::ptree& tree, Row& r);
+Status deserializeRow(const pt::ptree& tree, Row& r);
 
 /**
  * @brief Deserialize a Row object from a JSON string

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -542,7 +542,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return The query-time table data, retrieved from a backing store.
    */
-  virtual QueryData genTable(tables::QueryContext& context)
+  virtual QueryData genTable(QueryContext& context)
       __attribute__((used)) {
     return get(0, 0);
   }

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -542,8 +542,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return The query-time table data, retrieved from a backing store.
    */
-  virtual QueryData genTable(QueryContext& context)
-      __attribute__((used)) {
+  virtual QueryData genTable(QueryContext& context) __attribute__((used)) {
     return get(0, 0);
   }
 

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -52,8 +52,7 @@ inline std::string getExtensionSocket(
 Status queryExternal(const std::string& query, QueryData& results);
 
 /// External (extensions) SQL implementation of the osquery getQueryColumns API.
-Status getQueryColumnsExternal(const std::string& q,
-                               TableColumns& columns);
+Status getQueryColumnsExternal(const std::string& q, TableColumns& columns);
 
 /// External (extensions) SQL implementation plugin provider for "sql" registry.
 class ExternalSQLPlugin : SQLPlugin {
@@ -62,8 +61,7 @@ class ExternalSQLPlugin : SQLPlugin {
     return queryExternal(q, results);
   }
 
-  Status getQueryColumns(const std::string& q,
-                         TableColumns& columns) const {
+  Status getQueryColumns(const std::string& q, TableColumns& columns) const {
     return getQueryColumnsExternal(q, columns);
   }
 };

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -53,7 +53,7 @@ Status queryExternal(const std::string& query, QueryData& results);
 
 /// External (extensions) SQL implementation of the osquery getQueryColumns API.
 Status getQueryColumnsExternal(const std::string& q,
-                               tables::TableColumns& columns);
+                               TableColumns& columns);
 
 /// External (extensions) SQL implementation plugin provider for "sql" registry.
 class ExternalSQLPlugin : SQLPlugin {
@@ -63,7 +63,7 @@ class ExternalSQLPlugin : SQLPlugin {
   }
 
   Status getQueryColumns(const std::string& q,
-                         tables::TableColumns& columns) const {
+                         TableColumns& columns) const {
     return getQueryColumnsExternal(q, columns);
   }
 };

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -126,7 +126,8 @@ struct ModuleInfo {
 /// The call-in prototype for Registry modules.
 typedef void (*ModuleInitalizer)(void);
 
-template <class PluginItem> class PluginFactory {};
+template <class PluginItem>
+class PluginFactory {};
 
 class Plugin : private boost::noncopyable {
  public:

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -126,6 +126,8 @@ struct ModuleInfo {
 /// The call-in prototype for Registry modules.
 typedef void (*ModuleInitalizer)(void);
 
+template <class PluginItem> class PluginFactory {};
+
 class Plugin : private boost::noncopyable {
  public:
   Plugin() : name_("unnamed") {}

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -113,7 +113,7 @@ class SQL {
    */
   static QueryData selectAllFrom(const std::string& table,
                                  const std::string& column,
-                                 tables::ConstraintOperator op,
+                                 ConstraintOperator op,
                                  const std::string& expr);
 
  protected:
@@ -157,7 +157,7 @@ class SQLPlugin : public Plugin {
   /// Use the SQL implementation to parse a query string and return details
   /// (name, type) about the columns.
   virtual Status getQueryColumns(const std::string& q,
-                                 tables::TableColumns& columns) const = 0;
+                                 TableColumns& columns) const = 0;
 
   /**
    * @brief Attach a table at runtime.
@@ -215,7 +215,7 @@ Status query(const std::string& query, QueryData& results);
  *
  * @return status indicating success or failure of the operation
  */
-Status getQueryColumns(const std::string& q, tables::TableColumns& columns);
+Status getQueryColumns(const std::string& q, TableColumns& columns);
 
 /*
  * @brief A mocked subclass of SQL useful for testing

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -33,7 +33,6 @@
   } while (0)
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief The SQLite type affinities are available as macros
@@ -325,5 +324,4 @@ std::string columnDefinition(const TableColumns& columns);
 std::string columnDefinition(const PluginResponse& response);
 
 CREATE_LAZY_REGISTRY(TablePlugin, "table");
-}
 }

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -29,41 +29,41 @@ set(OSQUERY_LIBS
 if(NOT FREEBSD)
   set(OSQUERY_LIBS ${OSQUERY_LIBS} dl)
 else()
-  ADD_OSQUERY_LINK(TRUE "icuuc")
+  ADD_OSQUERY_LINK_CORE("icuuc")
 endif()
 
 # Add default linking details (the first argument means SDK + core).
-ADD_OSQUERY_LINK(TRUE "-rdynamic")
+ADD_OSQUERY_LINK_CORE("-rdynamic")
 foreach(DISTRO ${OSQUERY_REQUIRE_RUNTIMES})
   if(${OSQUERY_BUILD_DISTRO} STREQUAL ${DISTRO})
-    ADD_OSQUERY_LINK(FALSE "-static-libstdc++")
+    ADD_OSQUERY_LINK_ADDITIONAL("-static-libstdc++")
   endif()
 endforeach()
 
 # The platform-specific SDK + core libraries.
 if(APPLE)
-  ADD_OSQUERY_LINK(TRUE "-mmacosx-version-min=${APPLE_MIN_ABI}")
-  ADD_OSQUERY_LINK(TRUE "boost_thread-mt")
-  ADD_OSQUERY_LINK(TRUE "lz4")
+  ADD_OSQUERY_LINK_CORE("-mmacosx-version-min=${APPLE_MIN_ABI}")
+  ADD_OSQUERY_LINK_CORE("boost_thread-mt")
+  ADD_OSQUERY_LINK_CORE("lz4")
 else()
-  ADD_OSQUERY_LINK(TRUE "-Wl,-zrelro -Wl,-znow")
-  ADD_OSQUERY_LINK(TRUE "boost_thread")
-  ADD_OSQUERY_LINK(TRUE "rt")
+  ADD_OSQUERY_LINK_CORE("-Wl,-zrelro -Wl,-znow")
+  ADD_OSQUERY_LINK_CORE("boost_thread")
+  ADD_OSQUERY_LINK_CORE("rt")
 endif()
 
 # The remaining boost libraries are discovered with find_library.
-ADD_OSQUERY_LINK(TRUE "boost_system")
-ADD_OSQUERY_LINK(TRUE "boost_filesystem")
-ADD_OSQUERY_LINK(TRUE "boost_regex")
-ADD_OSQUERY_LINK(TRUE "yara")
+ADD_OSQUERY_LINK_CORE("boost_system")
+ADD_OSQUERY_LINK_CORE("boost_filesystem")
+ADD_OSQUERY_LINK_CORE("boost_regex")
+ADD_OSQUERY_LINK_CORE("yara")
 
 if(DEFINED ENV{SANITIZE})
   if(DEFINED ENV{SANITIZE_THREAD})
-    ADD_OSQUERY_LINK(TRUE -fsanitize=thread)
+    ADD_OSQUERY_LINK_CORE(-fsanitize=thread)
   else()
-    ADD_OSQUERY_LINK(TRUE -fsanitize=address -fsanitize=leak)
+    ADD_OSQUERY_LINK_CORE(-fsanitize=address -fsanitize=leak)
   endif()
-  ADD_OSQUERY_LINK(TRUE -fsanitize-blacklist=${SANITIZE_BLACKLIST})
+  ADD_OSQUERY_LINK_CORE(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
 endif()
 
 # Construct a set of all object files, starting with third-party and all
@@ -89,15 +89,16 @@ add_subdirectory(tables)
 # Amalgamate the utility tables needed to compile.
 GENERATE_UTILITIES("${CMAKE_SOURCE_DIR}/osquery/tables")
 AMALGAMATE("${CMAKE_SOURCE_DIR}" "utils" AMALGAMATION_UTILS)
-ADD_OSQUERY_LIBRARY(TRUE osquery_amalgamation ${AMALGAMATION_UTILS})
+ADD_OSQUERY_LIBRARY_CORE(osquery_amalgamation ${AMALGAMATION_UTILS})
 
 # Bubble the subdirectory (component) sources and links for this build.
 list(APPEND OSQUERY_OBJECTS ${OSQUERY_SOURCES})
 list(APPEND OSQUERY_LIBS ${OSQUERY_LINKS})
 
-# Create the static libosquery (everything but non-utility tables).
 set(CMAKE_MACOSX_RPATH 0)
 set(CMAKE_SKIP_RPATH TRUE)
+
+# Create the static libosquery (everything but non-utility tables).
 add_library(libosquery STATIC main/lib.cpp ${OSQUERY_OBJECTS})
 target_link_libraries(libosquery ${OSQUERY_LIBS})
 set_target_properties(libosquery PROPERTIES OUTPUT_NAME osquery)
@@ -122,7 +123,7 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
   # Generate the osquery additional tables (the non-util).
   GENERATE_TABLES("${CMAKE_SOURCE_DIR}/osquery/tables")
   AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
-  ADD_OSQUERY_LIBRARY(FALSE osquery_additional_amalgamation ${AMALGAMATION})
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
 
   # Create the static libosquery_additional.
   add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -290,8 +290,8 @@ Status Config::getMD5(std::string& hash_string) {
   return Status(0, "OK");
 }
 
-void Config::addScheduledQuery(const std::string name,
-                               const std::string query,
+void Config::addScheduledQuery(const std::string& name,
+                               const std::string& query,
                                const int interval) {
   // Create structure to add to the schedule.
   tree_node node;
@@ -307,7 +307,7 @@ Status Config::checkConfig() {
   return load();
 }
 
-bool Config::checkScheduledQuery(const std::string query) {
+bool Config::checkScheduledQuery(const std::string& query) {
   for (const auto& scheduled_query : getInstance().data_.schedule) {
     if (scheduled_query.second.query == query) {
       return true;
@@ -317,7 +317,7 @@ bool Config::checkScheduledQuery(const std::string query) {
   return false;
 }
 
-bool Config::checkScheduledQueryName(const std::string query_name) {
+bool Config::checkScheduledQueryName(const std::string& query_name) {
   if (getInstance().data_.schedule.count(query_name) == 0) {
     return false;
   }

--- a/osquery/config/parsers/query_packs.h
+++ b/osquery/config/parsers/query_packs.h
@@ -1,3 +1,15 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
 #include <osquery/config.h>
 #include <osquery/tables.h>
 
@@ -12,11 +24,12 @@ class QueryPackConfigParserPlugin : public ConfigParserPlugin {
   /// Request "packs" top level key.
   std::vector<std::string> keys() { return {"packs"}; }
 
-  std::map<std::string, pt::ptree> QueryPackParsePacks(const pt::ptree& raw_packs, bool check_platform, bool check_version);
-
  private:
   /// Store the signatures and file_paths and compile the rules.
   Status update(const std::map<std::string, ConfigTree>& config);
 };
 
+std::map<std::string, pt::ptree> queryPackParsePacks(const pt::ptree& raw_packs,
+                                                     bool check_platform,
+                                                     bool check_version);
 }

--- a/osquery/config/parsers/tests/query_packs_tests.cpp
+++ b/osquery/config/parsers/tests/query_packs_tests.cpp
@@ -87,4 +87,3 @@ TEST_F(QueryPacksConfigTests, test_query_packs_configuration) {
   EXPECT_EQ(expected["launchd"].get<std::string>("value"),
             data["launchd"].get<std::string>("value"));
 }
-}

--- a/osquery/config/parsers/tests/query_packs_tests.cpp
+++ b/osquery/config/parsers/tests/query_packs_tests.cpp
@@ -20,30 +20,17 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
-std::map<std::string, pt::ptree> QueryPackParsePacks(const pt::ptree& raw_packs,
-                                                     bool check_platform,
-                                                     bool check_version);
+// Test the pack version checker.
+bool versionChecker(const std::string& pack, const std::string& version);
 
 std::map<std::string, pt::ptree> getQueryPacksContent() {
-  std::map<std::string, pt::ptree> result;
   pt::ptree pack_tree;
   std::string pack_path = kTestDataPath + "test_pack.conf";
   Status status = osquery::parseJSON(pack_path, pack_tree);
   pt::ptree pack_file_element = pack_tree.get_child("test_pack_test");
 
-  ConfigDataInstance config;
-  const auto& pack_parser = config.getParser("packs");
-  if (pack_parser == nullptr) {
-    return result;
-  }
-  const auto& queryPackParser =
-      std::static_pointer_cast<QueryPackConfigParserPlugin>(pack_parser);
-  if (queryPackParser == nullptr) {
-    return result;
-  }
-
-  result = queryPackParser->QueryPackParsePacks(pack_file_element, false, true);
-
+  std::map<std::string, pt::ptree> result;
+  result = queryPackParsePacks(pack_file_element, false, false);
   return result;
 }
 
@@ -71,19 +58,27 @@ std::map<std::string, pt::ptree> getQueryPacksExpectedResults() {
 
 class QueryPacksConfigTests : public testing::Test {};
 
+TEST_F(QueryPacksConfigTests, version_comparisons) {
+  EXPECT_TRUE(versionChecker("1.0.0", "1.0.0"));
+  EXPECT_TRUE(versionChecker("1.0.0", "1.2.0"));
+  EXPECT_TRUE(versionChecker("1.0", "1.2.0"));
+  EXPECT_TRUE(versionChecker("1.0", "1.0.2"));
+  EXPECT_TRUE(versionChecker("1.0.0", "1.0.2-r1"));
+  EXPECT_FALSE(versionChecker("1.2", "1.0.2"));
+  EXPECT_TRUE(versionChecker("1.0.0-r1", "1.0.0"));
+}
+
 TEST_F(QueryPacksConfigTests, test_query_packs_configuration) {
-  std::map<std::string, pt::ptree> data = getQueryPacksContent();
-  std::map<std::string, pt::ptree> expected = getQueryPacksExpectedResults();
-  EXPECT_EQ(expected["launchd"].get<std::string>("query"),
-            data["launchd"].get<std::string>("query"));
-  EXPECT_EQ(expected["launchd"].get<int>("interval"),
-            data["launchd"].get<int>("interval"));
-  EXPECT_EQ(expected["launchd"].get<std::string>("platform"),
-            data["launchd"].get<std::string>("platform"));
-  EXPECT_EQ(expected["launchd"].get<std::string>("version"),
-            data["launchd"].get<std::string>("version"));
-  EXPECT_EQ(expected["launchd"].get<std::string>("description"),
-            data["launchd"].get<std::string>("description"));
-  EXPECT_EQ(expected["launchd"].get<std::string>("value"),
-            data["launchd"].get<std::string>("value"));
+  auto data = getQueryPacksContent();
+  auto expected = getQueryPacksExpectedResults();
+  auto& real_ld = data["launchd"];
+  auto& expect_ld = expected["launchd"];
+
+  EXPECT_EQ(expect_ld.get("query", ""), real_ld.get("query", ""));
+  EXPECT_EQ(expect_ld.get("interval", 0), real_ld.get("interval", 0));
+  EXPECT_EQ(expect_ld.get("platform", ""), real_ld.get("platform", ""));
+  EXPECT_EQ(expect_ld.get("version", ""), real_ld.get("version", ""));
+  EXPECT_EQ(expect_ld.get("description", ""), real_ld.get("description", ""));
+  EXPECT_EQ(expect_ld.get("value", ""), real_ld.get("value", ""));
+}
 }

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -16,7 +16,6 @@
 namespace pt = boost::property_tree;
 
 namespace osquery {
-namespace tables {
 
 Status TablePlugin::addExternal(const std::string& name,
                                 const PluginResponse& response) {
@@ -121,7 +120,7 @@ Status TablePlugin::call(const PluginRequest& request,
 }
 
 std::string TablePlugin::columnDefinition() const {
-  return tables::columnDefinition(columns());
+  return osquery::columnDefinition(columns());
 }
 
 PluginResponse TablePlugin::routeInfo() const {
@@ -230,6 +229,5 @@ void ConstraintList::unserialize(const boost::property_tree::ptree& tree) {
     constraints_.push_back(constraint);
   }
   affinity = tree.get<std::string>("affinity");
-}
 }
 }

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -13,7 +13,6 @@
 #include <osquery/tables.h>
 
 namespace osquery {
-namespace tables {
 
 class TablesTests : public testing::Test {};
 
@@ -124,6 +123,5 @@ TEST_F(TablesTests, test_constraint_map) {
   EXPECT_FALSE(cm["path"].notExistsOrMatches("not_some"));
   EXPECT_TRUE(cm["path"].exists());
   EXPECT_TRUE(cm["path"].existsAndMatches("some"));
-}
 }
 }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -223,8 +223,7 @@ void WatcherRunner::stopChild(pid_t child) {
 }
 
 bool WatcherRunner::isChildSane(pid_t child) {
-  auto rows =
-      SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child));
+  auto rows = SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child));
   if (rows.size() == 0) {
     // Could not find worker process?
     return false;
@@ -314,8 +313,7 @@ void WatcherRunner::createWorker() {
   }
 
   // Get the path of the current process.
-  auto qd = SQL::selectAllFrom("processes", "pid", EQUALS,
-    INTEGER(getpid()));
+  auto qd = SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(getpid()));
   if (qd.size() != 1 || qd[0].count("path") == 0 || qd[0]["path"].size() == 0) {
     LOG(ERROR) << "osquery watcher cannot determine process path";
     ::exit(EXIT_FAILURE);

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -224,7 +224,7 @@ void WatcherRunner::stopChild(pid_t child) {
 
 bool WatcherRunner::isChildSane(pid_t child) {
   auto rows =
-      SQL::selectAllFrom("processes", "pid", tables::EQUALS, INTEGER(child));
+      SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child));
   if (rows.size() == 0) {
     // Could not find worker process?
     return false;
@@ -314,7 +314,7 @@ void WatcherRunner::createWorker() {
   }
 
   // Get the path of the current process.
-  auto qd = SQL::selectAllFrom("processes", "pid", tables::EQUALS,
+  auto qd = SQL::selectAllFrom("processes", "pid", EQUALS,
     INTEGER(getpid()));
   if (qd.size() != 1 || qd[0].count("path") == 0 || qd[0]["path"].size() == 0) {
     LOG(ERROR) << "osquery watcher cannot determine process path";

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -72,12 +72,12 @@ Status getHostIdentifier(std::string& ident) {
 inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
   // Snapshot the performance and times for the worker before running.
   auto pid = std::to_string(getpid());
-  auto r0 = SQL::selectAllFrom("processes", "pid", tables::EQUALS, pid);
+  auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   auto t0 = time(nullptr);
   auto sql = SQL(query.query);
   // Snapshot the performance after, and compare.
   auto t1 = time(nullptr);
-  auto r1 = SQL::selectAllFrom("processes", "pid", tables::EQUALS, pid);
+  auto r1 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   if (r0.size() > 0 && r1.size() > 0) {
     size_t size = 0;
     for (const auto& row : sql.rows()) {

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -25,13 +25,13 @@ class ExampleConfigPlugin : public ConfigPlugin {
   }
 };
 
-class ExampleTable : public tables::TablePlugin {
+class ExampleTable : public TablePlugin {
  private:
-  tables::TableColumns columns() const {
+  TableColumns columns() const {
     return {{"example_text", "TEXT"}, {"example_integer", "INTEGER"}};
   }
 
-  QueryData generate(tables::QueryContext& request) {
+  QueryData generate(QueryContext& request) {
     QueryData results;
 
     Row r;

--- a/osquery/examples/example_module.cpp
+++ b/osquery/examples/example_module.cpp
@@ -12,13 +12,13 @@
 
 using namespace osquery;
 
-class ExampleTable : public tables::TablePlugin {
+class ExampleTable : public TablePlugin {
  private:
-  tables::TableColumns columns() const {
+  TableColumns columns() const {
     return {{"example_text", "TEXT"}, {"example_integer", "INTEGER"}};
   }
 
-  QueryData generate(tables::QueryContext& request) {
+  QueryData generate(QueryContext& request) {
     QueryData results;
 
     Row r;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -367,7 +367,7 @@ Status queryExternal(const std::string& query, QueryData& results) {
 
 Status getQueryColumnsExternal(const std::string& manager_path,
                                const std::string& query,
-                               tables::TableColumns& columns) {
+                               TableColumns& columns) {
   // Make sure the extension path exists, and is writable.
   auto status = extensionPathActive(manager_path);
   if (!status.ok()) {
@@ -393,7 +393,7 @@ Status getQueryColumnsExternal(const std::string& manager_path,
 }
 
 Status getQueryColumnsExternal(const std::string& query,
-                               tables::TableColumns& columns) {
+                               TableColumns& columns) {
   return getQueryColumnsExternal(FLAGS_extensions_socket, query, columns);
 }
 

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -131,7 +131,7 @@ void ExtensionManagerHandler::query(ExtensionResponse& _return,
 
 void ExtensionManagerHandler::getQueryColumns(ExtensionResponse& _return,
                                               const std::string& sql) {
-  tables::TableColumns columns;
+  TableColumns columns;
   auto status = osquery::getQueryColumns(sql, columns);
   _return.status.code = status.getCode();
   _return.status.message = status.getMessage();

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -10,7 +10,17 @@
 
 #pragma once
 
+// Our third-party version of cpp-netlib uses OpenSSL APIs.
+// On OS X these symbols are marked deprecated and clang will warn against
+// us including them. We are squashing the noise for OS X's OpenSSL only.
+#if defined(DARWIN)
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#endif
 #include <boost/network/protocol/http/client.hpp>
+#if defined(DARWIN)
+_Pragma("clang diagnostic pop")
+#endif
 
 #include <osquery/flags.h>
 

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -20,12 +20,12 @@ namespace osquery {
 
 FLAG(int32, value_max, 512, "Maximum returned row value size");
 
-const std::map<tables::ConstraintOperator, std::string> kSQLOperatorRepr = {
-    {tables::EQUALS, "="},
-    {tables::GREATER_THAN, ">"},
-    {tables::LESS_THAN_OR_EQUALS, "<="},
-    {tables::LESS_THAN, "<"},
-    {tables::GREATER_THAN_OR_EQUALS, ">="},
+const std::map<ConstraintOperator, std::string> kSQLOperatorRepr = {
+    {EQUALS, "="},
+    {GREATER_THAN, ">"},
+    {LESS_THAN_OR_EQUALS, "<="},
+    {LESS_THAN, "<"},
+    {GREATER_THAN_OR_EQUALS, ">="},
 };
 
 SQL::SQL(const std::string& q) { status_ = query(q, results_); }
@@ -65,14 +65,14 @@ QueryData SQL::selectAllFrom(const std::string& table) {
 
 QueryData SQL::selectAllFrom(const std::string& table,
                              const std::string& column,
-                             tables::ConstraintOperator op,
+                             ConstraintOperator op,
                              const std::string& expr) {
   PluginResponse response;
   PluginRequest request = {{"action", "generate"}};
-  tables::QueryContext ctx;
-  ctx.constraints[column].add(tables::Constraint(op, expr));
+  QueryContext ctx;
+  ctx.constraints[column].add(Constraint(op, expr));
 
-  tables::TablePlugin::setRequestFromContext(ctx, request);
+  TablePlugin::setRequestFromContext(ctx, request);
   Registry::call("table", table, request, response);
   return response;
 }
@@ -86,7 +86,7 @@ Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
   if (request.at("action") == "query") {
     return this->query(request.at("query"), response);
   } else if (request.at("action") == "columns") {
-    tables::TableColumns columns;
+    TableColumns columns;
     auto status = this->getQueryColumns(request.at("query"), columns);
     // Convert columns to response
     for (const auto& column : columns) {
@@ -108,7 +108,7 @@ Status query(const std::string& q, QueryData& results) {
       "sql", "sql", {{"action", "query"}, {"query", q}}, results);
 }
 
-Status getQueryColumns(const std::string& q, tables::TableColumns& columns) {
+Status getQueryColumns(const std::string& q, TableColumns& columns) {
   PluginResponse response;
   auto status = Registry::call(
       "sql", "sql", {{"action", "columns"}, {"query", q}}, response);

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -90,8 +90,8 @@ Status SQLiteSQLPlugin::attach(const std::string& name) {
     return status;
   }
 
-  auto statement = tables::columnDefinition(response);
-  return tables::attachTableInternal(name, statement, dbc.db());
+  auto statement = columnDefinition(response);
+  return attachTableInternal(name, statement, dbc.db());
 }
 
 void SQLiteSQLPlugin::detach(const std::string& name) {
@@ -99,13 +99,13 @@ void SQLiteSQLPlugin::detach(const std::string& name) {
   if (!dbc.isPrimary()) {
     return;
   }
-  tables::detachTableInternal(name, dbc.db());
+  detachTableInternal(name, dbc.db());
 }
 
 SQLiteDBInstance::SQLiteDBInstance() {
   primary_ = false;
   sqlite3_open(":memory:", &db_);
-  tables::attachVirtualTables(db_);
+  attachVirtualTables(db_);
 }
 
 SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db) {
@@ -144,7 +144,7 @@ SQLiteDBInstance SQLiteDBManager::get() {
     if (self.db_ == nullptr) {
       // Create primary sqlite DB instance.
       sqlite3_open(":memory:", &self.db_);
-      tables::attachVirtualTables(self.db_);
+      attachVirtualTables(self.db_);
     }
     return SQLiteDBInstance(self.db_);
   } else {
@@ -190,7 +190,7 @@ Status queryInternal(const std::string& q, QueryData& results, sqlite3* db) {
 }
 
 Status getQueryColumnsInternal(const std::string& q,
-                               tables::TableColumns& columns,
+                               TableColumns& columns,
                                sqlite3* db) {
   int rc;
 
@@ -208,7 +208,7 @@ Status getQueryColumnsInternal(const std::string& q,
 
   // Get column count
   int num_columns = sqlite3_column_count(stmt);
-  tables::TableColumns results;
+  TableColumns results;
   results.reserve(num_columns);
 
   // Get column names and types

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -168,8 +168,7 @@ class SQLiteSQLPlugin : SQLPlugin {
     return queryInternal(q, results, dbc.db());
   }
 
-  Status getQueryColumns(const std::string& q,
-                         TableColumns& columns) const {
+  Status getQueryColumns(const std::string& q, TableColumns& columns) const {
     auto dbc = SQLiteDBManager::get();
     return getQueryColumnsInternal(q, columns, dbc.db());
   }

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -157,7 +157,7 @@ Status queryInternal(const std::string& q, QueryData& results, sqlite3* db);
  * @return status indicating success or failure of the operation
  */
 Status getQueryColumnsInternal(const std::string& q,
-                               tables::TableColumns& columns,
+                               TableColumns& columns,
                                sqlite3* db);
 
 /// The SQLiteSQLPlugin implements the "sql" registry for internal/core.
@@ -169,7 +169,7 @@ class SQLiteSQLPlugin : SQLPlugin {
   }
 
   Status getQueryColumns(const std::string& q,
-                         tables::TableColumns& columns) const {
+                         TableColumns& columns) const {
     auto dbc = SQLiteDBManager::get();
     return getQueryColumnsInternal(q, columns, dbc.db());
   }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -26,13 +26,13 @@ TEST_F(SQLTests, test_raw_access) {
   EXPECT_EQ(results.size(), 1);
 }
 
-class TestTablePlugin : public tables::TablePlugin {
+class TestTablePlugin : public TablePlugin {
  private:
-  tables::TableColumns columns() const {
+  TableColumns columns() const {
     return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
   }
 
-  QueryData generate(tables::QueryContext& ctx) {
+  QueryData generate(QueryContext& ctx) {
     QueryData results;
     if (ctx.constraints["test_int"].existsAndMatches("1")) {
       results.push_back({{"test_int", "1"}, {"test_text", "0"}});
@@ -40,7 +40,7 @@ class TestTablePlugin : public tables::TablePlugin {
       results.push_back({{"test_int", "0"}, {"test_text", "1"}});
     }
 
-    auto ints = ctx.constraints["test_int"].getAll<int>(tables::EQUALS);
+    auto ints = ctx.constraints["test_int"].getAll<int>(EQUALS);
     for (const auto& int_match : ints) {
       results.push_back({{"test_int", INTEGER(int_match)}});
     }
@@ -56,10 +56,10 @@ TEST_F(SQLTests, test_raw_access_context) {
   EXPECT_EQ(results.size(), 1);
   EXPECT_EQ(results[0]["test_text"], "1");
 
-  results = SQL::selectAllFrom("test", "test_int", tables::EQUALS, "1");
+  results = SQL::selectAllFrom("test", "test_int", EQUALS, "1");
   EXPECT_EQ(results.size(), 2);
 
-  results = SQL::selectAllFrom("test", "test_int", tables::EQUALS, "2");
+  results = SQL::selectAllFrom("test", "test_int", EQUALS, "2");
   EXPECT_EQ(results.size(), 2);
   EXPECT_EQ(results[0]["test_int"], "0");
 }

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -116,7 +116,7 @@ TEST_F(SQLiteUtilTests, test_get_test_db_result_stream) {
 
 TEST_F(SQLiteUtilTests, test_get_query_columns) {
   auto dbc = getTestDBC();
-  tables::TableColumns results;
+  TableColumns results;
 
   std::string query = "SELECT seconds, version FROM time JOIN osquery_info";
   auto status = getQueryColumnsInternal(query, results, dbc.db());

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -17,7 +17,6 @@
 #include "osquery/sql/virtual_table.h"
 
 namespace osquery {
-namespace tables {
 
 class VirtualTableTests : public testing::Test {};
 
@@ -47,7 +46,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
 
   // Virtual tables require the registry/plugin API to query tables.
   auto status =
-      tables::attachTableInternal("failed_sample", "(foo INTEGER)", dbc.db());
+      attachTableInternal("failed_sample", "(foo INTEGER)", dbc.db());
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -57,8 +56,8 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   EXPECT_TRUE(status.ok());
 
   // Use the table name, plugin-generated schema to attach.
-  status = tables::attachTableInternal(
-      "sample", tables::columnDefinition(response), dbc.db());
+  status = attachTableInternal(
+      "sample", columnDefinition(response), dbc.db());
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
@@ -66,6 +65,5 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   status = queryInternal(q, results, dbc.db());
   EXPECT_EQ("CREATE VIRTUAL TABLE sample USING sample(foo INTEGER, bar TEXT)",
             results[0]["sql"]);
-}
 }
 }

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -45,8 +45,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto dbc = SQLiteDBManager::get();
 
   // Virtual tables require the registry/plugin API to query tables.
-  auto status =
-      attachTableInternal("failed_sample", "(foo INTEGER)", dbc.db());
+  auto status = attachTableInternal("failed_sample", "(foo INTEGER)", dbc.db());
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -56,8 +55,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   EXPECT_TRUE(status.ok());
 
   // Use the table name, plugin-generated schema to attach.
-  status = attachTableInternal(
-      "sample", columnDefinition(response), dbc.db());
+  status = attachTableInternal("sample", columnDefinition(response), dbc.db());
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -235,6 +235,7 @@ static int xFilter(sqlite3_vtab_cursor *pVtabCursor,
 
   return SQLITE_OK;
 }
+}
 
 Status attachTableInternal(const std::string &name,
                            const std::string &statement,
@@ -245,11 +246,30 @@ Status attachTableInternal(const std::string &name,
   }
 
   // A static module structure does not need specific logic per-table.
+  // clang-format off
   static sqlite3_module module = {
-      0,      xCreate, xCreate, xBestIndex, xDestroy, xDestroy, xOpen,
-      xClose, xFilter, xNext,   xEof,       xColumn,  xRowid,   0,
-      0,      0,       0,       0,          0,        0,
+      0,
+      tables::xCreate,
+      tables::xCreate,
+      tables::xBestIndex,
+      tables::xDestroy,
+      tables::xDestroy,
+      tables::xOpen,
+      tables::xClose,
+      tables::xFilter,
+      tables::xNext,
+      tables::xEof,
+      tables::xColumn,
+      tables::xRowid,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
   };
+  // clang-format on
 
   // Note, if the clientData API is used then this will save a registry call
   // within xCreate.
@@ -285,6 +305,5 @@ void attachVirtualTables(sqlite3 *db) {
       attachTableInternal(name, statement, db);
     }
   }
-}
 }
 }

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -15,7 +15,6 @@
 #include "osquery/sql/sqlite_util.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief osquery cursor object.
@@ -58,5 +57,4 @@ Status detachTableInternal(const std::string &name, sqlite3 *db);
 
 /// Attach all table plugins to an in-memory SQLite database.
 void attachVirtualTables(sqlite3 *db);
-}
 }

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -1,25 +1,24 @@
 if(APPLE)
   file(GLOB OSQUERY_OBJC_TABLES "*/darwin/*.mm")
-  ADD_OSQUERY_OBJCXX_LIBRARY(FALSE osquery_tables_objc
+  ADD_OSQUERY_OBJCXX_LIBRARY_ADDITIONAL(osquery_tables_objc
     ${OSQUERY_OBJC_TABLES}
   )
 
   file(GLOB OSQUERY_DARWIN_TABLES "*/darwin/*.cpp")
-  ADD_OSQUERY_LIBRARY(FALSE osquery_tables_darwin
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_darwin
     ${OSQUERY_DARWIN_TABLES}
   )
 
-  ADD_OSQUERY_LINK(FALSE "-framework CoreFoundation")
-  ADD_OSQUERY_LINK(FALSE "-framework Security")
-  ADD_OSQUERY_LINK(FALSE "-framework OpenDirectory")
-  ADD_OSQUERY_LINK(FALSE "-framework DiskArbitration")
-  ADD_OSQUERY_LINK(FALSE "-framework CoreServices")
-
   file(GLOB OSQUERY_DARWIN_TABLES_TESTS "*/darwin/tests/*.cpp")
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_DARWIN_TABLES_TESTS})
+
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreFoundation")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework Security")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework OpenDirectory")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework DiskArbitration")
 elseif(FREEBSD)
   file(GLOB OSQUERY_FREEBSD_TABLES "*/freebsd/*.cpp")
-  ADD_OSQUERY_LIBRARY(FALSE osquery_tables_freebsd
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_freebsd
     ${OSQUERY_FREEBSD_TABLES}
   )
 
@@ -27,7 +26,7 @@ elseif(FREEBSD)
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_FREEBSD_TABLES_TESTS})
 else()
   file(GLOB OSQUERY_LINUX_TABLES "*/linux/*.cpp")
-  ADD_OSQUERY_LIBRARY(FALSE osquery_tables_linux
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_linux
     ${OSQUERY_LINUX_TABLES}
   )
 
@@ -37,30 +36,30 @@ else()
   if(CENTOS OR RHEL OR AMAZON)
     # CentOS specific tables
     file(GLOB OSQUERY_REDHAT_TABLES "*/centos/*.cpp")
-    ADD_OSQUERY_LIBRARY(FALSE osquery_tables_redhat
+    ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_redhat
       ${OSQUERY_REDHAT_TABLES}
     )
 
-    ADD_OSQUERY_LINK(FALSE "rpm rpmio")
+    ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio")
   elseif(UBUNTU)
     # Ubuntu specific tables
     file(GLOB OSQUERY_UBUNTU_TABLES "*/ubuntu/*.cpp")
-    ADD_OSQUERY_LIBRARY(FALSE osquery_tables_ubuntu
+    ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_ubuntu
       ${OSQUERY_UBUNTU_TABLES}
     )
 
-    ADD_OSQUERY_LINK(FALSE "apt-pkg dpkg")
+    ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg")
   endif()
 
-  ADD_OSQUERY_LINK(FALSE "blkid")
-  ADD_OSQUERY_LINK(FALSE "cryptsetup libdevmapper.so libgcrypt.so")
-  ADD_OSQUERY_LINK(FALSE "udev")
-  ADD_OSQUERY_LINK(FALSE "uuid")
-  ADD_OSQUERY_LINK(FALSE "ip4tc")
+  ADD_OSQUERY_LINK_ADDITIONAL("blkid")
+  ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup libdevmapper.so libgcrypt.so")
+  ADD_OSQUERY_LINK_ADDITIONAL("udev")
+  ADD_OSQUERY_LINK_ADDITIONAL("uuid")
+  ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")
 endif()
 
 file(GLOB OSQUERY_CROSS_TABLES "[!ue]*/*.cpp")
-ADD_OSQUERY_LIBRARY(FALSE osquery_tables
+ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables
   ${OSQUERY_CROSS_TABLES}
 )
 
@@ -68,16 +67,16 @@ file(GLOB OSQUERY_CROSS_TABLES_TESTS "[!u]*/tests/*.cpp")
 ADD_OSQUERY_TABLE_TEST(${OSQUERY_CROSS_TABLES_TESTS})
 
 file(GLOB OSQUERY_UTILITY_TABLES "utility/*.cpp")
-ADD_OSQUERY_LIBRARY(TRUE osquery_tables_utility
+ADD_OSQUERY_LIBRARY_CORE(osquery_tables_utility
   ${OSQUERY_UTILITY_TABLES}
 )
 
 if(NOT FREEBSD)
   file(GLOB OSQUERY_UTILS "utils/*.cpp")
-  ADD_OSQUERY_LIBRARY(FALSE osquery_utils
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_utils
     ${OSQUERY_UTILS}
   )
 
   file(GLOB OSQUERY_UTILS_TESTS "utils/tests/*.cpp")
-  ADD_OSQUERY_TEST(FALSE ${OSQUERY_UTILS_TESTS})
+  ADD_OSQUERY_TEST_ADDITIONAL(${OSQUERY_UTILS_TESTS})
 endif()

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -20,7 +20,6 @@
 #include "osquery/events/darwin/fsevents.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief Track time, action changes to /etc/passwd
@@ -86,6 +85,5 @@ Status FileEventSubscriber::Callback(const FSEventsEventContextRef& ec,
     add(r, ec->time);
   }
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/events/darwin/hardware_events.cpp
+++ b/osquery/tables/events/darwin/hardware_events.cpp
@@ -15,7 +15,6 @@
 #include "osquery/events/darwin/iokit_hid.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief Track IOKit HID events.
@@ -61,6 +60,5 @@ Status HardwareEventSubscriber::Callback(const IOKitHIDEventContextRef& ec,
   r["time"] = INTEGER(ec->time);
   add(r, ec->time);
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/events/darwin/passwd_changes.cpp
+++ b/osquery/tables/events/darwin/passwd_changes.cpp
@@ -18,7 +18,6 @@
 #include "osquery/events/darwin/fsevents.h"
 
 namespace osquery {
-namespace tables {
 
 const std::vector<std::string> kDarwinPasswdPaths = {
     "/etc/passwd", "/private/etc/passwd", "/etc/shadow", "/private/etc/shadow",
@@ -75,6 +74,5 @@ Status PasswdChangesEventSubscriber::Callback(const FSEventsEventContextRef& ec,
     add(r, ec->time);
   }
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -20,7 +20,6 @@
 #include "osquery/events/linux/inotify.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief Track time, action changes to /etc/passwd
@@ -91,6 +90,5 @@ Status FileEventSubscriber::Callback(const INotifyEventContextRef& ec,
     add(r, ec->time);
   }
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -18,7 +18,6 @@
 #include "osquery/events/linux/udev.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief Track udev events in Linux
@@ -75,6 +74,5 @@ Status HardwareEventSubscriber::Callback(const UdevEventContextRef& ec,
   r["time"] = INTEGER(ec->time);
   add(r, ec->time);
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/events/linux/passwd_changes.cpp
+++ b/osquery/tables/events/linux/passwd_changes.cpp
@@ -18,7 +18,6 @@
 #include "osquery/events/linux/inotify.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * @brief Track time, action changes to /etc/passwd
@@ -72,6 +71,5 @@ Status PasswdChangesEventSubscriber::Callback(const INotifyEventContextRef& ec,
     add(r, ec->time);
   }
   return Status(0, "OK");
-}
 }
 }

--- a/osquery/tables/templates/amalgamation.cpp.in
+++ b/osquery/tables/templates/amalgamation.cpp.in
@@ -15,8 +15,9 @@
 #include <osquery/events.h>
 #include <osquery/tables.h>
 
-namespace osquery { namespace tables {
+
+namespace osquery {
 {% for table in tables %}
 {{table}}
 {% endfor %}
-}}
+}

--- a/osquery/tables/templates/default.cpp.in
+++ b/osquery/tables/templates/default.cpp.in
@@ -15,9 +15,10 @@
 #include <osquery/events.h>
 #include <osquery/tables.h>
 
-namespace osquery { namespace tables {
+namespace osquery {
 
 /// BEGIN[GENTABLE]
+namespace tables {
 {% if class_name == "" %}\
 osquery::QueryData {{function}}(QueryContext& request);
 {% else %}
@@ -26,6 +27,7 @@ class {{class_name}} {
   osquery::QueryData {{function}}(QueryContext& request);
 };
 {% endif %}\
+}
 
 class {{table_name_cc}}TablePlugin : public TablePlugin {
  private:
@@ -47,7 +49,7 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
       return {};
     }
 {% else %}\
-    return osquery::tables::{{function}}(request);
+    return tables::{{function}}(request);
 {% endif %}\
   }
 };
@@ -59,4 +61,4 @@ REGISTER({{table_name_cc}}TablePlugin, "table", "{{table_name}}");
 {% endif %}
 /// END[GENTABLE]
 
-}}
+}

--- a/osquery/tables/utils/tests/yara_tests.cpp
+++ b/osquery/tables/utils/tests/yara_tests.cpp
@@ -14,8 +14,6 @@
 
 #include "osquery/tables/utils/yara_utils.h"
 
-using namespace osquery::tables;
-
 namespace osquery {
 
 const std::string ruleFile = "/tmp/osquery-yara.sig";

--- a/osquery/tables/utils/yara.cpp
+++ b/osquery/tables/utils/yara.cpp
@@ -81,6 +81,9 @@ QueryData genYara(QueryContext& context) {
     return results;
   }
   const auto& yaraParser = std::static_pointer_cast<YARAConfigParserPlugin>(parser);
+  if (yaraParser == nullptr) {
+    return results;
+  }
   auto rules = yaraParser->rules();
 
   // Store resolved paths in a vector of pairs.

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -17,7 +17,6 @@
 #include "osquery/tables/utils/yara_utils.h"
 
 namespace osquery {
-namespace tables {
 
 /**
  * The callback used when there are compilation problems in the rules.
@@ -258,6 +257,4 @@ Status YARAConfigParserPlugin::update(const std::map<std::string, ConfigTree>& c
 
 /// Call the simple YARA ConfigParserPlugin "yara".
 REGISTER(YARAConfigParserPlugin, "config_parser", "yara");
-
-}
 }

--- a/osquery/tables/utils/yara_utils.cpp
+++ b/osquery/tables/utils/yara_utils.cpp
@@ -45,7 +45,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
     return Status(1, "Could not create compiler: " + std::to_string(result));
   }
 
-  yr_compiler_set_callback(compiler, YARACompilerCallback, NULL);
+  yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
 
   bool compiled = false;
   YR_RULES *tmp_rules;
@@ -72,10 +72,8 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
       return Status(1, "Could not open file: " + file);
     }
 
-    int errors = yr_compiler_add_file(compiler,
-                                      rule_file,
-                                      NULL,
-                                      file.c_str());
+    int errors =
+        yr_compiler_add_file(compiler, rule_file, nullptr, file.c_str());
 
     fclose(rule_file);
     rule_file = nullptr;
@@ -120,7 +118,7 @@ Status handleRuleFiles(const std::string& category,
     return Status(1, "Could not create compiler: " + std::to_string(result));
   }
 
-  yr_compiler_set_callback(compiler, YARACompilerCallback, NULL);
+  yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
 
   bool compiled = false;
   for (const auto& item : rule_files) {
@@ -170,10 +168,8 @@ Status handleRuleFiles(const std::string& category,
         return Status(1, "Could not open file: " + full_path);
       }
 
-      int errors = yr_compiler_add_file(compiler,
-                                        rule_file,
-                                        NULL,
-                                        full_path.c_str());
+      int errors =
+          yr_compiler_add_file(compiler, rule_file, nullptr, full_path.c_str());
 
       fclose(rule_file);
       rule_file = nullptr;

--- a/osquery/tables/utils/yara_utils.h
+++ b/osquery/tables/utils/yara_utils.h
@@ -17,8 +17,6 @@
 #include <yara.h>
 
 namespace osquery {
-namespace tables {
-
 
 void YARACompilerCallback(int error_level,
                           const char* file_name,
@@ -61,6 +59,4 @@ class YARAConfigParserPlugin : public ConfigParserPlugin {
   /// Store the signatures and file_paths and compile the rules.
   Status update(const std::map<std::string, ConfigTree>& config);
 };
-
-}
 }


### PR DESCRIPTION
Use the detected OpenSSL version to set the cpp-netlib-selected boost's ASIO SSL delegate's SSL method. Hopefully our patched cpp-netlib will soon restrict the cipher list and add some exceptions options from SSLvX.

There are a few "extras" included here:
1. Remove the `tables` namespace from code portions that are not table implementations. We add this namespace to separate symbol collisions in table-related code. This allows developers and contributors to be succinct about their symbols without our lib names impeding. Removing the namespace for osquery-core definitions allows us to easily add explicit template definitions.
2. Rename `ADD_OSQUERY_LIB(IS_CORE TARGETS)` to `ADD_OSQUERY_LIB_CORE(TARGETS)` and the `_ADDITIONAL` to be more clear about what these CMake macros mean.

The crux of this PR is to achieve the most recent and most secure TLS client possible, given the available system OpenSSL library. This is a large problem on Apple/OS X which has deprecated OpenSSL in 10.7 and only includes a 0.9.8 library without TLS1.1/TLS1.2 client capability. While trying to negotiate the most-recent TLS protocol version we also restrict the client cipher suite capabilities. On our Linux-supported platforms we do a good job at choosing HIGH, non-vulnerable HMAC/hashing and block chaining algorithms. On Apple/OS X we are forced to include CBC + SHA1 algorithms in our suites.

We should evaluate the SecureTransport and CFNetwork OS X APIs to see if we can further limit the supported algorithms.