### PR TITLE
Fix FSEvents multiplexing actions

### DIFF
--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -278,6 +278,17 @@ TEST_F(FSEventsTests, test_fsevents_event_action) {
   ASSERT_TRUE(sub->actions_.size() > 0);
   EXPECT_EQ(sub->actions_[0], "CREATED");
 
+  CreateEvents();
+  sub->WaitForEvents(kMaxEventLatency, 2);
+  bool has_updated = false;
+  // We may have triggered several updated events.
+  for (const auto& action : sub->actions_) {
+    if (action == "UPDATED") {
+      has_updated = true;
+    }
+  }
+  EXPECT_TRUE(has_updated);
+
   EndEventLoop();
 }
 }


### PR DESCRIPTION
The FSEvent action mask was overwriting multiplexed actions. We should fire an event for each action applied to a path during a transaction. For example: if a file was created, an FSEvents transaction may buffer the open and write events into a single transaction. Our publisher's callback would overwrite each action with the last in the mask-walk.