### PR TITLE
[Fix #1220] osqueryd watchdog tests

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -184,12 +184,12 @@ class ProcRunner(object):
         try:
             proc = psutil.Process(pid=self.proc.pid)
             delay = 0
-            while len(proc.get_children()) == 0:
+            while len(proc.children()) == 0:
                 if delay > max_interval:
                     return []
                 time.sleep(self.interval)
                 delay += self.interval
-            return [p.pid for p in proc.get_children()]
+            return [p.pid for p in proc.children()]
         except:
             pass
         return []


### PR DESCRIPTION
This change updates tests to use psutil's `Process.children()` instead of `Process.get_children()` as the latter has been deprecated.

`Process.get_children()` had been deprecated in psutil 2.x and is compeletely removed in 3.x versions
in favor of `Process.children()`.

[Here is the list](https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#200---2014-03-10) of replacement API for all `Process.get` functions.

This fixes #1220. I am not so sure that this is related to #1198, but I have yet to encounter it.

