### PR TITLE
Updated the readFile function to correctly handle symbolic links

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -146,7 +146,7 @@ Status resolveFilePattern(const boost::filesystem::path& pattern,
  * @brief Given a filesystem globbing patten, resolve all matching paths.
  *
  * See resolveFilePattern, but supply a limitation to request only directories
- * or files that patch the path.
+ * or files that match the path.
  *
  * @param pattern filesystem globbing pattern.
  * @param results output vector of matching paths.

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -68,7 +68,9 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
     if (file.st_uid != 0 && !FLAGS_read_user_links) {
       return Status(1, "User link reads disabled");
     }
-  } else if (stat(path.string().c_str(), &file) < 0) {
+  }
+
+  if (stat(path.string().c_str(), &file) < 0) {
     return Status(1, "Cannot access path: " + path.string());
   }
 
@@ -225,9 +227,9 @@ inline void replaceGlobWildcards(std::string& pattern) {
     auto canonicalized = fs::canonical(base, ec).string();
     if (canonicalized.size() > 0 && canonicalized != base) {
       if (isDirectory(canonicalized)) {
-        // Canonicalized directory paths will no include a trailing '/'.
-        // But if the wildcards applied to files within a directory then a the
-        // missing '/' changes the wildcard meaning.
+        // Canonicalized directory paths will not include a trailing '/'.
+        // However, if the wildcards are applied to files within a directory
+        // then the missing '/' changes the wildcard meaning.
         canonicalized += '/';
       }
       // We are unable to canonicalize the meaning of post-wildcard limiters.

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -56,6 +56,13 @@ TEST_F(FilesystemTests, test_read_file) {
   remove(kTestWorkingDirectory + "fstests-file");
 }
 
+TEST_F(FilesystemTests, test_read_symlink) {
+  std::string content;
+  auto status = readFile(kFakeDirectory + "/root2.txt", content);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(content, "root");
+}
+
 TEST_F(FilesystemTests, test_read_limit) {
   auto max = FLAGS_read_max;
   auto user_max = FLAGS_read_user_max;


### PR DESCRIPTION
Fix to the `osquery::readFile` function (#1344).