### PR TITLE
[Fix #1367] Disable user-controlled FIFO reads

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -72,6 +72,8 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
 
   if (stat(path.string().c_str(), &file) < 0) {
     return Status(1, "Cannot access path: " + path.string());
+  } else if (file.st_uid != 0 && S_ISFIFO(file.st_mode)) {
+    return Status(1, "User FIFO reads are disabled");
   }
 
   // Apply the max byte-read based on file/link target ownership.

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -71,10 +71,6 @@ QueryData genFile(QueryContext& context) {
 
   auto paths = context.constraints["path"].getAll(EQUALS);
   for (const auto& path_string : paths) {
-    if (!isReadable(path_string)) {
-      continue;
-    }
-
     fs::path path = path_string;
     genFileInfo(path_string,
                 path.filename().string(),
@@ -120,9 +116,6 @@ QueryData genFile(QueryContext& context) {
     }
 
     for (const auto& resolved : expanded_patterns) {
-      if (!isReadable(resolved)) {
-        continue;
-      }
       fs::path path = resolved;
       genFileInfo(resolved,
                   path.filename().string(),


### PR DESCRIPTION
1. Do not allow reads from user-owned FIFOs.
2. Allow users to stat non-readable files.