### PR TITLE
Base kernel module and circular user kernel queue.

### DIFF
--- a/docs/wiki/development/kernel.md
+++ b/docs/wiki/development/kernel.md
@@ -1,0 +1,28 @@
+## Kernel (OS X only)
+
+Currently an kernel extension is under development for OS X that will create new data feeds for event based information.
+
+WARNING:  This is currently under development.
+
+## Building on OS X for local loading (not recommended)
+
+Working in the kernel directory:
+
+First disable signature verification on the machine by running `make disable-signing` a reboot is required for this to take effect.  CAUTION: this lowers the security of your system.  It is better to have your kernel extensions signed.
+
+Once kernel extension signature verification is disabled, just `make` the kernel extension.  It can then be loaded and unloaded with `make load` and `make unload`.  For permanent installations it should be added to the systems startup kernel extensions.
+
+## Building on OS X for a debugging target machine (recommended)
+
+# Debugging environment setup.
+- Create an OS X VM to act as the target machine.
+- Make the osquery directory a shared folder between host and VM.
+- Get a [kernel debug kit](https://developer.apple.com/downloads/).
+- Install it on both the target machine VM and the host debugging machine.
+- Run make targets to configure the target machine and the debugger machine.
+  - `make configure-target`   (on VM, requires a reboot)
+  - `make configure-debugger` (on host)
+- Launch debugger on host using the `make db` target this loads the kernel symbols and commands.
+- Connect to VM using the `kdp-remote <ip-address>` command.
+- Once the VM is booted ssh in and load the kext by running the `make load` target.
+

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,0 +1,196 @@
+# OS X kext makefile
+VERSION:=$(shell git describe --tags HEAD --always)
+VERSION_DEFINE:=-DVERSION="\"$(VERSION)\""
+
+CC:=clang
+CXX:=clang++
+
+# Directories
+INCLUDE_DIR:=include/
+BUILD_DIR:=build/
+SOURCE_DIR:=src/
+KEXT:=osquery.kext
+CONTENTS_DIR:=$(BUILD_DIR)$(KEXT)/Contents/
+OUTPUT_DIR:=$(CONTENTS_DIR)MacOS/
+RUNDIR:=/tmp/
+USER_DIR:=user/
+
+INCLUDES:=$(wildcard $(INCLUDE_DIR)*.h)
+INCLUDE:=-I$(INCLUDE_DIR) -I/System/Library/Frameworks/Kernel.framework/Headers
+FLAGS:=-arch x86_64 -mkernel
+CXXFLAGS:=$(FLAGS) -nostdinc -fno-builtin $(INCLUDE) $(VERSION_DEFINE)
+CFLAGS:=$(FLAGS) -nostdinc -fno-builtin $(INCLUDE) $(VERSION_DEFINE)
+LDFLAGS:=$(FLAGS) -Xlinker -kext -nostdlib -lkmod
+CSOURCES:=$(wildcard $(SOURCE_DIR)*.c)
+CXXSOURCES:=$(wildcard $(SOURCE_DIR)*.cpp)
+SOURCES:=$(CSOURCES) $(CXXSOURCES)
+OBJECTS:=$(addprefix $(BUILD_DIR), $(notdir $(CXXSOURCES:.cpp=.cpp.o))) \
+	$(addprefix $(BUILD_DIR), $(notdir $(CSOURCES:.c=.c.o)))
+OUTPUT:=$(BUILD_DIR)output
+EXECUTABLE:=$(OUTPUT_DIR)osquery
+DSYM:=$(EXECUTABLE).dSYM
+BUNDLE_PLIST:=Info.plist
+
+# Can use the kernel suffix development to load the development kernel.  You
+# have to reconfigure the target after changing the suffix.
+KERNEL_SUFFIX:=
+ifeq ($(KERNEL_SUFFIX),)
+  KERNEL:=kernel
+else
+  KERNEL:=kernel.$(KERNEL_SUFFIX)
+endif
+ifeq ($(KERNEL_SUFFIX),developement)
+  NVRAM_FLAGS:=-v pmuflags=1
+else
+  NVRAM_FLAGS:=-v
+endif
+DEV_KERNEL:=/System/Library/Kernels/$(KERNEL)
+
+.PHONY: all
+all:  $(EXECUTABLE)
+
+.PHONY: debug
+debug: CXXFLAGS+= -DDEBUG -g
+debug: CFLAGS+= -DDEBUG -g
+debug: LDFLAGS+= -DDEBUG -g
+debug: $(DSYM)
+
+.PHONY: release
+release: CXXFLAGS+= -O3
+release: CCFLAGS+= -O3
+release: LDFLAGS+= -O3
+release: $(EXECUTABLE)
+	strip -S $<
+
+# For building and running tests.  Not debugging.  Disables signature checks!
+.PHONY: test
+test:   disable-signing
+	sudo ./test.sh $(BUILD_DIR)consumer.out $(BUILD_DIR)producer.out 5 && \
+	echo "Test success!"
+
+$(OUTPUT):
+	mkdir -p $(OUTPUT_DIR) &&\
+	touch $(OUTPUT)
+
+$(CONTENTS_DIR)$(BUNDLE_PLIST):
+	cp $(SOURCE_DIR)$(BUNDLE_PLIST) $(CONTENTS_DIR)
+
+$(BUILD_DIR)%.cpp.o: $(SOURCE_DIR)%.cpp $(INCLUDES) $(OUTPUT)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR)%.c.o: $(SOURCE_DIR)%.c $(INCLUDES) $(OUTPUT)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(EXECUTABLE): $(OBJECTS) $(OUTPUT) $(CONTENTS_DIR)$(BUNDLE_PLIST)
+	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@
+
+$(RUNDIR)$(KEXT): $(EXECUTABLE) $(OUTPUT) $(CONTENTS_DIR)$(BUNDLE_PLIST)
+	sudo cp -rp ./$(BUILD_DIR)$(KEXT) $(RUNDIR) && \
+	sudo chown -R root:wheel $(RUNDIR)$(KEXT) && \
+	sudo chmod -R 0644 $(RUNDIR)$(KEXT)
+
+$(DSYM): $(EXECUTABLE)
+	dsymutil $< -o $@ && strip -S $<
+
+.PHONY: clean
+clean:
+	sudo rm -rf -- $(BUILD_DIR)* $(RUNDIR)$(KEXT)
+
+$(DEV_KERNEL):
+	sudo cp /Library/Developer/KDKs/*/System/Library/Kernels/$(KERNEL) \
+	  /System/Library/Kernels/
+
+
+# Load the compiled kext.  If debugging make sure kext was compiled on the host
+# machine to get source level debugging.
+.PHONY: load
+load:  $(RUNDIR)$(KEXT)
+	sudo kextload -v $(RUNDIR)$(KEXT)
+
+# Unload the kext.
+.PHONY: unload
+unload:
+	sudo kextunload -v $(RUNDIR)$(KEXT)
+
+# Return boot arguments to default.  Used to turn back on signature checks and
+# disable dev kernel nvram flags.
+.PHONY: restore-target clear-boot-args
+restore-target clear-boot-args:
+	sudo nvram -d boot-args && echo 'REBOOT REQUIRED'
+
+###################################################
+#
+# Build and load on own machine (CAUTION).
+#
+##################################################
+# - If kext is not signed disable signature checks (disable-signing target).
+# - Run the load target.  This will compile and load a non debug version of
+#   the kext.
+
+# Stops kernel extension signatures from being checked before they are loaded.
+# configure-target disables signing as well
+.PHONY: disable-signing
+disable-signing:
+	sudo nvram boot-args=kext-dev-mode=1 && echo 'REBOOT REQUIRED'
+
+###################################################
+#
+# Debugging environment setup.
+#
+###################################################
+# - Create a VM to act as the target machine.
+# - Make this directory a shared folder between host and VM.
+# - Get a kernel debug kit from:
+#       https://developer.apple.com/downloads/
+# - Install it on both the target machine VM and the host debugging machine.
+# - Run make targets to configure the target machine and the debugger machine.
+#       - configure-target   (on VM, requires a reboot)
+#       - configure-debugger (on host)
+# - Launch debugger on host using the db target this loads the kernel symbols
+#   and commands.
+# - Connect to VM using the kdp-remote command.
+# - Once the VM is booted ssh in and load the kext by running the load target.
+
+# This target configuration does:
+#    Disables signature checking and sets OS X into kernel debug mode.
+#    if KERNEL_SUFFIX is set to development:
+#      OS X will not check PMU unit.
+#      OS X will boot development kernel (better have it installed from kernel
+#        debug kit).
+#    OS X will wait for a network debugger to attach at boot.
+#    OS X will not display panic dialogs
+#    OS X will interrupt when sent a cntrl + opt + cmd + shift + esc
+BOOT_ARGS:=$(NVRAM_FLAGS) kcsuffix=$(KERNEL_SUFFIX) kext-dev-mode=1 debug=0x14F
+.PHONY: configure-target kernel-debug
+configure-target kernel-debug: $(DEV_KERNEL)
+	sudo nvram boot-args="$(BOOT_ARGS)" \
+	&& echo 'REBOOT REQUIRED'
+
+# This debugger configuration does:
+#    Make debugging machine allow LLDB commands to be loaded from symbol files.
+#    In this case it is to allow it to load commands fromt the kernel symbol
+#    file.
+.PHONY: configure-debugger
+configure-debugger:
+	touch ~/.lldbinit && \
+	(grep -q -F 'settings set target.load-script-from-symbol-file true' \
+	  ~/.lldbinit \
+	|| echo "settings set target.load-script-from-symbol-file true" \
+	  >> ~/.lldbinit)
+
+# Compile debug and launch debugger.  Launch a congfigured target VM and attach
+# to it using kdp-remote once booted.  Load the kext using make load on the
+# target VM.  (NOTE build on debugging machine for source level debugging).
+.PHONY: db
+db:
+	make -p build && \
+	cd build && \
+	lldb /Library/Developer/KDKs/*/System/Library/Kernels/$(KERNEL)
+
+# Determine the libraries that are needed to be inclduded in the Info.plist
+# file.
+.PHONY: libs
+libs:  $(RUNDIR)$(KEXT)
+	sudo kextlibs $(RUNDIR)$(KEXT)
+
+

--- a/kernel/include/feeds.h
+++ b/kernel/include/feeds.h
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <sys/ioccom.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//
+// Event feed types
+//
+
+typedef enum osquery_event {
+  END_OF_BUFFER_EVENT = 0,  // Null event used to signal the end of the buffer.
+
+#ifdef DEBUG
+  OSQUERY_TEST_EVENT_0,
+  OSQUERY_TEST_EVENT_1,
+#endif // DEBUG
+
+  OSQUERY_EVENT_NUM_EVENTS  // Number of different event types.
+} osquery_event_t;
+
+#ifdef DEBUG
+typedef struct test_event_0 {
+  uint32_t my_num;
+  char my_str[64];
+} test_event_0_data_t;
+
+typedef struct test_event_1 {
+  uint32_t my_num;
+  char my_str[33];
+} test_event_1_data_t;
+#endif // DEBUG
+
+static inline size_t osquery_sizeof_event(osquery_event_t e) {
+  switch (e) {
+#ifdef DEBUG
+    case OSQUERY_TEST_EVENT_0:
+      return sizeof(test_event_0_data_t);
+    case OSQUERY_TEST_EVENT_1:
+      return sizeof(test_event_1_data_t);
+#endif // DEBUG
+    default:
+      return -1;
+  }
+}
+
+//
+// Header for event data.
+//
+
+typedef struct osquery_data_header {
+  osquery_event_t event;
+  int finished;
+} osquery_data_header_t;
+
+//
+// IOCTL messages
+//
+
+typedef struct osquery_subscription_args {
+  osquery_event_t event;
+  int subscribe;
+} osquery_subscription_args_t;
+
+typedef struct osquery_buf_update_args {
+  size_t read_offset;      // Offset of daemon read pointer.
+  size_t max_read_offset;  // (Output) Offset of max_read pointer.
+  int drops;               // (Output) Number of drops or negative on overflow.
+} osquery_buf_update_args_t;
+
+typedef struct osquery_buf_allocate_args {
+  size_t size;      // Size of shared user kernel buffer.
+  void *buffer;     // (Output) Pointer to buffer location.
+} osquery_buf_allocate_args_t;
+
+// TODO: Choose a proper IOCTL num.
+#define OSQUERY_IOCTL_NUM 0xFA
+#define OSQUERY_IOCTL_SUBSCRIPTION \
+  _IOW(OSQUERY_IOCTL_NUM, 0x1, osquery_subscription_args_t)
+#define OSQUERY_IOCTL_BUF_UPDATE \
+  _IOWR(OSQUERY_IOCTL_NUM, 0x2, osquery_buf_update_args_t)
+#define OSQUERY_IOCTL_BUF_ALLOCATE \
+  _IOWR(OSQUERY_IOCTL_NUM, 0x3, osquery_buf_allocate_args_t)
+
+#ifdef DEBUG
+#define OSQUERY_IOCTL_TEST \
+  _IOW(OSQUERY_IOCTL_NUM, 0x4, int)
+#endif // DEBUG
+
+#ifdef __cplusplus
+}  // end extern "c"
+#endif
+

--- a/kernel/src/Info.plist
+++ b/kernel/src/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>osquery</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.facebook.driver.osquery</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>osquery</string>
+	<key>CFBundlePackageType</key>
+	<string>KEXT</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2015, Facebook, Inc.</string>
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>com.apple.kpi.bsd</key>
+		<string>14.3</string>
+		<key>com.apple.kpi.libkern</key>
+		<string>14.3</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>14.3</string>
+		<key>com.apple.kpi.mach</key>
+		<string>14.3</string>
+	</dict>
+</dict>
+</plist>

--- a/kernel/src/circular_queue_kern.c
+++ b/kernel/src/circular_queue_kern.c
@@ -1,0 +1,278 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <libkern/libkern.h>
+
+#include <sys/proc.h>
+
+#include <kern/assert.h>
+
+
+#include "circular_queue_kern.h"
+
+static inline void setup_locks(osquery_cqueue_t *queue) {
+  /* Create locks.  Cannot be done on the stack. */
+  queue->lck_grp_attr = lck_grp_attr_alloc_init();
+  lck_grp_attr_setstat(queue->lck_grp_attr);
+
+  queue->lck_grp = lck_grp_alloc_init("osquery cqueue", queue->lck_grp_attr);
+
+  queue->lck_attr = lck_attr_alloc_init();
+
+  queue->lck = lck_spin_alloc_init(queue->lck_grp, queue->lck_attr);
+}
+
+static inline void destroy_locks(osquery_cqueue_t *queue) {
+  lck_spin_free(queue->lck, queue->lck_grp);
+
+  lck_attr_free(queue->lck_attr);
+
+  lck_grp_free(queue->lck_grp);
+
+  lck_grp_attr_free(queue->lck_grp_attr);
+}
+
+static inline void *advance_pointer(osquery_cqueue_t *queue, void *ptr,
+                                    size_t bytes) {
+  return ((uint8_t *)ptr + bytes - queue->buffer) % queue->size + queue->buffer;
+}
+
+static inline size_t get_distance(osquery_cqueue_t *queue, void *lower,
+                                  void *upper, int cannot_be_empty) {
+  ssize_t size = (uint8_t *)upper - (uint8_t *)lower;
+  if (size == 0) {
+    return cannot_be_empty ? queue->size : 0;
+  } else if (size < 0) {
+    return queue->size + size;
+  } else {
+    return size;
+  }
+}
+
+typedef enum {
+  OSQUERY_BETWEEN_INIT = 0,
+  OSQUERY_BETWEEN = 1,
+  OSQUERY_NOT_BETWEEN = 1 << 1,
+  OSQUERY_NOT_IN_BUFFER = 1 << 2
+} osquery_between_t;
+
+static inline osquery_between_t is_between(osquery_cqueue_t *queue, void *ptr,
+                                           void *lower, void *upper,
+                                           size_t size) {
+  osquery_between_t b = OSQUERY_BETWEEN_INIT;
+  if (ptr < (void *)queue->buffer
+      || ((uint8_t *)ptr) + size > (queue->buffer + queue->size)) {
+    b |= OSQUERY_NOT_IN_BUFFER;
+  }
+
+  if (lower <= upper && lower <= ptr
+      && ((void *)(((uint8_t *)ptr) + size)) <= upper) {
+    b |= OSQUERY_BETWEEN;
+  } else if (upper < lower
+             && (((void *)(((uint8_t *)ptr) + size)) <= upper || lower <= ptr)) {
+    b |= OSQUERY_BETWEEN;
+  } else {
+    b |= OSQUERY_NOT_BETWEEN;
+  }
+
+  return b;
+}
+
+void osquery_cqueue_init(osquery_cqueue_t *queue, void *buffer, size_t size) {
+  setup_locks(queue);
+
+  queue->buffer = (uint8_t *)buffer;
+  queue->size = size;
+
+  queue->write = queue->buffer;
+  queue->max_read = queue->buffer;
+  queue->read = queue->buffer;
+
+  queue->drops = 0;
+  queue->initialized = 1;
+}
+
+void osquery_cqueue_destroy(osquery_cqueue_t *queue) {
+  if (queue->initialized) {
+    queue->initialized = 0;
+    destroy_locks(queue);
+  }
+}
+
+int osquery_cqueue_advance_read(osquery_cqueue_t *queue, size_t read_offset,
+                                size_t *max_read_offset) {
+  if (!queue->initialized) {
+    return -1;
+  }
+  int err = 0;
+  lck_spin_lock(queue->lck);
+
+  uint8_t *new_read = queue->buffer + read_offset;
+  if (OSQUERY_BETWEEN == is_between(queue, new_read, queue->read,
+                                    queue->max_read, 0)) {
+    queue->read = new_read;
+  } else {
+    queue->read = queue->max_read;
+    err = -1;
+  }
+  *max_read_offset = queue->max_read - queue->buffer;
+
+  lck_spin_unlock(queue->lck);
+
+  return err;
+}
+
+ssize_t osquery_cqueue_wait_for_data(osquery_cqueue_t *queue) {
+  if (!queue->initialized) {
+    return -1;
+  }
+  wait_result_t wait_result = THREAD_AWAKENED;
+
+  lck_spin_lock(queue->lck);
+  while (wait_result == THREAD_AWAKENED && queue->max_read == queue->read) {
+    wait_result = lck_spin_sleep(queue->lck, LCK_SLEEP_DEFAULT,
+                                 &queue->max_read, THREAD_ABORTSAFE);
+  }
+  size_t offset = queue->max_read - queue->buffer;
+  
+  lck_spin_unlock(queue->lck);
+  return offset;
+}
+
+int osquery_cqueue_dropped_data(osquery_cqueue_t *queue) {
+  int drops;
+  if (!queue->initialized) {
+    return -1;
+  }
+
+  lck_spin_lock(queue->lck);
+  drops = queue->drops;
+  queue->drops = 0;
+  lck_spin_unlock(queue->lck);
+
+  return drops;
+}
+
+void *osquery_cqueue_reserve(osquery_cqueue_t *queue, osquery_event_t event) {
+  if (!queue->initialized) {
+    return NULL;
+  }
+  
+  void *ret = NULL;
+  osquery_data_header_t *header = NULL;
+
+  size_t size = osquery_sizeof_event(event) + sizeof(osquery_data_header_t);
+
+  lck_spin_lock(queue->lck);
+  
+  // We do not want the write pointer to ever equal the read pointer unless
+  // everything is empty.  Otherwise we need to track the empty states for the
+  // buffer.
+  if (get_distance(queue, queue->write, queue->read, 1) > size) {
+    if (get_distance(queue, queue->write,
+                     queue->buffer + queue->size, 0) >= size) {
+      // We can fit the allocation by advancing the write pointer.
+      header = (osquery_data_header_t *)queue->write;
+      queue->write = (uint8_t *)advance_pointer(queue, queue->write, size);
+    } else if (get_distance(queue, queue->buffer, queue->read, 0) > size) {
+      // We can fit the allocation by wrapping the write pointer.
+      if (get_distance(queue, queue->write, queue->buffer + queue->size, 0)
+          >= sizeof(osquery_data_header_t)) {
+        // Signal a Null event ie. jump to beginning of buf.  If there
+        // is not enough room to do so, this is ok because it will know to
+        // skip to the beginning of the buffer based on the amount of space
+        // left.
+        header = (osquery_data_header_t *)queue->write;
+        header->event = END_OF_BUFFER_EVENT;
+      }
+      header = (osquery_data_header_t *)queue->buffer;
+      queue->write = (uint8_t *)advance_pointer(queue, queue->buffer, size);
+    }
+  }
+
+  if (header) {
+    header->event = event;
+    header->finished = 0;
+
+    // Give them the pointer to the space not the header.
+    ret = (void *)(header + 1);
+  } else {
+    if (queue->drops >= 0) {
+      queue->drops += 1;
+    }
+    ret = NULL;
+  }
+
+  lck_spin_unlock(queue->lck);
+
+  return ret;
+}
+
+/** @brief Turn blocks that have been commited into readable space for user
+ *  level process.
+ *
+ *  REQUIRES the lock.
+ *
+ *  @param queue The queue to create readable space in.
+ *  @return Void.
+ */
+static inline void coalesce_readable(osquery_cqueue_t *queue) {
+  osquery_data_header_t *header = (osquery_data_header_t *)queue->max_read;
+  osquery_between_t b;
+
+  while (OSQUERY_BETWEEN & (b = is_between(queue, header, queue->max_read,
+                                       queue->write, sizeof(osquery_data_header_t)))) {
+    if (b & OSQUERY_NOT_IN_BUFFER || header->event == END_OF_BUFFER_EVENT) {
+      queue->max_read = queue->buffer;
+      header = (osquery_data_header_t *)queue->max_read;
+      continue;
+    } else if (!header->finished) {
+      break;
+    }
+
+    queue->max_read = (uint8_t *)advance_pointer(queue, queue->max_read,
+                                      osquery_sizeof_event(header->event)
+                                      + sizeof(osquery_data_header_t));
+  
+    header = (osquery_data_header_t *)queue->max_read;
+    wakeup(&queue->max_read);
+
+    lck_spin_unlock(queue->lck);
+    lck_spin_lock(queue->lck);
+  }
+}
+
+int osquery_cqueue_commit(osquery_cqueue_t *queue, void *space) {
+  if (!queue->initialized) {
+    return -1;
+  }
+  int err = 0;
+
+  lck_spin_lock(queue->lck);
+
+  // Retrieve the header for the initialized space.
+  osquery_data_header_t *header = ((osquery_data_header_t *)space) - 1;
+  if (OSQUERY_BETWEEN != is_between(queue, header, queue->max_read,
+                                    queue->write, sizeof(osquery_data_header_t))
+      || header->event == END_OF_BUFFER_EVENT
+      || header->finished) {
+    err = -1;  // Invalid space.
+    goto error_exit;
+  }
+
+  header->finished = 1;
+
+  coalesce_readable(queue);
+
+error_exit:
+  lck_spin_unlock(queue->lck);
+  return err;
+}
+

--- a/kernel/src/circular_queue_kern.h
+++ b/kernel/src/circular_queue_kern.h
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+/** @brief Circular queue implementation for a producer, consumer based setup.
+ *
+ *  Specifically this circular queue implementation is used for passing event
+ *  information from the kernel to the user.
+ *
+ *
+ *  For safety this queue on an error should log the error and reset to a known
+ *  safe state possibly dropping all data in held within it.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sys/lock.h>
+
+#include <feeds.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Circular queue data structure.
+typedef struct osquery_cqueue {
+  uint8_t *buffer;
+  size_t size;
+  uint8_t *write;
+  uint8_t *max_read;
+  uint8_t *read;
+  int drops;
+  int initialized;
+
+  lck_grp_attr_t *lck_grp_attr;
+  lck_grp_t *lck_grp;
+  lck_attr_t *lck_attr;
+  lck_spin_t *lck;
+} osquery_cqueue_t;
+
+
+/** @brief Initialize a circular queue.
+ *
+ *  Initializes a circular queue given a preallocated buffer of a given size.
+ *
+ *  @param queue The circular queue structure to initialize.
+ *  @param buffer The buffer to use in the queue.
+ *  @param size The size of the passed in buffer.
+ *  @return Void.
+ */
+void osquery_cqueue_init(osquery_cqueue_t *queue, void *buffer, size_t size);
+
+
+/** @brief Cleanup a cqueue.
+ *
+ *  @param queue The cqueue to destroy.
+ *  @return Void.
+ */
+void osquery_cqueue_destroy(osquery_cqueue_t *queue);
+
+
+/** @brief Advance the read head in the buffer.
+ *
+ *  @param queue The circular queue structure to advance the read head in.
+ *  @param read_offset Offset of pointer to new location of read head.
+ *  @param max_read_offset (Output) Output the offset of the max_read pointer.
+ *  @return Return negative on failure (invalid offset).
+ */
+int osquery_cqueue_advance_read(osquery_cqueue_t *queue, size_t read_offset,
+                                size_t *max_read_offset);
+
+
+/** @brief Find the position of the max_read pointer.  Block if buffer is empty.
+ *
+ *  @param queue The queue to find the offset of the max_read pointer in.
+ *  @return Return offset of max_read pointer.  Negative on failure.
+ */
+ssize_t osquery_cqueue_wait_for_data(osquery_cqueue_t *queue);
+
+/** @brief Returns if the cqueue has dropped data.
+ *
+ *  Returns whether data has been dropped since the last call of this function.
+ *
+ *  @param queue The cqueue to look for dropped data in.
+ *  @return 0 for no data dropped 1 for dropped data.
+ */
+int osquery_cqueue_dropped_data(osquery_cqueue_t *queue);
+
+/** @brief Reserve space to store an event in the queue.
+ *
+ *  This gives you a brief moment to write data to the returned space.
+ *  NOTE: You must call the commit function on your pointer shortly after
+ *  reserving it.  Otherwise the buffer will become deadlocked.
+ *
+ *  @param queue The queue to reserve space in.
+ *  @param event The event type to reserve space for.
+ *  @return Pointer to the space.  NULL if no space could be arranged.
+ */
+void *osquery_cqueue_reserve(osquery_cqueue_t *queue, osquery_event_t event);
+
+
+/** @brief Commit a write to a previously reserved space.
+ *
+ *  After commiting your space you may no longer access it.
+ *  All reserved spaces must be committed shortly after being
+ *  reserved.
+ *
+ *  @param queue The queue to commit the space in.
+ *  @param space The space to commit.
+ *  @return Negative on failure (invalid space or cqueue).
+ */
+int osquery_cqueue_commit(osquery_cqueue_t *queue, void *space);
+
+#ifdef __cplusplus
+}  // end extern "c"
+#endif
+

--- a/kernel/src/osquery.cpp
+++ b/kernel/src/osquery.cpp
@@ -1,0 +1,385 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <libkern/libkern.h>
+#include <libkern/OSKextLib.h>
+#include <mach/mach_types.h>
+
+#include <kern/debug.h>
+#include <sys/vnode.h>
+#include <sys/errno.h>
+#include <sys/conf.h>
+#include <sys/proc.h>
+#include <sys/systm.h>
+#include <miscfs/devfs/devfs.h>
+
+// IOKit headers
+#include <IOKit/IOMemoryDescriptor.h>
+#include <IOKit/IOLib.h>
+
+#include <feeds.h>
+#include "circular_queue_kern.h"
+
+#ifdef DEBUG
+#define dbg_printf(...) printf(__VA_ARGS__ )
+#else
+#define dbg_printf(...) do{ } while(0)
+#endif
+
+// Let the major number be decided for us.
+#define OSQUERY_MAJOR -1
+#define MAX_KMEM (20 * (1 << 20))
+#define MIN_KMEM (8 * (1 << 10))
+
+
+static struct osquery {
+  osquery_cqueue_t cqueue;
+  void *buffer;
+  size_t buf_size;
+  IOMemoryDescriptor *md;
+  IOMemoryMap *mm;
+  void *devfs;
+  int major_number;
+  int open_count;
+
+  lck_grp_attr_t *lck_grp_attr;
+  lck_grp_t *lck_grp;
+  lck_attr_t *lck_attr;
+  lck_mtx_t *mtx;
+} osquery = {
+  .open_count = 0,
+  .buffer = NULL,
+  .buf_size = 0,
+  .md = NULL,
+  .mm = NULL,
+  .devfs = NULL,
+  .major_number = OSQUERY_MAJOR
+};
+
+static inline void setup_locks() {
+  /* Create locks.  Cannot be done on the stack. */
+  osquery.lck_grp_attr = lck_grp_attr_alloc_init();
+  lck_grp_attr_setstat(osquery.lck_grp_attr);
+
+  osquery.lck_grp = lck_grp_alloc_init("osquery", osquery.lck_grp_attr);
+
+  osquery.lck_attr = lck_attr_alloc_init();
+
+  osquery.mtx = lck_mtx_alloc_init(osquery.lck_grp, osquery.lck_attr);
+}
+
+static inline void destroy_locks() {
+  lck_mtx_free(osquery.mtx, osquery.lck_grp);
+
+  lck_attr_free(osquery.lck_attr);
+
+  lck_grp_free(osquery.lck_grp);
+
+  lck_grp_attr_free(osquery.lck_grp_attr);
+}
+
+static int subscribe_to_event(osquery_event_t event, int subscribe) {
+  // TODO: Logic to start a subscription for events of a given type.
+  if (osquery.buffer == NULL) {
+    return -EINVAL;
+  }
+
+  return -EINVAL;
+}
+
+static int update_user_kernel_buffer(size_t read_offset,
+                                     size_t *max_read_offset,
+                                     int *drops) {
+  if (osquery_cqueue_advance_read(&osquery.cqueue,
+                                  read_offset,
+                                  max_read_offset)) {
+    return -EINVAL;
+  }
+
+  ssize_t offset = 0;
+  if ((offset = osquery_cqueue_wait_for_data(&osquery.cqueue)) < 0) {
+    return -EINVAL;
+  }
+
+  *max_read_offset = offset;
+  *drops = osquery_cqueue_dropped_data(&osquery.cqueue);
+  return 0;
+}
+
+static void cleanup_user_kernel_buffer() {
+  if (osquery.mm) {
+    osquery.mm->release();
+    osquery.mm = NULL;
+  }
+
+  if (osquery.md) {
+    osquery.md->release();
+    osquery.md = NULL;
+  }
+
+  osquery_cqueue_destroy(&osquery.cqueue);
+
+  if (osquery.buffer) {
+    IOFreeAligned(osquery.buffer, osquery.buf_size);
+    osquery.buffer = NULL;
+  }
+}
+
+static int allocate_user_kernel_buffer(size_t size, void **buf) {
+  int err = 0;
+  char *s;
+
+  if (size > MAX_KMEM || size < MIN_KMEM) {
+    err = -EINVAL;
+    goto error_exit;
+  }
+
+  osquery.buf_size = size;
+  osquery.buffer = IOMallocAligned(osquery.buf_size, PAGE_SIZE);
+  if (osquery.buffer == NULL) {
+    err = -EINVAL;
+    goto error_exit;
+  }
+  bzero(osquery.buffer, osquery.buf_size);  // Zero memory for safety.
+
+  osquery.md
+    = IOMemoryDescriptor::withAddressRange((mach_vm_address_t)osquery.buffer,
+                                           osquery.buf_size,
+                                           kIODirectionInOut, kernel_task);
+  if (osquery.md == NULL) {
+    err = -EINVAL;
+    goto error_exit;
+  }
+  osquery.mm = osquery.md->createMappingInTask(current_task(), NULL,
+                                               kIOMapAnywhere | kIOMapReadOnly);
+  if (osquery.mm == NULL) {
+    err = -EINVAL;
+    goto error_exit;
+  }
+  *buf = (void *)osquery.mm->getAddress();
+
+  osquery_cqueue_init(&osquery.cqueue, osquery.buffer, osquery.buf_size);
+
+  return 0;
+error_exit:
+  cleanup_user_kernel_buffer();
+
+  return err;
+}
+
+static int osquery_open(dev_t dev, int oflags, int devtype, struct proc *p) {
+  // Close isnt working so leave these out for now.
+  int err = 0;
+  lck_mtx_lock(osquery.mtx);
+  if (osquery.open_count == 0) {
+    OSKextRetainKextWithLoadTag(OSKextGetCurrentLoadTag());  
+    osquery.open_count ++;
+  }
+#ifndef DEBUG
+  else {
+    err = -EACCES;
+    goto error_exit;
+  }
+#endif // !DEBUG
+
+error_exit:
+  lck_mtx_unlock(osquery.mtx);
+  return err;
+}
+
+static int osquery_close(dev_t dev, int flag, int fmt, struct proc *p) {
+  lck_mtx_lock(osquery.mtx);
+  if (osquery.open_count == 1) {
+    osquery.open_count--;
+    cleanup_user_kernel_buffer();
+    OSKextReleaseKextWithLoadTag(OSKextGetCurrentLoadTag());
+  }
+  lck_mtx_unlock(osquery.mtx);
+
+  return 0;
+}
+
+
+// All control should be from a single consumer, so we wrap all these calls
+// in locks to guarantee proper use.
+static int osquery_ioctl(dev_t dev, u_long cmd, caddr_t data,
+                         int flag, struct proc *p) {
+#ifdef DEBUG
+  static unsigned int test_counter = 0;
+  if (cmd == OSQUERY_IOCTL_TEST) {
+    if (osquery.buffer == NULL) {
+      return -EINVAL;
+    }
+    test_counter++;
+
+    void *e = NULL;
+    switch (*(int *)data) {
+      case 0:
+        e = osquery_cqueue_reserve(&osquery.cqueue, OSQUERY_TEST_EVENT_0);
+        break;
+      case 1:
+        e = osquery_cqueue_reserve(&osquery.cqueue, OSQUERY_TEST_EVENT_1);
+        break;
+      default:
+        return -ENOTTY;
+    }
+    if (!e) {
+      return -EINVAL;
+    }
+
+    *(int *)e = test_counter;
+    char *s = (char *)((int *)e + 1);
+    s[0] = 'H';
+    s[1] = 'E';
+    s[2] = 'L';
+    s[3] = 'L';
+    s[4] = 'O';
+    s[5] = '!';
+    s[6] = '\0';
+
+    osquery_cqueue_commit(&osquery.cqueue, e);
+
+    return 0;
+  }
+#endif // DEBUG
+
+  lck_mtx_lock(osquery.mtx);
+
+  int err = 0;
+  osquery_subscription_args_t *sub;
+  osquery_buf_update_args_t *update;
+  osquery_buf_allocate_args_t *alloc;
+
+  switch (cmd) {
+    case OSQUERY_IOCTL_SUBSCRIPTION:
+      sub = (osquery_subscription_args_t *)data;
+      if ((err = subscribe_to_event(sub->event, sub->subscribe))) {
+        goto error_exit;
+      }
+      break;
+    case OSQUERY_IOCTL_BUF_UPDATE:
+      update = (osquery_buf_update_args_t *)data;
+      if (osquery.buffer == NULL) {
+        err = -EINVAL;
+        goto error_exit;
+      }
+      lck_mtx_unlock(osquery.mtx);
+      if ((err = update_user_kernel_buffer(update->read_offset,
+                                           &(update->max_read_offset),
+                                           &(update->drops)))) {
+        lck_mtx_lock(osquery.mtx);
+        goto error_exit;
+      }
+      lck_mtx_lock(osquery.mtx);
+      break;
+    case OSQUERY_IOCTL_BUF_ALLOCATE:
+      alloc = (osquery_buf_allocate_args_t *)data;
+
+      if (osquery.buffer != NULL) {
+        // We don't want to allocate a second buffer.
+        err = -EINVAL;
+        goto error_exit;
+      }
+
+      if ((err = allocate_user_kernel_buffer(alloc->size, &(alloc->buffer)))) {
+        goto error_exit;
+      }
+
+      dbg_printf("IOCTL alloc: size %lu, location %p\n",
+                 alloc->size, alloc->buffer);
+      break;
+    default:
+      err = -ENOTTY;
+      goto error_exit;
+      break;
+  }
+error_exit:
+  lck_mtx_unlock(osquery.mtx);
+  return err;
+}
+
+// OSQuery character device switch structure.
+static struct cdevsw osquery_cdevsw = {
+    osquery_open,    // open_close_fcn_t *d_open;
+    osquery_close,   // open_close_fcn_t *d_close;
+    eno_rdwrt,       // read_write_fcn_t *d_read;
+    eno_rdwrt,       // read_write_fcn_t *d_write;
+    &osquery_ioctl,  // ioctl_fcn_t      *d_ioctl;
+    eno_stop,        // stop_fcn_t       *d_stop;
+    eno_reset,       // reset_fcn_t      *d_reset;
+    NULL,            // struct tty      **d_ttys;
+    eno_select,      // select_fcn_t     *d_select;
+    eno_mmap,        // mmap_fcn_t       *d_mmap;
+    eno_strat,       // strategy_fcn_t   *d_strategy;
+    eno_getc,        // getc_fcn_t       *d_getc;
+    eno_putc,        // putc_fcn_t       *d_putc;
+    0                // int               d_type;
+};
+
+kern_return_t OSQueryStart(kmod_info_t *ki, void *d) {
+  dbg_printf("OSQuery kernel module starting!\n");
+
+  osquery.major_number = cdevsw_add(osquery.major_number, &osquery_cdevsw);
+  if (osquery.major_number < 0) {
+    dbg_printf("Could not get a major number!\n");
+    goto error_exit;
+  }
+
+  osquery.devfs = devfs_make_node(makedev(osquery.major_number, 0),
+                                          DEVFS_CHAR, UID_ROOT, GID_WHEEL,
+                                          0644, "osquery", 0);
+  if (osquery.devfs == NULL) {
+    dbg_printf("Could not get a devfs entry!\n");
+    goto error_exit;
+  }
+
+  setup_locks();
+
+  return KERN_SUCCESS;
+error_exit:
+  if (osquery.devfs != NULL) {
+    devfs_remove(osquery.devfs);
+    osquery.devfs = NULL;
+  }
+
+  if (!(osquery.major_number < 0)) {
+    if (cdevsw_remove(osquery.major_number, &osquery_cdevsw) < 0) {
+      panic("OSQuery kext:  Cannot remove osquery from cdevsw");
+    }
+  }
+  return KERN_FAILURE;
+}
+
+kern_return_t OSQueryStop(kmod_info_t *ki, void *d) {
+  dbg_printf("OSQuery kernel module stoping!\n");
+
+  destroy_locks();
+
+  cleanup_user_kernel_buffer();
+
+  devfs_remove(osquery.devfs);
+  osquery.devfs = NULL;
+
+  if (cdevsw_remove(osquery.major_number, &osquery_cdevsw) < 0) {
+    panic("OSQuery kext:  Cannot remove osquery from cdevsw");
+  }
+
+  return KERN_SUCCESS;
+}
+
+extern "C" {
+extern kern_return_t _start(kmod_info_t *ki, void *data);
+extern kern_return_t _stop(kmod_info_t *ki, void *data);
+}
+
+KMOD_EXPLICIT_DECL(com.facebook.driver.osquery, VERSION, _start, _stop)
+__private_extern__ kmod_start_func_t *_realmain = OSQueryStart;
+__private_extern__ kmod_stop_func_t *_antimain = OSQueryStop;
+__private_extern__ int _kext_apple_cc = __APPLE_CC__;
+

--- a/kernel/test.sh
+++ b/kernel/test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e;
+
+if [[ $# -ne 3 ]]; then
+  exit -1
+fi
+
+echo "Testing...."
+
+make clean
+make debug
+make load
+make -C user/ all
+
+CONSUMER=$1
+PRODUCER=$2
+NUMBER=$3
+
+sudo $CONSUMER &
+CONSUMER_PID=$!
+sleep 1;
+PRODUCERS=()
+RETPRODUCERS=0
+RETCONSUMERS=0
+for ((i=0;i<$NUMBER;i++)); do
+  sudo $PRODUCER $((i%2)) &
+  PRODUCERS[$i]=$!
+done
+wait ${PRODUCERS[@]} || RETPRODUCERS=$?
+sudo pkill -2 -P $CONSUMER_PID || true
+wait $CONSUMER_PID || RETCONSUMERS=$?
+
+make unload
+
+exit $(( RETPRODUCERS | RETCOSUMERS ))
+

--- a/kernel/user/Makefile
+++ b/kernel/user/Makefile
@@ -1,0 +1,45 @@
+# OS X kext testing makefile
+VERSION:=$(shell git describe --tags HEAD --always)
+VERSION_DEFINE:=-DVERSION="\"$(VERSION)\""
+
+CXX:=clang++
+SHELL:=/bin/bash
+
+USER_INCLUDE_DIR:=include/
+USER_INCLUDES:=$(wildcard $(USER_INCLUDE_DIR)*.h)
+USER_INCLUDE:=-I$(USER_INCLUDE_DIR)
+KERNEL_INCLUDE_DIR:=../include/
+KERNEL_INCLUDES:=$(wildcard $(KERNEL_INCLUDE_DIR)*.h)
+KERNEL_INCLUDE:=-I$(KERNEL_INCLUDE_DIR)
+INCLUDES:=$(USER_INCLUDES) $(KERNEL_INCLUDES)
+INCLUDE:=$(USER_INCLUDE) $(KERNEL_INCLUDE)
+
+CXXFLAGS:=$(INCLUDE) $(VERSION_DEFINE) -DDEBUG
+LDFLAGS:=
+
+SOURCE_DIR:=src/
+TEST_DIR:=test/
+BUILD_DIR:=../build/
+
+TEST_SOURCES:=$(wildcard $(TEST_DIR)*.cpp)
+CXXSOURCES:=$(wildcard $(SOURCE_DIR)*.cpp)
+SOURCES:=$(CXXSORUCES) $(TEST_SOURCES)
+CXXOBJECTS:= $(addprefix $(BUILD_DIR), $(notdir $(CXXSOURCES:.cpp=.cpp.o)))
+OBJECTS:= $(addprefix $(BUILD_DIR), $(notdir $(TEST_SORUCES:.cpp=.cpp.o))) \
+  $(CXXOBJECTS)
+
+EXECUTABLES:=$(addprefix $(BUILD_DIR), $(notdir $(TEST_SOURCES:.cpp=.out)))
+
+
+.PHONY: all
+all: $(EXECUTABLES)
+
+$(BUILD_DIR)%.cpp.o: $(TEST_DIR)%.cpp $(INCLUDES)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR)%.cpp.o: $(SOURCE_DIR)%.cpp $(INCLUDES)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(BUILD_DIR)%.out: $(BUILD_DIR)%.cpp.o $(CXXOBJECTS)
+	$(CXX) $(LDFLAGS) $< $(OBJECTS) -o $@
+

--- a/kernel/user/include/circular_queue_user.h
+++ b/kernel/user/include/circular_queue_user.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <feeds.h>
+
+#include <stdexcept>
+
+class CQueueException : public std::runtime_error {
+ public:
+  explicit CQueueException(const char *str) : std::runtime_error(str) {};
+};
+
+class CQueue {
+ public:
+  /**
+   * @brief Creates cqueue.
+   *
+   * This connects to the osquery kernel extension dev file and sets up a
+   * shared buffer of the specified size.  The size must be accepted by the
+   * kernel extension.
+   *
+   * @param size The size of the shared buffer used for communication.
+   */
+  CQueue(size_t size);
+
+  /**
+   * @brief Cleanup a cqueue.
+   *
+   * This closes the connection with dev port and frees up kernel resources.
+   * Like the shared buffer.
+   */
+  ~CQueue();
+
+  /**
+   * @brief Sends a subscription call to the kernel extension.
+   *
+   * This sets up the event callbacks so we start hearing about the given event.
+   *
+   * @param event The event we are interested in.
+   */
+  void subscribe(osquery_event_t event);
+
+  /**
+   * @brief Dequeue's an event from the shared buffer.
+   *
+   * @param event (ouput) A pointer to the event dequeue if any.
+   * @return Returns 0 if queue is empty, otherwise the number of the event put
+   * into event.
+   */
+  osquery_event_t dequeue(void **event);
+
+  /**
+   * @brief Sync the cqueue structure with the cqueue structure in the kernel.
+   *
+   * This allow the two view of the buffer to maintain consistency.
+   *
+   * @return Returns the number of dropped events, or negative if too many.
+   */
+  int kernelSync();
+
+ private:
+  uint8_t *buffer_;
+  size_t size_;
+  uint8_t *max_read_;
+  uint8_t *read_;
+  int fd_;
+};
+

--- a/kernel/user/src/circular_queue_user.cpp
+++ b/kernel/user/src/circular_queue_user.cpp
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <circular_queue_user.h>
+
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+CQueue::CQueue(size_t size) {
+  buffer_ = NULL;
+  size_ = 0;
+  max_read_ = NULL;
+  read_ = NULL;
+  fd_ = -1;
+
+  const char *filename = "/dev/osquery";
+  osquery_buf_allocate_args_t alloc;
+  alloc.size = size;
+  alloc.buffer = NULL;
+
+  fd_ = open(filename, O_RDWR);
+  if (fd_ < 0) {
+    throw CQueueException("Could not open character device.");
+  }
+
+  if (ioctl(fd_, OSQUERY_IOCTL_BUF_ALLOCATE, &alloc)) {
+    throw CQueueException("Could not allocate shared buffer.");
+  }
+
+  buffer_ = (uint8_t *)alloc.buffer;
+  size_ = size;
+  read_ = (uint8_t *)alloc.buffer;
+  max_read_ = (uint8_t *)alloc.buffer;
+}
+
+CQueue::~CQueue() {
+  if (fd_ >= 0) {
+    printf("Cleaning up %d\n", fd_);
+    close(fd_);
+    fd_ = -1;
+  }
+}
+
+void CQueue::subscribe(osquery_event_t event) {
+  osquery_subscription_args_t sub;
+  sub.event = event;
+  sub.subscribe = 1;
+
+  if (ioctl(fd_, OSQUERY_IOCTL_SUBSCRIPTION, &sub)) {
+    throw CQueueException("Could not subscribe to event.");
+  }
+}
+
+osquery_event_t CQueue::dequeue(void **event) {
+  if (read_ == max_read_) {
+    return (osquery_event_t)0;
+  }
+  osquery_data_header_t *header = (osquery_data_header_t *)read_;
+  if (header->event == END_OF_BUFFER_EVENT) {
+    read_ = buffer_;
+    if (read_ == max_read_) {
+      return (osquery_event_t)0;
+    }
+  }
+  header = (osquery_data_header_t *)read_;
+  if (header->event != END_OF_BUFFER_EVENT) {
+    size_t size = osquery_sizeof_event(header->event)
+      + sizeof(osquery_data_header_t);
+    read_ = (read_ + size - buffer_) % size_ + buffer_;
+  }
+
+
+  *event = (void *)(header + 1);
+  return header->event;
+}
+
+// return positive idicates drop, 0 is all good in the hood.
+int CQueue::kernelSync() {
+  osquery_buf_update_args_t update;
+  update.read_offset = read_ - buffer_;
+
+  int err = 0;
+  if ((err = ioctl(fd_, OSQUERY_IOCTL_BUF_UPDATE, &update))) {
+    throw CQueueException("Could not sync buffer with kernel properly.");
+  }
+  uint8_t *new_max_read =  update.max_read_offset + buffer_;
+  max_read_ = new_max_read;
+  if (err) {
+    read_ = max_read_;
+  }
+
+  return update.drops;
+}
+

--- a/kernel/user/test/consumer.cpp
+++ b/kernel/user/test/consumer.cpp
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <circular_queue_user.h>
+#include <stdio.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include <stdexcept>
+#include <iostream>
+
+static int exit_flag = 0;
+
+void sig_handler(int s){
+  printf("Consumer task has finished. Signal %d\n",s);
+  
+  exit_flag = 1;
+}
+
+int main() {
+  int drops = 0;
+  int reads = 0;
+  struct sigaction sigIntHandler;
+
+  sigIntHandler.sa_handler = sig_handler;
+  sigemptyset(&sigIntHandler.sa_mask);
+  sigIntHandler.sa_flags = 0;
+
+  sigaction(SIGINT, &sigIntHandler, NULL);
+  
+  try {
+  CQueue cqueue(20 * (1<<20));
+
+  test_event_0_data_t *my_event;
+  osquery_event_t event;
+  void *event_buf = NULL;
+  while(!exit_flag) {
+    drops += cqueue.kernelSync();
+    int max_before_sync = 2000;
+    while (max_before_sync > 0 && (event = cqueue.dequeue(&event_buf))) {
+      switch (event) {
+        case OSQUERY_TEST_EVENT_0:
+        case OSQUERY_TEST_EVENT_1:
+          // Do something with the event_buf now.
+          reads++;
+          break;
+        default:
+          throw std::runtime_error("Uh oh. Unknown event.");
+      }
+      max_before_sync --;
+    }
+  }
+  } catch (const CQueueException &e) {
+    std::cerr << e.what() << std::endl;
+  }
+  printf("Read %d, entries.\n", reads);
+  printf("Dropped %d, entries.\n", drops);
+
+  return 0;
+}
+

--- a/kernel/user/test/producer.cpp
+++ b/kernel/user/test/producer.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <feeds.h>
+
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  int err = 0;
+  if (argc < 2) {
+    return -10;
+  }
+
+  int n = atoi(argv[1]);
+  const char *filename = "/dev/osquery";
+  int fd = open(filename, O_RDWR);
+  if (fd < 0) {
+    err = -11;
+    goto error_exit;
+  }
+
+  for (uint32_t i = 0; i < 1000000; i ++) {
+    if ((err = ioctl(fd, OSQUERY_IOCTL_TEST, &n))) {
+      goto error_exit;
+    }
+  }
+
+error_exit:
+  if (fd >= 0) {
+    close(fd);
+  }
+  printf("Producer task finished. err = %d\n", err);
+
+  return err;
+}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,3 +35,4 @@ pages:
 - ['development/options-arguments.md', 'Development', 'Adding CLI Arguments']
 - ['development/reading-files.md', 'Development', 'Reading/Writing Files']
 - ['development/wildcard-rules.md', 'Development', 'Wildcards and Globbing']
+- ['development/kernel.md', 'Development', 'Kernel OS X']


### PR DESCRIPTION
This pull request is mostly for people to follow the development of osquery's entry into the kernel, and provide suggestions.

This kernel extension for OS X has the goal to create a communication channel for kernel event data to get to osquery's user land daemon.  A ring buffer will be used to pass data through a buffer that is mapped in the kernel's memory as well as the daemon's memory.