### PR TITLE
[Fix #1303] Only emit rows when appropriate for processes/users.

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -79,8 +79,12 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
                         ? FLAGS_read_max
                         : std::min(FLAGS_read_max, FLAGS_read_user_max);
   std::ifstream is(path.string(), std::ifstream::binary | std::ios::ate);
-  if (!is) {
-    return Status(1, "Error reading file: " + path.string());
+  if (!is.is_open()) {
+    // Attempt to read without seeking to the end.
+    is.open(path.string(), std::ifstream::binary);
+    if (!is) {
+      return Status(1, "Error reading file: " + path.string());
+    }
   }
 
   // Attempt to read the file size.

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -90,36 +90,40 @@ QueryData genUsers(QueryContext &context) {
   if (context.constraints["uid"].exists(EQUALS)) {
     auto uids = context.constraints["uid"].getAll<long long>(EQUALS);
     for (const auto &uid : uids) {
-      Row r;
       struct passwd *pwd = getpwuid(uid);
-      r["uid"] = BIGINT(uid);
-      if (pwd != nullptr) {
-        r["username"] = std::string(pwd->pw_name);
-        r["gid"] = BIGINT(pwd->pw_gid);
-        r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
-        r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
-        r["description"] = TEXT(pwd->pw_gecos);
-        r["directory"] = TEXT(pwd->pw_dir);
-        r["shell"] = TEXT(pwd->pw_shell);
+      if (pwd == nullptr) {
+        continue;
       }
+
+      Row r;
+      r["uid"] = BIGINT(uid);
+      r["username"] = std::string(pwd->pw_name);
+      r["gid"] = BIGINT(pwd->pw_gid);
+      r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
+      r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
+      r["description"] = TEXT(pwd->pw_gecos);
+      r["directory"] = TEXT(pwd->pw_dir);
+      r["shell"] = TEXT(pwd->pw_shell);
       results.push_back(r);
     }
   } else {
     std::set<std::string> usernames;
     genODEntries(kODRecordTypeUsers, usernames);
     for (const auto &username : usernames) {
+      struct passwd *pwd = getpwnam(username.c_str());
+      if (pwd == nullptr) {
+        continue;
+      }
+
       Row r;
       r["username"] = username;
-      struct passwd *pwd = getpwnam(username.c_str());
-      if (pwd != nullptr) {
-        r["uid"] = BIGINT(pwd->pw_uid);
-        r["gid"] = BIGINT(pwd->pw_gid);
-        r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
-        r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
-        r["description"] = TEXT(pwd->pw_gecos);
-        r["directory"] = TEXT(pwd->pw_dir);
-        r["shell"] = TEXT(pwd->pw_shell);
-      }
+      r["uid"] = BIGINT(pwd->pw_uid);
+      r["gid"] = BIGINT(pwd->pw_gid);
+      r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
+      r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
+      r["description"] = TEXT(pwd->pw_gecos);
+      r["directory"] = TEXT(pwd->pw_dir);
+      r["shell"] = TEXT(pwd->pw_shell);
       results.push_back(r);
     }
   }


### PR DESCRIPTION
I tried my hand at fixing #1303: I don't think optimizing around pid lists > than the number of running pids is worthwhile. Unless I am overlooking something obvious the number of individual `=` operands in a predicate should be 1, else they are superfluous. In the case of a join, there is a separate query for each match.

On OS X the pid existence determination can be quickly resolved using the already-needed sysctl for parent pid checking. On Linux this is a directory check within proc. On both platforms pids must be greater than 0.