### PR TITLE
Adding process events table.

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -112,6 +112,14 @@ macro(ADD_OSQUERY_TABLE_TEST)
   endif()
 endmacro(ADD_OSQUERY_TABLE_TEST)
 
+# Add kernel test macro.
+macro(ADD_OSQUERY_KERNEL_TEST)
+  if(NOT DEFINED ENV{SKIP_TESTS})
+    list(APPEND OSQUERY_KERNEL_TESTS ${ARGN})
+    set(OSQUERY_KERNEL_TESTS ${OSQUERY_KERNEL_TESTS} PARENT_SCOPE)
+  endif()
+endmacro(ADD_OSQUERY_KERNEL_TEST)
+
 # Add sources to libosquery.a (the core library)
 macro(ADD_OSQUERY_LIBRARY_CORE TARGET)
   ADD_OSQUERY_LIBRARY(TRUE ${TARGET} ${ARGN})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,9 +269,6 @@ endif()
 # Make sure the generated paths exist
 execute_process(COMMAND mkdir -p "${CMAKE_BINARY_DIR}/generated")
 
-# Include the kernel building targets/macros
-add_subdirectory(kernel)
-
 # We need to link some packages as dynamic/dependent.
 set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
 find_package(OpenSSL REQUIRED)
@@ -334,6 +331,9 @@ endif()
 
 add_subdirectory(osquery)
 add_subdirectory(tools/tests)
+
+# Include the kernel building targets/macros
+add_subdirectory(kernel)
 
 # make docs
 find_package(Doxygen)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # Set includes/compile options for kernel modules/extensions.
 set(CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS "")
@@ -146,6 +147,12 @@ if(APPLE)
     COMMENT "Generating symbols and launching a debugger with kernel target..."
   )
 
+  add_custom_target(
+    kernel-test
+    COMMAND echo ""
+    COMMAND echo "Running kernel tests requires root."
+    COMMAND sudo $<TARGET_FILE:osquery_kernel_tests>
+  )
 elseif(LINUX)
   add_custom_target(
     base_kernel
@@ -160,6 +167,11 @@ elseif(LINUX)
   add_custom_target(
     kernel-deps
     COMMAND echo "-- No kernel dependencies for Linux"
+  )
+
+  add_custom_target(
+    kernel-test
+    COMMAND echo "-- No kernel test is run for Linux"
   )
 else()
   add_custom_target(
@@ -176,6 +188,11 @@ else()
     kernel-deps
     COMMAND echo "-- No kernel dependencies for unsupported platform"
   )
+
+  add_custom_target(
+    kernel-test
+    COMMAND echo "-- No kernel test is run for unsupported platform"
+  )
 endif()
 
 # make kernel-build
@@ -183,11 +200,4 @@ add_custom_target(
   kernel-build
   DEPENDS kernel-layout base_kernel
   COMMAND echo "-- Building osquery kernel extension/module..."
-)
-
-# make kernel-test
-add_custom_target(
-  kernel-test
-  DEPENDS kernel-build
-  COMMAND echo "-- Running kernel-specific unit tests"
 )

--- a/kernel/src/circular_queue_kern.c
+++ b/kernel/src/circular_queue_kern.c
@@ -328,6 +328,12 @@ int osquery_cqueue_commit(osquery_cqueue_t *queue, void *space) {
   }
 
   header->finished = 1;
+  clock_sec_t seconds;
+  clock_usec_t microsecs;
+  clock_get_calendar_microtime(&seconds, &microsecs);
+  header->time.time = (uint64_t)seconds;
+  clock_get_system_microtime(&seconds, &microsecs);
+  header->time.uptime = (uint64_t)seconds;
 
   coalesce_readable(queue);
 

--- a/kernel/src/circular_queue_kern.h
+++ b/kernel/src/circular_queue_kern.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 // Circular queue data structure.
-typedef struct osquery_cqueue {
+typedef struct {
   uint8_t *buffer;
   size_t size;
   uint8_t *write;

--- a/kernel/src/osquery.cpp
+++ b/kernel/src/osquery.cpp
@@ -17,7 +17,9 @@
 #include <sys/conf.h>
 #include <sys/proc.h>
 #include <sys/systm.h>
+#include <sys/kauth.h>
 #include <miscfs/devfs/devfs.h>
+#include <sys/vnode.h>
 
 // IOKit headers
 #include <IOKit/IOMemoryDescriptor.h>
@@ -38,7 +40,7 @@
 #define MAX_KMEM (20 * (1 << 20))
 #define MIN_KMEM (8 * (1 << 10))
 
-static struct osquery {
+static struct {
   osquery_cqueue_t cqueue;
   void *buffer;
   size_t buf_size;
@@ -47,6 +49,7 @@ static struct osquery {
   void *devfs;
   int major_number;
   int open_count;
+  kauth_listener_t fileop_listener;
 
   lck_grp_attr_t *lck_grp_attr;
   lck_grp_t *lck_grp;
@@ -61,6 +64,68 @@ static struct osquery {
   .devfs = NULL,
   .major_number = OSQUERY_MAJOR
 };
+
+static int fileop_scope_callback(kauth_cred_t credential,
+                                 void *idata,
+                                 kauth_action_t action,
+                                 uintptr_t arg0,
+                                 uintptr_t arg1,
+                                 uintptr_t arg2,
+                                 uintptr_t arg3) {
+  vnode_t vp = (vnode_t)arg0;
+  if (action == KAUTH_FILEOP_EXEC && vp != NULL) {
+    // Someone is executing a file.
+    int path_len = MAXPATHLEN;
+
+    osquery_process_event_t *e =
+      (osquery_process_event_t *)osquery_cqueue_reserve(&osquery.cqueue,
+                                                        OSQUERY_PROCESS_EVENT);
+    if (e == NULL) {
+      // Failed to reserve space for the event.
+      return KAUTH_RESULT_DEFER;
+    }
+    e->pid = proc_selfpid();
+    e->ppid = proc_selfppid();
+    e->owner_uid = 0;
+    e->owner_gid = 0;
+    e->mode = -1;
+    vfs_context_t context = vfs_context_create(NULL);
+    if (context) {
+      struct vnode_attr vattr = {0};
+      VATTR_INIT(&vattr);
+      VATTR_WANTED(&vattr, va_uid);
+      VATTR_WANTED(&vattr, va_gid);
+      VATTR_WANTED(&vattr, va_mode);
+      VATTR_WANTED(&vattr, va_create_time);
+      VATTR_WANTED(&vattr, va_access_time);
+      VATTR_WANTED(&vattr, va_modify_time);
+      VATTR_WANTED(&vattr, va_change_time);
+
+      if (vnode_getattr(vp, &vattr, context) == 0) {
+        e->owner_uid = vattr.va_uid;
+        e->owner_gid = vattr.va_gid;
+        e->mode = vattr.va_mode;
+        e->create_time = vattr.va_create_time.tv_sec;
+        e->access_time = vattr.va_access_time.tv_sec;
+        e->modify_time = vattr.va_modify_time.tv_sec;
+        e->change_time = vattr.va_change_time.tv_sec;
+      }
+
+      vfs_context_rele(context);
+    }
+
+    e->uid = kauth_cred_getruid(credential);
+    e->euid = kauth_cred_getuid(credential);
+
+    e->gid = kauth_cred_getrgid(credential);
+    e->egid = kauth_cred_getgid(credential);
+
+    vn_getpath(vp, e->path, &path_len);
+
+    osquery_cqueue_commit(&osquery.cqueue, e);
+  }
+  return KAUTH_RESULT_DEFER;
+}
 
 static inline void setup_locks() {
   /* Create locks.  Cannot be done on the stack. */
@@ -85,15 +150,27 @@ static inline void teardown_locks() {
 }
 
 static void unsubscribe_all_events() {
+  if (osquery.fileop_listener) {
+    kauth_unlisten_scope(osquery.fileop_listener);
+    osquery.fileop_listener = NULL;
+  }
 }
 
 static int subscribe_to_event(osquery_event_t event, int subscribe) {
-  // TODO: Logic to start a subscription for events of a given type.
   if (osquery.buffer == NULL) {
     return -EINVAL;
   }
 
   switch (event) {
+  case OSQUERY_PROCESS_EVENT:
+    if (subscribe && osquery.fileop_listener == NULL) {
+      osquery.fileop_listener =
+          kauth_listen_scope(KAUTH_SCOPE_FILEOP, fileop_scope_callback, NULL);
+    } else if (!subscribe && osquery.fileop_listener) {
+      kauth_unlisten_scope(osquery.fileop_listener);
+      osquery.fileop_listener = NULL;
+    }
+    break;
   default:
     return -EINVAL;
   }

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(OSQUERY_SOURCES "")
 set(OSQUERY_LINKS "")
 set(OSQUERY_TESTS "")
+set(OSQUERY_KERNEL_TESTS "")
 
 # osquery core additional sources files not included with SDK (libosquery_additional).
 set(OSQUERY_ADDITIONAL_SOURCES "")
@@ -185,6 +186,13 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   target_link_libraries(osquery_tests gtest libosquery_testing)
   SET_OSQUERY_COMPILE(osquery_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
   add_test(osquery_tests osquery_tests)
+
+  # osquery kernel tests.
+  add_executable(osquery_kernel_tests main/tests.cpp ${OSQUERY_KERNEL_TESTS})
+  TARGET_OSQUERY_LINK_WHOLE(osquery_kernel_tests libosquery)
+  TARGET_OSQUERY_LINK_WHOLE(osquery_kernel_tests libosquery_additional)
+  target_link_libraries(osquery_kernel_tests gtest libosquery_testing)
+  SET_OSQUERY_COMPILE(osquery_kernel_tests "${CXX_COMPILE_FLAGS} -DKERNEL_TEST=1 -DGTEST_HAS_TR1_TUPLE=0")
 
   if(NOT OSQUERY_BUILD_SDK_ONLY)
     # osquery core (additional) set of unit tests built outside of SDK.

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -32,14 +32,16 @@ extern std::string kTestDataPath;
 
 /// Tests should limit intermediate input/output to a working directory.
 /// Config data, logging results, and intermediate database/caching usage.
+
 #ifdef DARWIN
-const std::string kTestWorkingDirectory = "/private/tmp/osquery-tests/";
+const std::string kTestWorkingDirectory = "/private/tmp/osquery-tests";
 #else
-const std::string kTestWorkingDirectory = "/tmp/osquery-tests/";
+const std::string kTestWorkingDirectory = "/tmp/osquery-tests";
 #endif
 
 /// A fake directory tree should be used for filesystem iterator testing.
-const std::string kFakeDirectory = kTestWorkingDirectory + "fstree";
+const std::string kFakeDirectoryName = "fstree";
+extern std::string kFakeDirectory;
 
 ScheduledQuery getOsqueryScheduledQuery();
 

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -1,3 +1,9 @@
+# We will introduce a "kernel-test" mode that builds for pull requests and
+# merges into master and includes additional unit-test facilities.
+if(NOT OSQUERY_BUILD_RELEASE)
+  add_definitions(-DKERNEL_TEST=1)
+endif()
+
 SET(OSQUERY_EVENTS_SOURCES "")
 
 if(APPLE)
@@ -28,17 +34,18 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_events
   events.cpp
 )
 
+file(GLOB OSQUERY_EVENTS_TESTS "tests/*.cpp")
+ADD_OSQUERY_TEST(TRUE ${OSQUERY_EVENTS_TESTS})
+
+
 file(GLOB OSQUERY_KERNEL_QUEUE "kernel/*.cpp")
 ADD_OSQUERY_LIBRARY(FALSE osquery_additional_events
   kernel.cpp
   ${OSQUERY_KERNEL_QUEUE}
 )
 
-file(GLOB OSQUERY_KERNEL_QUEUE_TEST "kernel/tests/*.cpp")
-ADD_OSQUERY_TEST(FALSE ${OSQUERY_KERNEL_QUEUE_TEST})
-
-file(GLOB OSQUERY_EVENTS_TESTS "tests/*.cpp")
-ADD_OSQUERY_TEST(TRUE ${OSQUERY_EVENTS_TESTS})
+file(GLOB OSQUERY_KERNEL_QUEUE_TESTS "kernel/tests/*.cpp")
+ADD_OSQUERY_KERNEL_TEST(${OSQUERY_KERNEL_QUEUE_TESTS})
 
 if(APPLE)
   file(GLOB OSQUERY_DARWIN_EVENTS_TESTS "darwin/tests/*.cpp")

--- a/osquery/events/kernel.h
+++ b/osquery/events/kernel.h
@@ -31,6 +31,9 @@ struct KernelSubscriptionContext : public SubscriptionContext {
 struct KernelEventContext : public EventContext {
   /// The event type.
   osquery_event_t event_type;
+
+  uint32_t time;
+  uint32_t uptime;
 };
 
 template <typename EventType>
@@ -66,7 +69,7 @@ class KernelEventPublisher
 
   template <typename EventType>
   KernelEventContextRef createEventContextFrom(osquery_event_t event_type,
-                                               void *event_buf) const;
+                                               CQueue::event *event) const;
 };
 
 }  // namespace osquery

--- a/osquery/events/kernel/circular_queue_user.cpp
+++ b/osquery/events/kernel/circular_queue_user.cpp
@@ -60,12 +60,13 @@ void CQueue::subscribe(osquery_event_t event) {
   }
 }
 
-osquery_event_t CQueue::dequeue(void **event) {
+osquery_event_t CQueue::dequeue(CQueue::event **event) {
   if (read_ == max_read_) {
     return (osquery_event_t)0;
   }
   osquery_data_header_t *header = (osquery_data_header_t *)read_;
-  if (header->event == END_OF_BUFFER_EVENT) {
+  if (read_ + sizeof(osquery_data_header_t) > buffer_ + size_ ||
+      header->event == END_OF_BUFFER_EVENT) {
     read_ = buffer_;
     if (read_ == max_read_) {
       return (osquery_event_t)0;
@@ -78,8 +79,7 @@ osquery_event_t CQueue::dequeue(void **event) {
     read_ = (read_ + size - buffer_) % size_ + buffer_;
   }
 
-
-  *event = (void *)(header + 1);
+  *event = (CQueue::event *)&(header->time);
   return header->event;
 }
 

--- a/osquery/events/kernel/circular_queue_user.h
+++ b/osquery/events/kernel/circular_queue_user.h
@@ -23,6 +23,14 @@ class CQueueException : public std::runtime_error {
 class CQueue {
  public:
   /**
+   * @brief Structure to hold event metadata and pointer to an event.
+   */
+  struct event {
+    osquery_event_time_t time;
+    char buf[];
+  };
+
+  /**
    * @brief Creates cqueue.
    *
    * This connects to the osquery kernel extension dev file and sets up a
@@ -57,7 +65,7 @@ class CQueue {
    * @return Returns 0 if queue is empty, otherwise the number of the event put
    * into event.
    */
-  osquery_event_t dequeue(void **event);
+  osquery_event_t dequeue(event **event);
 
   /**
    * @brief Sync the cqueue structure with the cqueue structure in the kernel.

--- a/osquery/events/kernel/tests/kernel_communication_tests.cpp
+++ b/osquery/events/kernel/tests/kernel_communication_tests.cpp
@@ -62,7 +62,7 @@ TEST_F(KernelCommunicationTests, test_communication) {
   }
 
   osquery_event_t event;
-  void *event_buf = nullptr;
+  osquery::CQueue::event *event_buf = nullptr;
   int tasks = 0;
   do {
     tasks = dispatcher.totalTaskCount();

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -24,6 +24,8 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
+std::string kFakeDirectory = "";
+
 DECLARE_string(database_path);
 DECLARE_string(extensions_socket);
 DECLARE_string(modules_autoload);
@@ -39,12 +41,16 @@ void initTesting() {
 
   // Set safe default values for path-based flags.
   // Specific unittests may edit flags temporarily.
-  fs::remove_all(kTestWorkingDirectory);
-  fs::create_directories(kTestWorkingDirectory);
-  FLAGS_database_path = kTestWorkingDirectory + "unittests.db";
-  FLAGS_extensions_socket = kTestWorkingDirectory + "unittests.em";
-  FLAGS_extensions_autoload = kTestWorkingDirectory + "unittests-ext.load";
-  FLAGS_modules_autoload = kTestWorkingDirectory + "unittests-mod.load";
+  std::string testWorkingDirectory =
+      kTestWorkingDirectory + std::to_string(getuid()) + "/";
+  kFakeDirectory = testWorkingDirectory + kFakeDirectoryName;
+
+  fs::remove_all(testWorkingDirectory);
+  fs::create_directories(testWorkingDirectory);
+  FLAGS_database_path = testWorkingDirectory + "unittests.db";
+  FLAGS_extensions_socket = testWorkingDirectory + "unittests.em";
+  FLAGS_extensions_autoload = testWorkingDirectory + "unittests-ext.load";
+  FLAGS_modules_autoload = testWorkingDirectory + "unittests-mod.load";
   FLAGS_disable_logging = true;
 
   // Create a default DBHandle instance before unittests.

--- a/osquery/tables/events/process_events.cpp
+++ b/osquery/tables/events/process_events.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/events/kernel.h"
+
+#include <osquery/logger.h>
+
+namespace osquery {
+
+class ProcessEventSubscriber
+  : public EventSubscriber<KernelEventPublisher> {
+ public:
+  Status init();
+
+  Status Callback(const TypedKernelEventContextRef<osquery_process_event_t> &ec,
+                  const void *user_data);
+};
+
+REGISTER(ProcessEventSubscriber, "event_subscriber", "process_events");
+
+Status ProcessEventSubscriber::init() {
+  auto sc = createSubscriptionContext();
+  sc->event_type = OSQUERY_PROCESS_EVENT;
+  subscribe(&ProcessEventSubscriber::Callback, sc, NULL);
+
+  return Status(0, "OK");
+}
+
+Status ProcessEventSubscriber::Callback(
+    const TypedKernelEventContextRef<osquery_process_event_t> &ec,
+    const void *user_data) {
+  Row r;
+  r["pid"] = BIGINT(ec->event.pid);
+  r["parent"] = BIGINT(ec->event.ppid);
+  r["uid"] = BIGINT(ec->event.uid);
+  r["euid"] = BIGINT(ec->event.euid);
+  r["gid"] = BIGINT(ec->event.gid);
+  r["egid"] = BIGINT(ec->event.egid);
+  r["owner_uid"] = BIGINT(ec->event.owner_uid);
+  r["owner_gid"] = BIGINT(ec->event.owner_gid);
+  r["create_time"] = BIGINT(ec->event.create_time);
+  r["access_time"] = BIGINT(ec->event.access_time);
+  r["modify_time"] = BIGINT(ec->event.modify_time);
+  r["change_time"] = BIGINT(ec->event.change_time);
+  r["mode"] = BIGINT(ec->event.mode);
+  r["path"] = ec->event.path;
+  r["uptime"] = BIGINT(ec->uptime);
+
+  add(r, ec->time);
+
+  return Status(0, "OK");
+}
+
+
+}  // namespace osquery

--- a/specs/darwin/process_events.table
+++ b/specs/darwin/process_events.table
@@ -1,0 +1,30 @@
+table_name("process_events")
+description("Track time/action process executions.")
+schema([
+    Column("pid", BIGINT,
+           "Process ID of the process executing this file."),
+    Column("parent", BIGINT,
+           "Parent process ID of the process executing this file."),
+    Column("uid", BIGINT,
+           "Real user ID of the user executing file at exec time."),
+    Column("euid", BIGINT,
+           "Effective user ID of the user executing file at exec time."),
+    Column("gid", BIGINT,
+           "Real group ID of the group executing file at exec time."),
+    Column("egid", BIGINT,
+           "Effective group ID of the group executing file at exec time."),
+    Column("owner_uid", BIGINT, "User ID of the owner of the executing file."),
+    Column("owner_gid", BIGINT, "Group ID of the owner of the executing file."),
+    Column("mode", BIGINT, "Indicates if the file had setuid permissions."),
+    Column("path", TEXT, "Path of executed file."),
+    Column("create_time", BIGINT, "Time of creation in UNIX epoch time."),
+    Column("access_time", BIGINT, "Time of last access in UNIX epoch time."),
+    Column("modify_time", BIGINT,
+      "Time of last modification in UNIX epoch time."),
+    Column("change_time", BIGINT,
+      "Time of last metadata change in UNIX epoch time."),
+    Column("time", BIGINT, "Time of execution in UNIX epoch time."),
+    Column("uptime", BIGINT, "Time of execution in system uptime."),
+])
+attributes(event_subscriber=True)
+implementation("process_events@process_events::genTable")


### PR DESCRIPTION
Creates `process_events` table which contains exec event information.

#1287 Tracks information we are interested in exposing.