### PR TITLE
[#1207] Add syslog plugin

### DIFF
--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -6,6 +6,7 @@ add_dependencies(osquery_logger libglog)
 ADD_OSQUERY_LIBRARY(FALSE osquery_logger_plugins
   plugins/filesystem.cpp
   plugins/tls.cpp
+  plugins/syslog.cpp
 )
 
 file(GLOB OSQUERY_LOGGER_TESTS "tests/*.cpp")

--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <syslog.h>
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+
+namespace osquery {
+
+FLAG(int32,
+     logger_syslog_facility,
+     LOG_LOCAL3 >> 3,
+     "Syslog facility for status and results logs (0-23, default 19)");
+
+class SyslogLoggerPlugin : public LoggerPlugin {
+ public:
+  Status logString(const std::string& s);
+  Status init(const std::string& name, const std::vector<StatusLogLine>& log);
+  Status logStatus(const std::vector<StatusLogLine>& log);
+};
+
+REGISTER(SyslogLoggerPlugin, "logger", "syslog");
+
+Status SyslogLoggerPlugin::logString(const std::string& s) {
+  for (const auto& line : osquery::split(s, "\n")) {
+    syslog(LOG_INFO, "result=%s", line.c_str());
+  }
+  return Status(0, "OK");
+}
+
+Status SyslogLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
+  for (const auto& item : log) {
+    int severity = LOG_NOTICE;
+    if (item.severity == O_INFO) {
+      severity = LOG_NOTICE;
+    } else if (item.severity == O_WARNING) {
+      severity = LOG_WARNING;
+    } else if (item.severity == O_ERROR) {
+      severity = LOG_ERR;
+    } else if (item.severity == O_FATAL) {
+      severity = LOG_CRIT;
+    }
+
+    std::string line = "severity=" + std::to_string(item.severity)
+                    + " location=" + item.filename + ":" + std::to_string(item.line) +
+                      " message=" + item.message;
+
+    syslog(severity, "%s", line.c_str());
+  }
+  return Status(0, "OK");
+}
+
+Status SyslogLoggerPlugin::init(const std::string& name,
+                                const std::vector<StatusLogLine>& log) {
+  closelog();
+
+  // Define the syslog/target's application name.
+  if (FLAGS_logger_syslog_facility < 0 ||
+      FLAGS_logger_syslog_facility > 23) {
+    FLAGS_logger_syslog_facility = LOG_LOCAL3 >> 3;
+  }
+  openlog(name.c_str(), LOG_PID | LOG_CONS, FLAGS_logger_syslog_facility << 3);
+
+  // Now funnel the intermediate status logs provided to `init`.
+  return logStatus(log);
+}
+}


### PR DESCRIPTION
How to use: `--logger_plugin=syslog`.

You *should* set up a facility sink for `LOG_LOCAL3` and expect the following:

1. Results go to `LOG_INFO`, this is typically dropped from the normal system log because it is verbose.
2. If using debug/verbose mode (`--verbose`) you will get `LOG_NOTICE` status lines.
3. Warning and osquery error logs go to `LOG_WARNING` and `LOG_ERR` respectively.

The result JSON in syslog format, note the `result=` followed by JSON:
```
Jun 12 18:12:24 reed-mbp.local osqueryd[86786]: result={"name":"info","hostIdentifier":"reed-mbp.local","calendarTime":"Sat Jun 13 01:12:24 2015 UTC","unixTime":"1434157944","columns":{"build_distro":"10.10","build_platform":"darwin","config_md5":"d3690eac60986d212fe52a687aed3431","config_path":"\/Users\/reed\/osquery-custom.conf","extensions":"active","hour":"18","minutes":"12","pid":"86786","resident_size":"7475200","seconds":"24","system_time":"20","user_time":"32","version":"1.4.6-4-g0e3fef9"},"action":"added"}
```

The status logs, note `severity={0,1,2}` for INFO, WARN, ERROR, `location=` for the location in code/source of the status and `message=` containing the raw string status:
```
Jun 12 18:12:21 reed-mbp.local osqueryd[86786]: severity=0 location=init.cpp:190 message=osquery worker initialized [watcher=86786]
Jun 12 18:12:21 reed-mbp.local osqueryd[86786]: severity=0 location=file_events.cpp:58 message=Added listener to: /bin/zsh
Jun 12 18:12:21 reed-mbp.local osqueryd[86786]: severity=0 location=file_events.cpp:58 message=Added listener to: /tmp
Jun 12 18:12:21 reed-mbp.local osqueryd[86786]: severity=0 location=events.cpp:429 message=Starting event publisher run loop: fsevents
```

N.B. In all cases, even if you do not enable the syslog plugin, the daemon will write an "announce" to syslog using the default facility and `LOG_NOTICE`, induced [here](https://github.com/facebook/osquery/blob/master/osquery/core/init.cpp#L217).