### PR TITLE
Updated the MkDocs config from the deprecated format

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,35 +4,36 @@ theme: readthedocs
 docs_dir: docs/wiki
 site_dir: build/wiki
 pages:
-- ['index.md', 'Introduction', 'Welcome to osquery']
+- Introduction:
+  - Welcome to osquery: index.md
+  - Features Overview: introduction/overview.md
+  - osqueryi (shell): introduction/using-osqueryi.md
+  - osqueryd (daemon): introduction/using-osqueryd.md
+- Installation:
+  - Install on OS X: installation/install-osx.md
+  - Install on Linux: installation/install-linux.md
+  - Command Line Flags: installation/cli-flags.md
+  - 'Optional: Custom Packages': installation/custom-packages.md
+- Deployment:
+  - Configuration: deployment/configuration.md
+  - Logging: deployment/logging.md
+  - Aggregating Logs: deployment/log-aggregation.md
+  - Performance Safety: deployment/performance-safety.md
+  - Anomaly Detection: deployment/anomaly-detection.md
+  - Extensions: deployment/extensions.md
+  - File Integrity Monitoring: deployment/file-integrity-monitoring.md
+  - YARA Scanning: deployment/yara.md
+  - Remote settings: deployment/remote.md
+- Development:
+  - Building osquery: development/building.md
+  - Contributing Code: development/contributing-code.md
+  - Creating New Tables: development/creating-tables.md
+  - Configuration Plugins: development/config-plugins.md
+  - Logging Plugins: development/logger-plugins.md
+  - SDK and Extensions: development/osquery-sdk.md
+  - Eventing Framework: development/pubsub-framework.md
+  - Writing Tests: development/unit-tests.md
+  - Adding CLI Arguments: development/options-arguments.md
+  - Reading/Writing Files: development/reading-files.md
+  - Wildcards and Globbing: development/wildcard-rules.md
 
-- ['introduction/overview.md', 'Introduction', 'Features Overview']
-- ['introduction/using-osqueryi.md', 'Introduction', 'osqueryi (shell)']
-- ['introduction/using-osqueryd.md', 'Introduction', 'osqueryd (daemon)']
-
-- ['installation/install-osx.md', 'Installation', 'Install on OS X']
-- ['installation/install-linux.md', 'Installation', 'Install on Linux']
-- ['installation/cli-flags.md', 'Installation', 'Command Line Flags']
-- ['installation/custom-packages.md', 'Installation', 'Optional: Custom Packages']
-
-- ['deployment/configuration.md', 'Deployment', 'Configuration']
-- ['deployment/logging.md', 'Deployment', 'Logging']
-- ['deployment/log-aggregation.md', 'Deployment', 'Aggregating Logs']
-- ['deployment/performance-safety.md', 'Deployment', 'Performance Safety']
-- ['deployment/anomaly-detection.md', 'Deployment', 'Anomaly Detection']
-- ['deployment/extensions.md', 'Deployment', 'Extensions']
-- ['deployment/file-integrity-monitoring.md', 'Deployment', 'File Integrity Monitoring']
-- ['deployment/yara.md', 'Deployment', 'YARA Scanning']
-- ['deployment/remote.md', 'Deployment', 'Remote settings']
-
-- ['development/building.md', 'Development', 'Building osquery']
-- ['development/contributing-code.md', 'Development', 'Contributing Code']
-- ['development/creating-tables.md', 'Development', 'Creating New Tables']
-- ['development/config-plugins.md', 'Development', 'Configuration Plugins']
-- ['development/logger-plugins.md', 'Development', 'Logging Plugins']
-- ['development/osquery-sdk.md', 'Development', 'SDK and Extensions']
-- ['development/pubsub-framework.md', 'Development', 'Eventing Framework']
-- ['development/unit-tests.md', 'Development', 'Writing Tests']
-- ['development/options-arguments.md', 'Development', 'Adding CLI Arguments']
-- ['development/reading-files.md', 'Development', 'Reading/Writing Files']
-- ['development/wildcard-rules.md', 'Development', 'Wildcards and Globbing']


### PR DESCRIPTION
This requires MkDocs version [>= 0.13](http://www.mkdocs.org/about/release-notes/#version-0130-2015-05-26). ReadTheDocs has supported this for almost [a month](https://github.com/rtfd/readthedocs.org/commit/45ad95e8a181775247d65540eed625e4fa454e01#diff-5b28a0936ff1b3e6ec6fadb83bf59fb5), they just updated to [0.14](https://github.com/rtfd/readthedocs.org/commit/7d4d2eb9de40c2593a3933b33413e95c2eadb345). The change will also fix the one build warning you [currently get](https://readthedocs.org/builds/osquery/3004041/).