### PR TITLE
Fix getifaddrs result / data checking

### DIFF
--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -77,9 +77,14 @@ Status FileEventSubscriber::Callback(const FSEventsEventContextRef& ec,
     r["category"] = "Undefined";
   }
   r["transaction_id"] = INTEGER(ec->transaction_id);
-  r["md5"] = hashFromFile(HASH_TYPE_MD5, ec->path);
-  r["sha1"] = hashFromFile(HASH_TYPE_SHA1, ec->path);
-  r["sha256"] = hashFromFile(HASH_TYPE_SHA256, ec->path);
+
+  // Only hash if the file content could have been modified.
+  if (ec->action == "CREATED" || ec->action == "UPDATED") {
+    r["md5"] = hashFromFile(HASH_TYPE_MD5, ec->path);
+    r["sha1"] = hashFromFile(HASH_TYPE_SHA1, ec->path);
+    r["sha256"] = hashFromFile(HASH_TYPE_SHA256, ec->path);
+  }
+
   if (ec->action != "") {
     add(r, ec->time);
   }

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -80,9 +80,13 @@ Status FileEventSubscriber::Callback(const INotifyEventContextRef& ec,
     r["category"] = "Undefined";
   }
   r["transaction_id"] = INTEGER(ec->event->cookie);
-  r["md5"] = hashFromFile(HASH_TYPE_MD5, ec->path);
-  r["sha1"] = hashFromFile(HASH_TYPE_SHA1, ec->path);
-  r["sha256"] = hashFromFile(HASH_TYPE_SHA256, ec->path);
+
+  if (ec->action == "CREATED" || ec->action == "UPDATED") {
+    r["md5"] = hashFromFile(HASH_TYPE_MD5, ec->path);
+    r["sha1"] = hashFromFile(HASH_TYPE_SHA1, ec->path);
+    r["sha256"] = hashFromFile(HASH_TYPE_SHA256, ec->path);
+  }
+
   if (ec->action != "" && ec->action != "OPENED") {
     // A callback is somewhat useless unless it changes the EventSubscriber
     // state or calls `add` to store a marked up event.

--- a/osquery/tables/utility/hash.cpp
+++ b/osquery/tables/utility/hash.cpp
@@ -36,7 +36,7 @@ void genHashForFile(const std::string& path,
 QueryData genHash(QueryContext& context) {
   QueryData results;
 
-  // The query must provide a predicate with constratins including path or
+  // The query must provide a predicate with constraints including path or
   // directory. We search for the parsed predicate constraints with the equals
   // operator.
   auto paths = context.constraints["path"].getAll(EQUALS);


### PR DESCRIPTION
1. There are observed cases where `getifaddrs` will return a success response but leave its output parameter set to `nullptr`. Our raw pointers were not initialized and were evading static analysis.
2. Attempt to reduce memory requirements for SQLite virtual table modules.
3. Avoid trying to hash files if file eventing does not indicate content changes.
