### PR TITLE
[Fix #1369] Limit IOKit HID events

### DIFF
--- a/osquery/events/darwin/iokit_hid.cpp
+++ b/osquery/events/darwin/iokit_hid.cpp
@@ -95,6 +95,13 @@ void IOKitHIDEventPublisher::MatchingCallback(void *context,
   fire(device, "add");
 }
 
+void IOKitHIDEventPublisher::RemovalCallback(void *context,
+                                             IOReturn result,
+                                             void *sender,
+                                             IOHIDDeviceRef device) {
+  fire(device, "remove");
+}
+
 void IOKitHIDEventPublisher::fire(const IOHIDDeviceRef &device,
                                   const std::string &action) {
   auto ec = createEventContext();
@@ -116,14 +123,10 @@ void IOKitHIDEventPublisher::fire(const IOHIDDeviceRef &device,
   ec->serial = getProperty(device, CFSTR(kIOHIDSerialNumberKey));
   ec->country_code = getProperty(device, CFSTR(kIOHIDCountryCodeKey));
 
-  EventFactory::fire<IOKitHIDEventPublisher>(ec);
-}
-
-void IOKitHIDEventPublisher::RemovalCallback(void *context,
-                                             IOReturn result,
-                                             void *sender,
-                                             IOHIDDeviceRef device) {
-  fire(device, "remove");
+  if (ec->location.size() > 0 || ec->model_id.size() > 0) {
+    // Only emit results that contain an location or model_id.
+    EventFactory::fire<IOKitHIDEventPublisher>(ec);
+  }
 }
 
 void IOKitHIDEventPublisher::InputValueCallback(void *context,

--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -126,21 +126,21 @@
       "value" : "Identify malware, adware, or vulnerable packages that are installed as an application."
     },
     "open_sockets": {
-      "query" : "select * from process_open_sockets;",
+      "query" : "select distinct pid, family, protocol, local_address, local_port, remote_address, remote_port, path from process_open_sockets where path <> '' or remote_address <> '';",
       "interval" : "86400",
       "version" : "1.4.5",
       "description" : "Retrieves all the open sockets per process in the target system.",
       "value" : "Identify malware via connections to known bad IP addresses as well as odd local or remote port bindings"
     },
     "open_files": {
-      "query" : "select * from process_open_files;",
+      "query" : "select distinct pid, path from process_open_files where path not like '/private/var/folders%' and path not like '/System/Library/%' and path not in ('/dev/null', '/dev/urandom', '/dev/random');",
       "interval" : "86400",
       "version" : "1.4.5",
       "description" : "Retrieves all the open files per process in the target system.",
       "value" : "Identify processes accessing sensitive files they shouldn't"
     },
     "logged_in_users": {
-      "query" : "select * from logged_in_users, processes where logged_in_users.pid = processes.pid;",
+      "query" : "select liu.*, p.name, p.cmdline, p.cwd, p.root from logged_in_users liu, p where liu.pid = p.pid;",
       "interval" : "3600",
       "version" : "1.4.5",
       "description" : "Retrieves the list of all the currently logged in users in the target system.",
@@ -228,7 +228,7 @@
       "value" : "Determine what access the user had, identify accounts to be remediated."
     },
     "hardware_events": {
-      "query" : "select * from hardware_events;",
+      "query" : "select distinct * from hardware_events where path <> '' or model <> '';",
       "interval" : "86400",
       "version" : "1.4.5",
       "description" : "Retrieves all the hardware related events in the target OSX system.",


### PR DESCRIPTION
1. Only emit results that contain an `location` or `model_id`.
2. Add limits to various incident response pack queries.