### PR TITLE
[Fix #1171, #1089] Add configurable max reads

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -153,6 +153,21 @@ See the **tls**/[remote](../deployment/remote.md) plugin documentation. This is 
 
 ## Runtime flags
 
+`--read_max=52428800` (50MB)
+
+Maximum file read size.
+The daemon or shell will first 'stat' each file before reading. If the reported size is greater than `read_max` a "file too large" error will be returned.
+
+`--read_user_max=10485760` (10MB)
+
+Maximum non-super user read size.
+Similar to `--read_max` but applied to user-controlled (owned) files.
+
+`--read_user_links=true`
+
+Read user-controlled (owned) filesystem links.
+This allows specific control over symbolic links owned by users.
+
 ### osquery daemon runtime control flags
 
 `--schedule_splay_percent=10`

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -42,6 +42,7 @@ struct FlagDetail {
   bool shell;
   bool external;
   bool cli;
+  bool hidden;
 };
 
 struct FlagInfo {
@@ -189,23 +190,24 @@ class FlagAlias {
  * @param value The default value, use a C++ literal.
  * @param desc A string literal used for help display.
  */
-#define OSQUERY_FLAG(t, n, v, d, s, e, c)              \
-  DEFINE_##t(n, v, d);                                 \
-  namespace flags {                                    \
-  const int flag_##n = Flag::create(#n, {d, s, e, c}); \
+#define OSQUERY_FLAG(t, n, v, d, s, e, c, h)              \
+  DEFINE_##t(n, v, d);                                    \
+  namespace flags {                                       \
+  const int flag_##n = Flag::create(#n, {d, s, e, c, h}); \
   }
 
-#define FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 0)
-#define SHELL_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 1, 0, 0)
-#define EXTENSION_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 1, 0)
-#define CLI_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 1)
+#define FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 0, 0)
+#define SHELL_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 1, 0, 0, 0)
+#define EXTENSION_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 1, 0, 0)
+#define CLI_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 1, 0)
+#define HIDDEN_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 0, 1)
 
-#define OSQUERY_FLAG_ALIAS(t, a, n, s, e)                          \
-  FlagAlias<t> FLAGS_##a(#a, #t, #n, &FLAGS_##n);                  \
-  namespace flags {                                                \
-  static GFLAGS_NAMESPACE::FlagRegisterer oflag_##a(               \
-      #a, #t, #a, #a, &FLAGS_##n, &FLAGS_##n);                     \
-  const int flag_alias_##a = Flag::createAlias(#a, {#n, s, e, 0}); \
+#define OSQUERY_FLAG_ALIAS(t, a, n, s, e)                             \
+  FlagAlias<t> FLAGS_##a(#a, #t, #n, &FLAGS_##n);                     \
+  namespace flags {                                                   \
+  static GFLAGS_NAMESPACE::FlagRegisterer oflag_##a(                  \
+      #a, #t, #a, #a, &FLAGS_##n, &FLAGS_##n);                        \
+  const int flag_alias_##a = Flag::createAlias(#a, {#n, s, e, 0, 1}); \
   }
 
 #define FLAG_ALIAS(t, a, n) OSQUERY_FLAG_ALIAS(t, a, n, 0, 0)

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -138,7 +138,7 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
       const auto& detail = details.at(flag.name);
       if ((shell && !detail.shell) || (!shell && detail.shell) ||
           (external && !detail.external) || (!external && detail.external) ||
-          (cli && !detail.cli) || (!cli && detail.cli)) {
+          (cli && !detail.cli) || (!cli && detail.cli) || detail.hidden) {
         continue;
       }
     } else if (aliases.count(flag.name) > 0) {

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -19,6 +19,8 @@
 
 #include "osquery/core/test_util.h"
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 
 /// Most tests will use binary or disk-backed content for parsing tests.
@@ -255,9 +257,8 @@ QueryData getEtcProtocolsExpectedResults() {
 }
 
 void createMockFileStructure() {
-  boost::filesystem::create_directories(kFakeDirectory +
-                                        "/deep11/deep2/deep3/");
-  boost::filesystem::create_directories(kFakeDirectory + "/deep1/deep2/");
+  fs::create_directories(kFakeDirectory + "/deep11/deep2/deep3/");
+  fs::create_directories(kFakeDirectory + "/deep1/deep2/");
   writeTextFile(kFakeDirectory + "/root.txt", "root");
   writeTextFile(kFakeDirectory + "/door.txt", "toor");
   writeTextFile(kFakeDirectory + "/roto.txt", "roto");
@@ -268,6 +269,10 @@ void createMockFileStructure() {
   writeTextFile(kFakeDirectory + "/deep11/level1.txt", "l1");
   writeTextFile(kFakeDirectory + "/deep11/deep2/level2.txt", "l2");
   writeTextFile(kFakeDirectory + "/deep11/deep2/deep3/level3.txt", "l3");
+
+  boost::system::error_code ec;
+  fs::create_symlink(
+      kFakeDirectory + "/root.txt", kFakeDirectory + "/root2.txt", ec);
 }
 
 void tearDownMockFileStructure() {

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -236,7 +236,7 @@ TEST_F(ExtensionsTest, test_extension_broadcast) {
 
 TEST_F(ExtensionsTest, test_extension_module_search) {
   createMockFileStructure();
-  EXPECT_TRUE(loadModules(kFakeDirectory));
+  EXPECT_FALSE(loadModules(kFakeDirectory + "/root.txt"));
   EXPECT_FALSE(loadModules("/dir/does/not/exist"));
   tearDownMockFileStructure();
 }

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -21,6 +21,8 @@
 
 namespace osquery {
 
+HIDDEN_FLAG(bool, registry_exceptions, false, "Allow plugin exceptions");
+
 void RegistryHelperCore::remove(const std::string& item_name) {
   if (items_.count(item_name) > 0) {
     items_[item_name]->tearDown();
@@ -299,10 +301,16 @@ Status RegistryFactory::call(const std::string& registry_name,
   } catch (const std::exception& e) {
     LOG(ERROR) << registry_name << " registry " << item_name
                << " plugin caused exception: " << e.what();
+    if (FLAGS_registry_exceptions) {
+      throw e;
+    }
     return Status(1, e.what());
   } catch (...) {
     LOG(ERROR) << registry_name << " registry " << item_name
                << " plugin caused unknown exception";
+    if (FLAGS_registry_exceptions) {
+      throw std::runtime_error(registry_name + ": " + item_name + " failed");
+    }
     return Status(2, "Unknown exception");
   }
 }


### PR DESCRIPTION
There are 3 new options that control how files are read:
- `--read_max` that controls the maximum size, in bytes, for file reads. If a file is larger than `read_max` the read will fail.
- `--read_user_max`, similar to `read_max` but applies additional limitations to user-controlled files.
- `--read_user_links`, a boolean control to enable/disable following symlinks for user-controlled files.

Important highlights:
- If files exceed the configured max, those reads will fail.
- The `read_max` will override `read_user_max` if it is set lower.
- A default integer value of `0` will disable the limitations. 

The default `read_max` is set to 50M and the default `read_user_max` is 10M.