### PR TITLE
Kernel extension fixes for daemon shutdown process.

### DIFF
--- a/kernel/include/feeds.h
+++ b/kernel/include/feeds.h
@@ -60,16 +60,16 @@ typedef struct test_event_1 {
 } test_event_1_data_t;
 #endif // KERNEL_TEST
 
-static inline size_t osquery_sizeof_event(osquery_event_t e) {
+static inline ssize_t osquery_sizeof_event(osquery_event_t e) {
   switch (e) {
 #ifdef KERNEL_TEST
-    case OSQUERY_TEST_EVENT_0:
-      return sizeof(test_event_0_data_t);
-    case OSQUERY_TEST_EVENT_1:
-      return sizeof(test_event_1_data_t);
+  case OSQUERY_TEST_EVENT_0:
+    return sizeof(test_event_0_data_t);
+  case OSQUERY_TEST_EVENT_1:
+    return sizeof(test_event_1_data_t);
 #endif // KERNEL_TEST
-    default:
-      return -1;
+  default:
+    return -1;
   }
 }
 
@@ -124,4 +124,3 @@ typedef struct osquery_buf_allocate_args {
 #ifdef __cplusplus
 }  // end extern "c"
 #endif
-

--- a/osquery/events/kernel/circular_queue_user.cpp
+++ b/osquery/events/kernel/circular_queue_user.cpp
@@ -91,13 +91,12 @@ int CQueue::kernelSync(int options) {
   sync.options = options;
 
   int err = 0;
-  if ((err = ioctl(fd_, OSQUERY_IOCTL_BUF_SYNC, &sync))) {
-    throw CQueueException("Could not sync buffer with kernel properly.");
-  }
+  err = ioctl(fd_, OSQUERY_IOCTL_BUF_SYNC, &sync);
   uint8_t *new_max_read =  sync.max_read_offset + buffer_;
   max_read_ = new_max_read;
   if (err) {
     read_ = max_read_;
+    throw CQueueException("Could not sync buffer with kernel properly.");
   }
 
   return sync.drops;


### PR DESCRIPTION
This makes the daemon disconnect process safe.  The kernel extension will now wait for pending events before freeing the buffer up.  One race is still possible: daemon disconnects followed by an extension unload before all pending events have gone through.  The risk of this is reduced by a 1 second delay that is enforced from the time the buffer is freed up to the time the extension may be unloaded.  During this period the kernel extension will refuse to be unloaded.