### PR TITLE
[Fix #1332] Check mode for links in readFile

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -42,10 +42,23 @@ const std::string kSQLGlobRecursive = kSQLGlobWildcard + kSQLGlobWildcard;
  * @param path the path of the file that you would like to read.
  * @param content a reference to a string which will be populated with the
  * contents of the path indicated by the path parameter.
+ * @param dry_run do not actually read the file content.
  *
  * @return an instance of Status, indicating success or failure.
  */
-Status readFile(const boost::filesystem::path& path, std::string& content);
+Status readFile(const boost::filesystem::path& path,
+                std::string& content,
+                bool dry_run = false);
+
+/**
+ * @brief Return the status of an attempted file read.
+ *
+ * @param path the path of the file that you would like to read.
+ *
+ * @return success iff the file would have been read. On success the status
+ * message is the complete/absolute path.
+ */
+Status readFile(const boost::filesystem::path& path);
 
 /**
  * @brief Write text to disk.

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -11,6 +11,7 @@
 #include <iomanip>
 #include <sstream>
 
+#include <osquery/filesystem.h>
 #include <osquery/hash.h>
 #include <osquery/logger.h>
 
@@ -91,9 +92,15 @@ std::string hashFromBuffer(HashType hash_type, const void* buffer, size_t size) 
 }
 
 std::string hashFromFile(HashType hash_type, const std::string& path) {
-  Hash hash(hash_type);
+  // Perform a dry-run of a file read without filling in any content.
+  auto status = readFile(path);
+  if (!status.ok()) {
+    return "";
+  }
 
-  FILE* file = fopen(path.c_str(), "rb");
+  Hash hash(hash_type);
+  // Use the canonicalized path returned from a successful readFile dry-run.
+  FILE* file = fopen(status.what().c_str(), "rb");
   if (file == nullptr) {
     VLOG(1) << "Cannot hash/open file " << path;
     return "";

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -73,12 +73,18 @@ TEST_F(FilesystemTests, test_read_limit) {
     FLAGS_read_user_max = user_max;
 
     // Test that user symlinks aren't followed if configured.
+    // 'root2.txt' is a symlink in this case.
     FLAGS_read_user_links = false;
     content.erase();
     status = readFile(kFakeDirectory + "/root2.txt", content);
     EXPECT_FALSE(status.ok());
 
-    // But they are read if enabled.
+    // Make sure non-link files are still readable.
+    content.erase();
+    status = readFile(kFakeDirectory + "/root.txt", content);
+    EXPECT_TRUE(status.ok());
+
+    // Any the links are readable if enabled.
     FLAGS_read_user_links = true;
     status = readFile(kFakeDirectory + "/root2.txt", content);
     EXPECT_TRUE(status.ok());


### PR DESCRIPTION
1. "really" check for links in readFile
2. Apply the same restrictions and flag ACLs to file hashing.