### PR TITLE
Extended Attributes: Use LaunchServices API for quarantine data 

### DIFF
--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -19,8 +19,6 @@
 #include <osquery/filesystem.h>
 #include <osquery/core/conversions.h>
 
-namespace pt = boost::property_tree;
-
 namespace osquery {
 namespace tables {
 
@@ -31,60 +29,17 @@ struct XAttrAttribute {
   int buffer_length;
 };
 
-typedef void (*xattrParseFunction)(QueryData &,
-                                   const XAttrAttribute &,
-                                   const std::string &,
-                                   const std::string &);
+const std::string kMetadataXattr = "com.apple.metadata:kMDItemWhereFroms";
+const std::string kQuarantineXattr = "com.apple.quarantine";
 
-// Forward declares of all parse functions
-void parseWhereFrom(QueryData &results,
-                    const XAttrAttribute &x_att,
-                    const std::string &path,
-                    const std::string &directory);
-
-void parseQuarantineFile(QueryData &results,
-                         const XAttrAttribute &x_att,
-                         const std::string &path,
-                         const std::string &directory);
-
-// Extended attribute name to the required parse function. If there is no parse
-// function, the data is returned as is.
-const std::map<std::string, xattrParseFunction> xParseMap = {
-    {"com.apple.metadata:kMDItemWhereFroms", parseWhereFrom},
-    {"com.apple.quarantine", parseQuarantineFile},
-};
-
-// Handle any errors thrown by sys/xattr
-std::string handleError() {
-  switch (errno) {
-  case ENOATTR:
-    return "No such attribute";
-  case ENOTSUP:
-    return "No system support, or support disabled";
-  case ERANGE:
-    return "Size too small to hold attribute";
-  case EPERM:
-    return "The named attribute is not permitted for this type of object";
-  case EINVAL:
-    return "Name is invalid, or options has an unsupported bit set";
-  case EISDIR:
-    return "The path is not a regular file";
-  case ENOTDIR:
-    return "Part of the path was not a directory";
-  case ENAMETOOLONG:
-    return "The filename was too long";
-  case EACCES:
-    return "Insufficient permissions to read the requested file";
-  case ELOOP:
-    return "Too many symbolic links were encountered";
-  case EFAULT:
-    return "The path or name is invalid";
-  case EIO:
-    return "There was an I/O error while reading";
-  default:
-    return "No data";
-  }
-}
+const std::map<std::string, std::string> kQuarantineKeys = {
+    {"quarantine_agent", "LSQuarantineAgentName"},
+    {"quarantine_type", "LSQuarantineType"},
+    {"quarantine_timestamp", "LSQuarantineTimeStamp"},
+    {"quarantine_event_id", "LSQuarantineEventIdentifier"},
+    {"quarantine_sender", "LSQuarantineSenderName"},
+    {"quarantine_data_url", "LSQuarantineDataURL"},
+    {"quarantine_origin_url", "LSQuarantineOriginURL"}};
 
 // Pull the requested extended attribute from the path and return
 // the XAttrAttribute structure
@@ -134,10 +89,21 @@ std::vector<std::string> parseExtendedAttributeList(const std::string &path) {
   return attributes;
 }
 
-void parseWhereFrom(QueryData &results,
-                    const XAttrAttribute &x_att,
-                    const std::string &path,
-                    const std::string &directory) {
+void setRow(QueryData &results,
+            const std::string &path,
+            const std::string &key,
+            const std::string &value) {
+  Row r;
+  r["path"] = path;
+  r["directory"] = boost::filesystem::path(path).parent_path().string();
+  r["key"] = key;
+  auto value_printable = isPrintable(value);
+  r["value"] = (value_printable) ? value : base64Encode(value);
+  r["base64"] = (value_printable) ? INTEGER(0) : INTEGER(1);
+  results.push_back(r);
+}
+
+void parseWhereFrom(QueryData &results, const std::string &path) {
 
   CFStringRef CFPath = CFStringCreateWithCString(
       kCFAllocatorDefault, path.c_str(), kCFStringEncodingUTF8);
@@ -164,72 +130,100 @@ void parseWhereFrom(QueryData &results,
 
   for (CFIndex i = 0; i < count; i++) {
     CFStringRef attribute = (CFStringRef)CFArrayGetValueAtIndex(attribs, i);
-    Row r;
-    r["path"] = path;
-    r["directory"] = directory;
-    r["key"] = "where_from";
-    r["value"] = stringFromCFString(attribute);
-    r["base64"] = INTEGER(0);
-    results.push_back(r);
+    auto where_from_attribute = stringFromCFString(attribute);
+    if (!where_from_attribute.empty()) {
+      setRow(results, path, "where_from", where_from_attribute);
+    }
   }
 
   CFRelease(attributes);
 }
 
-// Parse a given XAttrAttribute struct as an OS X quarantine string
-void parseQuarantineFile(QueryData &results,
-                         const XAttrAttribute &x_att,
-                         const std::string &path,
-                         const std::string &directory) {
-  std::vector<std::string> values = osquery::split(x_att.attribute_data, ";");
-  if (values.size() < 2) {
+void extractQuarantineProperty(const std::string table_key_name,
+                               CFTypeRef property,
+                               const std::string path,
+                               QueryData &results) {
+  std::string value;
+  if (CFGetTypeID(property) == CFStringGetTypeID()) {
+    value = stringFromCFString((CFStringRef)property);
+  } else if (CFGetTypeID(property) == CFDateGetTypeID()) {
+    auto unix_time = CFDateGetAbsoluteTime((CFDateRef)property) +
+                     kCFAbsoluteTimeIntervalSince1970;
+    value = INTEGER(std::llround(unix_time));
+  } else if (CFGetTypeID(property) == CFURLGetTypeID()) {
+    value = stringFromCFString(CFURLGetString((CFURLRef)property));
+  }
+  setRow(results, path, table_key_name, value);
+}
+
+void parseQuarantineFile(QueryData &results, const std::string &path) {
+  CFURLRef url = CFURLCreateFromFileSystemRepresentation(
+      kCFAllocatorDefault, (const UInt8 *)path.c_str(), path.length(), false);
+
+  if (url == nullptr) {
+    VLOG(1) << "Error obtaining CFURLRef for " << path;
+    VLOG(1) << "Unable to fetch quarantine data";
     return;
   }
 
-  Row r1;
-  r1["path"] = path;
-  r1["directory"] = directory;
-  r1["key"] = "quarantine_creator";
-  r1["base64"] = INTEGER(0);
-  r1["value"] = values[2];
+  CFTypeRef quarantine_properties;
+#if defined(DARWIN_10_9)
+  FSRef fs_url;
+  if (!CFURLGetFSRef(url, &fs_url)) {
+    VLOG(1) << "Error obtaining FSRef for " << path;
+    VLOG(1) << "Unable to fetch quarantine data";
+    CFRelease(url);
+    return;
+  }
+  if (LSCopyItemAttribute(&fs_url, kLSRolesAll, kLSItemQuarantineProperties,
+                          &quarantine_properties) != noErr) {
+    VLOG(1) << "Error retrieving quarantine properties for " << path;
+    CFRelease(url);
+    return;
+  }
+#else
+  if (!CFURLCopyResourcePropertyForKey(url, kCFURLQuarantinePropertiesKey,
+                                       &quarantine_properties, nullptr)) {
+    VLOG(1) << "Error retrieving quarantine properties for " << path;
+    CFRelease(url);
+    return;
+  }
+#endif
 
-  Row r2;
-  r2["path"] = path;
-  r2["directory"] = directory;
-  r2["key"] = "quarantine_state";
-  r2["base64"] = INTEGER(0);
-  r2["value"] = values[0];
+  if (quarantine_properties == nullptr) {
+    VLOG(1) << "Error retrieving quarantine properties for " << path;
+    CFRelease(url);
+    return;
+  }
 
-  results.push_back(r1);
-  results.push_back(r2);
+  CFTypeRef property;
+  for (const auto &kv : kQuarantineKeys) {
+    CFStringRef key = CFStringCreateWithCString(
+        kCFAllocatorDefault, kv.second.c_str(), kCFStringEncodingUTF8);
+
+    if (CFDictionaryGetValueIfPresent((CFDictionaryRef)quarantine_properties,
+                                      key, &property)) {
+      extractQuarantineProperty(kv.first, property, path, results);
+    }
+    CFRelease(key);
+  }
+
+  CFRelease(quarantine_properties);
+  CFRelease(url);
 }
 
 // Process a file and extract all attribute information, parsed or not.
-void getFileData(QueryData &results,
-                 const std::string &path,
-                 const std::string &directory) {
+void getFileData(QueryData &results, const std::string &path) {
   std::vector<std::string> attributes = parseExtendedAttributeList(path);
   for (const auto &attribute : attributes) {
     struct XAttrAttribute x_att = getAttribute(path, attribute);
-    if (xParseMap.count(attribute) > 0) {
-      (*xParseMap.at(attribute))(results, x_att, path, directory);
+
+    if (attribute == kMetadataXattr) {
+      parseWhereFrom(results, path);
+    } else if (attribute == kQuarantineXattr) {
+      parseQuarantineFile(results, path);
     } else {
-      // We don't have a function in our map for this key so throw it in
-      // verbatim
-      Row r;
-      r["path"] = path;
-      r["directory"] = directory;
-      r["key"] = attribute;
-
-      if (isPrintable(x_att.attribute_data)) {
-        r["base64"] = INTEGER(0);
-        r["value"] = x_att.attribute_data;
-      } else {
-        r["base64"] = INTEGER(1);
-        r["value"] = base64Encode(x_att.attribute_data);
-      }
-
-      results.push_back(r);
+      setRow(results, path, attribute, x_att.attribute_data);
     }
   }
 }
@@ -245,7 +239,7 @@ QueryData genXattr(QueryContext &context) {
           boost::filesystem::is_directory(path))) {
       continue;
     }
-    getFileData(results, path.string(), path.parent_path().string());
+    getFileData(results, path.string());
   }
 
   auto directories = context.constraints["directory"].getAll(EQUALS);
@@ -257,7 +251,7 @@ QueryData genXattr(QueryContext &context) {
     listFilesInDirectory(directory, files);
 
     for (auto &file : files) {
-      getFileData(results, file, directory);
+      getFileData(results, file);
     }
   }
   return results;

--- a/osquery/tables/system/darwin/tests/extended_attributes_tests.cpp
+++ b/osquery/tables/system/darwin/tests/extended_attributes_tests.cpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <sys/xattr.h>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include "osquery/core/test_util.h"
+
+namespace osquery {
+namespace tables {
+
+std::vector<std::string> parseExtendedAttributeList(const std::string &path);
+void parseQuarantineFile(QueryData &results, const std::string &path);
+void parseWhereFrom(QueryData &results, const std::string &path);
+void getFileData(QueryData &results, const std::string &path);
+
+const std::string kQuarantineKey = "com.apple.quarantine";
+const unsigned char kQuarantineValue[] = {
+    0x30, 0x30, 0x30, 0x31, 0x3B, 0x35, 0x35, 0x34, 0x39, 0x34, 0x64, 0x65,
+    0x33, 0x3B, 0x47, 0x6F, 0x6F, 0x67, 0x6C, 0x65, 0x5C, 0x78, 0x32, 0x30,
+    0x43, 0x68, 0x72, 0x6F, 0x6D, 0x65, 0x3B, 0x36, 0x41, 0x30, 0x45, 0x43,
+    0x39, 0x32, 0x44, 0x2D, 0x31, 0x38, 0x38, 0x32, 0x2D, 0x34, 0x33, 0x35,
+    0x38, 0x2D, 0x41, 0x33, 0x31, 0x35, 0x2D, 0x35, 0x38, 0x36, 0x42, 0x41,
+    0x36, 0x35, 0x46, 0x38, 0x46, 0x37, 0x37};
+
+const std::string kMetedataKey = "com.apple.metadata:kMDItemWhereFroms";
+const unsigned char kMetadataWhereFromValue[] = {
+    0x62, 0x70, 0x6C, 0x69, 0x73, 0x74, 0x30, 0x30, 0xA2, 0x01, 0x02, 0x5F,
+    0x10, 0x3D, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A, 0x2F, 0x2F, 0x64, 0x6C,
+    0x2E, 0x67, 0x6F, 0x6F, 0x67, 0x6C, 0x65, 0x2E, 0x63, 0x6F, 0x6D, 0x2F,
+    0x63, 0x68, 0x72, 0x6F, 0x6D, 0x65, 0x2F, 0x6D, 0x61, 0x63, 0x2F, 0x73,
+    0x74, 0x61, 0x62, 0x6C, 0x65, 0x2F, 0x47, 0x47, 0x52, 0x4F, 0x2F, 0x67,
+    0x6F, 0x6F, 0x67, 0x6C, 0x65, 0x63, 0x68, 0x72, 0x6F, 0x6D, 0x65, 0x2E,
+    0x64, 0x6D, 0x67, 0x5F, 0x10, 0x40, 0x68, 0x74, 0x74, 0x70, 0x73, 0x3A,
+    0x2F, 0x2F, 0x77, 0x77, 0x77, 0x2E, 0x67, 0x6F, 0x6F, 0x67, 0x6C, 0x65,
+    0x2E, 0x63, 0x6F, 0x6D, 0x2F, 0x63, 0x68, 0x72, 0x6F, 0x6D, 0x65, 0x2F,
+    0x62, 0x72, 0x6F, 0x77, 0x73, 0x65, 0x72, 0x2F, 0x74, 0x68, 0x61, 0x6E,
+    0x6B, 0x79, 0x6F, 0x75, 0x2E, 0x68, 0x74, 0x6D, 0x6C, 0x3F, 0x70, 0x6C,
+    0x61, 0x74, 0x66, 0x6F, 0x72, 0x6D, 0x3D, 0x6D, 0x61, 0x63, 0x08, 0x0B,
+    0x4B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x8E};
+
+const std::string kFsckKey = "com.apple.diskimages.fsck";
+const unsigned char kFsckValue[] = {0x38, 0xFF, 0xBE, 0x7E, 0xEF, 0xBE, 0x27,
+                                    0xC0, 0x7B, 0x00, 0x6C, 0x88, 0xB2, 0xA1,
+                                    0x50, 0x4D, 0x16, 0x70, 0x6C, 0x7A};
+
+const std::string kDiskImagefsckBase64 = "OP++fu++J8B7AGyIsqFQTRZwbHo=";
+
+void removexattrs(const std::string &path) {
+  auto xattrs = parseExtendedAttributeList(path);
+  for (const auto &xattr : xattrs) {
+    removexattr(path.c_str(), xattr.c_str(), XATTR_NOFOLLOW);
+  }
+}
+
+void setxattrs(const std::string &path) {
+  setxattr(path.c_str(), kQuarantineKey.c_str(), (void *)kQuarantineValue,
+           sizeof(kQuarantineValue), 0, XATTR_NOFOLLOW);
+  setxattr(path.c_str(), kMetedataKey.c_str(), (void *)kMetadataWhereFromValue,
+           sizeof(kMetadataWhereFromValue), 0, XATTR_NOFOLLOW);
+  setxattr(path.c_str(), kFsckKey.c_str(), (void *)kFsckValue,
+           sizeof(kFsckValue), 0, XATTR_NOFOLLOW);
+  // insert arbitrary xattr
+  const std::string key = "foobar";
+  const unsigned char val[] = {0x62, 0x61, 0x7A}; // baz
+  setxattr(path.c_str(), key.c_str(), (void *)val, sizeof(val), 0,
+           XATTR_NOFOLLOW);
+}
+
+class ExtendedAttributesTests : public testing::Test {
+ protected:
+  virtual void SetUp() {
+    removexattrs(kTestFilePath);
+    setxattrs(kTestFilePath);
+  }
+
+  virtual void TearDown() { removexattrs(kTestFilePath); }
+
+  const std::string kTestFilePath = kTestDataPath + "test_xattrs.txt";
+  const std::string kTestFileDir =
+      boost::filesystem::path(kTestFilePath).parent_path().string();
+};
+
+TEST_F(ExtendedAttributesTests, test_extended_attributes) {
+  QueryData results;
+  getFileData(results, kTestFilePath);
+
+  const std::map<std::string, std::string> expected = {
+      {"quarantine_agent", "Google Chrome"},
+      {"quarantine_type", "LSQuarantineTypeWebDownload"},
+      {"quarantine_timestamp", "1430867421"},
+      {"quarantine_event_id", "6A0EC92D-1882-4358-A315-586BA65F8F77"},
+      {"quarantine_data_url",
+       "https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"},
+      {"quarantine_origin_url",
+       "https://www.google.com/chrome/browser/thankyou.html?platform=mac"},
+      {"foobar", "baz"},
+      {kFsckKey, kDiskImagefsckBase64}};
+
+  for (auto row : results) {
+    for (auto elems : row) {
+      auto key = elems.first;
+      auto value = elems.second;
+      if (expected.count(key) > 0) {
+        if (key == "quarantime_timestamp") {
+          long timeExpected = std::stol(expected.at("quarantine_timestamp"));
+          long actual = std::stol(value);
+          EXPECT_GE(timeExpected, actual);
+        } else {
+          EXPECT_EQ(expected.at(key), value);
+        }
+      }
+    }
+  }
+}
+}
+}

--- a/tools/tests/test_xattrs.txt
+++ b/tools/tests/test_xattrs.txt
@@ -1,0 +1,1 @@
+This file is to test extended attributes on Darwin.


### PR DESCRIPTION
Now uses LaunchServices API to grab quarantine data.

* No more manual parsing (often prone to breaking on updates)
* More insight into quarantine events: timestamp, type (webdownload, mail.app attachment, ical attachment, airdrop), etc 
* Added tests

```
osquery> select key,value,base64 from extended_attributes where path = "/Users/sbs/Downloads/foo_bar/googlechrome.dmg";
+----------------------------------+------------------------------------------------------------------+--------+
| key                              | value                                                            | base64 |
+----------------------------------+------------------------------------------------------------------+--------+
| com.apple.diskimages.fsck        | OP++fu++J8B7AGyIsqFQTRZwbHo=                                     | 1      |
| com.apple.diskimages.recentcksum | (truncated)                                                      | 0      |
| where_from                       | https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg    | 0      |
| where_from                       | https://www.google.com/chrome/browser/thankyou.html?platform=mac | 0      |
| quarantine_agent                 | Google Chrome                                                    | 0      |
| quarantine_data_url              | https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg    | 0      |
| quarantine_event_id              | 6A0EC92D-1882-4358-A315-586BA65F8F77                             | 0      |
| quarantine_origin_url            | https://www.google.com/chrome/browser/thankyou.html?platform=mac | 0      |
| quarantine_timestamp             | 1430867421                                                       | 0      |
| quarantine_type                  | LSQuarantineTypeWebDownload                                      | 0      |
+----------------------------------+------------------------------------------------------------------+--------+
```

```
osquery> select key,value,base64 from extended_attributes where path = "/Users/sbs/Downloads/foo_bar/foobar.jpg";
+-----------------------------------------+---------------------------------------+--------+
| key                                     | value                                 | base64 |
+-----------------------------------------+---------------------------------------+--------+
| where_from                              | iPhone                                | 0      |
| com.apple.metadata:kMDLabel_(truncated) | (truncated)                           | 1      |
| quarantine_agent                        | sharingd                              | 0      |
| quarantine_event_id                     | 5E928A03-6E22-4B5D-A5D8-F9C19F23ED9A  | 0      |
| quarantine_sender                       | iPhone                                | 0      |
| quarantine_timestamp                    | 1430940342                            | 0      |
| quarantine_type                         | LSQuarantineTypeAirDrop               | 0      |
+-----------------------------------------+---------------------------------------+--------+
```

**profiler:**

```bash
❯ sudo -E python ./tools/profile.py --leaks --query "select * from extended_attributes where directory = \"/Users/sbs/Downloads/foo_bar\";"
Analyzing leaks in query: select * from extended_attributes where directory = "/Users/sbs/Downloads/foo_bar";
  definitely: 0 leaks for 0 total leaked bytes.

❯ sudo -E python ./tools/profile.py --leaks --query "select * from extended_attributes where path = \"/Users/sbs/Downloads/foo_bar/foobar.jpg\";"
Analyzing leaks in query: select * from extended_attributes where path = "/Users/sbs/Downloads/foo_bar/foobar.jpg";
  definitely: 0 leaks for 0 total leaked bytes.

❯ sudo -E python ./tools/profile.py --leaks --query "select * from extended_attributes where path = \"/Users/sbs/Downloads/foo_bar/googlechrome.dmg\";"
Analyzing leaks in query: select * from extended_attributes where path = "/Users/sbs/Downloads/foo_bar/googlechrome.dmg";
  definitely: 0 leaks for 0 total leaked bytes.
```