### PR TITLE
Silence OS X OpenSSL-related deprecations

### DIFF
--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -23,7 +23,16 @@
 #include <openssl/pem.h>
 #include <openssl/bio.h>
 
+#include <osquery/tables.h>
+
 #include "osquery/core/conversions.h"
+
+// If using the system-provided OpenSSL on 10.10, mark x509 methods deprecated.
+#ifdef SSL_TXT_TLSV1_2
+#define OSX_OPENSSL(x) (x)
+#else
+#define OSX_OPENSSL(x) OSQUERY_USE_DEPRECATED(x)
+#endif
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/tests/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/tests/certificates_tests.cpp
@@ -62,7 +62,7 @@ TEST_F(CACertsTests, test_certificate_sha1) {
 TEST_F(CACertsTests, test_certificate_properties) {
   EXPECT_EQ("localhost.localdomain", genCommonName(x_cert));
 
-  X509_check_ca(x_cert);
+  OSX_OPENSSL(X509_check_ca(x_cert));
   auto skid = genKIDProperty(x_cert->skid->data, x_cert->skid->length);
   EXPECT_EQ("f2b99b00e0ee60d57c426ce3e64e3fdc6f6411c0", skid);
 


### PR DESCRIPTION
This adds a macro to `keychain.h` on OS X that silences OpenSSL deprecation warnings when using the Apple-system provided OpenSSL by detecting if `SSL_TXT_TLSV1_2` is defined. This TLS1.2 macro only exists on newer OpenSSL distributions.