### PR TITLE
Apply query options to pack queries

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -115,10 +115,11 @@ class Config : private boost::noncopyable {
   /**
    * @brief Adds a new query to the scheduled queries.
    *
+   * @param name Canonicalized name of scheduled query.
+   * @param node The JSON-tree node containing query, interval, and options.
    */
   static void addScheduledQuery(const std::string& name,
-                                const std::string& query,
-                                int interval);
+                                const boost::property_tree::ptree::value_type&);
 
   /**
    * @brief Checks if a query exists in the query schedule.

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -145,7 +145,7 @@ inline void mergeOption(const tree_node& option, ConfigData& conf) {
   conf.all_data.add_child("options." + key, option.second);
 }
 
-inline void additionalScheduledQuery(const std::string& name,
+static void additionalScheduledQuery(const std::string& name,
                                      const tree_node& node,
                                      ConfigData& conf) {
   // Read tree/JSON into a query structure.
@@ -312,15 +312,7 @@ Status Config::getMD5(std::string& hash_string) {
   return Status(0, "OK");
 }
 
-void Config::addScheduledQuery(const std::string& name,
-                               const std::string& query,
-                               const int interval) {
-  // Create structure to add to the schedule.
-  tree_node node;
-  node.second.put("query", query);
-  node.second.put("interval", interval);
-
-  // Call to the inline function.
+void Config::addScheduledQuery(const std::string& name, const tree_node& node) {
   additionalScheduledQuery(name, node, getInstance().data_);
 }
 

--- a/osquery/config/parsers/query_packs.cpp
+++ b/osquery/config/parsers/query_packs.cpp
@@ -114,13 +114,8 @@ Status parsePack(const std::string& name, const pt::ptree& data) {
       continue;
     }
 
-    // Hope there is a supplied/non-0 query interval to apply this query pack
-    // query to the osquery schedule.
-    auto query_interval = query.second.get("interval", 0);
-    if (query_interval > 0) {
-      auto query_name = "pack_" + name + "_" + query.first;
-      Config::addScheduledQuery(query_name, query_string, query_interval);
-    }
+    auto query_name = "pack_" + name + "_" + query.first;
+    Config::addScheduledQuery(query_name, query);
   }
 
   return Status(0, "OK");


### PR DESCRIPTION
Having the ability to NOT emit "removed" events from queries in packs is essential!