### PR TITLE
[Fix #1374] Allow subscription subclassing

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -548,7 +548,7 @@ class EventSubscriberPlugin : public Plugin {
    * publishers. The namespace is a combination of the publisher and subscriber
    * registry plugin names.
    */
-  virtual EventPublisherID& dbNamespace() const = 0;
+  virtual EventPublisherID dbNamespace() const = 0;
 
   /// Disable event expiration for this subscriber.
   void doNotExpire() { expire_events_ = false; }
@@ -831,15 +831,14 @@ class EventSubscriber : public EventSubscriberPlugin {
    * plugin name assigned to publishers. The corresponding publisher name is
    * interpreted as the subscriber's event 'type'.
    */
-  EventPublisherID& getType() const {
+  virtual EventPublisherID& getType() const {
     static EventPublisherID type = EventFactory::getType<PUB>();
     return type;
   }
 
   /// See getType for lookup rational.
-  EventPublisherID& dbNamespace() const {
-    static EventPublisherID _ns = getType() + '.' + getName();
-    return _ns;
+  virtual EventPublisherID dbNamespace() const {
+    return getType() + '.' + getName();
   }
 
  public:

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -178,7 +178,7 @@ class Plugin : private boost::noncopyable {
   /// Allow the plugin to introspect into the registered name (for logging).
   void setName(const std::string& name) { name_ = name; }
 
-  const std::string& getName() const { return name_; }
+  virtual const std::string& getName() const { return name_; }
 
   /// Allow a specialized plugin type to act when an external plugin is
   /// registered (e.g., a TablePlugin will attach the table name).
@@ -267,7 +267,7 @@ class RegistryHelperCore : private boost::noncopyable {
   void setName(const std::string& name);
 
   /// Allow others to introspect into the registered name (for reporting).
-  const std::string& getName() const { return name_; }
+  virtual const std::string& getName() const { return name_; }
 
   /// Check if a given plugin name is considered internal.
   bool isInternal(const std::string& item_name) const;

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -439,12 +439,7 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
   // Get and increment the EID for this module.
   EventID eid = getEventID();
   // Without encouraging a missing event time, do not support a 0-time.
-  auto index_time = getUnixTime();
-  if (event_time == 0) {
-    r["time"] = std::to_string(index_time);
-  } else {
-    r["time"] = std::to_string(event_time);
-  }
+  r["time"] = std::to_string((event_time == 0) ? getUnixTime() : event_time);
 
   // Serialize and store the row data, for query-time retrieval.
   std::string data;

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -314,6 +314,9 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
     sub_ctx->require_this_value = 42;
     subscribe(&FakeEventSubscriber::SpecialCallback, sub_ctx, nullptr);
   }
+
+ private:
+  FRIEND_TEST(EventsTests, test_subscriber_names);
 };
 
 TEST_F(EventsTests, test_event_sub) {
@@ -381,5 +384,27 @@ TEST_F(EventsTests, test_fire_event) {
   second_subscription->callback = TestTheeCallback;
   pub->fire(ec, 0);
   EXPECT_EQ(kBellHathTolled, 4);
+}
+
+class SubFakeEventSubscriber : public FakeEventSubscriber {
+ public:
+  SubFakeEventSubscriber() { setName("SubFakeSubscriber"); }
+
+ private:
+  FRIEND_TEST(EventsTests, test_subscriber_names);
+};
+
+TEST_F(EventsTests, test_subscriber_names) {
+  auto pub = std::make_shared<BasicEventPublisher>();
+  EventFactory::registerEventPublisher(pub);
+
+  auto subsub = std::make_shared<SubFakeEventSubscriber>();
+  EXPECT_EQ(subsub->getType(), "FakePublisher");
+  EXPECT_EQ(subsub->getName(), "SubFakeSubscriber");
+  EXPECT_EQ(subsub->dbNamespace(), "FakePublisher.SubFakeSubscriber");
+
+  auto sub = std::make_shared<FakeEventSubscriber>();
+  EXPECT_EQ(sub->getName(), "FakeSubscriber");
+  EXPECT_EQ(sub->dbNamespace(), "FakePublisher.FakeSubscriber");
 }
 }

--- a/osquery/tables/events/linux/passwd_changes.cpp
+++ b/osquery/tables/events/linux/passwd_changes.cpp
@@ -65,8 +65,7 @@ Status PasswdChangesEventSubscriber::Callback(const INotifyEventContextRef& ec,
   r["transaction_id"] = INTEGER(ec->event->cookie);
   if (ec->action != "" && ec->action != "OPENED") {
     // A callback is somewhat useless unless it changes the EventSubscriber
-    // state
-    // or calls `add` to store a marked up event.
+    // state or calls `add` to store a marked up event.
     add(r, ec->time);
   }
   return Status(0, "OK");

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -149,7 +149,7 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
     }
   }
 
-  if (ec->action != "") {
+  if (ec->action != "" && r.at("matches").size() > 0) {
     add(r, ec->time);
   }
 


### PR DESCRIPTION
1. Allow multiple namespaces using the same publisher and event subscriber combination. The "multiple" means a unique/different namespace for potential subclassing subscribers.
2. Limit YARA results adding to events with matches.