### PR TITLE
[#1190] Schedule queries without logging removed results

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -150,6 +150,7 @@ inline void additionalScheduledQuery(const std::string& name,
 
   // This is a candidate for a catch-all iterator with a catch for boolean type.
   query.options["snapshot"] = node.second.get<bool>("snapshot", false);
+  query.options["removed"] = node.second.get<bool>("removed", true);
 
   // Check if this query exists, if so, check if it was changed.
   if (conf.schedule.count(name) > 0) {

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 
+#include <math.h>
 #include <sys/wait.h>
 #include <signal.h>
 
@@ -308,7 +309,10 @@ void WatcherRunner::createWorker() {
     if (Watcher::getState(Watcher::getWorker()).last_respawn_time >
         getUnixTime() - getWorkerLimit(RESPAWN_LIMIT)) {
       LOG(WARNING) << "osqueryd worker respawning too quickly";
+      Watcher::workerRestarted();
       interruptableSleep(getWorkerLimit(RESPAWN_DELAY) * 1000);
+      // Exponential back off for quickly-respawning clients.
+      interruptableSleep(pow(2, Watcher::workerRestartCount()) * 1000);
     }
   }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -130,6 +130,10 @@ void launchQuery(const std::string& name, const ScheduledQuery& query) {
 
   VLOG(1) << "Found results for query (" << name << ") for host: " << ident;
   item.results = diff_results;
+  if (query.options.count("removed") && !query.options.at("removed")) {
+    item.results.removed.clear();
+  }
+
   status = logQueryLogItem(item);
   if (!status.ok()) {
     LOG(ERROR) << "Error logging the results of query (" << query.query

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -227,7 +227,7 @@ def main(argc, argv):
         help="Compare API changes API_PREVIOUS API_CURRENT"
     )
     parser.add_argument("vars", nargs="*")
-    args = parser.parse_args(argv)
+    args = parser.parse_args()
 
     if args.debug:
         logging.basicConfig(format=LOG_FORMAT, level=logging.DEBUG)

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -63,7 +63,8 @@ function install_gcc() {
     [ -L /usr/bin/g++ ] && sudo unlink /usr/bin/g++
     sudo ln -sf $TARGET/bin/gcc4.8.4 /usr/bin/gcc
     sudo ln -sf $TARGET/bin/g++4.8.4 /usr/bin/g++
-    sudo ln -sf $TARGET/lib64/libstdc++.so.6.0.19 /usr/lib64/libstdc++.so.6
+    sudo ln -sf $TARGET/lib64/libstdc++.so.6.0.19 /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.19
+    sudo ln -sf $TARGET/lib64/libstdc++.so.6.0.19 /usr/lib/x86_64-linux-gnu/libstdc++.so.6
     popd
   fi
 }


### PR DESCRIPTION
1. Add `"removed":false` to a scheduled queries to only emit `"action":"added"` results.
2. Workers now abort with an exponential backoff. 