### PR TITLE
[Fix #1492] Fix firefox key counting and spec typo

### DIFF
--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -14,6 +14,8 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+#include "osquery/tables/applications/browser_utils.h"
+
 namespace fs = boost::filesystem;
 namespace pt = boost::property_tree;
 
@@ -61,24 +63,16 @@ void genFirefoxAddonsFromExtensions(const std::string& path,
     Row r;
     // Most of the keys are in the top-level JSON dictionary.
     for (const auto& it : kFirefoxAddonKeys) {
-      if (addon.second.count(it.first)) {
-        r[it.second] = addon.second.get<std::string>(it.first, "");
-      }
+      r[it.second] = addon.second.get(it.first, "");
 
       // Convert bool-types to an integer.
-      if (r[it.second] == "true" || r[it.second] == "YES" ||
-          r[it.first] == "Yes") {
-        r[it.second] = INTEGER(1);
-      } else if (r[it.second] == "false" || r[it.second] == "NO" ||
-                 r[it.second] == "No") {
-        r[it.second] = INTEGER(0);
-      }
+      jsonBoolAsInt(r[it.second]);
     }
 
     // There are several ways to disabled the addon, check each.
-    if (addon.second.get<std::string>("softDisable", "false") == "true" ||
-        addon.second.get<std::string>("appDisabled", "false") == "true" ||
-        addon.second.get<std::string>("userDisabled", "false") == "true") {
+    if (addon.second.get("softDisable", "false") == "true" ||
+        addon.second.get("appDisabled", "false") == "true" ||
+        addon.second.get("userDisabled", "false") == "true") {
       r["disabled"] = INTEGER(1);
     } else {
       r["disabled"] = INTEGER(0);

--- a/osquery/tables/applications/browser_utils.h
+++ b/osquery/tables/applications/browser_utils.h
@@ -20,5 +20,13 @@ namespace tables {
 
 QueryData genChromeBasedExtensions(QueryContext& context, const fs::path sub_dir);
 
+/// A helper check to rename bool-type values as 1 or 0.
+inline void jsonBoolAsInt(std::string& s) {
+  if (s == "true" || s == "YES" || s == "Yes") {
+    s = "1";
+  } else if (s == "false" || s == "NO" || s == "No") {
+    s = "0";
+  }
+}
 }
 }

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -15,6 +15,8 @@
 #include <archive.h>
 #include <archive_entry.h>
 
+#include "osquery/tables/applications/browser_utils.h"
+
 namespace fs = boost::filesystem;
 namespace pt = boost::property_tree;
 
@@ -57,14 +59,8 @@ void genBrowserPlugin(const std::string& path, QueryData& results) {
     for (const auto& it : kBrowserPluginKeys) {
       r[it.second] = tree.get(it.first, "");
 
-      // Convert Plist bool-types to an integer.
-      if (r.at(it.second) == "true" || r.at(it.second) == "YES" ||
-          r.at(it.second) == "Yes") {
-        r[it.second] = "1";
-      } else if (r.at(it.second) == "false" || r.at(it.second) == "NO" ||
-                 r.at(it.second) == "No") {
-        r[it.second] = "0";
-      }
+      // Convert bool-types to an integer.
+      jsonBoolAsInt(r[it.second]);
     }
   }
 

--- a/specs/firefox_addons.table
+++ b/specs/firefox_addons.table
@@ -3,7 +3,7 @@ description("Firefox browser extensions, webapps, and addons.")
 schema([
     Column("name", TEXT, "Addon display name"),
     Column("identifier", TEXT, "Addon identifier"),
-    Column("creator", TEXT< "Addon-supported creator string"),
+    Column("creator", TEXT, "Addon-supported creator string"),
     Column("type", TEXT, "Extension, addon, webapp"),
     Column("version", TEXT, "Addon-supplied version string"),
     Column("description", TEXT, "Addon-supplied description string"),


### PR DESCRIPTION
Plist `.count` does not evaluate embedded keys. We can skip the existence checking and supply a default value = `""` when the key or embedded key does not exist in the input JSON.