### PR TITLE
RocksDB usage speedups

### DIFF
--- a/osquery/database/db_handle.h
+++ b/osquery/database/db_handle.h
@@ -210,7 +210,7 @@ class DBHandle {
   /////////////////////////////////////////////////////////////////////////////
 
   /// The database handle
-  rocksdb::DB* db_;
+  rocksdb::DB* db_{nullptr};
 
   /// Column family descriptors which are used to connect to RocksDB
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
@@ -220,6 +220,9 @@ class DBHandle {
 
   /// The RocksDB connection options that are used to connect to RocksDB
   rocksdb::Options options_;
+
+  /// The database was opened in a ReadOnly mode.
+  bool read_only_{false};
 
  private:
   friend class RocksDatabasePlugin;

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -68,15 +68,20 @@ class BenchmarkEventSubscriber
 };
 
 static void EVENTS_subscribe_fire(benchmark::State& state) {
+  // Register a publisher.
   auto pub = std::make_shared<BenchmarkEventPublisher>();
   EventFactory::registerEventPublisher(pub);
 
+  // Register a subscriber.
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
   EventFactory::registerEventSubscriber(sub);
+
   // Simulate the event factory initialization.
+  // This creates a subscription and adds it and a callback.
   sub->benchmarkInit();
 
   while (state.KeepRunning()) {
+    // Fire an event from the publisher, and let the subscriber handle.
     pub->benchmarkFire();
   }
 }
@@ -89,6 +94,7 @@ static void EVENTS_add_events(benchmark::State& state) {
 
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
   EventFactory::registerEventSubscriber(sub);
+
   // Simulate the event factory initialization.
   sub->benchmarkInit();
 
@@ -105,12 +111,7 @@ static void EVENTS_retrieve_events(benchmark::State& state) {
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
 
   for (int i = 0; i < 10000; i++) {
-    sub->benchmarkAdd(i);
-  }
-
-  // Trigger RocksDB compaction.
-  for (int i = 0; i < 4; ++i) {
-    sub->benchmarkGet(0, 1);
+    sub->benchmarkAdd(i++);
   }
 
   while (state.KeepRunning()) {

--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -70,7 +70,7 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
   }
   r["mac"] = macAsString(addr);
 
-  if (addr->ifa_data != nullptr) {
+  if (addr->ifa_data != nullptr && addr->ifa_name != nullptr) {
 #ifdef __linux__
     // Linux/Netlink interface details parsing.
     auto ifd = (struct rtnl_link_stats *)addr->ifa_data;

--- a/tools/analysis/clang-analyze.sh
+++ b/tools/analysis/clang-analyze.sh
@@ -7,6 +7,8 @@ declare -a BLACKLIST=(
     "logging.cc"
     "logging_unittest.cc"
     "signalhandler_unittest.cc"
+    "string_util.cc"
+    "sysinfo.cc"
   )
 
 for BL_ITEM in ${BLACKLIST[@]}; do


### PR DESCRIPTION
Focusing on reducing the system/user time in the events-based benchmarking: `make run-benchmarks`.

My current results (after change):
```
Benchmark                      Time(ns)    CPU(ns) Iterations
-------------------------------------------------------------
EVENTS_add_events_mean                       246374     137434      10000                                 
EVENTS_retrieve_events/0/100_mean              2463       2330     248993                                 
EVENTS_retrieve_events/0/500_mean              2393       2226     242145                                 
EVENTS_retrieve_events/0/1000_mean             2203       2084     310875                                 
EVENTS_retrieve_events/0/9.76562k_mean         2780       2639     221248 
```
