### PR TITLE
Wrote a user_groups table for darwin and linux based system.

### DIFF
--- a/osquery/tables/specs/user_groups.table
+++ b/osquery/tables/specs/user_groups.table
@@ -1,0 +1,7 @@
+table_name("user_groups")
+description("Local system user group relationships.")
+schema([
+    Column("uid", BIGINT, "User ID"),
+    Column("gid", BIGINT, "Group ID")
+])
+implementation("user_groups@genUserGroups")

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <OpenDirectory/OpenDirectory.h>
+
+#include "osquery/tables/system/user_groups.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genUserGroups(QueryContext &context) {
+  @autoreleasepool {
+    QueryData results;
+    struct passwd *pwd = nullptr;
+
+    // TODO(1160):  Add exists uid EQUALS constraint
+    if (context.constraints["uid"].exists()) {
+      std::set<std::string> uids = context.constraints["uid"].getAll(EQUALS);
+      for (const auto &uid : uids) {
+        pwd = getpwuid(std::strtol(uid.c_str(), NULL, 10));
+        if (pwd != nullptr) {
+          user_t<int, int> user;
+          user.name = pwd->pw_name;
+          user.uid = pwd->pw_uid;
+          user.gid = pwd->pw_gid;
+          getGroupsForUser<int, int>(results, user);
+        }
+      }
+    } else {
+        ODSession *session = [ODSession defaultSession];
+        NSError *err;
+        ODNode *root =
+            [ODNode nodeWithSession:session name:@"/Local/Default" error:&err];
+        if (err) {
+          TLOG << "Error with OD node: "
+                     << std::string([[err localizedDescription] UTF8String]);
+          return results;
+        }
+        ODQuery *q = [ODQuery queryWithNode:root
+                             forRecordTypes:kODRecordTypeUsers
+                                  attribute:nil
+                                  matchType:0
+                                queryValues:nil
+                           returnAttributes:nil
+                             maximumResults:0
+                                      error:&err];
+        if (err) {
+          TLOG << "Error with OD query: "
+                     << std::string([[err localizedDescription] UTF8String]);
+          return results;
+        }
+
+        NSArray *od_results = [q resultsAllowingPartial:NO error:&err];
+        if (err) {
+          TLOG << "Error with OD results: "
+                     << std::string([[err localizedDescription] UTF8String]);
+          return results;
+        }
+
+        for (ODRecord *re in od_results) {
+          std::string username = std::string([[re recordName] UTF8String]);
+          struct passwd *pwd = getpwnam(username.c_str());
+          if (pwd != nullptr) {
+            user_t<int, int> user;
+            user.name = pwd->pw_name;
+            user.uid = pwd->pw_uid;
+            user.gid = pwd->pw_gid;
+            getGroupsForUser<int, int>(results, user);
+          }
+        }
+      }
+
+    return results;
+  }
+}
+}
+}

--- a/osquery/tables/system/linux/user_groups.cpp
+++ b/osquery/tables/system/linux/user_groups.cpp
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/tables/system/user_groups.h"
+
+namespace osquery {
+namespace tables {
+
+extern std::mutex pwdEnumerationMutex;
+
+QueryData genUserGroups(QueryContext &context) {
+  QueryData results;
+  struct passwd *pwd = nullptr;
+
+  // TODO(1160):  Add exists uid EQUALS constraint
+  if (context.constraints["uid"].exists()) {
+    std::set<std::string> uids = context.constraints["uid"].getAll(EQUALS);
+    for (const auto &uid : uids) {
+      pwd = getpwuid(std::strtol(uid.c_str(), NULL, 10));
+      if (pwd != nullptr) {
+        user_t<uid_t, gid_t> user;
+        user.name = pwd->pw_name;
+        user.uid = pwd->pw_uid;
+        user.gid = pwd->pw_gid;
+        getGroupsForUser<uid_t, gid_t>(results, user);
+      }
+    }
+  } else {
+    std::lock_guard<std::mutex> lock(pwdEnumerationMutex);
+    std::set<gid_t> users_in;
+    while ((pwd = getpwent()) != nullptr) {
+      if (std::find(users_in.begin(), users_in.end(), pwd->pw_uid) ==
+          users_in.end()) {
+        user_t<uid_t, gid_t> user;
+        user.name = pwd->pw_name;
+        user.uid = pwd->pw_uid;
+        user.gid = pwd->pw_gid;
+        getGroupsForUser<uid_t, gid_t>(results, user);
+        users_in.insert(pwd->pw_uid);
+      }
+    }
+    endpwent();
+    users_in.clear();
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/user_groups.h
+++ b/osquery/tables/system/user_groups.h
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <vector>
+#include <string>
+
+#include <grp.h>
+#include <pwd.h>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+// This is also the max supported number for OS X right now.
+#define EXPECTED_GROUPS_MAX 64
+
+namespace osquery {
+namespace tables {
+
+template <typename T>
+static inline void addGroupsToResults(QueryData &results,
+                                      int uid,
+                                      T *groups,
+                                      int ngroups) {
+  for (int i = 0; i < ngroups; i++) {
+    Row r;
+    r["uid"] = BIGINT(uid);
+    r["gid"] = BIGINT(groups[i]);
+    results.push_back(r);
+  }
+
+  return;
+}
+
+template <typename uid_type, typename gid_type>
+struct user_t {
+  const char *name;
+  uid_type uid;
+  gid_type gid;
+};
+
+template <typename uid_type, typename gid_type>
+static void getGroupsForUser(QueryData &results,
+                             const user_t<uid_type, gid_type> &user) {
+  gid_type groups_buf[EXPECTED_GROUPS_MAX];
+  gid_type *groups = groups_buf;
+  int ngroups = EXPECTED_GROUPS_MAX;
+
+  // GLIBC version before 2.3.3 may have a buffer overrun:
+  // http://man7.org/linux/man-pages/man3/getgrouplist.3.html
+  if (getgrouplist(user.name, user.gid, groups, &ngroups) < 0) {
+    // EXPECTED_GROUPS_MAX was probably not large enough.
+    // Try a larger size buffer.
+    // Darwin appears to not resize ngroups correctly.  We can hope
+    // we had enough space to start with.
+    groups = new gid_type[ngroups];
+    if (!groups) {
+      TLOG << "Couldn't allocated memory to get user's groups";
+      return;
+    }
+
+    if (getgrouplist(user.name, user.gid, groups, &ngroups) < 0) {
+      TLOG << "Error could not get user's group list.";
+      delete groups;
+      return;
+    }
+
+    addGroupsToResults(results, user.uid, groups, ngroups);
+
+    delete groups;
+    return;
+  }
+  addGroupsToResults(results, user.uid, groups, ngroups);
+
+  return;
+}
+}
+}


### PR DESCRIPTION
The user_groups table represents the association between user ids and group ids.

Darwin Issue:
Issues arise in darwin systems with users that are members of many groups due
to a bug in Apple's implementation of [getgrouplist](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/getgrouplist.3.html).  If the number of groups a
user is a member of is greater than 64 a truncated association table may
be returned.