### PR TITLE
Various quality control fixes

### DIFF
--- a/docs/doxygen/DOXYGEN-LICENSE.txt
+++ b/docs/doxygen/DOXYGEN-LICENSE.txt
@@ -1,4 +1,4 @@
-AL PUBLIC LICENSE
+                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>

--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -13,8 +13,7 @@ a query schedule from a configuration.
 ## Configuration components
 
 The osquery "configuration" is read from a config plugin. This plugin is a data retrieval method and is set to **filesystem** by default.
-Other retrieval and run-time updating methods may include an HTTL/TLS request.
-In each case the response data must be JSON-formatted.
+Other retrieval and run-time updating methods may include a HTTP/TLS request using the **tls** config plugin. In all cases the response data must be JSON-formatted.
 
 There are several components to a configuration:
 

--- a/docs/wiki/development/osquery-sdk.md
+++ b/docs/wiki/development/osquery-sdk.md
@@ -63,7 +63,7 @@ The osqueryi or osqueryd processes start an "extension manager" thrift service t
 
 **Extension API**
 
-An extension process should implement the following API. During an extension's set up it will "broadcast" all the registered plugins to and osqueryi or osqueryd process. Then the extension will be asked to start a UNIX domain socket and thrift service thread implementing the `ping` and `call` methods.
+An extension process should implement the following API. During an extension's set up it will "broadcast" all the registered plugins to an osqueryi or osqueryd process. Then the extension will be asked to start a UNIX domain socket and thrift service thread implementing the `ping` and `call` methods.
 
 ```thrift
 service Extension {


### PR DESCRIPTION
1. Doxygen license was missing a few bytes.
2. RTD wiki pages have some grammar issues.