### PR TITLE
Fixed URLs and some typos in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,11 @@ The pattern here should be pretty obvious. Please put the appropriate effort int
 
 ## Unit Test expectations
 
-All code that you submit to osquery should include automated tests. See the [unit testing guide](https://osquery.readthedocs.org/development/unit-tests/) for instructions on how to create tests.
+All code that you submit to osquery should include automated tests. See the [unit testing guide](https://osquery.readthedocs.org/en/latest/development/unit-tests/) for instructions on how to create tests.
 
 ## Memory leak expectations
 
-osquery runs in the context of long running processes. It's critical that there are no memory leaks in osquery code. All code should be thoroughly tested for leaks. See the [memory leak testing guide](https://osquery.readthedocs.org/deployment/performance-safety/) for more information on how to test your code for memory leaks.
+osquery runs in the context of long running processes. It's critical that there are no memory leaks in osquery code. All code should be thoroughly tested for leaks. See the [memory leak testing guide](https://osquery.readthedocs.org/en/latest/deployment/performance-safety/) for more information on how to test your code for memory leaks.
 
 When you submit a Pull Request, please consider including the output of a valgrind analysis.
 

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -51,7 +51,7 @@ By adding an outer join of `time` and using `time.minutes` as a counter this que
 
 Snapshot logs are an alternate form of query result logging. A snapshot is an 'exact point in time' set of results, no differentials. If you always want a list of mounts, not the added and removed mounts, use a snapshot. In the mounts case, where differential results are seldom emitted (assuming hosts do not often mount and unmount), a complete snapshot will log after every query execution. This *will* be a lot of data amortized across your fleet.
 
-Data snapshots may generate _a large amount_ of output. For log collection safety, output is written to a dedicated sink. The **filesystem** logger plugins writes snapshot results to **/var/log/osquery/osqueryd.snapshots.log**.
+Data snapshots may generate _a large amount_ of output. For log collection safety, output is written to a dedicated sink. The **filesystem** logger plugin writes snapshot results to **/var/log/osquery/osqueryd.snapshots.log**.
 
 To schedule a snapshot query, use:
 ```json

--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -61,7 +61,7 @@ osquery>
 
 The [**file_events**](https://osquery.io/docs/tables/#file_events) table recorded that a file named */Users/wxs/tmp/foo* was created with the corresponding hashes and a timestamp.
 
-The [**yara_events**](https://osquery.io/docs/tables/#yara_events) table recorded that 1 matching rule (*always_true*) was found when the file was created. In this example every file will always have at least one match because I am using a rule which always evaluates to true. In this next example I'll issue the same command to create a file in a monitored directory but have removed the *always_true* rule from my signature files.
+The [**yara_events**](https://osquery.io/docs/tables/#yara_events) table recorded that 1 matching rule (*always_true*) was found when the file was created. In this example every file will always have at least one match because I am using a rule which always evaluates to true. In the next example I'll issue the same command to create a file in a monitored directory but have removed the *always_true* rule from my signature files.
 
 ```bash
 osquery> select * from yara_events;


### PR DESCRIPTION
Fixed some typos and two links to the documentation in the [CONTRIBUTING.md](https://github.com/facebook/osquery/blob/master/CONTRIBUTING.md) file.