### PR TITLE
[#1455] Add libgcrypt11 as a package dependency for debian builds

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -17,6 +17,7 @@ elseif(LINUX)
       "zlib1g"
       "libbz2-1.0"
       "libreadline6"
+      "libgcrypt11"
     )
     if(NOT OSQUERY_BUILD_DISTRO STREQUAL "lucid")
       set(PACKAGE_ITERATION "1.ubuntu10")


### PR DESCRIPTION
Fun fact, this wont build on Debian stable, since Jesse only includes libgcrypt20. For our purposes, and from our build/package host's perspective, `debian-based` means Ubuntu.