### PR TITLE
initialize schedule to a consistent time

### DIFF
--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -142,9 +142,7 @@ void launchQuery(const std::string& name, const ScheduledQuery& query) {
 }
 
 void SchedulerRunner::start() {
-  time_t t = std::time(nullptr);
-  struct tm* local = std::localtime(&t);
-  unsigned long int i = local->tm_sec;
+  unsigned long int i = getUnixTime();
   for (; (timeout_ == 0) || (i <= timeout_); ++i) {
     {
       ConfigDataInstance config;


### PR DESCRIPTION
With this change, queries that are scheduled to run with a certain
interval will be consistently ran at a consistent time of the day,
modified only by their splay, regardless of when you started / reloaded
the osqueryd process.

Explicitly, queries that are to be ran once a day will run, splayed, at
midnight. Queries set to run every four hours will run at 0:00, 4:00,
8:00, etc.

Do we think that the schedule should offer this level of consistency, or
is the natural global splay that leaving the value without significant
initialization desired?