### PR TITLE
Fixing problem with versionChecker and adding usecase to tests

### DIFF
--- a/osquery/config/parsers/query_packs.cpp
+++ b/osquery/config/parsers/query_packs.cpp
@@ -48,6 +48,8 @@ bool versionChecker(const std::string& pack, const std::string& version) {
     try {
       if (std::stoi(chunk) < std::stoi(required_version[index])) {
         return false;
+      } else if (std::stoi(chunk) > std::stoi(required_version[index])) {
+        return true;
       }
     } catch (const std::invalid_argument& e) {
       if (chunk.compare(required_version[index]) < 0) {

--- a/osquery/config/parsers/tests/query_packs_tests.cpp
+++ b/osquery/config/parsers/tests/query_packs_tests.cpp
@@ -57,6 +57,7 @@ class QueryPacksConfigTests : public testing::Test {};
 TEST_F(QueryPacksConfigTests, version_comparisons) {
   EXPECT_TRUE(versionChecker("1.0.0", "1.0.0"));
   EXPECT_TRUE(versionChecker("1.0.0", "1.2.0"));
+  EXPECT_TRUE(versionChecker("1.4.5", "1.5.0"));
   EXPECT_TRUE(versionChecker("1.0", "1.2.0"));
   EXPECT_TRUE(versionChecker("1.0", "1.0.2"));
   EXPECT_TRUE(versionChecker("1.0.0", "1.0.2-r1"));


### PR DESCRIPTION
Comparing 1.4.5 with 1.5.0 was not considered in the tests and it was making the versionChecker to fail. This fixes it.