### PR TITLE
Add date information to time table

### DIFF
--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ctime>
+#include <boost/algorithm/string/trim.hpp>
 
 #include <osquery/tables.h>
 
@@ -19,9 +20,30 @@ QueryData genTime(QueryContext& context) {
   Row r;
   time_t _time = time(0);
   struct tm* now = localtime(&_time);
+  struct tm* gmt = gmtime(&_time);
+
+  char weekday[10] = {0};
+  strftime(weekday, sizeof(weekday), "%A", now);
+
+  std::string timestamp;
+  timestamp = asctime(gmt);
+  boost::algorithm::trim(timestamp);
+  timestamp += " UTC";
+
+  char iso_8601[21] = {0};
+  strftime(iso_8601, sizeof(iso_8601), "%FT%TZ", gmt);
+
+  r["weekday"] = TEXT(weekday);
+  r["year"] = INTEGER(now->tm_year + 1900);
+  r["month"] = INTEGER(now->tm_mon + 1);
+  r["day"] = INTEGER(now->tm_mday);
   r["hour"] = INTEGER(now->tm_hour);
   r["minutes"] = INTEGER(now->tm_min);
   r["seconds"] = INTEGER(now->tm_sec);
+  r["unix_time"] = INTEGER(_time);
+  r["timestamp"] = TEXT(timestamp);
+  r["iso_8601"] = TEXT(iso_8601);
+
   QueryData results;
   results.push_back(r);
   return results;

--- a/specs/utility/time.table
+++ b/specs/utility/time.table
@@ -1,9 +1,16 @@
 table_name("time")
-description("Track current time in the system.")
+description("Track current date and time in the system.")
 schema([
+    Column("weekday", TEXT),
+    Column("year", INTEGER),
+    Column("month", INTEGER),
+    Column("day", INTEGER),
     Column("hour", INTEGER),
     Column("minutes", INTEGER),
     Column("seconds", INTEGER),
+    Column("unix_time", INTEGER),
+    Column("timestamp", TEXT),
+    Column("iso_8601", TEXT),
 ])
 attributes(utility=True)
 implementation("time@genTime")


### PR DESCRIPTION
Add information about the date as well as unix_time and an ISO 8601-formatted string to the table.

See #1297.