### PR TITLE
Fix build on OS X 10.11

### DIFF
--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -174,7 +174,7 @@ Status genKeychainACLAppsForEntry(SecKeychainRef keychain,
   KeychainItemMetadata item_metadata;
   item_metadata.keychain_path = path;
 
-  SecItemClass item_class = 0;
+  SecItemClass item_class;
   SecKeychainItemCopyAttributesAndData(
       item, nullptr, &item_class, nullptr, nullptr, nullptr);
 
@@ -271,7 +271,6 @@ Status genKeychainACLAppsForEntry(SecKeychainRef keychain,
 Status genKeychainACLApps(const std::string &path, QueryData &results) {
   SecKeychainRef keychain = nullptr;
   OSStatus os_status = 0;
-
   os_status = SecKeychainOpen(path.c_str(), &keychain);
   if (os_status != noErr || keychain == nullptr) {
     if (keychain != nullptr) {
@@ -282,7 +281,7 @@ Status genKeychainACLApps(const std::string &path, QueryData &results) {
 
   SecKeychainSearchRef search = nullptr;
   OSQUERY_USE_DEPRECATED(os_status = SecKeychainSearchCreateFromAttributes(
-                             keychain, CSSM_DL_DB_RECORD_ANY, NULL, &search););
+      keychain, (SecItemClass) CSSM_DL_DB_RECORD_ANY, NULL, &search););
   if (os_status != noErr || search == nullptr) {
     if (search != nullptr) {
       CFRelease(search);

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -52,7 +52,7 @@ void genKeychainItem(const SecKeychainItemRef& item, QueryData& results) {
   info.tag = tags;
   info.format = nullptr;
 
-  SecItemClass item_class = 0;
+  SecItemClass item_class;
   SecKeychainAttributeList* attr_list = nullptr;
 
   // Any tag that does not exist for the item will prevent the entire result.


### PR DESCRIPTION
enum `SecItemClass` changed in 10.11 headers, so don't instantiate with rvalue of int.
Update `SecKeychainSearchCreateFromAttributes` to match the stricter definition.

After we figure out a way forward with OpenSSL, this should be good.

Fixes #1423

