### PR TITLE
Install snappy headers instead of just the library

### DIFF
--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -16,6 +16,7 @@
 
 #include <rocksdb/env.h>
 #include <rocksdb/options.h>
+#include <snappy.h>
 
 #include <osquery/database.h>
 #include <osquery/filesystem.h>

--- a/osquery/database/query.cpp
+++ b/osquery/database/query.cpp
@@ -34,7 +34,7 @@ Status Query::getPreviousQueryResults(QueryData& results) {
 
 Status Query::getPreviousQueryResults(QueryData& results, DBHandleRef db) {
   if (!isQueryNameInDatabase()) {
-    return Status(1, "Query name not found in database");
+    return Status(0, "Query name not found in database");
   }
 
   std::string raw;
@@ -89,6 +89,9 @@ Status Query::addNewResults(const QueryData& current_qd,
   // Get the rows from the last run of this query name.
   QueryData previous_qd;
   auto status = getPreviousQueryResults(previous_qd);
+  if (!status.ok()) {
+    return status;
+  }
 
   // Sanitize all non-ASCII characters from the query data values.
   QueryData escaped_current_qd;

--- a/osquery/database/tests/query_tests.cpp
+++ b/osquery/database/tests/query_tests.cpp
@@ -108,7 +108,8 @@ TEST_F(QueryTests, test_query_name_not_found_in_db) {
   auto query = getOsqueryScheduledQuery();
   auto cf = Query("not_a_real_query", query);
   auto status = cf.getPreviousQueryResults(previous_qd, db_);
-  EXPECT_FALSE(status.ok());
+  EXPECT_TRUE(status.toString() == "Query name not found in database");
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(QueryTests, test_is_query_name_in_database) {

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -142,15 +142,14 @@ function install_snappy() {
   URL=$DEPS_URL/snappy-1.1.1.tar.gz
   SOURCE=snappy-1.1.1
 
-  if provision snappy /usr/local/lib/libsnappy.a; then
-    if [[ ! -f snappy-1.1.1/.libs/libsnappy.a ]]; then
-      pushd $SOURCE
-      CC="$CC" CXX="$CXX" ./configure --with-pic --enable-static
+  if provision snappy /usr/local/include/snappy.h; then
+    pushd $SOURCE
+    CC="$CC" CXX="$CXX" ./configure --with-pic --enable-static
+    if [[ ! -f .libs/libsnappy.a ]]; then
       make -j $THREADS
-      popd
     fi
-    # We do not need the snappy include headers, just static library.
-    sudo cp snappy-1.1.1/.libs/libsnappy.a /usr/local/lib
+    sudo make install
+    popd
   fi
 }
 


### PR DESCRIPTION
We found that not installing the headers for snappy caused RocksDB's
snappy detection to not find that snappy was installed:
https://goo.gl/YOWJl0

The snippet there requires that the headers are installed, not just the
library. By installing the headers, we can ensure that snappy is linked.

OR, alternatively, we could just leave it and not link snappy. It's
uncertain what the specific benefits of including snappy are for our
use-case. (CC @igorcanadi)