### PR TITLE
[Fix #1185, #1183] Use RocksDB from Homebrew on OS X

### DIFF
--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -23,11 +23,8 @@ function main_darwin() {
   package makedepend
   package boost
   package gflags
+  package rocksdb
   package thrift
   package yara
   package doxygen
-
-  # RocksDB is in Homebrew, but we like more control over our compile.
-  remove_package rocksdb
-  install_rocksdb
 }


### PR DESCRIPTION
We were building RocksDB from source hosted on S3, we should have been using Homebrew but there was a problem building portable code (non-CPU optimized).