### PR TITLE
Fix OS X build: Deallocate array with delete[] instead of delete

### DIFF
--- a/osquery/tables/system/user_groups.h
+++ b/osquery/tables/system/user_groups.h
@@ -69,13 +69,13 @@ static void getGroupsForUser(QueryData &results,
 
     if (getgrouplist(user.name, user.gid, groups, &ngroups) < 0) {
       TLOG << "Error could not get user's group list.";
-      delete groups;
+      delete[] groups;
       return;
     }
 
     addGroupsToResults(results, user.uid, groups, ngroups);
 
-    delete groups;
+    delete[] groups;
     return;
   }
   addGroupsToResults(results, user.uid, groups, ngroups);


### PR DESCRIPTION
OS X build errors on current master 7d4142b28cb8dd7e3bc8f29553b422a65e61b1a9: 

```bash
In file included from ./osquery/osquery/tables/system/darwin/user_groups.mm:13:
./osquery/osquery/tables/system/user_groups.h:72:7: warning: Memory allocated by 'new[]' should be deallocated by 'delete[]', not 'delete'
      delete groups;
      ^~~~~~~~~~~~~
./osquery/osquery/tables/system/user_groups.h:78:5: warning: Memory allocated by 'new[]' should be deallocated by 'delete[]', not 'delete'
    delete groups;
    ^~~~~~~~~~~~~
2 warnings generated.
make[3]: *** [osquery/tables/CMakeFiles/TARGET.dir/system/darwin/user_groups.mm.o] Error 1
make[2]: *** [osquery/tables/CMakeFiles/TARGET.dir/all] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 2
```

(Not sure why Jenkins didn't catch it)

This fixes it.