### PR TITLE
Different build directory for darwin != 10.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ endif
 DISTRO := $(shell . ./tools/lib.sh; _platform)
 DISTRO_VERSION := $(shell . ./tools/lib.sh; _distro $(DISTRO))
 ifeq ($(DISTRO),darwin)
-	BUILD_DIR = darwin
+  ifeq ($(DISTRO_VERSION), 10.10)
+    BUILD_DIR = darwin
+  else
+    BUILD_DIR = darwin$(DISTRO_VERSION)
+  endif
 else
 	BUILD_DIR = $(DISTRO_VERSION)
 endif


### PR DESCRIPTION
When building for OSX 10.9, we need to use a different build directory. This can be used forward when 10.11 comes along.