### PR TITLE
Speedup type conversions, yara, and 10.10 symbols at runtime

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <deque>
 #include <map>
 #include <memory>
 #include <vector>
@@ -77,7 +78,7 @@ namespace osquery {
 /// Helper alias for TablePlugin names.
 typedef std::string TableName;
 typedef std::vector<std::pair<std::string, std::string> > TableColumns;
-typedef std::map<std::string, std::vector<std::string> > TableData;
+typedef std::map<std::string, std::deque<std::string> > TableData;
 
 /**
  * @brief A ConstraintOperator is applied in an query predicate.

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -28,9 +28,7 @@ class BenchmarkTablePlugin : public TablePlugin {
   QueryData generate(QueryContext& ctx) {
     QueryData results;
     results.push_back({{"test_int", "0"}});
-    results.push_back({
-        {"test_int", "0"}, {"test_text", "hello"},
-    });
+    results.push_back({{"test_int", "0"}, {"test_text", "hello"}});
     return results;
   }
 };
@@ -46,17 +44,6 @@ static void SQL_virtual_table_registry(benchmark::State& state) {
 }
 
 BENCHMARK(SQL_virtual_table_registry);
-
-static void SQL_select_metadata(benchmark::State& state) {
-  auto dbc = SQLiteDBManager::get();
-  while (state.KeepRunning()) {
-    QueryData results;
-    queryInternal("select count(*) from sqlite_temp_master;", results,
-                  dbc.db());
-  }
-}
-
-BENCHMARK(SQL_select_metadata);
 
 static void SQL_virtual_table_internal(benchmark::State& state) {
   Registry::add<BenchmarkTablePlugin>("table", "benchmark");
@@ -74,6 +61,49 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 }
 
 BENCHMARK(SQL_virtual_table_internal);
+
+class BenchmarkLongTablePlugin : public TablePlugin {
+ private:
+  TableColumns columns() const {
+    return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
+  }
+
+  QueryData generate(QueryContext& ctx) {
+    QueryData results;
+    for (int i = 0; i < 1000; i++) {
+      results.push_back({{"test_int", "0"}, {"test_text", "hello"}});
+    }
+    return results;
+  }
+};
+
+static void SQL_virtual_table_internal_long(benchmark::State& state) {
+  Registry::add<BenchmarkLongTablePlugin>("table", "long_benchmark");
+  PluginResponse res;
+  Registry::call("table", "long_benchmark", {{"action", "columns"}}, res);
+
+  // Attach a sample virtual table.
+  auto dbc = SQLiteDBManager::get();
+  attachTableInternal("long_benchmark", columnDefinition(res), dbc.db());
+
+  while (state.KeepRunning()) {
+    QueryData results;
+    queryInternal("select * from long_benchmark", results, dbc.db());
+  }
+}
+
+BENCHMARK(SQL_virtual_table_internal_long);
+
+static void SQL_select_metadata(benchmark::State& state) {
+  auto dbc = SQLiteDBManager::get();
+  while (state.KeepRunning()) {
+    QueryData results;
+    queryInternal(
+        "select count(*) from sqlite_temp_master;", results, dbc.db());
+  }
+}
+
+BENCHMARK(SQL_select_metadata);
 
 static void SQL_select_basic(benchmark::State& state) {
   // Profile executing a query against an internal, already attached table.

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -126,20 +126,24 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
   if (type == "TEXT") {
     sqlite3_result_text(ctx, value.c_str(), value.size(), SQLITE_STATIC);
   } else if (type == "INTEGER") {
+    char *end;
     int afinite;
-    try {
-      afinite = boost::lexical_cast<int>(value);
-    } catch (const boost::bad_lexical_cast &e) {
+    long int val = strtol(value.c_str(), &end, 10);
+    if (end == value.c_str() || *end != '\0' ||
+        ((val == LONG_MIN || val == LONG_MAX) && errno == ERANGE) ||
+        val < INT_MIN || val > INT_MAX) {
       afinite = -1;
       VLOG(1) << "Error casting " << column_name << " (" << value
               << ") to INTEGER";
+    } else {
+      afinite = (int)val;
     }
     sqlite3_result_int(ctx, afinite);
   } else if (type == "BIGINT") {
-    long long int afinite;
-    try {
-      afinite = boost::lexical_cast<long long int>(value);
-    } catch (const boost::bad_lexical_cast &e) {
+    char *end;
+    long long int afinite = strtoll(value.c_str(), &end, 10);
+    if (end == value.c_str() || *end != '\0' ||
+        ((afinite == LLONG_MIN || afinite == LLONG_MAX) && errno == ERANGE)) {
       afinite = -1;
       VLOG(1) << "Error casting " << column_name << " (" << value
               << ") to BIGINT";

--- a/osquery/tables/other/yara_utils.h
+++ b/osquery/tables/other/yara_utils.h
@@ -28,7 +28,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rule);
 
 Status handleRuleFiles(const std::string& category,
                        const pt::ptree& rule_files,
-                       std::map<std::string, YR_RULES *>* rules);
+                       std::map<std::string, YR_RULES*>& rules);
 
 int YARACallback(int message, void *message_data, void *user_data);
 
@@ -48,7 +48,7 @@ class YARAConfigParserPlugin : public ConfigParserPlugin {
   std::vector<std::string> keys() { return {"yara"}; }
 
   // Retrieve compiled rules.
-  std::map<std::string, YR_RULES *> rules() { return rules_; }
+  std::map<std::string, YR_RULES*>& rules() { return rules_; }
 
   Status setUp();
 


### PR DESCRIPTION
1. This commandeers @mofarrell's improvements to SQLite data casting within virtual tables. This will yield about a 10~ improvement for INT, BIGINT, DOUBLE affinite types.
2. A cache of signature compiles for YARA is used when issuing ad-hoc `sigfile` JOINs or SELECTs. The content of the signature file is cached for the life of the `osqueryi` or `osqueryd` process. Changing the underlying signature file will NOT affect the process. This will make pattern-based matching a lot faster. We need benchmarking around this style of scanning.
3. The 10.9 `ifndef/ifdef`s are removed in favor of runtime capability checking.