### PR TITLE
[Fix #1428] Remove `-mtune` compile flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ else()
 endif()
 
 if(NOT DEFINED ENV{OPTIMIZED})
-  add_compile_options(-march=x86-64 -mtune=i386 -mno-avx)
+  add_compile_options(-march=x86-64 -mno-avx)
 endif()
 
 # make analyze (environment variable from Makefile)

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -9,7 +9,7 @@
 
 set -e
 
-CFLAGS="-fPIE -fPIC -O2 -DNDEBUG -march=x86-64 -mtune=i386 -mno-avx"
+CFLAGS="-fPIE -fPIC -O2 -DNDEBUG -march=x86-64 -mno-avx"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/../build"
 WORKING_DIR="/tmp/osquery-provisioning"


### PR DESCRIPTION
Having `-mtune=i386` is causing compilation failure for gflags on ubuntu. This change removes the `mtune` compile flag.
`-march` flag is already set to `x86-64` and according to gcc docs:
specifying `-march=cpu-type` implies `-mtune=cpu-type.`

Fixes #1428

The `python_test_release` passes:

```bash
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ export RUN_RELEASE_TESTS=1
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ make test
cd build/trusty && cmake ../../ && \
		CTEST_OUTPUT_ON_FAILURE=1 make --no-print-directory test
-- Building for platform Ubuntu (ubuntu, trusty)
-- Building osquery version  1.4.5-401-g1eea02e sdk 1.4.5
-- Configuring done
-- Generating done
-- Build files have been written to: /vagrant/build/trusty
Running tests...
Test project /vagrant/build/trusty
      Start  1: osquery_tests
 1/10 Test  #1: osquery_tests ....................   Passed    0.11 sec
      Start  2: osquery_additional_tests
 2/10 Test  #2: osquery_additional_tests .........   Passed    9.12 sec
      Start  3: osquery_tables_tests
 3/10 Test  #3: osquery_tables_tests .............   Passed    0.04 sec
      Start  4: python_test_osqueryi
 4/10 Test  #4: python_test_osqueryi .............   Passed    6.08 sec
      Start  5: python_test_osqueryd
 5/10 Test  #5: python_test_osqueryd .............   Passed    1.59 sec
      Start  6: python_test_modules
 6/10 Test  #6: python_test_modules ..............   Passed    2.15 sec
      Start  7: python_test_extensions
 7/10 Test  #7: python_test_extensions ...........   Passed    5.76 sec
      Start  8: python_test_additional
 8/10 Test  #8: python_test_additional ...........   Passed    1.18 sec
      Start  9: python_test_example_queries
 9/10 Test  #9: python_test_example_queries ......   Passed    2.74 sec
      Start 10: python_test_release
10/10 Test #10: python_test_release ..............   Passed    3.99 sec

100% tests passed, 0 tests failed out of 10

Total Test time (real) =  32.85 sec
```

