### PR TITLE
Fix doxygen docs generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ ifeq ($(DISTRO),unknown_version)
 	@echo Unknown, non-Redhat, non-Ubuntu based Linux distro
 	false
 endif
+	@mkdir -p build/docs
 	@mkdir -p build/$(BUILD_DIR)
 	@mkdir -p build/debug_$(BUILD_DIR)
 ifeq ($(PLATFORM),Linux)


### PR DESCRIPTION
I occasionally rely on doxygen generated wiki, and `make docs` is currently broken with `no such directory/file error`

`genapi.py` (and hence `make docs`) [expects `build/docs` directory to exist.](https://github.com/facebook/osquery/blob/master/CMakeLists.txt#L359)

However this directory wouldn't exist if `make distclean` is run or `build` directory is nuked.

This change creates the docs directory if it doesn't exist.