### PR TITLE
[#1402] Add notes around pack paths in example.conf

### DIFF
--- a/docs/wiki/deployment/kernel-linux.md
+++ b/docs/wiki/deployment/kernel-linux.md
@@ -1,1 +1,0 @@
-Kernel integration used to include introspection into potentially malicious modules. We have deprecated the proof-of-concept module and are preparing for more robust kernel introspection.

--- a/docs/wiki/development/kernel.md
+++ b/docs/wiki/development/kernel.md
@@ -2,13 +2,13 @@ osquery may optionally use a kernel extension (on OS X)/module (Linux) to intros
 
 Currently an kernel extension is under development for OS X. Once the OS X implementation is finished a Linux module will be considered. There are several options for retrieving real time process and socket events. User-land implementation are preferred to having kernel presence.
 
-WARNING: This is currently under heavy development.
+**WARNING**: This is currently under heavy development.
 
 The osquery kernel introspection architecture is designed with simplicity and portability. It uses a small ring buffer, backed by shared memory, filled by kernel callback registrations to maintain simple structures. A process creation structure may contain a path to the program image, assigned pid, and ownership information. When the ring buffer fills, osquery drops information. The user-land process, osqueryd, will periodically request a minimum and maximum read into the ring buffer and pass structures to an event subscriber.
 
-This code is mostly shared between BSD-based kernels and Linux. The ring buffer uses spin locks to reserve structure blocks and synchronize simple writes. The minimum and maximum block reads are synchronized and reserved using an `ioctl` API. Each platform uses respective APIs to register callback methods that implement the ring buffer reserve, copy, and write.
+This code is mostly shared between BSD-based kernels and Linux. The ring buffer uses spin locks to reserve structure blocks and synchronize simple writes. The minimum and maximum block reads are synchronized and reserved using an `ioctl` API and `/dev/osquery` device node. Each platform uses respective APIs to register callback methods that implement the ring buffer reserve, copy, and write.
 
-The kernel applies calling-process ownership limitations to super users. Only 1 process should issues IOCTL commands, if another pid interrupts the queue and buffer are consider invalid and all pointers reset. Clear tear down assures deregistration of callback functions and will result in maximum performance. Improper tear down may trigger timeouts and in the worst scenario continue to track callbacks.
+The kernel applies calling-process ownership limitations to super users. Only 1 process should issues IOCTL commands, if another process (pid) uses the device node the queue and buffer are considered invalid and all pointers are reset. Clean tear down assures deregistration of callback functions and will result in maximum performance. Improper tear down may trigger timeouts and in the worst scenario continue to track callbacks.
 
 # Apple OS X Kernel Extensions
 

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -17,7 +17,8 @@ The default packages create the following structure:
 
 ```sh
 /etc/osquery/
-/var/osquery/osquery.example.conf
+/usr/share/osquery/osquery.example.conf
+/usr/share/osquery/packs/
 /var/log/osquery/
 /usr/lib/osquery/
 /usr/bin/osqueryctl
@@ -69,3 +70,15 @@ $ sudo apt-get install osquery
 \* You may also set a different config plugin using `/etc/osquery/osquery.flags`.<br />
 \** We do not recommend using the latest/unstable package as it is built
 from our master branch and does not guarentee safety.
+
+## Running osquery
+
+To start a standalone osquery use: `$ osqueryi`. This does not need a server or service. All the table implementations are included!
+
+After exploring the rest of the documentation you should understand the basics of configuration and logging. These and most other concepts apply to the `osqueryd`, the daemon, tool. To start the daemon:
+
+- `sudo cp /usr/share/osquery/osquery.example.conf /etc/osquery/osquery.conf`
+- `sudo service osquery start`
+- `sudo service osquery status`
+
+Note: The interactive shell and daemon do NOT communicate!

--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -31,6 +31,7 @@ The default package creates the following structure:
 /private/var/osquery/com.facebook.osqueryd.plist
 /private/var/osquery/osquery.example.conf
 /private/var/log/osquery/
+/private/var/osquery/packs/
 /usr/local/lib/osquery/
 /usr/local/bin/osqueryctl
 /usr/local/bin/osqueryd
@@ -38,3 +39,15 @@ The default package creates the following structure:
 ```
 
 This package does NOT install a LaunchDaemon to start osqueryd. You may use the `osqueryctl` script to install the sample launch daemon script.
+
+## Running osquery
+
+To start a standalone osquery use: `$ osqueryi`. This does not need a server or service. All the table implementations are included!
+
+After exploring the rest of the documentation you should understand the basics of configuration and logging. These and most other concepts apply to the `osqueryd`, the daemon, tool. To start the daemon as a LaunchDaemon:
+
+- `sudo cp /var/osquery/osquery.example.conf /var/osquery/osquery.conf`
+- `sudo cp /var/osquery/com.facebook.osqueryd.plist /Library/LaunchDaemons`
+- `sudo launchctl load /Library/LaunchDaemons/com.facebook.osqueryd.plist`
+
+Note: The interactive shell and daemon do NOT communicate!

--- a/docs/wiki/introduction/using-osqueryd.md
+++ b/docs/wiki/introduction/using-osqueryd.md
@@ -17,7 +17,6 @@ The primary daemon feature is executing a query schedule. This schedule is defin
 
 This simple **usb_devices** query will run approximately every 60 seconds on the host running osqueryd.
 
-
 ## Logging and reporting
 
 Each query represents a monitored view of your operating system. The first time a scheduled query runs it logs every row in the resulting table with the "added" action. In this example, on an OS X laptop, after the first 60 seconds it would log:

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -119,8 +119,8 @@ if(APPLE)
     COMMAND sudo cp -R "${CMAKE_BINARY_DIR}/kernel/osquery.kext" "/tmp/"
     COMMAND sudo chown -R root:wheel "/tmp/osquery.kext"
     COMMAND sudo chmod -R 0644 "/tmp/osquery.kext"
-    COMMAND sudo kextload -v "/tmp/osquery.kext"
     COMMAND echo "Wrote unsigned extension bundle: /tmp/osquery.kext"
+    COMMAND sudo kextload -v "/tmp/osquery.kext"
   )
 
   # make kernel-unload

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,4 +36,4 @@ pages:
   - Writing Tests: development/unit-tests.md
   - Adding CLI Arguments: development/options-arguments.md
   - Reading/Writing Files: development/reading-files.md
-  - Kernel OS X: development/kernel.md
+  - Kernel: development/kernel.md

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -30,7 +30,7 @@
     //"pidfile": "/var/osquery/osquery.pidfile",
 
     // Clear events from the osquery backing store after a number of seconds.
-    "event_pubsub_expiry": "86000",
+    "events_expiry": "3600",
 
     // A filesystem path for disk-based backing storage used for events and
     // and query results differentials. See also 'use_in_memory_database'.
@@ -41,11 +41,15 @@
     //"disable_tables": "foo_bar,time",
 
     // Enable debug or verbose debug output when logging.
-    "debug": "false",
-    "verbose_debug": "false",
+    "verbose": "false",
 
     // The number of threads for concurrent query schedule execution.
-    "worker_threads": "4"
+    "worker_threads": "2",
+
+    // Enable schedule profiling, this will fill in averages and totals for
+    // system/user CPU time and memory for every query in the schedule.
+    // Add a query: "select * from osquery_schedule" to record the performances.
+    //"enable_monitor": "true"
   },
 
   /* Define a schedule of queries */
@@ -59,7 +63,17 @@
     }
   },
 
-  /* Add default osquery packs or install your own. */
+  /**
+   * Add default osquery packs or install your own.
+   *
+   * There are several 'default' packs installed with 'make install' or via
+   * packages and/or Homebrew.
+   *
+   * Linux:        /usr/share/osquery/packs
+   * OS X:         /var/osquery/packs
+   * Homebrew:     /usr/local/share/osquery/packs
+   * make install: {PREFIX}/share/osquery/packs
+   */
   "packs": {
     // "incident-response": "/usr/share/osquery/packs/incident-response.conf",
     // "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",


### PR DESCRIPTION
Add notes for the default packs location based on the method of osquery install.