### PR TITLE
Fix broken JOIN predicate passing

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -292,7 +292,11 @@ Status Config::getMD5(std::string& hash_string) {
   ConfigDataInstance config;
 
   std::stringstream out;
-  pt::write_json(out, config.data());
+  try {
+    pt::write_json(out, config.data(), false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    return Status(1, e.what());
+  }
 
   hash_string = osquery::hashFromBuffer(
       HASH_TYPE_MD5, (void*)out.str().c_str(), out.str().length());

--- a/osquery/config/plugins/tls.cpp
+++ b/osquery/config/plugins/tls.cpp
@@ -74,7 +74,13 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
     auto status = makeTLSConfigRequest(uri, recv);
     if (status.ok()) {
       std::stringstream ss;
-      write_json(ss, recv);
+      try {
+        pt::write_json(ss, recv, false);
+      } catch (const pt::json_parser::json_parser_error& e) {
+        // The response content could not be represented as JSON.
+        continue;
+      }
+
       config["tls_plugin"] = ss.str();
       return Status(0, "OK");
     } else if (i == CONFIG_TLS_MAX_ATTEMPTS) {

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -53,7 +53,11 @@ void TablePlugin::setRequestFromContext(const QueryContext& context,
 
   // Write the property tree as a JSON string into the PluginRequest.
   std::ostringstream output;
-  pt::write_json(output, tree, false);
+  try {
+    pt::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The content could not be represented as JSON.
+  }
   request["context"] = output.str();
 }
 
@@ -165,7 +169,7 @@ bool ConstraintList::matches(const std::string& expr) const {
     UNSIGNED_BIGINT_LITERAL lexpr = AS_LITERAL(UNSIGNED_BIGINT_LITERAL, expr);
     return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr);
   } else {
-    // Unsupprted affinity type.
+    // Unsupported affinity type.
     return false;
   }
 }

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -82,7 +82,12 @@ Status serializeRowJSON(const Row& r, std::string& json) {
   }
 
   std::ostringstream output;
-  pt::write_json(output, tree, false);
+  try {
+    pt::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The content could not be represented as JSON.
+    return Status(1, e.what());
+  }
   json = output.str();
   return Status(0, "OK");
 }
@@ -133,7 +138,12 @@ Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
   }
 
   std::ostringstream output;
-  pt::write_json(output, tree, false);
+  try {
+    pt::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The content could not be represented as JSON.
+    return Status(1, e.what());
+  }
   json = output.str();
   return Status(0, "OK");
 }
@@ -210,7 +220,12 @@ Status serializeDiffResultsJSON(const DiffResults& d, std::string& json) {
   }
 
   std::ostringstream output;
-  pt::write_json(output, tree, false);
+  try {
+    pt::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The content could not be represented as JSON.
+    return Status(1, e.what());
+  }
   json = output.str();
   return Status(0, "OK");
 }
@@ -274,7 +289,12 @@ Status serializeQueryLogItemJSON(const QueryLogItem& i, std::string& json) {
   }
 
   std::ostringstream output;
-  pt::write_json(output, tree, false);
+  try {
+    pt::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The content could not be represented as JSON.
+    return Status(1, e.what());
+  }
   json = output.str();
   return Status(0, "OK");
 }
@@ -360,7 +380,11 @@ Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& i,
 
   std::ostringstream output;
   for (auto& event : tree) {
-    pt::write_json(output, event.second, false);
+    try {
+      pt::write_json(output, event.second, false);
+    } catch (const pt::json_parser::json_parser_error& e) {
+      return Status(1, e.what());
+    }
   }
   json = output.str();
   return Status(0, "OK");

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -89,8 +89,7 @@ Status DistributedQueryHandler::serializeResults(
         return s;
       }
     }
-  }
-  catch (const std::exception& e) {
+  } catch (const std::exception& e) {
     return Status(1, std::string("Error serializing results: ") + e.what());
   }
   return Status();
@@ -139,8 +138,7 @@ Status DistributedQueryHandler::doQueries() {
     std::ostringstream ss;
     pt::write_json(ss, serialized_results, false);
     json = ss.str();
-  }
-  catch (const std::exception& e) {
+  } catch (const pt::json_parser::json_parser_error& e) {
     return Status(1, e.what());
   }
 

--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -150,9 +150,15 @@ Status TLSLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
     buffer.put("filename", item.filename);
     buffer.put("line", item.line);
     buffer.put("message", item.message);
+
     // Convert to JSON, for storing a string-representation in the database.
     std::stringstream json_output;
-    write_json(json_output, buffer, false);
+    try {
+      pt::write_json(json_output, buffer, false);
+    } catch (const pt::json_parser::json_parser_error& e) {
+      // The log could not be represented as JSON.
+      return Status(1, e.what());
+    }
 
     // Store the status line in a backing store.
     auto index = genLogIndex(false, log_index_);

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -526,7 +526,11 @@ void Plugin::setResponse(const std::string& key,
                          const boost::property_tree::ptree& tree,
                          PluginResponse& response) {
   std::ostringstream output;
-  boost::property_tree::write_json(output, tree, false);
+  try {
+    boost::property_tree::write_json(output, tree, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    // The plugin response could not be serialized.
+  }
   response.push_back({{key, output.str()}});
 }
 }

--- a/osquery/remote/serializers/json.cpp
+++ b/osquery/remote/serializers/json.cpp
@@ -19,7 +19,11 @@ namespace osquery {
 Status JSONSerializer::serialize(const pt::ptree& params,
                                  std::string& serialized) {
   std::ostringstream output;
-  pt::write_json(output, params, false);
+  try {
+    pt::write_json(output, params, false);
+  } catch (const pt::json_parser::json_parser_error& e) {
+    return Status(1, e.what());
+  }
   serialized = output.str();
   return Status(0, "OK");
 }

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -64,4 +64,17 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   EXPECT_EQ("CREATE VIRTUAL TABLE sample USING sample(foo INTEGER, bar TEXT)",
             results[0]["sql"]);
 }
+
+TEST_F(VirtualTableTests, test_sqlite3_table_joins) {
+  // Get a database connection.
+  auto dbc = SQLiteDBManager::get();
+
+  QueryData results;
+  // Run a query with a join within.
+  std::string statement =
+      "SELECT p.pid FROM osquery_info oi, processes p WHERE oi.pid=p.pid";
+  auto status = queryInternal(statement, results, dbc.db());
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(results.size(), 1);
+}
 }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -124,7 +124,7 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
   // Attempt to cast each xFilter-populated row/column to the SQLite type.
   auto &value = pVtab->content->data[column_name][pCur->row];
   if (type == "TEXT") {
-    sqlite3_result_text(ctx, value.c_str(), value.size(), SQLITE_TRANSIENT);
+    sqlite3_result_text(ctx, value.c_str(), value.size(), SQLITE_STATIC);
   } else if (type == "INTEGER") {
     int afinite;
     try {
@@ -156,8 +156,6 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
     }
     sqlite3_result_double(ctx, afinite);
   }
-  // Instead of moving the content it was casted, so clear the container.
-  value.clear();
 
   return SQLITE_OK;
 }


### PR DESCRIPTION
When filling in column data, do not clear intermediate `QueryData` and `Row` data. Instead, tell SQLite that the text content will be statically accessible until the callback is complete. In this case the callback is the iteration as rows are returned.

This also includes wrapping some `write_json` calls with exception handling "pretty close" to the problematic/encoding sites. Parsing a property tree into JSON may fail if the content contains binary or otherwise null information.