### PR TITLE
Remove OS X 10.9 code path

### DIFF
--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -167,28 +167,12 @@ void parseQuarantineFile(QueryData &results, const std::string &path) {
   }
 
   CFTypeRef quarantine_properties;
-#if defined(DARWIN_10_9)
-  FSRef fs_url;
-  if (!CFURLGetFSRef(url, &fs_url)) {
-    VLOG(1) << "Error obtaining FSRef for " << path;
-    VLOG(1) << "Unable to fetch quarantine data";
-    CFRelease(url);
-    return;
-  }
-  if (LSCopyItemAttribute(&fs_url, kLSRolesAll, kLSItemQuarantineProperties,
-                          &quarantine_properties) != noErr) {
-    VLOG(1) << "Error retrieving quarantine properties for " << path;
-    CFRelease(url);
-    return;
-  }
-#else
   if (!CFURLCopyResourcePropertyForKey(url, kCFURLQuarantinePropertiesKey,
                                        &quarantine_properties, nullptr)) {
     VLOG(1) << "Error retrieving quarantine properties for " << path;
     CFRelease(url);
     return;
   }
-#endif
 
   if (quarantine_properties == nullptr) {
     VLOG(1) << "Error retrieving quarantine properties for " << path;


### PR DESCRIPTION
Just noticed osquery 1.4.7 land in brew, and that it removes Mavericks supports.

This change removes 10.9 code path since we no longer support it. 
This is the only instance of it that I found, which I had added in `extended_attributes` to support Mavericks.

Context: File Manager, `FSRef` (carbon era) APIs have been deprecated in favor of CoreFoundation ones.