### PR TITLE
Minor fixes to support building on Ubuntu 10.04

### DIFF
--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -264,7 +264,8 @@ function install_automake() {
     pushd $SOURCE
     ./bootstrap.sh
     ./configure --prefix=/usr
-    CC="$CC" CXX="$CXX" make -j $THREADS
+    # Version 1.14 of automake fails to build with more than one thread
+    CC="$CC" CXX="$CXX" make -j 1
     sudo make install
     popd
   fi
@@ -354,9 +355,9 @@ function install_libaptpkg() {
     mkdir -p build
     pushd build
     ../configure --prefix=/usr/local
-    make -j $THREADS library
+    make -j $THREADS STATICLIBS=1 library
     sudo cp bin/libapt-pkg.so.4.12.0 /usr/local/lib/
-    sudo ln -sf /usr/lib/local/libapt-pkg.so.4.12.0 /usr/local/lib/libapt-pkg.so
+    sudo ln -sf /usr/local/lib/libapt-pkg.so.4.12.0 /usr/local/lib/libapt-pkg.so
     sudo cp bin/libapt-pkg.a /usr/local/lib/
     sudo mkdir -p /usr/local/include/apt-pkg/
     sudo cp include/apt-pkg/*.h /usr/local/include/apt-pkg/

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -11,6 +11,7 @@ function add_repo() {
   REPO=$1
   echo "Adding repository: $REPO"
   if [[ $DISTRO = "lucid" ]]; then
+    package python-software-properties
     sudo add-apt-repository $REPO
   else
     sudo add-apt-repository -y $REPO
@@ -62,6 +63,7 @@ function main_ubuntu() {
     package libopenssl-ruby
 
     package clang
+    package g++-multilib
     install_gcc
   elif [[ $DISTRO = "precise" ]]; then
     # Need gcc 4.8 from ubuntu-toolchain-r/test to compile RocksDB/osquery.


### PR DESCRIPTION
This a PR for supporting Ubuntu 10 builds. It was tested on a fresh VM.

Note: On Ubuntu 10, linking the executables produces the following errors/warnings:

```
/usr/bin/ld: Dwarf Error: found dwarf version '4', this reader only handles version 2 and 3 information.
/usr/local/lib/libapt-pkg.a(fileutl.o): In function `FileFd::Open(std::string, unsigned int, APT::Configuration::Compressor const&, unsigned long)':
fileutl.cc:(.text+0x2b3c): warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
```

The warning about `mktemp` is obviously due to using an old `libapt-pkg` version. The dwarf messages I believe stem from building `libapt-pkg` with a newer `gcc`, but linking uses an older version of `ld`. This does not appear to affect the binaries, however the version of GDB in apt-get for Ubuntu 10 fails to parse v4 DWARF headers.

If desired - it is possible to remove the `STATICLIBS=1` from the `lib.sh`, and the build will use the shared object instead (`libapt-pkg.so`) which doesn't produce the messages in the build (but then obviously requires systems osquery is deployed to having a compatible libapt-pkg.so installed).

Please let me know if you have any questions/comments.