### PR TITLE
Allow unit tests execs from project root

### DIFF
--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -21,6 +21,13 @@
 
 namespace osquery {
 
+/// Most tests will use binary or disk-backed content for parsing tests.
+#ifndef OSQUERY_BUILD_SDK
+std::string kTestDataPath = "../../../tools/tests/";
+#else
+std::string kTestDataPath = "../../../../tools/tests/";
+#endif
+
 QueryData getTestDBExpectedResults() {
   QueryData d;
   Row row1;

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -28,12 +28,7 @@ namespace osquery {
 /// Any SQL-dependent tests should use kTestQuery for a pre-populated example.
 const std::string kTestQuery = "SELECT * FROM test_table";
 
-/// Most tests will use binary or disk-backed content for parsing tests.
-#ifndef OSQUERY_BUILD_SDK
-const std::string kTestDataPath = "../../../tools/tests/";
-#else
-const std::string kTestDataPath = "../../../../tools/tests/";
-#endif
+extern std::string kTestDataPath;
 
 /// Tests should limit intermediate input/output to a working directory.
 /// Config data, logging results, and intermediate database/caching usage.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -233,7 +233,7 @@ bool WatcherRunner::isChildSane(pid_t child) {
   // Get the performance state for the worker or extension.
   size_t sustained_latency = 0;
   // Compare CPU utilization since last check.
-  BIGINT_LITERAL footprint, user_time, system_time, parent;
+  BIGINT_LITERAL footprint = 0, user_time = 0, system_time = 0, parent = 0;
   // IV is the check interval in seconds, and utilization is set per-second.
   auto iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
 

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -20,6 +20,8 @@
 
 #include "osquery/core/test_util.h"
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 DECLARE_string(database_path);
 DECLARE_string(extensions_socket);
@@ -37,8 +39,8 @@ void initTesting() {
 
   // Set safe default values for path-based flags.
   // Specific unittests may edit flags temporarily.
-  boost::filesystem::remove_all(kTestWorkingDirectory);
-  boost::filesystem::create_directories(kTestWorkingDirectory);
+  fs::remove_all(kTestWorkingDirectory);
+  fs::create_directories(kTestWorkingDirectory);
   FLAGS_database_path = kTestWorkingDirectory + "unittests.db";
   FLAGS_extensions_socket = kTestWorkingDirectory + "unittests.em";
   FLAGS_extensions_autoload = kTestWorkingDirectory + "unittests-ext.load";
@@ -51,6 +53,17 @@ void initTesting() {
 }
 
 int main(int argc, char* argv[]) {
+  // Allow unit test execution from anywhere in the osquery source/build tree.
+  while (osquery::kTestDataPath != "/") {
+    if (!fs::exists(osquery::kTestDataPath)) {
+      printf("not: %s\n", osquery::kTestDataPath.c_str());
+      osquery::kTestDataPath =
+          osquery::kTestDataPath.substr(3, osquery::kTestDataPath.size());
+    } else {
+      break;
+    }
+  }
+
   osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging


### PR DESCRIPTION
Some simple logic to "test" variations of the `kTestWorkingDirectory` variable. Normally unit test executables run with a cwd=./build/PLATFORM/osquery/. They discover file-based assets from ../../../tools/tests. We add some "search" steps to discover this asset folder if cwd=./