### PR TITLE
Several small optimizations around internal SQL queries

### DIFF
--- a/osquery/dispatcher/CMakeLists.txt
+++ b/osquery/dispatcher/CMakeLists.txt
@@ -1,7 +1,12 @@
 ADD_OSQUERY_LIBRARY(TRUE osquery_dispatcher
   dispatcher.cpp
+)
+
+ADD_OSQUERY_LIBRARY(FALSE osquery_dispatch_scheduler
   scheduler.cpp
 )
 
+# Note: if there are ever scheduler tests this needs to set the
+# test files manually.
 file(GLOB OSQUERY_DISPATCHER_TESTS "tests/*.cpp")
 ADD_OSQUERY_TEST(TRUE ${OSQUERY_DISPATCHER_TESTS})

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -48,8 +48,8 @@ extern const int kDefaultThreadPoolSize;
 
 class InternalRunnable : public Runnable {
  public:
-  virtual ~InternalRunnable() {}
   InternalRunnable() : run_(false) {}
+  virtual ~InternalRunnable() {}
 
  public:
   /// The boost::thread entrypoint.
@@ -252,10 +252,13 @@ class Dispatcher : private boost::noncopyable {
    * Since instances of Dispatcher should only be created via instance(),
    * Dispatcher's constructor is private.
    */
-  Dispatcher();
+  Dispatcher() {}
   Dispatcher(Dispatcher const&);
   void operator=(Dispatcher const&);
   virtual ~Dispatcher();
+
+  /// Initialize the thread poll when the first dispatcher thread is needed.
+  void init();
 
  private:
   /**
@@ -268,7 +271,7 @@ class Dispatcher : private boost::noncopyable {
    *
    * @see getThreadManager
    */
-  InternalThreadManagerRef thread_manager_;
+  InternalThreadManagerRef thread_manager_{nullptr};
 
   /// The set of shared osquery service threads.
   std::vector<InternalThreadRef> service_threads_;

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -15,10 +15,10 @@
 #include <osquery/database.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
-#include <osquery/sql.h>
 
 #include "osquery/database/query.h"
 #include "osquery/dispatcher/scheduler.h"
+#include "osquery/sql/sqlite_util.h"
 
 namespace osquery {
 
@@ -61,7 +61,7 @@ inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
   auto pid = std::to_string(getpid());
   auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   auto t0 = time(nullptr);
-  auto sql = SQL(query.query);
+  auto sql = SQLInternal(query.query);
   // Snapshot the performance after, and compare.
   auto t1 = time(nullptr);
   auto r1 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
@@ -81,7 +81,8 @@ inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
 void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // Execute the scheduled query and create a named query object.
   VLOG(1) << "Executing query: " << query.query;
-  auto sql = (FLAGS_enable_monitor) ? monitor(name, query) : SQL(query.query);
+  auto sql =
+      (FLAGS_enable_monitor) ? monitor(name, query) : SQLInternal(query.query);
 
   if (!sql.ok()) {
     LOG(ERROR) << "Error executing query (" << query.query

--- a/osquery/main/run.cpp
+++ b/osquery/main/run.cpp
@@ -14,7 +14,8 @@
 #include <osquery/events.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
-#include <osquery/sql.h>
+
+#include "osquery/sql/sqlite_util.h"
 
 DEFINE_string(query, "", "query to execute");
 DEFINE_int32(iterations, 1, "times to run the query in question");
@@ -51,7 +52,8 @@ int main(int argc, char* argv[]) {
   osquery::QueryData results;
   osquery::Status status;
   for (int i = 0; i < FLAGS_iterations; ++i) {
-    status = osquery::query(FLAGS_query, results);
+    auto dbc = osquery::SQLiteDBManager::get();
+    status = osquery::queryInternal(FLAGS_query, results, dbc.db());
     if (!status.ok()) {
       fprintf(stderr, "Query failed: %d\n", status.getCode());
       break;

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -183,6 +183,22 @@ class SQLiteSQLPlugin : SQLPlugin {
 };
 
 /**
+ * @brief SQLInternal: SQL, but backed by internal calls.
+ */
+class SQLInternal : public SQL {
+ public:
+  /**
+   * @brief Instantiate an instance of the class with an internal query
+   *
+   * @param q An osquery SQL query
+   */
+  explicit SQLInternal(const std::string& q) {
+    auto dbc = SQLiteDBManager::get();
+    status_ = queryInternal(q, results_, dbc.db());
+  }
+};
+
+/**
  * @brief Get a string representation of a SQLite return code
  */
 std::string getStringForSQLiteReturnCode(int code);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -220,9 +220,8 @@ static int xFilter(sqlite3_vtab_cursor *pVtabCursor,
         pVtab->content->constraints[i].second);
   }
 
-  PluginRequest request;
+  PluginRequest request = {{"action", "generate"}};
   PluginResponse response;
-  request["action"] = "generate";
   TablePlugin::setRequestFromContext(context, request);
   Registry::call("table", pVtab->content->name, request, response);
 
@@ -278,13 +277,6 @@ Status attachTableInternal(const std::string &name,
       tables::xEof,
       tables::xColumn,
       tables::xRowid,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
   };
   // clang-format on
 

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -44,12 +44,12 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 {% if class_name != "" %}\
     if (EventFactory::exists("{{class_name}}")) {
       auto subscriber = EventFactory::getEventSubscriber("{{class_name}}");
-      return subscriber->{{function}}(request);
+      return std::move(subscriber->{{function}}(request));
     } else {
       throw std::runtime_error("Subscriber table: {{class_name}} missing.");
     }
 {% else %}\
-    return tables::{{function}}(request);
+    return std::move(tables::{{function}}(request));
 {% endif %}\
   }
 };


### PR DESCRIPTION
Small tweaks to use less data structures and registry calls when making internal SQL queries. Internal applies to the core components directly using the SQLite implementation.