### PR TITLE
Update build/test for 10.9 (do not test extension)

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -13,6 +13,16 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/lib.sh
 
 threads THREADS
+platform PLATFORM
+distro $PLATFORM DISTRO
+
+# Build kernel extension/module and tests.
+BUILD_KERNEL=0
+if [[ "$PLATFORM" = "darwin" ]]; then
+  if [[ "$DISTRO" = "10.10" ]]; then
+    BUILD_KERNEL=1
+  fi
+fi
 
 cd $SCRIPT_DIR/../
 
@@ -30,14 +40,16 @@ make clean
 # Build osquery.
 make -j$THREADS
 
-# Build osquery kernel (optional).
-make kernel-build
+if [[ $BUILD_KERNEL = 1 ]]; then
+  # Build osquery kernel (optional).
+  make kernel-build
 
-# Setup cleanup code for catastrophic test failures.
-trap cleanUp EXIT INT TERM
+  # Setup cleanup code for catastrophic test failures.
+  trap cleanUp EXIT INT TERM
 
-# Load osquery kernel (optional).
-make kernel-load
+  # Load osquery kernel (optional).
+  make kernel-load
+fi
 
 # Request that tests include addition 'release' or 'package' units.
 export RUN_RELEASE_TESTS=1
@@ -45,7 +57,9 @@ export RUN_RELEASE_TESTS=1
 # Run code unit and integration tests.
 make test/fast
 
-# Run kernel unit and integration tests (optional).
-make kernel-test/fast
+if [[ $BUILD_KERNEL = 1 ]]; then
+  # Run kernel unit and integration tests (optional).
+  make kernel-test/fast
+fi
 
 exit 0


### PR DESCRIPTION
OS X 10.9 should not build/test a kernel extension yet. The MAC policy framework is slightly different and the APIs/version dependencies need to be tested.