### PR TITLE
Process open sockets on Linux needs '['

### DIFF
--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -9,6 +9,7 @@ schema([
     Column("remote_address", TEXT, "Socket remote address"),
     Column("local_port", INTEGER, "Socket local port"),
     Column("remote_port", INTEGER, "Socket remote port"),
+    Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
 ])
 implementation("system/process_open_sockets@genOpenSockets")
 examples([


### PR DESCRIPTION
Again, this is only network/raw sockets. The format for UNIX sockets is a bit different and might be able to be merged into the `process_open_sockets` table with an optional `path` column. 