### PR TITLE
[#1329] Statically link against brew bottled libressl on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 
 if(PLATFORM STREQUAL "")
   WARNING_LOG("Unable to detect osquery platform: ./tools/provision.sh failed")
-  message(FATAL "Cannot proceed without knowing the build platform")
+  message(FATAL_ERROR "Cannot proceed without knowing the build platform")
 endif()
 list(GET PLATFORM 0 OSQUERY_BUILD_PLATFORM)
 list(GET PLATFORM 1 OSQUERY_BUILD_DISTRO)
@@ -267,16 +267,27 @@ endif()
 # Make sure the generated paths exist
 execute_process(COMMAND mkdir -p "${CMAKE_BINARY_DIR}/generated")
 
-# We need to link some packages as dynamic/dependent.
-set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
-find_package(OpenSSL REQUIRED)
-find_package(BZip2 REQUIRED)
-find_package(Dl REQUIRED)
-find_package(Readline REQUIRED)
+# Apple has deprecated OpenSSL, static link with brew bottled libressl
+if(APPLE)
+  if(NOT DEFINED ENV{BUILD_LINK_SHARED})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a .dylib .so)
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
+  endif()
+  execute_process(COMMAND brew --prefix OUTPUT_VARIABLE BREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(OPENSSL_ROOT_DIR "${BREW_PREFIX}/opt/libressl")
+  find_package(OpenSSL REQUIRED)
+  include_directories("${OPENSSL_INCLUDE_DIR}")
+else()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
+  find_package(OpenSSL REQUIRED)
+endif()
 
 # Make sure the OpenSSL/ssl library has a TLS client method.
 # Prefer the highest version of TLS, but accept 1.2, 1.1, or 1.0.
 include(CheckLibraryExists)
+set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES})
 CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_2_client_method" "" OPENSSL_TLSV12)
 CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_1_client_method" "" OPENSSL_TLSV11)
 CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_client_method" "" OPENSSL_TLSV10)
@@ -289,8 +300,16 @@ elseif(OPENSSL_TLSV11)
 elseif(OPENSSL_TLSV10)
   add_definitions(-DSSL_TXT_TLSV1)
 else()
-  message(FATAL "Cannot find any TLS client methods")
+  message(FATAL_ERROR "Cannot find any TLS client methods")
 endif()
+
+
+# We need to link some packages as dynamic/dependent.
+set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
+find_package(BZip2 REQUIRED)
+find_package(Dl REQUIRED)
+find_package(Readline REQUIRED)
+
 
 # Most dependent packages/libs we want static.
 if(NOT DEFINED ENV{BUILD_LINK_SHARED})

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -18,6 +18,7 @@ function main_darwin() {
 
   brew update
 
+  package libressl
   package wget
   package cmake
   package makedepend

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -399,6 +399,8 @@ function package() {
         HOMEBREW_ARGS="--build-bottle --with-lite"
       elif [[ $1 = "gflags" ]]; then
         HOMEBREW_ARGS="--build-bottle --with-static"
+      elif [[ $1 = "libressl" ]]; then
+        HOMEBREW_ARGS="--build-bottle"
       fi
       brew install -v $HOMEBREW_ARGS $1 || brew upgrade -v $HOMEBREW_ARGS $@
     fi


### PR DESCRIPTION
Recapping from #1425:

* It wasn't straightforward to get OpenSSL building without avx/vxorps optimizations on 10.10
* After chatting with @theopolis, we decided libressl was the way to go. It is essentially a modern/lean-ish drop-in replacement for OpenSSL and we can build without avx optimizations to support older Macs.

This change:

* Installs libressl (builds a bottle) using homebrew
* And statically links `libcrypto.a` and `libssl.a`

##### Rough estimate of added code size:

| binary | libressl static link size | size after striping symbols | difference |
| -------- | ----------------------------: | ----------------------------------: | ------------: |
| osqueryd |  9232344 | 7841472 | 1390872 (~1.32MiB) |
| osqueryi |  9261632 | 7866872 | 1394760 (~1.33MiB)|


Thanks again for all the help on this @theopolis

Fixes #1329
