### PR TITLE
[Fix #1319] CentOS version reporting and file read error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ set(OSQUERY_REQUIRE_RUNTIMES
 if(DEFINED ENV{DEBUG})
   set(DEBUG TRUE)
   set(CMAKE_BUILD_TYPE "Debug")
-  add_compile_options(-g -O0 -fstandalone-debug)
+  add_compile_options(-g -O0)
   add_definitions(-DDEBUG)
   WARNING_LOG("Setting DEBUG build")
 elseif(DEFINED ENV{SANITIZE})

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -76,19 +76,19 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
   size_t read_max = (file.st_uid == 0)
                         ? FLAGS_read_max
                         : std::min(FLAGS_read_max, FLAGS_read_user_max);
-  std::ifstream is(path.string(), std::ifstream::binary);
+  std::ifstream is(path.string(), std::ifstream::binary | std::ios::ate);
   if (!is) {
     return Status(1, "Error reading file: " + path.string());
   }
 
   // Attempt to read the file size.
-  ssize_t size = file.st_size;
+  ssize_t size = is.tellg();
 
   // Erase/clear provided string buffer.
   content.erase();
-  if (file.st_size > read_max) {
-    VLOG(1) << "Cannot read " << path
-            << " size exceeds limit: " << file.st_size << " > " << read_max;
+  if (size > read_max) {
+    VLOG(1) << "Cannot read " << path << " size exceeds limit: " << size
+            << " > " << read_max;
     return Status(1, "File exceeds read limits");
   }
 
@@ -98,6 +98,8 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
     return Status(0, fs::canonical(path, ec).string());
   }
 
+  // Reset seek to the start of the stream.
+  is.seekg(0);
   if (size == -1 || size == 0) {
     // Size could not be determined. This may be a special device.
     std::stringstream buffer;

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -22,11 +22,11 @@ namespace xp = boost::xpressive;
 namespace osquery {
 namespace tables {
 
-#if defined(CENTOS) || defined(RHEL)
+#if defined(REDHAT_BASED)
 const std::string kLinuxOSRelease = "/etc/redhat-release";
 const std::string kLinuxOSRegex =
     "(?P<name>\\w+) .* "
-    "(?P<major>[0-9]+).(?P<minor>[0-9]+)[\\.]{0,1}(?P<patch>[0-9]+)";
+    "(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)[\\.]{0,1}(?P<patch>[0-9]+).*";
 #else
 const std::string kLinuxOSRelease = "/etc/os-release";
 const std::string kLinuxOSRegex =


### PR DESCRIPTION
1. Redhat-based distributions were not reporting their version correct.
2. The file read API assumed stat would return an accurate file size. This has been replaced with an attempt to seek to the end of the file.