### PR TITLE
Added loading of kernel.

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -9,9 +9,11 @@ if(APPLE)
     darwin/iokit_hid.cpp
     darwin/diskarbitration.cpp
     darwin/scnetwork.cpp
+    darwin/kernel_util.cpp
   )
 elseif(FREEBSD)
   ADD_OSQUERY_LIBRARY(FALSE osquery_events_freebsd
+    freebsd/kernel_util.cpp
   )
 else()
   ADD_OSQUERY_LINK(FALSE "udev")
@@ -19,6 +21,7 @@ else()
   ADD_OSQUERY_LIBRARY(FALSE osquery_events_linux
     linux/inotify.cpp
     linux/udev.cpp
+    linux/kernel_util.cpp
   )
 endif()
 

--- a/osquery/events/darwin/kernel_util.cpp
+++ b/osquery/events/darwin/kernel_util.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/events/kernel.h"
+
+#include <boost/regex.hpp>
+#include <boost/xpressive/xpressive.hpp>
+
+#include <IOKit/kext/KextManager.h>
+
+#include <osquery/config.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+
+namespace xp = boost::xpressive;
+
+namespace osquery {
+
+DECLARE_bool(disable_kernel);
+
+static const CFStringRef kKernelBundleId =
+    CFSTR("com.facebook.security.osquery");
+static const CFStringRef kKernelExtensionDirectory =
+    CFSTR("/Library/Extensions/");
+static const std::string kKernelBundleRegex =
+    ".*Kernel Extensions in "
+    "backtrace:.*com\\.facebook\\.security\\.osquery.*Kernel version:";
+static const std::string kBlockingFile = "/var/osquery/.gtfo";
+
+void loadKernelExtension() {
+  // Find the panic log file for the last panic if we are just booting out of
+  // panic.
+  auto results =
+      SQL::SQL(
+          "SELECT f.path AS path FROM (SELECT * FROM nvram WHERE name like "
+          "'%panic%') AS nv JOIN (SELECT * FROM file WHERE "
+          "directory='/Library/Logs/DiagnosticReports/' AND path like "
+          "'%/Kernel%' ORDER BY ctime DESC LIMIT 1) as f;")
+          .rows();
+
+  if (results.size() == 1) {
+    std::string panic_content;
+    if (readFile(results[0]["path"], panic_content).ok()) {
+      auto rx = xp::sregex::compile(kKernelBundleRegex);
+      xp::smatch matches;
+      if (xp::regex_search(panic_content, matches, rx)) {
+        LOG(ERROR) << "Panic was caused by osquery kernel extension.";
+        writeTextFile(kBlockingFile, "");
+      }
+    }
+  }
+
+  results =
+      SQL::selectAllFrom("file", "path", EQUALS, "/var/osquery/.gtfo");
+
+  if (FLAGS_disable_kernel) {
+    LOG(INFO) << "Kernel extension is disabled.";
+  } else if (results.size() > 0) {
+    LOG(WARNING) << "Kernel extension disabled by file.";
+  } else {
+    CFURLRef urls[1];
+    CFArrayRef directoryArray;
+
+    urls[0] = CFURLCreateWithString(NULL, kKernelExtensionDirectory, NULL);
+
+    directoryArray =
+        CFArrayCreate(NULL, (const void **)urls, 1, &kCFTypeArrayCallBacks);
+    if (KextManagerLoadKextWithIdentifier(kKernelBundleId, directoryArray) !=
+        kOSReturnSuccess) {
+    }
+    CFRelease(directoryArray);
+  }
+}
+
+} // namespace osquery

--- a/osquery/events/freebsd/kernel_util.cpp
+++ b/osquery/events/freebsd/kernel_util.cpp
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/events/kernel.h"
+
+#include <osquery/config.h>
+
+namespace osquery {
+
+void loadKernelExtension() {
+}
+
+} // namespace osquery

--- a/osquery/events/kernel.cpp
+++ b/osquery/events/kernel.cpp
@@ -11,9 +11,10 @@
 #include "osquery/events/kernel.h"
 
 #include <osquery/logger.h>
-#include <osquery/core.h>
 
 namespace osquery {
+
+FLAG(bool, disable_kernel, false, "Disable osquery kernel extension");
 
 static const size_t shared_buffer_size_bytes = (20 * (1 << 20));
 static const int max_events_before_sync = 1000;
@@ -21,6 +22,10 @@ static const int max_events_before_sync = 1000;
 REGISTER(KernelEventPublisher, "event_publisher", "kernel");
 
 Status KernelEventPublisher::setUp() {
+  if (kToolType == OSQUERY_TOOL_DAEMON) {
+    loadKernelExtension();
+  }
+
   try {
     queue_ = new CQueue(shared_buffer_size_bytes);
   } catch (const CQueueException &e) {

--- a/osquery/events/kernel.h
+++ b/osquery/events/kernel.h
@@ -20,6 +20,11 @@
 namespace osquery {
 
 /**
+ * @brief Load kernel extension if applicable.
+ */
+void loadKernelExtension();
+
+/**
  * @brief Subscription details for KernelEventPublisher events.
  */
 struct KernelSubscriptionContext : public SubscriptionContext {

--- a/osquery/events/linux/kernel_util.cpp
+++ b/osquery/events/linux/kernel_util.cpp
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/events/kernel.h"
+
+#include <osquery/config.h>
+
+namespace osquery {
+
+void loadKernelExtension() {
+}
+
+} // namespace osquery


### PR DESCRIPTION
Checks for panics we are involved in and does not load kernel extension.  Otherwise looks for `/var/osquery/.gtfo` with `0660` permissions or a `disable_kernel` flag in the config options.