### PR TITLE
Build on Debian Wheezy and Debian Jessie

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,11 @@
 targets = {
+  "debian7" => {
+    "box" => "deb/wheezy-amd64"
+  },
+  "debian8" => {
+    "box" => "deb/jessie-amd64"
+  },
+
   "centos6.5" => {
     "box" => "chef/centos-6.5"
   },

--- a/osquery/tables/networking/linux/tests/iptables_tests.cpp
+++ b/osquery/tables/networking/linux/tests/iptables_tests.cpp
@@ -32,9 +32,10 @@ ipt_ip* getIpEntryContent() {
   inet_aton("45.45.45.45", &ip_entry.dst);
   inet_aton("250.251.252.253", &ip_entry.smsk);
   inet_aton("253.252.251.250", &ip_entry.dmsk);
-  memset(ip_entry.iniface_mask, 0xfe, IFNAMSIZ );
-  memset(ip_entry.outiface_mask, 0xfa, IFNAMSIZ );
-
+  memset(ip_entry.iniface_mask, 0xfe, IFNAMSIZ);
+  memset(ip_entry.outiface_mask, 0xfa, IFNAMSIZ);
+  ip_entry.iniface_mask[IFNAMSIZ-1] = 0x00;
+  ip_entry.outiface_mask[IFNAMSIZ-1] = 0x00;
   return &ip_entry;
 }
 
@@ -48,8 +49,8 @@ Row getIpEntryExpectedResults() {
   row["dst_ip"] = "45.45.45.45";
   row["src_mask"] = "250.251.252.253";
   row["dst_mask"] = "253.252.251.250";
-  row["iniface_mask"] = "FEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFE";
-  row["outiface_mask"] = "FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFA";
+  row["iniface_mask"] = "FEFEFEFEFEFEFEFEFEFEFEFEFEFEFE";
+  row["outiface_mask"] = "FAFAFAFAFAFAFAFAFAFAFAFAFAFAFA";
 
   return row;
 }

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -10,6 +10,7 @@
 ORACLE_RELEASE=/etc/oracle-release
 SYSTEM_RELEASE=/etc/system-release
 LSB_RELEASE=/etc/lsb-release
+DEBIAN_VERSION=/etc/debian_version
 
 function platform() {
   local  __out=$1
@@ -28,6 +29,9 @@ function platform() {
   elif [[ -f "$LSB_RELEASE" ]] && grep -q 'DISTRIB_ID=Ubuntu' $LSB_RELEASE; then
     FAMILY="debian"
     eval $__out="ubuntu"
+  elif [[ -f "$DEBIAN_VERSION" ]]; then
+    FAMILY="debian"
+    eval $__out="debian"
   else
     eval $__out=`uname -s | tr '[:upper:]' '[:lower:]'`
   fi
@@ -53,7 +57,9 @@ function distro() {
   elif [[ $1 = "darwin" ]]; then
     eval $__out=`sw_vers -productVersion | awk -F '.' '{print $1 "." $2}'`
   elif [[ $1 = "freebsd" ]]; then
-    eval $__out=`uname -r | awk -F '-' '{print $1}'`
+    eval $__out=`uname -r | awk -F '-' '{print $1}'` 
+  elif [[ $1 = "debian" ]]; then
+    eval $__out="`lsb_release -cs`"
   else
     eval $__out="unknown_version"
   fi

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -69,6 +69,10 @@ function main() {
     log "detected freebsd ($DISTRO)"
     source "$SCRIPT_DIR/provision/freebsd.sh"
     main_freebsd
+  elif [[ $OS = "debian" ]]; then
+    log "detected debian ($DISTRO)"
+    source "$SCRIPT_DIR/provision/debian.sh"
+    main_debian
   else
     fatal "could not detect the current operating system. exiting."
   fi

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# g++ stuff in wheezy has a bug which has been fixed in gcc 4.7.3 which conveniently is exactly 
+# the version that is not shipped in wheezy
+# See https://gcc.gnu.org/viewcvs/gcc/branches/gcc-4_7-branch/libstdc%2B%2B-v3/include/std/condition_variable?view=patch&r1=189276&r2=193528&pathrev=193528
+
+function patch_condition_variable() {
+  TARGET_DIR=/usr/include/c++/4.7
+  pushd $TARGET_DIR
+  
+  if [[ ! -f condition_variable.orig ]]; then   
+    sudo cp condition_variable condition_variable.orig
+    sudo patch -p5 < $FILES_DIR/debian/condition_variable.patch
+
+    log "patched $TARGET_DIR/condition_variable which prevents rocksdb from building"
+  else
+    log "$TARGET_DIR/condition_variable already patched: found a .orig"
+  fi
+  
+  popd
+}
+  
+function main_debian() {
+  sudo apt-get update -y
+  sudo apt-get upgrade -y
+
+  package git-core
+  package wget
+  
+  # Add LLVM to the APT sources 
+  
+  if [[ $DISTRO == "wheezy" ]]; then 
+    set_cc clang
+    set_cxx clang++
+  
+    if [[ ! -f /usr/bin/clang ]]; then      
+      wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+      sudo sh -c "echo 'deb http://llvm.org/apt/wheezy/ llvm-toolchain-wheezy-3.4-binaries main' > /etc/apt/sources.list.d/llvm.list"
+  
+      sudo apt-get update -y
+    
+      package clang-3.4
+      package lldb-3.4
+    fi
+  fi
+  
+  package unzip
+  package build-essential
+  package libtool
+  package autoconf
+  package pkg-config
+  
+  package bison
+  package flex
+  package devscripts
+  package debhelper
+  package python-pip
+  package python-dev
+
+  package ruby-dev
+  package gcc
+  package doxygen
+
+  package autopoint
+  package libssl-dev
+  package liblzma-dev
+  package uuid-dev
+  package libpopt-dev
+  package libdpkg-dev
+  package libudev-dev
+  package libblkid-dev
+
+  package libbz2-dev
+  package libreadline-dev
+
+  package g++-multilib
+  package iptables-dev
+
+  package libsnappy-dev
+  package libgflags-dev
+
+  if [[ $DISTRO == "wheezy" ]]; then 
+    patch_condition_variable
+    
+    install_cmake
+    install_boost   
+  elif [[ $DISTRO == "jessie" ]]; then 
+    package cmake
+    package libboost-all-dev
+  fi 
+  
+
+  install_thrift
+  install_rocksdb 
+  install_yara
+  
+  # Need headers and PC macros
+  package libgcrypt-dev
+  package libdevmapper-dev
+
+  package libcryptsetup-dev
+}

--- a/tools/provision/files/debian/condition_variable.patch
+++ b/tools/provision/files/debian/condition_variable.patch
@@ -1,0 +1,13 @@
+--- branches/gcc-4_7-branch/libstdc++-v3/include/std/condition_variable	2012/07/05 01:12:47	189276
++++ branches/gcc-4_7-branch/libstdc++-v3/include/std/condition_variable	2012/11/15 01:56:05	193528
+@@ -107,8 +107,8 @@
+ 	// DR 887 - Sync unknown clock to known clock.
+ 	const typename _Clock::time_point __c_entry = _Clock::now();
+ 	const __clock_t::time_point __s_entry = __clock_t::now();
+-	const chrono::nanoseconds __delta = __atime - __c_entry;
+-	const __clock_t::time_point __s_atime = __s_entry + __delta;
++	const auto __delta = __atime - __c_entry;
++	const auto __s_atime = __s_entry + __delta;
+ 
+ 	return __wait_until_impl(__lock, __s_atime);
+       }


### PR DESCRIPTION
Refs https://github.com/facebook/osquery/issues/320
Add provisioning scripts to build osquery on Debian Wheezy and Debian Jessie.

The build for Debian Wheezy isn't pretty: it downloads Clang 3.4 (not 3.5, because it has some issues with some specific code. That's fixable, but wasn't sure it was needed. It also patches a header file in /usr/include/ to be able to build. The result is that osquery can run without anything special on a clean wheezy system. 