### PR TITLE
linux users table: Do not drop users with duplicate UIDs

### DIFF
--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -27,26 +27,20 @@ QueryData genUsers(QueryContext& context) {
   std::lock_guard<std::mutex> lock(pwdEnumerationMutex);
   QueryData results;
   struct passwd *pwd = nullptr;
-  std::set<long> users_in;
 
   while ((pwd = getpwent()) != nullptr) {
-    if (std::find(users_in.begin(), users_in.end(), pwd->pw_uid) ==
-        users_in.end()) {
-      Row r;
-      r["uid"] = BIGINT(pwd->pw_uid);
-      r["gid"] = BIGINT(pwd->pw_gid);
-      r["uid_signed"] = BIGINT((int32_t) pwd->pw_uid);
-      r["gid_signed"] = BIGINT((int32_t) pwd->pw_gid);
-      r["username"] = TEXT(pwd->pw_name);
-      r["description"] = TEXT(pwd->pw_gecos);
-      r["directory"] = TEXT(pwd->pw_dir);
-      r["shell"] = TEXT(pwd->pw_shell);
-      results.push_back(r);
-      users_in.insert(pwd->pw_uid);
-    }
+    Row r;
+    r["uid"] = BIGINT(pwd->pw_uid);
+    r["gid"] = BIGINT(pwd->pw_gid);
+    r["uid_signed"] = BIGINT((int32_t) pwd->pw_uid);
+    r["gid_signed"] = BIGINT((int32_t) pwd->pw_gid);
+    r["username"] = TEXT(pwd->pw_name);
+    r["description"] = TEXT(pwd->pw_gecos);
+    r["directory"] = TEXT(pwd->pw_dir);
+    r["shell"] = TEXT(pwd->pw_shell);
+    results.push_back(r);
   }
   endpwent();
-  users_in.clear();
 
   return results;
 }


### PR DESCRIPTION
See Github issue #1301. FreeBSD (which also uses this table) by default has two
users which are UID 0 -- both `toor` and `root`. 19a2d64959 made it so that we
would only get the first one from `getpwent`, but this feature is undesirable
in cases where two different users share the same UID.