### PR TITLE
[Fix #1368] Restore autostart post-install scripts

### DIFF
--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -195,6 +195,9 @@ function main() {
     if [ $CLEAN == true ]; then
         echo "$POSTINSTALL_CLEAN_TEXT" >> $POSTINSTALL
     fi
+    if [ $AUTOSTART == true ]; then
+        echo "$POSTINSTALL_AUTOSTART_TEXT" >> $POSTINSTALL
+    fi
   fi
 
   log "creating package"


### PR DESCRIPTION
This is fixing a regression with the `make_osx_package.sh` deployment script. The autostart postinstall commands had been removed.