### PR TITLE
[Fix #1355] Allow plist keys with '.'

### DIFF
--- a/osquery/filesystem/darwin/tests/plist_tests.cpp
+++ b/osquery/filesystem/darwin/tests/plist_tests.cpp
@@ -66,6 +66,13 @@ TEST_F(PlistTests, test_parse_plist_from_file) {
 
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
+
+  // The tree has a key with ".", the plist level delimiter.
+  EXPECT_EQ(tree.size(), 8);
+  EXPECT_EQ(tree.count("com"), 0);
+
+  // Make sure "." iteration still works.
+  EXPECT_EQ(tree.get("inetdCompatibility.Wait", ""), "0");
 }
 
 TEST_F(PlistTests, test_parse_plist_array) {

--- a/tools/tests/test.plist
+++ b/tools/tests/test.plist
@@ -32,5 +32,7 @@
     <key>Wait</key>
     <false/>
   </dict>
+  <key>com.apple.Sync</key>
+  <string>TestDotStringAsKey</string>
 </dict>
 </plist>


### PR DESCRIPTION
Boost property trees are level delimited using '.' characters.
An Apple property list may contain keys with '.' characters, so the plist conversion must use iterators and raw node appends.