### PR TITLE
Formatting the callback function in the model_specific_register table

### DIFF
--- a/osquery/tables/system/linux/model_specific_register.cpp
+++ b/osquery/tables/system/linux/model_specific_register.cpp
@@ -94,7 +94,7 @@ const static msr_record_t fields[] = {
      .is_flag = false}};
 
 void getModelSpecificRegisterData(QueryData &results, int cpu_number) {
-  auto msr_filename = 
+  auto msr_filename =
     std::string("/dev/cpu/") + std::to_string(cpu_number) + "/msr";
 
   int fd = open(msr_filename.c_str(), O_RDONLY);
@@ -130,7 +130,7 @@ void getModelSpecificRegisterData(QueryData &results, int cpu_number) {
 }
 
 // Filter only for filenames starting with a digit.
-int filter(const struct dirent *entry) {
+int msrScandirFilter(const struct dirent *entry) {
   if (isdigit(entry->d_name[0])) {
     return 1;
   } else {
@@ -142,7 +142,7 @@ QueryData genModelSpecificRegister(QueryContext &context) {
   QueryData results;
 
   struct dirent **entries = nullptr;
-  int num_entries = scandir("/dev/cpu", &entries, filter, 0);
+  int num_entries = scandir("/dev/cpu", &entries, msrScandirFilter, 0);
   if (num_entries < 1) {
     LOG(WARNING) << "No msr information check msr kernel module is enabled.";
     return results;

--- a/specs/linux/msr.table
+++ b/specs/linux/msr.table
@@ -1,4 +1,4 @@
-table_name("model_specific_register")
+table_name("msr")
 description("Various pieces of data stored in the model specific register per "
             "processor. NOTE: the msr kernel module must be enabled, and "
             "osquery must be run as root.")


### PR DESCRIPTION
`int osquery::filter(const struct dirent*)` seemed like a pretty generic
symbol to have in our symbol table, so I changed it to
`int osquery::msrScandirFilter(const struct dirent*)`