### PR TITLE
Silence google benchmark CMake output, remove benchmark tests

### DIFF
--- a/CMake/FindBenchmark.cmake
+++ b/CMake/FindBenchmark.cmake
@@ -1,2 +1,8 @@
-INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/third-party/benchmark/include")
-ADD_SUBDIRECTORY("${CMAKE_SOURCE_DIR}/third-party/benchmark")
+set(BENCHMARK_SOURCE_DIR "${CMAKE_SOURCE_DIR}/third-party/benchmark")
+set(BENCHMARK_BUILD_DIR "${CMAKE_BINARY_DIR}/third-party/benchmark")
+
+# Only build the benchmark shared library for benchmark targets.
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
+
+INCLUDE_DIRECTORIES("${BENCHMARK_SOURCE_DIR}/include")
+ADD_SUBDIRECTORY("${BENCHMARK_SOURCE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,10 +378,3 @@ add_custom_target(
   COMMENT "Generating sdk sync: ${CMAKE_BINARY_DIR}/sync"
   DEPENDS osquery_extensions osquery_amalgamation
 )
-
-# make benchmark
-add_custom_target(
-  run-benchmark
-  COMMAND sudo bash -c "$<TARGET_FILE:osquery_benchmarks> $ENV{BENCHMARK_TO_FILE}"
-  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-)

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # Set includes/compile options for kernel modules/extensions.
 set(CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS "")
@@ -159,20 +158,22 @@ if(APPLE)
     COMMENT "Generating symbols and launching a debugger with kernel target..."
   )
 
-  add_custom_target(
-    kernel-test
-    COMMAND echo ""
-    COMMAND echo "Running kernel tests requires root."
-    COMMAND sudo $<TARGET_FILE:osquery_kernel_tests>
-  )
+  if(NOT DEFINED ENV{SKIP_TESTS})
+    add_custom_target(
+      kernel-test
+      COMMAND echo ""
+      COMMAND echo "Running kernel tests requires root."
+      COMMAND sudo $<TARGET_FILE:osquery_kernel_tests>
+    )
 
-  add_custom_target(
-    run-kernel-benchmark
-    COMMAND echo ""
-    COMMAND echo "Running kernel benchmarks requires root."
-    COMMAND sudo bash -c "$<TARGET_FILE:osquery_kernel_benchmarks> $ENV{BENCHMARK_TO_FILE}"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-  )
+    add_custom_target(
+      run-kernel-benchmark
+      COMMAND echo ""
+      COMMAND echo "Running kernel benchmarks requires root."
+      COMMAND sudo bash -c "$<TARGET_FILE:osquery_kernel_benchmarks> $ENV{BENCHMARK_TO_FILE}"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    )
+  endif()
 elseif(LINUX)
   add_custom_target(
     base_kernel
@@ -199,15 +200,17 @@ elseif(LINUX)
     COMMAND echo "-- No kernel unload for Linux"
   )
 
-  add_custom_target(
-    kernel-test
-    COMMAND echo "-- No kernel test is run for Linux"
-  )
+  if(NOT DEFINED ENV{SKIP_TESTS})
+    add_custom_target(
+      kernel-test
+      COMMAND echo "-- No kernel test is run for Linux"
+    )
 
-  add_custom_target(
-    run-kernel-benchmark
-    COMMAND echo "-- No kernel benchmark is run for Linux"
-  )
+    add_custom_target(
+      run-kernel-benchmark
+      COMMAND echo "-- No kernel benchmark is run for Linux"
+    )
+  endif()
 else()
   add_custom_target(
     base_kernel
@@ -234,15 +237,17 @@ else()
     COMMAND echo "-- No kernel unload for unsupported platform"
   )
 
-  add_custom_target(
-    kernel-test
-    COMMAND echo "-- No kernel test is run for unsupported platform"
-  )
+  if(NOT DEFINED ENV{SKIP_TESTS})
+    add_custom_target(
+      kernel-test
+      COMMAND echo "-- No kernel test is run for unsupported platform"
+    )
 
-  add_custom_target(
-    run-kernel-benchmark
-    COMMAND echo "-- No kernel benchmark is run for unsupported platform"
-  )
+    add_custom_target(
+      run-kernel-benchmark
+      COMMAND echo "-- No kernel benchmark is run for unsupported platform"
+    )
+  endif()
 endif()
 
 # make kernel-build

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -218,6 +218,13 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   target_link_libraries(osquery_kernel_benchmarks benchmark libosquery_testing)
   SET_OSQUERY_COMPILE(osquery_kernel_benchmarks "${CXX_COMPILE_FLAGS} -DKERNEL_TEST=1")
 
+  # make benchmark
+  add_custom_target(
+    run-benchmark
+    COMMAND sudo bash -c "$<TARGET_FILE:osquery_benchmarks> $ENV{BENCHMARK_TO_FILE}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  )
+
   if(NOT OSQUERY_BUILD_SDK_ONLY)
     # osquery core (additional) set of unit tests built outside of SDK.
     add_executable(osquery_additional_tests main/tests.cpp ${OSQUERY_ADDITIONAL_TESTS})


### PR DESCRIPTION
Do not build google benchmark tests during default make/build. Also, gate the benchmarking and testing to test-inclusionary build requests.