### PR TITLE
Install additional configs for HB/packages

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -166,6 +166,9 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
   # make install (config files)
   install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf"
     DESTINATION "${CMAKE_INSTALL_PREFIX}/share/osquery/" COMPONENT main)
+
+  install(DIRECTORY "${CMAKE_SOURCE_DIR}/packs/"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/share/osquery/packs" COMPONENT main)
   if(APPLE)
     install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/com.facebook.osqueryd.plist"
       DESTINATION "${CMAKE_INSTALL_PREFIX}/share/osquery/" COMPONENT main)

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -30,9 +30,9 @@ OUTPUT_PKG_PATH="$BUILD_DIR/$PACKAGE_NAME-$PACKAGE_VERSION."
 # Config files
 INITD_SRC="$SCRIPT_DIR/osqueryd.initd"
 INITD_DST="/etc/init.d/osqueryd"
-
 CTL_SRC="$SCRIPT_DIR/osqueryctl"
-
+PACKS_SRC="$SOURCE_DIR/packs"
+PACKS_DST="/usr/share/osquery/packs/"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"
 OSQUERY_LOG_DIR="/var/log/osquery/"
@@ -101,8 +101,10 @@ function main() {
   mkdir -p $INSTALL_PREFIX/$OSQUERY_VAR_DIR
   mkdir -p $INSTALL_PREFIX/$OSQUERY_LOG_DIR
   mkdir -p $INSTALL_PREFIX/$OSQUERY_ETC_DIR
+  mkdir -p $INSTALL_PREFIX/$PACKS_DST
   mkdir -p `dirname $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST`
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
+  cp $PACKS_SRC/* $INSTALL_PREFIX/$PACKS_DST
 
   mkdir -p `dirname $INSTALL_PREFIX$INITD_DST`
   cp $INITD_SRC $INSTALL_PREFIX$INITD_DST

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -32,6 +32,8 @@ LAUNCHD_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.plist"
 LAUNCHD_DST="/private/var/osquery/$LD_IDENTIFIER.plist"
 NEWSYSLOG_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.conf"
 NEWSYSLOG_DST="/private/var/osquery/$LD_IDENTIFIER.conf"
+PACKS_SRC="$SOURCE_DIR/packs"
+PACKS_DST="/private/var/osquery/packs/"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/private/var/osquery/osquery.example.conf"
 OSQUERY_CONFIG_SRC=""
@@ -179,9 +181,11 @@ function main() {
   # Move configurations into the packaging root.
   log "copying osquery configurations"
   mkdir -p `dirname $INSTALL_PREFIX$LAUNCHD_DST`
+  mkdir -p $INSTALL_PREFIX$PACKS_DST
   cp $LAUNCHD_SRC $INSTALL_PREFIX$LAUNCHD_DST
   cp $NEWSYSLOG_SRC $INSTALL_PREFIX$NEWSYSLOG_DST
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
+  cp $PACKS_SRC/* $INSTALL_PREFIX$PACKS_DST
 
   # Move/install pre/post install scripts within the packaging root.
   log "finalizing preinstall and postinstall scripts"

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -57,5 +57,13 @@
       // The interval in seconds to run this query, not an exact interval.
       "interval": 3600
     }
+  },
+
+  /* Add default osquery packs or install your own. */
+  "packs": {
+    // "incident-response": "/usr/share/osquery/packs/incident-response.conf",
+    // "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
+    // "osx-attacks": "/usr/share/osquery/packs/osx-attacks.conf",
+    // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf"
   }
 }


### PR DESCRIPTION
For Homebrew (HB) and `make install` targets, all configuration files are installed into the CMake install target. This is `/usr/local/` and then we use `./share` from that base. For package builds on OS X this is modified to `/var/osquery/`. This allows dual Homebrew + enterprise/site deployments. On Linux based platforms the package installs target `/usr/share/osquery`. 

Ideally site deployments on OS X could mirror Linux but with 10.11 and SIP we are limited to potential collisions with Homebrew in local.