### PR TITLE
Optimize event publisher database namespace lookups.

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -137,16 +137,29 @@ class Plugin : private boost::noncopyable {
  public:
   /// The plugin may perform some initialization, not required.
   virtual Status setUp() { return Status(0, "Not used"); }
+
   /// The plugin may perform some tear down, release, not required.
   virtual void tearDown() {}
+
   /// The plugin may publish route info (other than registry type and name).
   virtual PluginResponse routeInfo() const {
     PluginResponse info;
     return info;
   }
-  /// The plugin will act on a serialized request, and if a response is needed
-  /// (response is set to true) then response should be a reference to a
-  /// string ready for a serialized response.
+
+  /**
+   * @brief Plugins act by being called, using a request, returning a response.
+   *
+   * The plugin request is a thrift-serializable object. A response is optional
+   * but the API for using a plugin's call is defined by the registry. In most
+   * cases there are multiple supported call 'actions'. A registry type, or
+   * the plugin class, will define the action key and supported actions.
+   *
+   * @param request A plugin request input, including optional action.
+   * @param response A plugin response output.
+   *
+   * @return Status of the call, if the action was handled corrected.
+   */
   virtual Status call(const PluginRequest& request, PluginResponse& response) {
     return Status(0, "Not used");
   }

--- a/osquery/events/darwin/iokit_hid.h
+++ b/osquery/events/darwin/iokit_hid.h
@@ -103,7 +103,7 @@ class IOKitHIDEventPublisher
                                  IOHIDValueRef value);
 
  private:
-  /// Helper fire fuction to parse properties/actions.
+  /// Helper fire function to parse properties/actions.
   static void fire(const IOHIDDeviceRef &device, const std::string &action);
 
  public:

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -202,6 +202,10 @@ class TestFSEventsEventSubscriber
  public:
   int callback_count_;
   std::vector<std::string> actions_;
+
+ private:
+  FRIEND_TEST(FSEventsTests, test_fsevents_fire_event);
+  FRIEND_TEST(FSEventsTests, test_fsevents_event_action);
 };
 
 TEST_F(FSEventsTests, test_fsevents_run) {

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -126,28 +126,43 @@ class INotifyEventPublisher
 
  private:
   INotifyEventContextRef createEventContextFrom(struct inotify_event* event);
+
   /// Check all added Subscription%s for a path.
   bool isPathMonitored(const std::string& path);
+
   /// Add an INotify watch (monitor) on this path.
   bool addMonitor(const std::string& path, bool recursive);
+
   /// Remove an INotify watch (monitor) from our tracking.
   bool removeMonitor(const std::string& path, bool force = false);
   bool removeMonitor(int watch, bool force = false);
+
   /// Given a SubscriptionContext and INotifyEventContext match path and action.
   bool shouldFire(const INotifySubscriptionContextRef& mc,
                   const INotifyEventContextRef& ec) const;
+
   /// Get the INotify file descriptor.
   int getHandle() { return inotify_handle_; }
+
   /// Get the number of actual INotify active descriptors.
   int numDescriptors() { return descriptors_.size(); }
+
   /// If we overflow, try and restart the monitor
   Status restartMonitoring();
 
   // Consider an event queue if separating buffering from firing/servicing.
   DescriptorVector descriptors_;
+
+  /// Map of watched path string to inotify watch file descriptor.
   PathDescriptorMap path_descriptors_;
+
+  /// Map of inotify watch file descriptor to watched path string.
   DescriptorPathMap descriptor_paths_;
+
+  /// The inotify file descriptor handle.
   int inotify_handle_;
+
+  /// Time in seconds of the last inotify restart.
   int last_restart_;
 
  public:

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -202,6 +202,12 @@ class TestINotifyEventSubscriber
  public:
   int callback_count_;
   std::vector<std::string> actions_;
+
+ private:
+  FRIEND_TEST(INotifyTests, test_inotify_fire_event);
+  FRIEND_TEST(INotifyTests, test_inotify_event_action);
+  FRIEND_TEST(INotifyTests, test_inotify_optimization);
+  FRIEND_TEST(INotifyTests, test_inotify_recursion);
 };
 
 TEST_F(INotifyTests, test_inotify_run) {

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -51,7 +51,7 @@ struct FakeEventContext : EventContext {
   int required_value;
 };
 
-// Typdef the shared_ptr accessors.
+// Typedef the shared_ptr accessors.
 typedef std::shared_ptr<FakeSubscriptionContext> FakeSubscriptionContextRef;
 typedef std::shared_ptr<FakeEventContext> FakeEventContextRef;
 
@@ -318,7 +318,7 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
 
 TEST_F(EventsTests, test_event_sub) {
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EXPECT_EQ(sub->type(), "FakePublisher");
+  EXPECT_EQ(sub->getType(), "FakePublisher");
   EXPECT_EQ(sub->getName(), "FakeSubscriber");
 }
 


### PR DESCRIPTION
Previously, event publishers used a canonicalized 'type' name for async callbacks.
This type was used to lookup the publisher plugin in the registry as well as for backing store namespacing. The type is still used but subscribers, which made heavy used of the lookup, store the value locally. This prevents unneeded publisher plugin allocation when adding events.