### PR TITLE
Remove VirtualTable matrix rotation

### DIFF
--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -43,47 +43,47 @@ Status filterArray(id plist, const std::string& root, pt::ptree& tree);
 
 Status filterDictionary(id plist, const std::string& root, pt::ptree& tree) {
   Status total_status = Status(0, "OK");
-  @autoreleasepool {
-    for (id key in [plist allKeys]) {
-      if (key == nil || ![key isKindOfClass:[NSString class]]) {
-        // Unknown type as dictionary key, most likely a malformed plist.
-        continue;
-      }
+  for (id key in [plist allKeys]) {
+    if (key == nil || ![key isKindOfClass:[NSString class]]) {
+      // Unknown type as dictionary key, most likely a malformed plist.
+      continue;
+    }
 
-      id value = [plist objectForKey:key];
-      if (value == nil) {
-        continue;
-      }
+    id value = [plist objectForKey:key];
+    if (value == nil) {
+      continue;
+    }
 
-      auto path_node = std::string([key UTF8String]);
-      if ([value isKindOfClass:[NSString class]]) {
-        tree.push_back(ptvalue(path_node, pt::ptree([value UTF8String])));
-      } else if ([value isKindOfClass:[NSNumber class]]) {
-        tree.push_back(ptvalue(path_node, pt::ptree([[value stringValue] UTF8String])));
-      } else if ([value isKindOfClass:[NSArray class]]) {
-        auto status = filterArray(value, path_node, tree);
-        if (!status.ok()) {
-          total_status = status;
-        }
-      } else if ([value isKindOfClass:[NSDictionary class]]) {
-        pt::ptree child;
-        auto status = filterDictionary(value, "", child);
-        if (!status.ok()) {
-          total_status = status;
-        }
-        tree.push_back(ptvalue(path_node, child));
-      } else if ([value isKindOfClass:[NSData class]]) {
-        NSString* dataString = [value base64EncodedStringWithOptions:0];
-        tree.push_back(ptvalue(path_node, pt::ptree([dataString UTF8String])));
-      } else if ([value isKindOfClass:[NSDate class]]) {
-        NSNumber* seconds =
-            [[NSNumber alloc] initWithDouble:[value timeIntervalSince1970]];
-        tree.push_back(ptvalue(path_node, pt::ptree([[seconds stringValue] UTF8String])));
-      } else if ([value isEqual:@(YES)]) {
-        tree.push_back(ptvalue(path_node, pt::ptree("true")));
-      } else if ([value isEqual:@(NO)]) {
-        tree.push_back(ptvalue(path_node, pt::ptree("false")));
+    auto path_node = std::string([key UTF8String]);
+    if ([value isKindOfClass:[NSString class]]) {
+      tree.push_back(ptvalue(path_node, pt::ptree([value UTF8String])));
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+      tree.push_back(
+          ptvalue(path_node, pt::ptree([[value stringValue] UTF8String])));
+    } else if ([value isKindOfClass:[NSArray class]]) {
+      auto status = filterArray(value, path_node, tree);
+      if (!status.ok()) {
+        total_status = status;
       }
+    } else if ([value isKindOfClass:[NSDictionary class]]) {
+      pt::ptree child;
+      auto status = filterDictionary(value, "", child);
+      if (!status.ok()) {
+        total_status = status;
+      }
+      tree.push_back(ptvalue(path_node, child));
+    } else if ([value isKindOfClass:[NSData class]]) {
+      NSString* dataString = [value base64EncodedStringWithOptions:0];
+      tree.push_back(ptvalue(path_node, pt::ptree([dataString UTF8String])));
+    } else if ([value isKindOfClass:[NSDate class]]) {
+      NSNumber* seconds =
+          [[NSNumber alloc] initWithDouble:[value timeIntervalSince1970]];
+      tree.push_back(
+          ptvalue(path_node, pt::ptree([[seconds stringValue] UTF8String])));
+    } else if ([value isEqual:@(YES)]) {
+      tree.push_back(ptvalue(path_node, pt::ptree("true")));
+    } else if ([value isEqual:@(NO)]) {
+      tree.push_back(ptvalue(path_node, pt::ptree("false")));
     }
   }
   return total_status;
@@ -92,53 +92,49 @@ Status filterDictionary(id plist, const std::string& root, pt::ptree& tree) {
 Status filterArray(id plist, const std::string& root, pt::ptree& tree) {
   Status total_status = Status(0, "OK");
   pt::ptree child_tree;
-  @autoreleasepool {
-    for (id value in plist) {
-      if (value == nil) {
-        continue;
-      }
-
-      pt::ptree child;
-      if ([value isKindOfClass:[NSString class]]) {
-        child.put_value([value UTF8String]);
-      } else if ([value isKindOfClass:[NSNumber class]]) {
-        child.put_value([[value stringValue] UTF8String]);
-      } else if ([value isKindOfClass:[NSArray class]]) {
-        auto status = filterArray(value, "", child);
-        if (!status.ok()) {
-          total_status = status;
-        }
-      } else if ([value isKindOfClass:[NSDictionary class]]) {
-        auto status = filterDictionary(value, "", child);
-        if (!status.ok()) {
-          total_status = status;
-        }
-      } else if ([value isKindOfClass:[NSData class]]) {
-        NSString* dataString = [value base64EncodedStringWithOptions:0];
-        child.put_value([dataString UTF8String]);
-      } else if ([value isKindOfClass:[NSDate class]]) {
-        NSNumber* seconds =
-            [[NSNumber alloc] initWithDouble:[value timeIntervalSince1970]];
-        child.put_value([[seconds stringValue] UTF8String]);
-      } else if ([value isEqual:@(YES)]) {
-        child.put_value("true");
-      } else if ([value isEqual:@(NO)]) {
-        child.put_value("false");
-      }
-      child_tree.push_back(std::make_pair("", child));
+  for (id value in plist) {
+    if (value == nil) {
+      continue;
     }
+
+    pt::ptree child;
+    if ([value isKindOfClass:[NSString class]]) {
+      child.put_value([value UTF8String]);
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+      child.put_value([[value stringValue] UTF8String]);
+    } else if ([value isKindOfClass:[NSArray class]]) {
+      auto status = filterArray(value, "", child);
+      if (!status.ok()) {
+        total_status = status;
+      }
+    } else if ([value isKindOfClass:[NSDictionary class]]) {
+      auto status = filterDictionary(value, "", child);
+      if (!status.ok()) {
+        total_status = status;
+      }
+    } else if ([value isKindOfClass:[NSData class]]) {
+      NSString* dataString = [value base64EncodedStringWithOptions:0];
+      child.put_value([dataString UTF8String]);
+    } else if ([value isKindOfClass:[NSDate class]]) {
+      NSNumber* seconds =
+          [[NSNumber alloc] initWithDouble:[value timeIntervalSince1970]];
+      child.put_value([[seconds stringValue] UTF8String]);
+    } else if ([value isEqual:@(YES)]) {
+      child.put_value("true");
+    } else if ([value isEqual:@(NO)]) {
+      child.put_value("false");
+    }
+    child_tree.push_back(std::make_pair("", child));
   }
   tree.push_back(pt::ptree::value_type(root, child_tree));
   return total_status;
 }
 
 static inline Status filterPlist(NSData* plist, pt::ptree& tree) {
-  @autoreleasepool {
-    if ([plist isKindOfClass:[NSDictionary class]]) {
-      return filterDictionary((NSMutableDictionary*)plist, "", tree);
-    } else {
-      return filterArray((NSMutableArray*)plist, "root", tree);
-    }
+  if ([plist isKindOfClass:[NSDictionary class]]) {
+    return filterDictionary((NSMutableDictionary*)plist, "", tree);
+  } else {
+    return filterArray((NSMutableArray*)plist, "root", tree);
   }
   return Status(0, "OK");
 }
@@ -170,6 +166,7 @@ Status parsePlistContent(const std::string& content, pt::ptree& tree) {
 
 Status parsePlist(const boost::filesystem::path& path, pt::ptree& tree) {
   tree.clear();
+  Status status;
   @autoreleasepool {
     id ns_path = [NSString stringWithUTF8String:path.string().c_str()];
     id stream = [NSInputStream inputStreamWithFileAtPath:ns_path];
@@ -185,12 +182,16 @@ Status parsePlist(const boost::filesystem::path& path, pt::ptree& tree) {
                                                                  format:NULL
                                                                   error:&error];
     if (plist_data == nil) {
+      // The most common error is lack of read permissions.
       std::string error_message([[error localizedFailureReason] UTF8String]);
       VLOG(1) << error_message;
+      [stream close];
       return Status(1, error_message);
     }
     // Parse the plist data into a core foundation dictionary-literal.
-    return filterPlist(plist_data, tree);
+    status = filterPlist(plist_data, tree);
+    [stream close];
   }
+  return status;
 }
 }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -42,7 +42,7 @@ int xEof(sqlite3_vtab_cursor *cur) {
   if (pCur->row >= pVtab->content->n) {
     // If the requested row exceeds the size of the row set then all rows
     // have been visited, clear the data container.
-    pVtab->content->data.clear();
+    QueryData().swap(pVtab->content->data);
     return true;
   }
   return false;
@@ -158,7 +158,7 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
     double afinite = strtod(value.c_str(), &end);
     if (end == nullptr || end == value.c_str() || *end != '\0') {
       afinite = 0;
-      VLOG(1) << "Error casting" << column_name << " (" << value
+      VLOG(1) << "Error casting " << column_name << " (" << value
               << ") to DOUBLE";
     }
     sqlite3_result_double(ctx, afinite);
@@ -169,7 +169,7 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
 
 static int xBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   auto *pVtab = (VirtualTable *)tab;
-  pVtab->content->constraints.clear();
+  ConstraintSet().swap(pVtab->content->constraints);
 
   int expr_index = 0;
   int cost = 0;

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -31,7 +31,7 @@ struct BaseCursor {
 struct VirtualTableContent {
   TableName name;
   TableColumns columns;
-  TableData data;
+  QueryData data;
   ConstraintSet constraints;
   size_t n;
 };

--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -201,7 +201,7 @@ void genApplication(const pt::ptree& tree,
       r[item.second] = "";
     }
   }
-  results.push_back(r);
+  results.push_back(std::move(r));
 }
 
 Status genAppsFromLaunchServices(std::set<std::string>& apps) {
@@ -284,7 +284,7 @@ QueryData genApps(QueryContext& context) {
     genApplication(tree, path, results);
   }
 
-  return results;
+  return std::move(results);
 }
 
 QueryData genAppSchemes(QueryContext& context) {

--- a/osquery/tables/system/darwin/launchd.cpp
+++ b/osquery/tables/system/darwin/launchd.cpp
@@ -88,7 +88,7 @@ void genLaunchdItem(const pt::ptree& tree,
     r[it.second] = boost::algorithm::join(arguments, " ");
   }
 
-  results.push_back(r);
+  results.push_back(std::move(r));
 }
 
 QueryData genLaunchd(QueryContext& context) {
@@ -128,7 +128,7 @@ QueryData genLaunchd(QueryContext& context) {
     genLaunchdItem(tree, path, results);
   }
 
-  return results;
+  return std::move(results);
 }
 
 void genLaunchdOverride(const fs::path& path, QueryData& results) {

--- a/osquery/tables/system/darwin/packages.cpp
+++ b/osquery/tables/system/darwin/packages.cpp
@@ -272,7 +272,7 @@ void genPackageReceipt(const std::string& path, QueryData& results) {
       r[kPkgReceiptKeys.at(row.at("key"))] = row.at("value");
     }
   }
-  results.push_back(r);
+  results.push_back(std::move(r));
 }
 
 QueryData genPackageReceipts(QueryContext& context) {
@@ -311,7 +311,7 @@ QueryData genPackageReceipts(QueryContext& context) {
     }
   }
 
-  return results;
+  return std::move(results);
 }
 }
 }

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -111,7 +111,7 @@ void genOSXPrefValues(const CFTypeRef& value,
     return;
   }
 
-  results.push_back(r);
+  results.push_back(std::move(r));
 }
 
 void genOSXDomainPrefs(const CFStringRef& domain, QueryData& results) {
@@ -197,7 +197,7 @@ void genOSXPlistPrefValue(const pt::ptree& tree,
   if (tree.empty()) {
     Row r = base;
     r["value"] = tree.data();
-    results.push_back(r);
+    results.push_back(std::move(r));
     // No more levels to parse.
     return;
   }
@@ -254,7 +254,7 @@ QueryData genOSXPreferences(QueryContext& context) {
     genOSXDefaultPreferences(context, results);
   }
 
-  return results;
+  return std::move(results);
 }
 }
 }


### PR DESCRIPTION
Instead of rotating the generated data from row to columns, access each row/column directly. Although there were optimizations around space within the rotation, this improves query performance by a factor of `1.25`.

Before:
```
Benchmark                         Time(ns)    CPU(ns) Iterations
----------------------------------------------------------------
SQL_virtual_table_registry            2134       2128     311644                                 
SQL_virtual_table_internal          113019     112584       6089                                 
SQL_virtual_table_internal_long    1971752    1964762        340                                 
SQL_virtual_table_internal_wide    2192625    2185087        310                                 
SQL_select_metadata                  40653      40457      16772                                 
SQL_select_basic                    113714     113172       5979  
```

After:
```
Benchmark                         Time(ns)    CPU(ns) Iterations
----------------------------------------------------------------
SQL_virtual_table_registry            2159       2148     315375                                 
SQL_virtual_table_internal          112635     112197       6186                                 
SQL_virtual_table_internal_long    1595019    1587392        424                                 
SQL_virtual_table_internal_wide    1825092    1818562        368                                 
SQL_select_metadata                  41246      41101      16989                                 
SQL_select_basic                    106747     106351       6162 
```