### PR TITLE
Add google group email to the wiki

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -17,4 +17,7 @@ If you're interested in **using osquery's functionality in your own tool**, chec
 ## Getting help
 
 If you any part of osquery isn't working as expected, please create a [GitHub Issue](https://github.com/facebook/osquery/issues).
+
 Keep in touch with osquery developers and users in **#osquery** on **freenode**.
+
+If you have long-form questions, please email [osquery@googlegroups.com](mailto:osquery@googlegroups.com).


### PR DESCRIPTION
Let's start using our google group for long-form questions so that we can leave issues for implementation tasks.