### PR TITLE
Build non-10.10 darwin platforms side-by-side

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,15 @@ ifeq ($(PLATFORM),FreeBSD)
 	MAKE = gmake
 endif
 
+DARWIN_LATEST=10.9
 DISTRO := $(shell . ./tools/lib.sh; _platform)
 DISTRO_VERSION := $(shell . ./tools/lib.sh; _distro $(DISTRO))
 ifeq ($(DISTRO),darwin)
-	BUILD_DIR = darwin
+	ifeq ($(DISTRO_VERSION),$(DARWIN_LATEST))
+		BUILD_DIR = darwin
+	else
+		BUILD_DIR = darwin$(DISTRO_VERSION)
+	endif
 else
 	BUILD_DIR = $(DISTRO_VERSION)
 endif


### PR DESCRIPTION
Non-darwin latest builds will use a `./build/darwinVERSION` subdirectory. This let's us copy and maintain packages per OS release while maintaining the latest as `darwin/*`.