### PR TITLE
Converted CFAbsoluteTime in X509 certificates to UNIX time

### DIFF
--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -81,6 +81,11 @@ std::string stringFromCFString(const CFStringRef& cf_string);
 std::string stringFromCFNumber(const CFDataRef& cf_number);
 std::string stringFromCFNumber(const CFDataRef& cf_number, CFNumberType type);
 
+/**
+ * @brief Convert a CFAbsoluteTime to a std::string.
+ */
+std::string stringFromCFAbsoluteTime(const CFDataRef& cf_abstime);
+
 std::string stringFromCFData(const CFDataRef& cf_data);
 #endif
 

--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -95,4 +95,19 @@ std::string stringFromCFNumber(const CFDataRef& cf_number, CFNumberType type) {
   // Cast as a string.
   return "0";
 }
+
+std::string stringFromCFAbsoluteTime(const CFDataRef& cf_abstime) {
+  double value;
+  if (CFNumberGetValue((CFNumberRef)cf_abstime, kCFNumberDoubleType, &value)) {
+    // Add seconds difference between CFAbsoluteTime and UNIX times.
+    value += 978307200;
+
+    // Return "0" if the above overflows.
+    if (value > 0) {
+      return boost::lexical_cast<std::string>(value);
+    }
+  }
+
+  return "0";
+}
 }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -22,8 +22,8 @@ namespace tables {
 const std::map<std::string, CertProperty> kCertificateProperties = {
     {"common_name", {kSecOIDCommonName, genCommonNameProperty}},
     {"ca", {kSecOIDBasicConstraints, genCAProperty}},
-    {"not_valid_before", {kSecOIDX509V1ValidityNotBefore, stringFromCFNumber}},
-    {"not_valid_after", {kSecOIDX509V1ValidityNotAfter, stringFromCFNumber}},
+    {"not_valid_before", {kSecOIDX509V1ValidityNotBefore, stringFromCFAbsoluteTime}},
+    {"not_valid_after", {kSecOIDX509V1ValidityNotAfter, stringFromCFAbsoluteTime}},
     {"key_algorithm", {kSecOIDX509V1SubjectPublicKeyAlgorithm, genAlgProperty}},
     {"key_usage", {kSecOIDKeyUsage, stringFromCFNumber}},
     {"subject_key_id", {kSecOIDSubjectKeyIdentifier, genKIDProperty}},


### PR DESCRIPTION
Adds an offset to the CFAbsoluteTime in `not_valid_before` and `not_valid_before` to convert both to UNIX time.

I also suggest changing the [documentation on the certificates table](https://osquery.io/docs/tables/#certificates) to reflect this change.