### PR TITLE
Benchmark using mean across 5 runs.

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -587,6 +587,7 @@ class EventSubscriberPlugin : public Plugin {
   FRIEND_TEST(EventsDatabaseTests, test_record_indexing);
   FRIEND_TEST(EventsDatabaseTests, test_record_range);
   FRIEND_TEST(EventsDatabaseTests, test_record_expiration);
+  friend class BenchmarkEventSubscriber;
 };
 
 /**

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -45,10 +45,12 @@ OUTDIR="$SCRIPT_DIR/../build/benchmarks"
 NODE=$(echo $NODE_LABELS | awk '{print $NF}')
 mkdir -p $OUTDIR
 
-export BENCHMARK_TO_FILE="--benchmark_format=csv :>$OUTDIR/$NODE-benchmark.csv"
+REPETITIONS=5
+
+export BENCHMARK_TO_FILE="--benchmark_format=csv --benchmark_repetitions=$REPETITIONS :>$OUTDIR/$NODE-benchmark.csv"
 make run-benchmark/fast
 
-export BENCHMARK_TO_FILE="--benchmark_format=csv :>$OUTDIR/$NODE-kernel-benchmark.csv"
+export BENCHMARK_TO_FILE="--benchmark_format=csv --benchmark_repetitions=$REPETITIONS :>$OUTDIR/$NODE-kernel-benchmark.csv"
 make run-kernel-benchmark/fast
 
 strip $SCRIPT_DIR/../build/*/*/osqueryi


### PR DESCRIPTION
Benchmarks will be more stable with an average across 5 benchmark runs.