### PR TITLE
[Fix #1032] Better/faster performance when querying certificates on OS X

### DIFF
--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -15,62 +15,56 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
 
+#include <openssl/x509v3.h>
+#include <openssl/bn.h>
+#include <openssl/asn1.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+
 #include "osquery/core/conversions.h"
 
 namespace osquery {
 namespace tables {
 
-typedef std::string (*PropGenerator)(const CFDataRef&);
-
-/// A helper data structure to apply a decode generator to property.
-struct CertProperty {
-  /// Property key.
-  CFTypeRef type;
-  /// Generator function.
-  PropGenerator generate;
-};
-
 extern const std::vector<std::string> kSystemKeychainPaths;
 extern const std::vector<std::string> kUserKeychainPaths;
+
+// The flags are defined in openssl/x509v3.h,
+// and its keys in crypto/x509v3/v3_bitst.c
+// clang-format off
+const std::map<unsigned long, std::string> kKeyUsageFlags = {
+    {0x0001, "Encipher Only"},
+    {0x0002, "CRL Sign"},
+    {0x0004, "Key Cert Sign"},
+    {0x0008, "Key Agreement"},
+    {0x0010, "Data Encipherment"},
+    {0x0020, "Key Encipherment"},
+    {0x0040, "Non Repudiation"},
+    {0x0080, "Digital Signature"},
+    {0x8000, "Decipher Only"}
+};
+// clang-format on
 
 void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
 std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Certificate property parsing functions.
-std::string genKIDProperty(const CFDataRef& kid);
-std::string genCommonNameProperty(const CFDataRef& constraints);
-std::string genAlgProperty(const CFDataRef& alg);
-std::string genCAProperty(const CFDataRef& ca);
+std::string genKIDProperty(const unsigned char* data, int len);
+std::string genAlgProperty(const X509* cert);
+std::string genCommonName(X509* cert);
+time_t genEpoch(ASN1_TIME* time);
 
-/// Not a property generator, do not use in kCertificateProperties.
-std::string genSHA1ForCertificate(const SecCertificateRef& ca);
-
-CFDataRef CreatePropertyFromCertificate(const SecCertificateRef& cert,
-                                        const CFTypeRef& oid);
-bool CertificateIsCA(const SecCertificateRef& cert);
+std::string genSHA1ForCertificate(const CFDataRef& raw_cert);
+bool CertificateIsCA(X509* cert);
 
 /// Generate a list of keychain items for a given item type.
 CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
                                const CFTypeRef& item_type);
 
 std::set<std::string> getKeychainPaths();
-
-// From SecCertificatePriv.h
-typedef uint32_t SecKeyUsage;
-enum {
-  kSecKeyUsageUnspecified = 0,
-  kSecKeyUsageDigitalSignature = 1 << 0,
-  kSecKeyUsageNonRepudiation = 1 << 1,
-  kSecKeyUsageContentCommitment = 1 << 1,
-  kSecKeyUsageKeyEncipherment = 1 << 2,
-  kSecKeyUsageDataEncipherment = 1 << 3,
-  kSecKeyUsageKeyAgreement = 1 << 4,
-  kSecKeyUsageKeyCertSign = 1 << 5,
-  kSecKeyUsageCRLSign = 1 << 6,
-  kSecKeyUsageEncipherOnly = 1 << 7,
-  kSecKeyUsageDecipherOnly = 1 << 8,
-  kSecKeyUsageCritical = 1 << 31,
-  kSecKeyUsageAll = 0x7FFFFFFF
-};
+std::string genKeyUsage(unsigned long flag);
+std::string genHumanReadableDateTime(ASN1_TIME* time);
 }
 }

--- a/osquery/tables/system/darwin/tests/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/tests/certificates_tests.cpp
@@ -26,59 +26,51 @@ class CACertsTests : public ::testing::Test {
 
     raw = base64Decode(getCACertificateContent());
     data =
-        CFDataCreate(nullptr, (const UInt8*)raw.c_str(), (CFIndex)raw.size());
+        CFDataCreate(nullptr, (const UInt8 *)raw.c_str(), (CFIndex)raw.size());
     cert = SecCertificateCreateWithData(nullptr, data);
+    cert_der_data = SecCertificateCopyData(cert);
+    auto bytes = CFDataGetBytePtr(cert_der_data);
+    x_cert = d2i_X509(nullptr, &bytes, CFDataGetLength(cert_der_data));
+
     CFRelease(data);
   }
 
   virtual void TearDown() {
-    if (cert != NULL) {
+    if (cert != nullptr) {
       CFRelease(cert);
+    }
+    if (cert_der_data != nullptr) {
+      CFRelease(cert_der_data);
+    }
+    if (x_cert != nullptr) {
+      X509_free(x_cert);
     }
   }
 
   SecCertificateRef cert;
+  CFDataRef cert_der_data;
+  X509 *x_cert;
 };
 
 TEST_F(CACertsTests, test_certificate_sha1) {
   std::string sha1;
-  sha1 = genSHA1ForCertificate(cert);
+  sha1 = genSHA1ForCertificate(cert_der_data);
 
   EXPECT_EQ("f149bae28e3c754ff4bb062b2c1b8bac81b8783e", sha1);
 }
 
 TEST_F(CACertsTests, test_certificate_properties) {
-  CFDataRef property;
-  CFTypeRef oid;
-  std::string prop_string;
+  EXPECT_EQ("localhost.localdomain", genCommonName(x_cert));
 
-  oid = kSecOIDCommonName;
-  property = CreatePropertyFromCertificate(cert, oid);
-  prop_string = genCommonNameProperty(property);
+  X509_check_ca(x_cert);
+  auto skid = genKIDProperty(x_cert->skid->data, x_cert->skid->length);
+  EXPECT_EQ("f2b99b00e0ee60d57c426ce3e64e3fdc6f6411c0", skid);
 
-  EXPECT_EQ("localhost.localdomain", prop_string);
-  CFRelease(property);
+  auto not_before = std::to_string(genEpoch(X509_get_notBefore(x_cert)));
+  EXPECT_EQ("1408475536", not_before);
 
-  oid = kSecOIDSubjectKeyIdentifier;
-  property = CreatePropertyFromCertificate(cert, oid);
-  prop_string = genKIDProperty(property);
-
-  EXPECT_EQ("f2b99b00e0ee60d57c426ce3e64e3fdc6f6411c0", prop_string);
-  CFRelease(property);
-
-  oid = kSecOIDX509V1ValidityNotBefore;
-  property = CreatePropertyFromCertificate(cert, oid);
-  prop_string = stringFromCFNumber(property);
-
-  EXPECT_EQ("430168336", prop_string);
-  CFRelease(property);
-
-  oid = kSecOIDBasicConstraints;
-  property = CreatePropertyFromCertificate(cert, oid);
-  prop_string = genCAProperty(property);
-
-  EXPECT_EQ("1", prop_string);
-  CFRelease(property);
+  auto ca = (CertificateIsCA(x_cert)) ? "1" : "0";
+  EXPECT_EQ("1", ca);
 }
 }
 }


### PR DESCRIPTION
X509 parsing is now handled by OpenSSL as there does seem to be a
memory leak in SecCertificateCopyValues of Security framework which resulted
performance hit when querying certificates. This fixes #1032.

Quick and dirty benchmark:

```bash
❯ time ./build/darwin/osquery/run --query "select * from certificates" --iterations 10
0.60s user
0.08s system 
87% cpu 
0.785 total
```

And here's the same run on master build:
```bash
❯ time ./build/darwin/osquery/run --query "select * from certificates" --iterations 10
7.30s user
0.10s system 
98% cpu 
7.534 total
```

`key_usage` and `key_algorithm` columns now display human readable strings
(e.g. Digital Signature, CRL Sign rsaEncryption) than the raw flags and OIDs (e.g 0x86, 1.2.840.1).

Here's how it looks:
```
     
   key_algorithm = rsaEncryption
       key_usage = Digital Signature, Key Cert Sign, CRL Sign
  

     common_name = Charles Proxy Custom Root Certificate
              ca = 1
not_valid_before = 946684800
 not_valid_after = 2349272255
   key_algorithm = rsaEncryption
       key_usage = Key Cert Sign
  subject_key_id = 50c52641d8ea1b0f18e00e9e74224b953fb9605d
authority_key_id =
            sha1 = 2eb6f51492b2ce4461590fe5cc0344550837d67c
            path = /Users/sbs/Library/Keychains/login.keychain
```

And no complaints from the profiler:

```
❯ sudo python ./tools/profile.py --leaks --rounds 10 --query "select * from certificates;"
Analyzing leaks in query: select * from certificates;
  definitely: 0 leaks for 0 total leaked bytes.
```