### PR TITLE
[Fix #1433] Correct os_version reporting on 10.11

### DIFF
--- a/osquery/tables/system/darwin/os_version.cpp
+++ b/osquery/tables/system/darwin/os_version.cpp
@@ -39,11 +39,15 @@ QueryData genOSVersion(QueryContext& context) {
     }
   }
 
+  r["patch"] = "0";
   auto version = osquery::split(version_string, ".");
-  if (version.size() == 3) {
-    r["major"] = INTEGER(version[0]);
-    r["minor"] = INTEGER(version[1]);
+  switch (version.size()) {
+  case 3:
     r["patch"] = INTEGER(version[2]);
+  case 2:
+    r["minor"] = INTEGER(version[1]);
+    r["major"] = INTEGER(version[0]);
+    break;
   }
   return {r};
 }


### PR DESCRIPTION
#1433 

```
osquery> .all os_version;
+----------+-------+-------+-------+---------+
| name     | major | minor | patch | build   |
+----------+-------+-------+-------+---------+
| Mac OS X | 10    | 11    | -1    | 15A244d |
+----------+-------+-------+-------+---------+
```

```
osquery> .all os_version;
+----------+-------+-------+-------+-------+
| name     | major | minor | patch | build |
+----------+-------+-------+-------+-------+
| Mac OS X | 10    | 10    | 4     | 14E46 |
+----------+-------+-------+-------+-------+
```