### PR TITLE
Allow static linking when BUILD_LINK_SHARED is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ endif()
 execute_process(COMMAND mkdir -p "${CMAKE_BINARY_DIR}/generated")
 
 # We need to link some packages as dynamic/dependent.
-set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so)
+set(CMAKE_FIND_LIBRARY_SUFFIXES .dylib .so .a)
 find_package(BZip2 REQUIRED)
 find_package(Dl REQUIRED)
 find_package(Readline REQUIRED)


### PR DESCRIPTION
A build will fail if you install libraries (like gflags) that only include a static version and include the `BUILD_LINK_SHARED` environment flag. Practically, this will fail when installing from brew.