### PR TITLE
Add 'hidden' flags to customize TLS plugins

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -83,6 +83,14 @@ The posted logger data is exactly the same as logged to disk by the **filesystem
 {}
 ```
 
+**Customizations**
+
+There are several unlisted flags to further control the remote settings. These controls are helpful if using a somewhat opaque API.
+
+`--tls_secret_always=True` will always send the enrollment secret. This will not perform an enrollment request with every config/logger attempt but rather "also" include the secret. If this is enabled, the secret is appended as a URI variable.
+
+`--tls_enroll_override=enroll_secret` this allows one to rename the enrollment key request body or URI variable.
+
 ## Remote logging buffering
 
 In most cases the client plugins default to 3-strikes-you're-out when attempting to POST to the configured endpoints. If a configuration cannot be retrieved the client will exit non-0 but a non-responsive logger endpoint will cause logs to buffer in RocksDB. The logging buffer size can be controlled by a [CLI flag](../installation/cli-flags.md), and if the size overflows logs will drop.

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -211,6 +211,13 @@ std::string getHostname();
 std::string generateHostUuid();
 
 /**
+ * @brief Get a configured UUID/name that uniquely identify this machine
+ *
+ * @return string to identify this machine
+ */
+std::string getHostIdentifier();
+
+/**
  * @brief Getter for the current time, in a human-readable format.
  *
  * @return the current date/time in the format: "Wed Sep 21 10:27:52 2011"

--- a/include/osquery/enroll.h
+++ b/include/osquery/enroll.h
@@ -83,7 +83,7 @@ std::string getNodeKey(const std::string& enroll_plugin, bool force = false);
  *
  * @return enroll_secret The trimmed content read from FLAGS_enroll_secret_path.
  */
-std::string getEnrollSecret();
+const std::string& getEnrollSecret();
 
 /**
  * @brief Enroll plugin registry.

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -28,6 +28,19 @@ namespace fs = boost::filesystem;
 namespace osquery {
 std::string kFakeDirectory = "";
 
+#ifdef DARWIN
+std::string kTestWorkingDirectory = "/private/tmp/osquery-tests";
+#else
+std::string kTestWorkingDirectory = "/tmp/osquery-tests";
+#endif
+
+/// Most tests will use binary or disk-backed content for parsing tests.
+#ifndef OSQUERY_BUILD_SDK
+std::string kTestDataPath = "../../../tools/tests/";
+#else
+std::string kTestDataPath = "../../../../tools/tests/";
+#endif
+
 DECLARE_string(database_path);
 DECLARE_string(extensions_socket);
 DECLARE_string(modules_autoload);
@@ -53,28 +66,20 @@ void initTesting() {
 
   // Set safe default values for path-based flags.
   // Specific unittests may edit flags temporarily.
-  std::string testWorkingDirectory =
-      kTestWorkingDirectory + std::to_string(getuid()) + "/";
-  kFakeDirectory = testWorkingDirectory + kFakeDirectoryName;
+  kTestWorkingDirectory += std::to_string(getuid()) + "/";
+  kFakeDirectory = kTestWorkingDirectory + kFakeDirectoryName;
 
-  fs::remove_all(testWorkingDirectory);
-  fs::create_directories(testWorkingDirectory);
-  FLAGS_database_path = testWorkingDirectory + "unittests.db";
-  FLAGS_extensions_socket = testWorkingDirectory + "unittests.em";
-  FLAGS_extensions_autoload = testWorkingDirectory + "unittests-ext.load";
-  FLAGS_modules_autoload = testWorkingDirectory + "unittests-mod.load";
+  fs::remove_all(kTestWorkingDirectory);
+  fs::create_directories(kTestWorkingDirectory);
+  FLAGS_database_path = kTestWorkingDirectory + "unittests.db";
+  FLAGS_extensions_socket = kTestWorkingDirectory + "unittests.em";
+  FLAGS_extensions_autoload = kTestWorkingDirectory + "unittests-ext.load";
+  FLAGS_modules_autoload = kTestWorkingDirectory + "unittests-mod.load";
   FLAGS_disable_logging = true;
 
   // Create a default DBHandle instance before unittests.
   (void)DBHandle::getInstance();
 }
-
-/// Most tests will use binary or disk-backed content for parsing tests.
-#ifndef OSQUERY_BUILD_SDK
-std::string kTestDataPath = "../../../tools/tests/";
-#else
-std::string kTestDataPath = "../../../../tools/tests/";
-#endif
 
 QueryData getTestDBExpectedResults() {
   QueryData d;

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -27,19 +27,19 @@ namespace osquery {
 /// Init function for tests and benchmarks.
 void initTesting();
 
+/// Cleanup/stop function for tests and benchmarks.
+void cleanupTesting();
+
 /// Any SQL-dependent tests should use kTestQuery for a pre-populated example.
 const std::string kTestQuery = "SELECT * FROM test_table";
 
+/// Tests can be run from within the source or build directory.
+/// The test initializer will attempt to discovery the current working path.
 extern std::string kTestDataPath;
 
 /// Tests should limit intermediate input/output to a working directory.
 /// Config data, logging results, and intermediate database/caching usage.
-
-#ifdef DARWIN
-const std::string kTestWorkingDirectory = "/private/tmp/osquery-tests";
-#else
-const std::string kTestWorkingDirectory = "/tmp/osquery-tests";
-#endif
+extern std::string kTestWorkingDirectory;
 
 /// A fake directory tree should be used for filesystem iterator testing.
 const std::string kFakeDirectoryName = "fstree";

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -24,12 +24,11 @@ namespace osquery {
 
 const int kDelayUS = 2000;
 const int kTimeoutUS = 1000000;
-const std::string kTestManagerSocket = kTestWorkingDirectory + "test.em";
 
 class ExtensionsTest : public testing::Test {
  protected:
   void SetUp() {
-    socket_path = kTestManagerSocket + std::to_string(rand());
+    socket_path = kTestWorkingDirectory + "test.em" + std::to_string(rand());
     remove(socket_path);
     if (pathExists(socket_path).ok()) {
       throw std::domain_error("Cannot test sockets: " + socket_path);

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -61,11 +61,11 @@ std::string getNodeKey(const std::string& enroll_plugin, bool force) {
   return node_key;
 }
 
-std::string getEnrollSecret() {
+const std::string& getEnrollSecret() {
   static std::string enrollment_secret;
 
   if (enrollment_secret.size() == 0) {
-    // Secret has not been read
+    // Secret has not been read yet.
     if (FLAGS_enroll_secret_path != "") {
       osquery::readFile(FLAGS_enroll_secret_path, enrollment_secret);
       boost::trim(enrollment_secret);

--- a/osquery/remote/enroll/plugins/tls.cpp
+++ b/osquery/remote/enroll/plugins/tls.cpp
@@ -28,6 +28,18 @@ CLI_FLAG(string,
          "",
          "TLS/HTTPS endpoint for client enrollment");
 
+/// Undocumented feature for TLS access token passing.
+HIDDEN_FLAG(bool,
+            tls_secret_always,
+            false,
+            "Include TLS enroll secret in every request");
+
+/// Undocumented feature to override TLS enrollment key name.
+HIDDEN_FLAG(string,
+            tls_enroll_override,
+            "enroll_secret",
+            "Override the TLS enroll secret key name");
+
 class TLSEnrollPlugin : public EnrollPlugin {
  private:
   /// Enroll called, return cached key or if no key cached, call requestKey.
@@ -47,6 +59,11 @@ REGISTER(TLSEnrollPlugin, "enroll", "tls");
 std::string TLSEnrollPlugin::enroll(bool force) {
   // If no node secret has been negotiated, try a TLS request.
   auto uri = "https://" + FLAGS_tls_hostname + FLAGS_enroll_tls_endpoint;
+  if (FLAGS_tls_secret_always) {
+    uri += ((uri.find("?") != std::string::npos) ? "&" : "?") +
+           FLAGS_tls_enroll_override + "=" + getEnrollSecret();
+  }
+
   if (node_secret_key_.size() == 0 || force) {
     VLOG(1) << "TLSEnrollPlugin requesting a node enroll key from: " << uri;
     for (size_t i = 1; i <= ENROLL_TLS_MAX_ATTEMPTS; i++) {
@@ -67,7 +84,8 @@ std::string TLSEnrollPlugin::enroll(bool force) {
 Status TLSEnrollPlugin::requestKey(const std::string& uri) {
   // Read the optional enrollment secret data (sent with an enrollment request).
   boost::property_tree::ptree params;
-  params.put<std::string>("enroll_secret", getEnrollSecret());
+  params.put<std::string>(FLAGS_tls_enroll_override, getEnrollSecret());
+  params.put<std::string>("host_identifier", getHostIdentifier());
 
   auto request = Request<TLSTransport, JSONSerializer>(uri);
   auto status = request.call(params);
@@ -82,13 +100,16 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri) {
     return status;
   }
 
+  // Support multiple response keys as a node key (identifier).
   if (recv.count("node_key") > 0) {
-    // Set the enroll key, should be stored in the RocksDB cache.
-    // TODO: Store this response key in RocksDB.
-    node_secret_key_ = recv.get<std::string>("node_key", "");
-    return Status(0, "OK");
-  } else {
+    node_secret_key_ = recv.get("node_key", "");
+  } else if (recv.count("id") > 0) {
+    node_secret_key_ = recv.get("id", "");
+  }
+
+  if (node_secret_key_.size() == 0) {
     return Status(1, "No enrollment key returned from TLS enroll plugin");
   }
+  return Status(0, "OK");
 }
 }

--- a/osquery/remote/requests.h
+++ b/osquery/remote/requests.h
@@ -89,6 +89,11 @@ class Transport {
     return response_params_;
   }
 
+  template <typename T>
+  void setOption(const std::string& name, const T& value) {
+    options_.put(name, value);
+  }
+
   /**
    * @brief Virtual destructor
    */
@@ -106,6 +111,9 @@ class Transport {
 
   /// storage for response parameters
   boost::property_tree::ptree response_params_;
+
+  /// options from request call (use defined by specific transport)
+  boost::property_tree::ptree options_;
 };
 
 /**
@@ -250,6 +258,11 @@ class Request {
   Status getResponse(boost::property_tree::ptree& params) {
     params = transport_->getResponseParams();
     return transport_->getResponseStatus();
+  }
+
+  template <typename T>
+  void setOption(const std::string& name, const T& value) {
+    transport_->setOption(name, value);
   }
 
  private:

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -38,16 +38,24 @@ DECLARE_string(tls_client_cert);
 DECLARE_string(tls_hostname);
 
 /**
+ * @brief HTTP verb selections.
+ */
+enum HTTPVerb {
+  HTTP_POST = 0,
+  HTTP_PUT,
+};
+
+/**
  * @brief HTTPS (TLS) transport.
  */
 class TLSTransport : public Transport {
  public:
-
   /**
    * @brief Send a simple request to the destination with no parameters
    *
-   * @return An instance of osquery::Status indicating the success or failure
-   * of the operation
+   * @return A status indicating socket, network, or transport success/error.
+   * Return code (1) for general connectivity problems, return code (2) for TLS
+   * specific errors.
    */
   Status sendRequest();
 
@@ -56,8 +64,9 @@ class TLSTransport : public Transport {
    *
    * @param params A string representing the serialized parameters
    *
-   * @return An instance of osquery::Status indicating the success or failure
-   * of the operation
+   * @return A status indicating socket, network, or transport success/error.
+   * Return code (1) for general connectivity problems, return code (2) for TLS
+   * specific errors.
    */
   Status sendRequest(const std::string& params);
 


### PR DESCRIPTION
This extends the TLS-based plugin configuration options by allowing the configuration/flags to set the name of the enrollment/access key as well as a boolean to toggle "always on" enrollment authentication in the case where a shared deployment secret must be included with every request.