### PR TITLE
[Fix #1198] Faster death/timeout checks in extensions tests

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -23,7 +23,7 @@ DECLARE_string(extensions_timeout);
 DECLARE_bool(disable_extensions);
 
 /// A millisecond internal applied to extension initialization.
-extern const int kExtensionInitializeMLatency;
+extern const size_t kExtensionInitializeLatencyUS;
 
 /**
  * @brief Helper struct for managing extenion metadata.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -304,15 +304,18 @@ void Initializer::initActivePlugin(const std::string& type,
                                    const std::string& name) {
   // Use a delay, meaning the amount of milliseconds waited for extensions.
   size_t delay = 0;
-  // The timeout is the maximum time in seconds to wait for extensions.
-  size_t timeout = atoi(FLAGS_extensions_timeout.c_str());
+  // The timeout is the maximum microseconds in seconds to wait for extensions.
+  size_t timeout = atoi(FLAGS_extensions_timeout.c_str()) * 1000000;
+  if (timeout < kExtensionInitializeLatencyUS * 10) {
+    timeout = kExtensionInitializeLatencyUS * 10;
+  }
   while (!Registry::setActive(type, name)) {
-    if (!Watcher::hasManagedExtensions() || delay > timeout * 1000) {
+    if (!Watcher::hasManagedExtensions() || delay > timeout) {
       LOG(ERROR) << "Active " << type << " plugin not found: " << name;
       ::exit(EXIT_CATASTROPHIC);
     }
-    ::usleep(kExtensionInitializeMLatency * 1000);
-    delay += kExtensionInitializeMLatency;
+    delay += kExtensionInitializeLatencyUS;
+    ::usleep(kExtensionInitializeLatencyUS);
   }
 }
 

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -197,6 +197,7 @@ class ExtensionWatcher : public InternalRunnable {
   virtual ~ExtensionWatcher() {}
   ExtensionWatcher(const std::string& path, size_t interval, bool fatal)
       : path_(path), interval_(interval), fatal_(fatal) {
+    // Set the interval to a minimum of 200 milliseconds.
     interval_ = (interval_ < 200) ? 200 : interval_;
   }
 

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -22,8 +22,8 @@ using namespace osquery::extensions;
 
 namespace osquery {
 
-const int kDelayUS = 200;
-const int kTimeoutUS = 10000;
+const int kDelayUS = 2000;
+const int kTimeoutUS = 1000000;
 const std::string kTestManagerSocket = kTestWorkingDirectory + "test.em";
 
 class ExtensionsTest : public testing::Test {

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -61,8 +61,8 @@ DEFAULT_CONFIG = {
         "pidfile": "%s.pid" % CONFIG_NAME,
         "config_path": "%s.conf" % CONFIG_NAME,
         "extensions_socket": "%s.em" % CONFIG_NAME,
-        "extensions_interval": "1",
-        "extensions_timeout": "1",
+        "extensions_interval": "0",
+        "extensions_timeout": "0",
         "watchdog_level": "3",
         "disable_logging": "true",
         "force": "true",
@@ -159,6 +159,7 @@ class ProcRunner(object):
         thread.start()
 
     def run(self):
+        code = -1
         try:
             if self.silent:
                 self.proc = subprocess.Popen([self.path] + self.args,
@@ -172,10 +173,11 @@ class ProcRunner(object):
         try:
             while self.proc.poll() is None:
                 time.sleep(self.interval)
+            code = self.proc.poll()
             self.proc = None
         except:
             return
-        print ("Process %s ended" % self.name)
+        print ("Process %s ended: %s" % (self.name, code))
 
     def getChildren(self, max_interval=1):
         '''Get the child pids.'''
@@ -207,7 +209,7 @@ class ProcRunner(object):
                     pass
         if self.proc:
             try:
-                self.proc.kill()
+                os.kill(self.pid, 9)
             except:
                 pass
         self.proc = None
@@ -287,7 +289,7 @@ class ProcessGenerator(object):
                 "--socket=%s" % path,
                 "--verbose" if ARGS.verbose else "",
                 "--timeout=%d" % timeout,
-                "--interval=%d" % 1,
+                "--interval=%d" % 0,
             ],
             silent=silent)
         self.generators.append(extension)
@@ -437,7 +439,7 @@ class Tester(object):
         unittest.main(argv=unittest_args)
 
 
-def expect(functional, expected, interval=0.2, timeout=2):
+def expect(functional, expected, interval=0.01, timeout=4):
     """Helper function to run a function with expected latency"""
     delay = 0
     result = None
@@ -445,7 +447,9 @@ def expect(functional, expected, interval=0.2, timeout=2):
         try:
             result = functional()
             if len(result) == expected: break
-        except: pass
+        except Exception as e:
+            print ("Expect exception (%s): %s not %s" % (
+                str(e), str(functional), expected))
         if delay >= timeout:
             return None
         time.sleep(interval)
@@ -453,7 +457,7 @@ def expect(functional, expected, interval=0.2, timeout=2):
     return result
 
 
-def expectTrue(functional, interval=0.2, timeout=2):
+def expectTrue(functional, interval=0.01, timeout=4):
     """Helper function to run a function with expected latency"""
     delay = 0
     while delay < timeout:


### PR DESCRIPTION
Mostly try to be clear about time and units in death and socket timeout checks. Allow unit tests to be more aggressive in delay/latency. 