### PR TITLE
OS X application duti/scheme listing table

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -51,6 +51,8 @@ namespace osquery {
 #define BIGINT(x) boost::lexical_cast<std::string>(x)
 /// See the affinity type documentation for TEXT.
 #define UNSIGNED_BIGINT(x) boost::lexical_cast<std::string>(x)
+/// See the affinity type documentation for TEXT.
+#define DOUBLE(x) boost::lexical_cast<std::string>(x)
 
 /**
  * @brief The SQLite type affinities as represented as implementation literals.
@@ -67,6 +69,8 @@ namespace osquery {
 #define BIGINT_LITERAL long long int
 /// See the literal type documentation for TEXT_LITERAL.
 #define UNSIGNED_BIGINT_LITERAL unsigned long long int
+/// See the literal type documentation for TEXT_LITERAL.
+#define DOUBLE_LITERAL double
 /// Cast an SQLite affinity type to the literal type.
 #define AS_LITERAL(literal, value) boost::lexical_cast<literal>(value)
 
@@ -89,7 +93,7 @@ enum ConstraintOperator : unsigned char {
   GREATER_THAN_OR_EQUALS = 32
 };
 
-/// Type for flags for what constraint operators are admissable.
+/// Type for flags for what constraint operators are admissible.
 typedef unsigned char ConstraintOperatorFlag;
 /// Flag for any operator type.
 #define ANY_OP 0xFFU

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -172,7 +172,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
       if (Flag::isDefault("database_path")) {
         osquery::FLAGS_database_path = homedir + "/shell.db";
       }
-      if (Flag::isDefault("extension_socket")) {
+      if (Flag::isDefault("extensions_socket")) {
         osquery::FLAGS_extensions_socket = homedir + "/shell.em";
       }
     }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -144,6 +144,16 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
               << ") to BIGINT";
     }
     sqlite3_result_int64(ctx, afinite);
+  } else if (type == "DOUBLE") {
+    double afinite;
+    try {
+      afinite = boost::lexical_cast<double>(value);
+    } catch (const boost::bad_lexical_cast &e) {
+      afinite = 0;
+      VLOG(1) << "Error casting" << column_name << " (" << value
+              << ") to DOUBLE";
+    }
+    sqlite3_result_double(ctx, afinite);
   }
 
   return SQLITE_OK;

--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -139,9 +139,9 @@ void parseWhereFrom(QueryData &results, const std::string &path) {
   CFRelease(attributes);
 }
 
-void extractQuarantineProperty(const std::string table_key_name,
+void extractQuarantineProperty(const std::string &table_key_name,
                                CFTypeRef property,
-                               const std::string path,
+                               const std::string &path,
                                QueryData &results) {
   std::string value;
   if (CFGetTypeID(property) == CFStringGetTypeID()) {

--- a/specs/darwin/app_schemes.table
+++ b/specs/darwin/app_schemes.table
@@ -1,0 +1,12 @@
+table_name("app_schemes")
+description("OS X application schemes and handlers (e.g., http, file, mailto.")
+schema([
+    Column("scheme", TEXT, "Name of the scheme/protocol"),
+    Column("handler", TEXT, "Application label for the handler"),
+    Column("enabled", INTEGER, "1 if this handler is the OS default, else 0"),
+    Column("external", INTEGER,
+        "1 if this handler does NOT exist on OS X by default, else 0"),
+    Column("protected", INTEGER,
+        "1 if this handler is protected (reserved) by OS X, else 0"),
+])
+implementation("apps@genAppSchemes")

--- a/specs/darwin/package_receipts.table
+++ b/specs/darwin/package_receipts.table
@@ -5,7 +5,7 @@ schema([
     Column("package_filename", TEXT, "Filename of original .pkg file"),
     Column("version", TEXT, "Installed package version"),
     Column("location", TEXT, "Optional relative install path on volume"),
-    Column("install_time", INTEGER, "Timestamp of install time"),
+    Column("install_time", DOUBLE, "Timestamp of install time"),
     Column("installer_name", TEXT, "Name of installer process"),
     Column("path", TEXT, "Path of receipt plist",
       index=True, additional=True),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -53,6 +53,7 @@ DATETIME = DataType("TEXT")
 INTEGER = DataType("INTEGER", "int")
 BIGINT = DataType("BIGINT", "long long int")
 UNSIGNED_BIGINT = DataType("UNSIGNED_BIGINT", "long long unsigned int")
+DOUBLE = DataType("DOUBLE", "double")
 
 # Define table-category MACROS from the table specs
 UNKNOWN = "UNKNOWN"


### PR DESCRIPTION
This virtual table adds information about common OS X application schemes. A scheme, or protocol (e.g., `https://`, `tel://`, `ssh://`), may be used for IPC between applications by constructing URI definitions. Because of this, applications may define somewhat-arbitrary scheme names. We say "common" because automatic enumeration of schemes is handled by private OS X APIs in Core and Launch Services. However, we know the scheme name a-priori we can query for information.

There are several well-known schemes that are handled by the OS. This means the application handler is determined by a preference or ACL/enable controlled by the user/OS. Launch Services/Inter-App Communication [documentation](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/Inter-AppCommunication/Inter-AppCommunication.html) lists: `http`, `mailto`, `tel`, and `sms` as non-overridable/controllable. We call these "protected" such that an application cannot request to be the scheme application/handler without an acknowledge from the system owner.

We consider the following definitions from Launch Services as the protected set, it may not be complete/accurate:
```
__const:0000000000128C60 _FSNodeCopyURLFromLocatorContent_interestingSchemes dq offset cfstr_Nwnode
__const:0000000000128C60                                         ; DATA XREF: _FSNodeCopyURLFromLocatorContent+12Ao
__const:0000000000128C60                                         ; "nwnode"
__const:0000000000128C68                 dq offset cfstr_Afp     ; "afp"
__const:0000000000128C70                 dq offset cfstr_Smb     ; "smb"
__const:0000000000128C78                 align 20h
```
and
```
__const:0000000000128B50 _FSNodeCopyURLFromLocatorContent_schemeExtensionMap dq offset cfstr_Http
__const:0000000000128B50                                         ; DATA XREF: _FSNodeCopyURLFromLocatorContent+372o
__const:0000000000128B50                                         ; _FSNodeCopyURLFromLocatorContent+5A6o
__const:0000000000128B50                                         ; "http"
__const:0000000000128B58                 dq offset aWebloc       ; "webloc"
__const:0000000000128B60 aThli           db 'thli',0
__const:0000000000128B65                 align 8
__const:0000000000128B68 off_128B68      dq offset cfstr_Https   ; DATA XREF: _FSNodeCopyURLFromLocatorContent+5C0o
__const:0000000000128B68                                         ; "https"
__const:0000000000128B70 off_128B70      dq offset aWebloc       ; DATA XREF: _FSNodeCopyURLFromLocatorContent+2F8o
__const:0000000000128B70                                         ; _FSNodeCopyURLFromLocatorContent+34Fo
__const:0000000000128B70                                         ; "webloc"
__const:0000000000128B78 aThli_0         db 'thli',0
__const:0000000000128B7D                 align 20h
__const:0000000000128B80                 dq offset cfstr_Ftp     ; "ftp"
__const:0000000000128B88                 dq offset aFtploc       ; "ftploc"
__const:0000000000128B90 aTfli           db 'tfli',0
__const:0000000000128B95                 align 8
__const:0000000000128B98                 dq offset cfstr_File    ; "file"
__const:0000000000128BA0                 dq offset aFileloc      ; "fileloc"
__const:0000000000128BA8 aIfli           db 'ifli',0
__const:0000000000128BAD                 align 10h
__const:0000000000128BB0                 dq offset cfstr_Mailto  ; "mailto"
__const:0000000000128BB8                 dq offset aMailloc      ; "mailloc"
__const:0000000000128BC0 aAmli           db 'amli',0
__const:0000000000128BC5                 db    0
__const:0000000000128BC6                 db    0
__const:0000000000128BC7                 db    0
__const:0000000000128BC8                 dq offset cfstr_News    ; "news"
__const:0000000000128BD0                 dq offset aNewsloc      ; "newsloc"
__const:0000000000128BD8 aWnli           db 'wnli',0
__const:0000000000128BDD                 align 20h
__const:0000000000128BE0                 dq offset cfstr_Afp     ; "afp"
__const:0000000000128BE8                 dq offset aAfploc       ; "afploc"
__const:0000000000128BF0 aFali           db 'fali',0
__const:0000000000128BF5                 align 8
__const:0000000000128BF8                 dq offset cfstr_At      ; "at"
__const:0000000000128C00                 dq offset aAtloc        ; "atloc"
__const:0000000000128C08 aTali           db 'tali',0
__const:0000000000128C0D                 align 10h
__const:0000000000128C10                 dq offset cfstr_Vnc     ; "vnc"
__const:0000000000128C18                 dq offset aVncloc       ; "vncloc"
__const:0000000000128C20 aNvli           db 'nvli',0
__const:0000000000128C25                 align 10h
__const:0000000000128C30                 dq offset aInetloc      ; "inetloc"
```

There are also schemes present at OS install, and they include handlers for application-used schemes as well as common network protocol schemes. We define any scheme "added" post OS-install as "external".