### PR TITLE
Add tags and strings columns to YARA tables.

### DIFF
--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -110,6 +110,10 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
     return Status(1, "No YARA category string provided");
   }
 
+  if (ec->action != "UPDATED" && ec->action != "CREATED") {
+    return Status(1, "Invalid action");
+  }
+
   Row r;
   r["action"] = ec->action;
   r["target_path"] = ec->path;
@@ -121,6 +125,8 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
   // These are default values, to be updated in YARACallback.
   r["count"] = INTEGER(0);
   r["matches"] = std::string("");
+  r["strings"] = std::string("");
+  r["tags"] = std::string("");
 
   ConfigDataInstance config;
   const auto& parser = config.getParser("yara");

--- a/osquery/tables/other/yara.cpp
+++ b/osquery/tables/other/yara.cpp
@@ -36,6 +36,8 @@ Status doYARAScan(YR_RULES* rules,
   // These are default values, to be updated in YARACallback.
   r["count"] = INTEGER(0);
   r["matches"] = std::string("");
+  r["strings"] = std::string("");
+  r["tags"] = std::string("");
 
   // XXX: use target_path instead to be consistent with yara_events?
   r["path"] = path;

--- a/osquery/tables/other/yara_utils.cpp
+++ b/osquery/tables/other/yara_utils.cpp
@@ -208,11 +208,38 @@ int YARACallback(int message, void *message_data, void *user_data) {
   if (message == CALLBACK_MSG_RULE_MATCHING) {
     Row *r = (Row *) user_data;
     YR_RULE *rule = (YR_RULE *) message_data;
+
     if ((*r)["matches"].length() > 0) {
       (*r)["matches"] += "," + std::string(rule->identifier);
     } else {
       (*r)["matches"] = std::string(rule->identifier);
     }
+
+    YR_STRING *string = nullptr;
+    yr_rule_strings_foreach(rule, string) {
+      YR_MATCH *match = nullptr;
+      yr_string_matches_foreach(string, match) {
+        if ((*r)["strings"].length() > 0) {
+          (*r)["strings"] += "," + std::string(string->identifier);
+        } else {
+          (*r)["strings"] = std::string(string->identifier);
+        }
+
+        std::stringstream ss;
+        ss << std::hex << (match->base + match->offset);
+        (*r)["strings"] += ":" + ss.str();
+      }
+    }
+
+    const char *tag = nullptr;
+    yr_rule_tags_foreach(rule, tag) {
+      if ((*r)["tags"].length() > 0) {
+        (*r)["tags"] += "," + std::string(tag);
+      } else {
+        (*r)["tags"] = std::string(tag);
+      }
+    }
+
     (*r)["count"] = INTEGER(std::stoi((*r)["count"]) + 1);
   }
 

--- a/specs/yara.table
+++ b/specs/yara.table
@@ -7,6 +7,7 @@ schema([
     Column("sig_group", TEXT, "Signature group used"),
     Column("sigfile", TEXT, "Signature file used"),
     Column("pattern", TEXT, "A pattern which can be used to match file paths"),
-
+    Column("strings", TEXT, "Matching strings"),
+    Column("tags", TEXT, "Matching tags"),
 ])
 implementation("yara@genYara")

--- a/specs/yara_events.table
+++ b/specs/yara_events.table
@@ -8,6 +8,8 @@ schema([
     Column("matches", TEXT, "List of YARA matches"),
     Column("count", INTEGER, "Number of YARA matches"),
     Column("time", BIGINT, "Time of the scan"),
+    Column("strings", TEXT, "Matching strings"),
+    Column("tags", TEXT, "Matching tags"),
 ])
 attributes(event_subscriber=True)
 implementation("yara@yara_events::genTable")


### PR DESCRIPTION
When strings match they will be populated into the "strings" column of the table. The format is identifier:offset.

When a matching rule has tags defined the tags will be put into the "tags" column of the table in a comma separated list.

Also, only operate on CREATED or UPDATED events in the yara_events table.