### PR TITLE
[Fix #1434] version reporting for homewbrew_packages

### DIFF
--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -47,7 +47,7 @@ std::vector<std::string> getHomebrewVersionsFromInfoPlistPath(
   auto status = osquery::listDirectoriesInDirectory(path, app_versions);
   if (status.ok()) {
     for (const auto& version : app_versions) {
-      results.push_back(fs::path(version).filename().string());
+      results.push_back(fs::path(version).parent_path().filename().string());
     }
   } else {
     TLOG << "Error listing " << path << ": " << status.toString();


### PR DESCRIPTION
#1434

```
osquery> select * from homebrew_packages where name = "osquery";
+---------+----------------------------+---------+
| name    | path                       | version |
+---------+----------------------------+---------+
| osquery | /usr/local/Cellar/osquery/ | 1.5.0_1 |
+---------+----------------------------+---------+
osquery> select * from homebrew_packages where name = "valgrind";
+----------+-----------------------------+---------+
| name     | path                        | version |
+----------+-----------------------------+---------+
| valgrind | /usr/local/Cellar/valgrind/ | HEAD    |
+----------+-----------------------------+---------+
osquery> select * from homebrew_packages where name = "clang-format";
+--------------+---------------------------------+------------+
| name         | path                            | version    |
+--------------+---------------------------------+------------+
| clang-format | /usr/local/Cellar/clang-format/ | 2015-07-31 |
+--------------+---------------------------------+------------+
```