### PR TITLE
Static analysis cleanups, static libmagic

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -91,7 +91,7 @@ class Schedule {
  */
 class Config {
  private:
-  Config() { schedule_ = Schedule(); };
+  Config() : schedule_(Schedule()){};
 
  protected:
   typedef boost::unique_lock<boost::shared_mutex> WriteLock;
@@ -440,19 +440,6 @@ class ConfigParserPlugin : public Plugin {
   /// Allow the config parser to keep some global state.
   boost::property_tree::ptree data_;
 };
-
-/**
- * @brief Calculate a splayed integer based on a variable splay percentage
- *
- * The value of splayPercent must be between 1 and 100. If it's not, the
- * value of original will be returned.
- *
- * @param original The original value to be modified
- * @param splayPercent The percent in which to splay the original value by
- *
- * @return The modified version of original
- */
-int splayValue(int original, int splayPercent);
 
 /**
  * @brief Config plugin registry.

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -240,10 +240,9 @@ inline size_t incUtf8StringIterator(_Iterator1& it, const _Iterator2& last) {
     return 0;
   }
 
-  unsigned char c;
   size_t res = 1;
   for (++it; last != it; ++it, ++res) {
-    c = *it;
+    unsigned char c = *it;
     if (!(c & 0x80) || ((c & 0xC0) == 0xC0)) {
       break;
     }

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -294,7 +294,7 @@ class EventPublisherPlugin : public Plugin {
   EventContextID next_ec_id_;
 
  private:
-  EventPublisherPlugin(EventPublisherPlugin const&);
+  explicit EventPublisherPlugin(EventPublisherPlugin const&);
   EventPublisherPlugin& operator=(EventPublisherPlugin const&);
 
  private:
@@ -554,7 +554,7 @@ class EventSubscriberPlugin : public Plugin {
   void doNotExpire() { expire_events_ = false; }
 
  private:
-  EventSubscriberPlugin(EventSubscriberPlugin const&);
+  explicit EventSubscriberPlugin(EventSubscriberPlugin const&);
   EventSubscriberPlugin& operator=(EventSubscriberPlugin const&);
 
  private:

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -386,25 +386,4 @@ Status ConfigParserPlugin::setUp() {
   }
   return Status(0, "OK");
 }
-
-int splayValue(int original, int splayPercent) {
-  if (splayPercent <= 0 || splayPercent > 100) {
-    return original;
-  }
-
-  float percent_to_modify_by = (float)splayPercent / 100;
-  int possible_difference = original * percent_to_modify_by;
-  int max_value = original + possible_difference;
-  int min_value = original - possible_difference;
-
-  if (max_value == min_value) {
-    return max_value;
-  }
-
-  std::default_random_engine generator;
-  generator.seed(
-      std::chrono::high_resolution_clock::now().time_since_epoch().count());
-  std::uniform_int_distribution<int> distribution(min_value, max_value);
-  return distribution(generator);
-}
 }

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -134,26 +134,6 @@ class TestConfigParserPlugin : public ConfigParserPlugin {
 // An intermediate boolean to check parser updates.
 bool TestConfigParserPlugin::update_called = false;
 
-TEST_F(ConfigTests, test_splay) {
-  auto val1 = splayValue(100, 10);
-  EXPECT_GE(val1, 90);
-  EXPECT_LE(val1, 110);
-
-  auto val2 = splayValue(100, 10);
-  EXPECT_GE(val2, 90);
-  EXPECT_LE(val2, 110);
-
-  auto val3 = splayValue(10, 0);
-  EXPECT_EQ(val3, 10);
-
-  auto val4 = splayValue(100, 1);
-  EXPECT_GE(val4, 99);
-  EXPECT_LE(val4, 101);
-
-  auto val5 = splayValue(1, 10);
-  EXPECT_EQ(val5, 1);
-}
-
 TEST_F(ConfigTests, test_parse) {
   auto c = Config();
   auto tree = getExamplePacksConfig();

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -19,6 +19,8 @@ namespace osquery {
 
 class PacksTests : public testing::Test {};
 
+extern int splayValue(int original, int splayPercent);
+
 pt::ptree getExamplePacksConfig() {
   std::string content;
   auto s = readFile(kTestDataPath + "test_inline_pack.conf", content);
@@ -130,5 +132,25 @@ TEST_F(PacksTests, test_discovery_zero_state) {
   EXPECT_EQ(stats.total, 0);
   EXPECT_EQ(stats.hits, 0);
   EXPECT_EQ(stats.misses, 0);
+}
+
+TEST_F(PacksTests, test_splay) {
+  auto val1 = splayValue(100, 10);
+  EXPECT_GE(val1, 90);
+  EXPECT_LE(val1, 110);
+
+  auto val2 = splayValue(100, 10);
+  EXPECT_GE(val2, 90);
+  EXPECT_LE(val2, 110);
+
+  auto val3 = splayValue(10, 0);
+  EXPECT_EQ(val3, 10);
+
+  auto val4 = splayValue(100, 1);
+  EXPECT_GE(val4, 99);
+  EXPECT_LE(val4, 101);
+
+  auto val5 = splayValue(1, 10);
+  EXPECT_EQ(val5, 1);
 }
 }

--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -46,10 +46,9 @@ std::string stringFromCFData(const CFDataRef& cf_data) {
   memset(buffer, 0, range.length + 1);
 
   std::stringstream result;
-  uint8_t byte;
   CFDataGetBytes(cf_data, range, (UInt8*)buffer);
   for (CFIndex i = 0; i < range.length; ++i) {
-    byte = buffer[i];
+    uint8_t byte = buffer[i];
     if (isprint(byte)) {
       result << byte;
     } else if (buffer[i] == 0) {

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -233,13 +233,14 @@ bool WatcherRunner::isChildSane(pid_t child) {
   // Get the performance state for the worker or extension.
   size_t sustained_latency = 0;
   // Compare CPU utilization since last check.
-  BIGINT_LITERAL footprint = 0, user_time = 0, system_time = 0, parent = 0;
+  BIGINT_LITERAL footprint = 0, parent = 0;
   // IV is the check interval in seconds, and utilization is set per-second.
   auto iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
 
   {
     WatcherLocker locker;
     auto& state = Watcher::getState(child);
+    BIGINT_LITERAL user_time = 0, system_time = 0;
     try {
       parent = AS_LITERAL(BIGINT_LITERAL, rows[0].at("parent"));
       user_time = AS_LITERAL(BIGINT_LITERAL, rows[0].at("user_time")) / iv;

--- a/osquery/events/kernel/circular_queue_user.h
+++ b/osquery/events/kernel/circular_queue_user.h
@@ -41,7 +41,7 @@ class CQueue {
    *
    * @param size The size of the shared buffer used for communication.
    */
-  CQueue(size_t size);
+  explicit CQueue(size_t size);
 
   /**
    * @brief Cleanup a cqueue.

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -239,7 +239,7 @@ class ExtensionManagerWatcher : public ExtensionWatcher {
 class ExtensionRunnerCore : public InternalRunnable {
  public:
   virtual ~ExtensionRunnerCore();
-  ExtensionRunnerCore(const std::string& path)
+  explicit ExtensionRunnerCore(const std::string& path)
       : path_(path), server_(nullptr) {}
 
  public:
@@ -318,8 +318,10 @@ class EXInternal {
 /// Internal accessor for a client to an extension (from an extension manager).
 class EXClient : public EXInternal {
  public:
-  explicit EXClient(const std::string& path) : EXInternal(path) {
-    client_ = std::make_shared<extensions::ExtensionClient>(protocol_);
+  explicit EXClient(const std::string& path)
+      : EXInternal(path),
+        client_(std::make_shared<extensions::ExtensionClient>(protocol_)) {
+
     (void)transport_->open();
   }
 
@@ -333,8 +335,9 @@ class EXClient : public EXInternal {
 class EXManagerClient : public EXInternal {
  public:
   explicit EXManagerClient(const std::string& manager_path)
-      : EXInternal(manager_path) {
-    client_ = std::make_shared<extensions::ExtensionManagerClient>(protocol_);
+      : EXInternal(manager_path),
+        client_(
+            std::make_shared<extensions::ExtensionManagerClient>(protocol_)) {
     (void)transport_->open();
   }
 

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -304,7 +304,7 @@ Status RegistryFactory::call(const std::string& registry_name,
     LOG(ERROR) << registry_name << " registry " << item_name
                << " plugin caused exception: " << e.what();
     if (FLAGS_registry_exceptions) {
-      throw e;
+      throw;
     }
     return Status(1, e.what());
   } catch (...) {

--- a/osquery/remote/requests.h
+++ b/osquery/remote/requests.h
@@ -194,7 +194,7 @@ class Request {
    *
    * @param destination A string of the remote URI destination
    */
-  Request(const std::string& destination)
+  explicit Request(const std::string& destination)
       : destination_(destination),
         serializer_(new TSerializer),
         transport_(new TTransport) {

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -18,6 +18,7 @@ if(APPLE)
   ADD_OSQUERY_LINK_ADDITIONAL("-framework DiskArbitration")
 
   ADD_OSQUERY_LINK_ADDITIONAL("archive")
+  ADD_OSQUERY_LINK_ADDITIONAL("magic")
 elseif(FREEBSD)
   file(GLOB OSQUERY_FREEBSD_TABLES "*/freebsd/*.cpp")
   ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_freebsd
@@ -62,9 +63,9 @@ else()
   ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup libdevmapper.so libgcrypt.so")
   ADD_OSQUERY_LINK_ADDITIONAL("libuuid.so")
   ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")
+  ADD_OSQUERY_LINK_ADDITIONAL("libmagic.so")
 endif()
 
-ADD_OSQUERY_LINK_ADDITIONAL("magic")
 
 file(GLOB OSQUERY_CROSS_APPLICATIONS_TABLES "applications/*.cpp")
 file(GLOB OSQUERY_CROSS_SYSTEM_TABLES "system/*.cpp")

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -51,7 +51,7 @@ void parseIpEntry(ipt_ip *ip, Row &r) {
 
   char aux_char[2] = {0};
   std::string iniface_mask;
-  for (int i = 0; ip->iniface_mask[i] != 0x00 && i<IFNAMSIZ; i++) {
+  for (int i = 0; i < IFNAMSIZ && ip->iniface_mask[i] != 0x00; i++) {
     aux_char[0] = MAP[(int) ip->iniface_mask[i] >> HIGH_BITS];
     aux_char[1] = MAP[(int) ip->iniface_mask[i] & LOW_BITS];
     iniface_mask += aux_char[0];
@@ -60,7 +60,7 @@ void parseIpEntry(ipt_ip *ip, Row &r) {
 
   r["iniface_mask"] = TEXT(iniface_mask);
   std::string outiface_mask = "";
-  for (int i = 0; ip->outiface_mask[i] != 0x00 && i<IFNAMSIZ; i++) {
+  for (int i = 0; i < IFNAMSIZ && ip->outiface_mask[i] != 0x00; i++) {
     aux_char[0] = MAP[(int) ip->outiface_mask[i] >> HIGH_BITS];
     aux_char[1] = MAP[(int) ip->outiface_mask[i] & LOW_BITS];
     outiface_mask += aux_char[0];

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -20,36 +20,39 @@ namespace tables {
 
 QueryData genMounts(QueryContext &context) {
   QueryData results;
-  FILE *mounts;
-  struct mntent *ent;
-  char real_path[PATH_MAX];
-  struct statfs st;
 
-  if ((mounts = setmntent("/proc/mounts", "r"))) {
-    while ((ent = getmntent(mounts))) {
-      Row r;
-
-      r["device"] = std::string(ent->mnt_fsname);
-      r["device_alias"] = std::string(
-          realpath(ent->mnt_fsname, real_path) ? real_path : ent->mnt_fsname);
-      r["path"] = std::string(ent->mnt_dir);
-      r["type"] = std::string(ent->mnt_type);
-      r["flags"] = std::string(ent->mnt_opts);
-      if (!statfs(ent->mnt_dir, &st)) {
-        r["blocks_size"] = BIGINT(st.f_bsize);
-        r["blocks"] = BIGINT(st.f_blocks);
-        r["blocks_free"] = BIGINT(st.f_bfree);
-        r["blocks_available"] = BIGINT(st.f_bavail);
-        r["inodes"] = BIGINT(st.f_files);
-        r["inodes_free"] = BIGINT(st.f_ffree);
-      }
-
-      results.push_back(r);
-    }
-    endmntent(mounts);
+  FILE *mounts = setmntent("/proc/mounts", "r");
+  if (mounts == nullptr) {
+    return {};
   }
 
-  return results;
+  char real_path[PATH_MAX + 1] = {0};
+  struct mntent *ent = nullptr;
+  while ((ent = getmntent(mounts))) {
+    Row r;
+
+    r["device"] = std::string(ent->mnt_fsname);
+    r["device_alias"] = std::string(
+        realpath(ent->mnt_fsname, real_path) ? real_path : ent->mnt_fsname);
+    r["path"] = std::string(ent->mnt_dir);
+    r["type"] = std::string(ent->mnt_type);
+    r["flags"] = std::string(ent->mnt_opts);
+
+    struct statfs st;
+    if (!statfs(ent->mnt_dir, &st)) {
+      r["blocks_size"] = BIGINT(st.f_bsize);
+      r["blocks"] = BIGINT(st.f_blocks);
+      r["blocks_free"] = BIGINT(st.f_bfree);
+      r["blocks_available"] = BIGINT(st.f_bavail);
+      r["inodes"] = BIGINT(st.f_files);
+      r["inodes_free"] = BIGINT(st.f_ffree);
+    }
+
+    results.push_back(std::move(r));
+  }
+  endmntent(mounts);
+
+  return std::move(results);
 }
 }
 }


### PR DESCRIPTION
1. Apply performance and style cleanups from `cppcheck`.
2. Prefer dynamic/dependent linking of `libmagic` on Linux.
3. Use the boost package alias on Ubuntu to avoid deep dependency error for `make deps`.