### PR TITLE
Fix lucid package building

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -14,12 +14,18 @@ elseif(LINUX)
     set(PACKAGE_TYPE "deb")
     set(PACKAGE_ITERATION "1.ubuntu")
     set(PACKAGE_DEPENDENCIES
-      "libc6 (>=2.15)"
       "zlib1g"
       "libbz2-1.0"
-      "libapt-pkg4.12"
       "libreadline6"
     )
+    if(NOT OSQUERY_BUILD_DISTRO STREQUAL "lucid")
+      set(PACKAGE_ITERATION "1.ubuntu10")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libc6 (>=2.15)"
+        "libapt-pkg4.12"
+      )
+    endif()
     if(OSQUERY_BUILD_DISTRO STREQUAL "precise")
       set(PACKAGE_ITERATION "1.ubuntu12")
       set(PACKAGE_DEPENDENCIES

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -118,7 +118,14 @@ function main() {
     PACKAGE_DEPENDENCIES="$PACKAGE_DEPENDENCIES -d \"$element\""
   done
 
-  CMD="fpm -s dir -t $PACKAGE_TYPE \
+  platform OS
+  distro $OS DISTRO
+  FPM="fpm"
+  if [[ $DISTRO == "lucid" ]]; then
+    FPM="/var/lib/gems/1.8/bin/fpm"
+  fi
+
+  CMD="$FPM -s dir -t $PACKAGE_TYPE \
     -n $PACKAGE_NAME -v $PACKAGE_VERSION \
     --iteration $PACKAGE_ITERATION \
     -a $PACKAGE_ARCH               \

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -448,7 +448,7 @@ function gem_install() {
   if [[ -n "$(gem list | grep $1)" ]]; then
     log "$1 is already installed. skipping."
   else
-    sudo gem install $1
+    sudo gem install $@
   fi
 }
 

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -122,12 +122,14 @@ function main_ubuntu() {
   if [[ $DISTRO = "lucid" ]]; then
     install_snappy
     install_libaptpkg
+    gem_install --no-user-install fpm -v 1.3.3
   else
     # No clang++ on lucid
     set_cc clang
     set_cxx clang++
     package libsnappy-dev
     package libapt-pkg-dev
+    gem_install fpm
   fi
 
   install_thrift
@@ -140,5 +142,4 @@ function main_ubuntu() {
 
   install_libcryptsetup
 
-  gem_install fpm
 }


### PR DESCRIPTION
Had some troubles getting the package to install on lucid. It looks like there are some dependencies specified by the package that are not actually required.
```
vagrant@vagrant:~/osquery_official/osquery/build/lucid$ sudo dpkg -i osquery-1.5.1-59-g43cf5f1.deb
(Reading database ... 56769 files and directories currently installed.)
Preparing to replace osquery 1.5.1-1-g7a72534-1.ubuntu (using osquery-1.5.1-59-g43cf5f1.deb) ...
Unpacking replacement osquery ...
dpkg: dependency problems prevent configuration of osquery:
 osquery depends on libc6 (>= 2.15); however:
  Version of libc6 on system is 2.11.1-0ubuntu7.21.
 osquery depends on libapt-pkg4.12; however:
  Package libapt-pkg4.12 is not installed.
dpkg: error processing osquery (--install):
 dependency problems - leaving unconfigured
Processing triggers for ureadahead ...
Errors were encountered while processing:
 osquery
```
I had some issues with fpm when making the package. Lucid gems are installed somewhere that is not in $PATH by default, so I modified the build script to use the full path. Also, I had some issues with fpm 1.4.0, so I just pinned v 1.3.3. Maybe not the best solution, but up to you guys.

