### PR TITLE
[Fix #1341] Add osqueryctl to make install target

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -160,6 +160,8 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
   # make install (executables)
   install(TARGETS shell RUNTIME DESTINATION bin COMPONENT main)
   install(TARGETS daemon RUNTIME DESTINATION bin COMPONENT main)
+  install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osqueryctl"
+    DESTINATION bin COMPONENT main)
 
   # make install (config files)
   install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf"


### PR DESCRIPTION
`osqueryctl` was previously missing from the `make install` target in CMake.