### PR TITLE
[#1259] Use RocksDB LITE if available

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -140,12 +140,12 @@ endmacro(ADD_OSQUERY_LIBRARY TARGET)
 
 # Add sources to libosquery.a (the core library)
 macro(ADD_OSQUERY_OBJCXX_LIBRARY_CORE TARGET)
-  ADD_OSQUERY_OBJCXX_LIBRARY(TRUE TARGET ${ARGN})
+  ADD_OSQUERY_OBJCXX_LIBRARY(TRUE ${TARGET} ${ARGN})
 endmacro(ADD_OSQUERY_OBJCXX_LIBRARY_CORE)
 
 # Add sources to libosquery_additional.a (the non-sdk library)
 macro(ADD_OSQUERY_OBJCXX_LIBRARY_ADDITIONAL TARGET)
-  ADD_OSQUERY_OBJCXX_LIBRARY(FALSE TARGET ${ARGN})
+  ADD_OSQUERY_OBJCXX_LIBRARY(FALSE ${TARGET} ${ARGN})
 endmacro(ADD_OSQUERY_OBJCXX_LIBRARY_ADDITIONAL)
 
 # Core/non core lists of target source files compiled as ObjC++.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,6 @@ add_definitions(
   -D${OSQUERY_BUILD_PLATFORM_DEFINE}_${OSQUERY_BUILD_DISTRO_DEFINE}
   -DSTRIP_FLAG_HELP=1
   -DBOOST_NETWORK_ENABLE_HTTPS
-  # There are platform incompatibilities on OS X with lite and construction.
-  #-DROCKSDB_LITE=1
 )
 
 if(APPLE)
@@ -279,9 +277,9 @@ find_package(Readline REQUIRED)
 # Make sure the OpenSSL/ssl library has a TLS client method.
 # Prefer the highest version of TLS, but accept 1.2, 1.1, or 1.0.
 include(CheckLibraryExists)
-CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_2_client_method" "" OPENSSL_TLSV12)
-CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_1_client_method" "" OPENSSL_TLSV11)
-CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_client_method" "" OPENSSL_TLSV10)
+check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_2_client_method" "" OPENSSL_TLSV12)
+check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_1_client_method" "" OPENSSL_TLSV11)
+check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_client_method" "" OPENSSL_TLSV10)
 
 # Add a define based on the highest TLS version found. Fatal if no TLS client.
 if(OPENSSL_TLSV12)

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -21,7 +21,7 @@ using namespace apache::thrift::concurrency;
 namespace osquery {
 
 /// The worker_threads define the default thread pool size.
-FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
+FLAG(int32, worker_threads, 1, "Number of work dispatch threads");
 
 void interruptableSleep(size_t milli) {
   boost::this_thread::sleep(boost::posix_time::milliseconds(milli));
@@ -58,7 +58,7 @@ Status Dispatcher::addService(InternalRunnableRef service) {
   auto& self = instance();
   auto thread = std::make_shared<boost::thread>(
       boost::bind(&InternalRunnable::run, &*service));
-  self.service_threads_.push_back(thread);
+  self.service_threads_.push_back(std::move(thread));
   self.services_.push_back(std::move(service));
   return Status(0, "OK");
 }

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -186,8 +186,8 @@ void ExtensionRunnerCore::startServer(TProcessorRef processor) {
   auto transport_fac = TTransportFactoryRef(new TBufferedTransportFactory());
   auto protocol_fac = TProtocolFactoryRef(new TBinaryProtocolFactory());
 
-  auto thread_manager_ =
-      ThreadManager::newSimpleThreadManager((size_t)FLAGS_worker_threads, 0);
+  size_t client_size = std::max((int)FLAGS_worker_threads, 2);
+  auto thread_manager_ = ThreadManager::newSimpleThreadManager(client_size, 0);
   auto thread_fac = ThriftThreadFactory(new PosixThreadFactory());
   thread_manager_->threadFactory(thread_fac);
   thread_manager_->start();


### PR DESCRIPTION
This adds a CMake macro to compile a test program to check for a RocksDB symbol at linktime. If the symbol is available then RocksDB was NOT built as RocksDB Lite. We prefer LITE to improve binary size and memory usage.