### PR TITLE
Update tooling/profiling paths and use a better random seed

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <chrono>
 #include <mutex>
 #include <random>
 #include <sstream>
@@ -21,10 +22,11 @@
 
 namespace pt = boost::property_tree;
 
+namespace osquery {
+
 typedef pt::ptree::value_type tree_node;
 typedef std::map<std::string, std::vector<std::string> > EventFileMap_t;
-
-namespace osquery {
+typedef std::chrono::high_resolution_clock chrono_clock;
 
 CLI_FLAG(string, config_plugin, "filesystem", "Config plugin name");
 
@@ -402,6 +404,7 @@ int splayValue(int original, int splayPercent) {
   }
 
   std::default_random_engine generator;
+  generator.seed(chrono_clock::now().time_since_epoch().count());
   std::uniform_int_distribution<int> distribution(min_value, max_value);
   return distribution(generator);
 }

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -8,6 +8,9 @@
  *
  */
 
+#include <chrono>
+#include <random>
+
 #include <syslog.h>
 #include <stdio.h>
 #include <time.h>
@@ -52,6 +55,8 @@ namespace osquery {
   " - https://osquery.readthedocs.org/en/latest/introduction/using-osqueryd/" \
   "\n\n";
 
+typedef std::chrono::high_resolution_clock chrono_clock;
+
 CLI_FLAG(bool,
          config_check,
          false,
@@ -95,7 +100,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
       argv_(&argv),
       tool_(tool),
       binary_(fs::path(std::string(argv[0])).filename().string()) {
-  std::srand(time(nullptr));
+  std::srand(chrono_clock::now().time_since_epoch().count());
 
   // osquery implements a custom help/usage output.
   for (int i = 1; i < *argc_; i++) {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -47,8 +47,7 @@ CLI_FLAG(bool,
          "Force osqueryd to kill previously-running daemons");
 
 std::string getHostname() {
-  char hostname[256]; // Linux max should be 64.
-  memset(hostname, 0, sizeof(hostname));
+  char hostname[256] = {0}; // Linux max should be 64.
   gethostname(hostname, sizeof(hostname) - 1);
   std::string hostname_string = std::string(hostname);
   boost::algorithm::trim(hostname_string);

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -23,19 +23,19 @@
 namespace fs = boost::filesystem;
 
 namespace osquery {
+
 DECLARE_string(database_path);
 DECLARE_string(extensions_socket);
 DECLARE_string(modules_autoload);
 DECLARE_string(extensions_autoload);
 DECLARE_bool(disable_logging);
 
+typedef std::chrono::high_resolution_clock chrono_clock;
+
 void initTesting() {
   // Seed the random number generator, some tests generate temporary files
   // ports, sockets, etc using random numbers.
-  std::chrono::milliseconds ms =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::system_clock::now().time_since_epoch());
-  srand(ms.count());
+  std::srand(chrono_clock::now().time_since_epoch().count());
 
   // Set safe default values for path-based flags.
   // Specific unittests may edit flags temporarily.

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -1,3 +1,13 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
 #include <unistd.h>
 
 #include <osquery/core.h>

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -27,11 +27,11 @@ import time
 
 # Import the testing utils
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/tests/")
-from utils import *
+import utils
 
 KB = 1024 * 1024
 RANGES = {
-    "colors": (blue, green, yellow, red),
+    "colors": (utils.blue, utils.green, utils.yellow, utils.red),
     "utilization": (8, 20, 50),
     "cpu_time": (0.4, 1, 10),
     "memory": (8 * KB, 12 * KB, 24 * KB),
@@ -45,7 +45,7 @@ def get_stats(p, interval=1):
     utilization = p.cpu_percent(interval=interval)
     return {
         "utilization": utilization,
-        "counters": p.io_counters() if platform() != "darwin" else None,
+        "counters": p.io_counters() if utils.platform() != "darwin" else None,
         "fds": p.num_fds(),
         "cpu_times": p.cpu_times(),
         "memory": p.memory_info_ex(),
@@ -101,7 +101,7 @@ def check_leaks_darwin(shell, query, count=1):
 
 
 def check_leaks(shell, query, count=1, supp_file=None):
-    if platform() == "darwin":
+    if utils.platform() == "darwin":
         return check_leaks_darwin(shell, query, count=count)
     else:
         return check_leaks_linux(shell, query, count=count, supp_file=supp_file)
@@ -289,7 +289,7 @@ if __name__ == "__main__":
         help="Limit to a list of comma-separated tables."
     )
     group.add_argument(
-        "--tables", metavar="PATH", default="./osquery/tables/specs",
+        "--tables", metavar="PATH", default="./specs",
         help="Path to the osquery table specs."
     )
     group.add_argument(
@@ -316,7 +316,7 @@ if __name__ == "__main__":
     )
     group.add_argument(
         "--shell", metavar="PATH", default="./build/%s/osquery/run" % (
-            platform()),
+            utils.platform()),
         help="Path to osquery run wrapper (./build/<sys>/osquery/run)."
     )
 
@@ -365,11 +365,11 @@ if __name__ == "__main__":
         if not os.path.exists(args.config):
             print ("Cannot find --config: %s" % (args.config))
             exit(1)
-        queries = queries_from_config(args.config)
+        queries = utils.queries_from_config(args.config)
     elif args.query is not None:
         queries["manual"] = args.query
     else:
-        queries = queries_from_tables(args.tables, args.restrict)
+        queries = utils.queries_from_tables(args.tables, args.restrict)
 
     if args.leaks:
         results = profile_leaks(

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -82,7 +82,7 @@ def queries_from_tables(path, restrict):
     """Construct select all queries from all tables."""
     # Let the caller limit the tables
     restrict_tables = [t.strip() for t in restrict.split(",")]
-    platform = platform()
+    spec_platform = platform()
     tables = []
     for base, _, files in os.walk(path):
         for spec in files:


### PR DESCRIPTION
1. The release tooling had regressions from recent refactors such as new paths for specs and platform detections.
2. License/copyright missing from disk_encryption.
3. Initializer's random number generator was seeded using second-precision and the splay calculation was not seeded.