### PR TITLE
Remove some non-warning/error log lines from tables

### DIFF
--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -54,7 +54,6 @@ QueryData genEtcHosts(QueryContext& context) {
   if (s.ok()) {
     return parseEtcHostsContent(content);
   } else {
-    LOG(ERROR) << "Error reading /etc/hosts: " << s.toString();
     return {};
   }
 }

--- a/osquery/tables/networking/etc_services.cpp
+++ b/osquery/tables/networking/etc_services.cpp
@@ -44,16 +44,12 @@ QueryData parseEtcServicesContent(const std::string& content) {
     // [n]: [aliasesn]
     auto service_info = split(service_info_comment[0]);
     if (service_info.size() < 2) {
-      LOG(WARNING) << "Line of /etc/services wasn't properly formatted. "
-                   << "Expected at least 2, got " << service_info.size();
       continue;
     }
 
     // [0]: port [1]: protocol
     auto service_port_protocol = split(service_info[1], "/");
     if (service_port_protocol.size() != 2) {
-      LOG(WARNING) << "Line of /etc/services wasn't properly formatted. "
-                   << "Expected 2, got " << service_port_protocol.size();
       continue;
     }
 
@@ -69,7 +65,8 @@ QueryData parseEtcServicesContent(const std::string& content) {
     // If there is a comment for the service.
     if (service_info_comment.size() > 1) {
       // Removes everything except the comment (parts of the comment).
-      service_info_comment.erase(service_info_comment.begin(), service_info_comment.begin() + 1);
+      service_info_comment.erase(service_info_comment.begin(),
+                                 service_info_comment.begin() + 1);
       r["comment"] = TEXT(boost::algorithm::join(service_info_comment, " # "));
     }
     results.push_back(r);
@@ -83,7 +80,6 @@ QueryData genEtcServices(QueryContext& context) {
   if (s.ok()) {
     return parseEtcServicesContent(content);
   } else {
-    LOG(ERROR) << "Error reading /etc/services: " << s.toString();
     return {};
   }
 }

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -85,8 +85,8 @@ void genOSXPrefValues(const CFTypeRef& value,
 
   // Since we recurse when parsing Arrays/Dicts, monitor stack limits.
   if (++depth > kPreferenceDepthLimit) {
-    LOG(WARNING) << "OS X Preference: " << base.at("domain")
-                 << " exceeded subkey depth limit: " << kPreferenceDepthLimit;
+    TLOG << "OS X Preference: " << base.at("domain")
+         << " exceeded subkey depth limit: " << kPreferenceDepthLimit;
     return;
   }
 

--- a/osquery/tables/system/linux/model_specific_register.cpp
+++ b/osquery/tables/system/linux/model_specific_register.cpp
@@ -103,7 +103,7 @@ void getModelSpecificRegisterData(QueryData &results, int cpu_number) {
     TLOG << "Could not open msr file " << msr_filename
          << " check the msr kernel module is enabled.";
     if (err == EACCES) {
-      LOG(WARNING) << "Could not access msr device.  Run osquery as root.";
+      TLOG << "Could not access msr device.  Run osquery as root.";
     }
     return;
   }
@@ -144,7 +144,7 @@ QueryData genModelSpecificRegister(QueryContext &context) {
   struct dirent **entries = nullptr;
   int num_entries = scandir("/dev/cpu", &entries, msrScandirFilter, 0);
   if (num_entries < 1) {
-    LOG(WARNING) << "No msr information check msr kernel module is enabled.";
+    TLOG << "No msr information check msr kernel module is enabled.";
     return results;
   }
   while (num_entries--) {


### PR DESCRIPTION
This is an attempt to clean up spurious log lines from table implementations. Table code should emit verbose logs at best. 