### PR TITLE
[Fix #1202] Replace argv[*] with spaces, fallback to path in [0]

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -270,15 +270,20 @@ void Initializer::initWatcher() {
 void Initializer::initWorker(const std::string& name) {
   // Clear worker's arguments.
   size_t name_size = strlen((*argv_)[0]);
+  auto original_name = std::string((*argv_)[0]);
   for (int i = 0; i < *argc_; i++) {
     if ((*argv_)[i] != nullptr) {
-      memset((*argv_)[i], 0, strlen((*argv_)[i]));
+      memset((*argv_)[i], ' ', strlen((*argv_)[i]));
     }
   }
 
   // Set the worker's process name.
-  if (name.size() <= name_size) {
+  if (name.size() < name_size) {
     std::copy(name.begin(), name.end(), (*argv_)[0]);
+    (*argv_)[0][name.size()] = '\0';
+  } else {
+    std::copy(original_name.begin(), original_name.end(), (*argv_)[0]);
+    (*argv_)[0][original_name.size()] = '\0';
   }
 
   // Start a watcher watcher thread to exit the process if the watcher exits.


### PR DESCRIPTION
If the original string size of argv[0] was less than the size of the overwriting (helpful) worker name replacement, the argv[*] memory would remain = NULL.