### PR TITLE
[#1488] Use signal handlers for teardown and reloading

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -180,6 +180,9 @@ void WatcherRunner::start() {
   // Enter the watch loop.
   do {
     if (use_worker_ && !watch(Watcher::getWorker())) {
+      if (Watcher::fatesBound()) {
+        break;
+      }
       // The watcher failed, create a worker.
       createWorker();
     }

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -65,6 +65,7 @@ DEFAULT_CONFIG = {
         "extensions_timeout": "0",
         "watchdog_level": "3",
         "disable_logging": "true",
+        "disable_events": "true",
         "force": "true",
     },
     "schedule": {},
@@ -155,13 +156,13 @@ class ProcRunner(object):
         self.args = _args
         self.interval = interval
         self.silent = silent
+        self.retcode = -1
         thread = threading.Thread(target=self.run, args=())
         thread.daemon = True
         thread.start()
 
     def run(self):
         pid = 0
-        code = -1
         try:
             if self.silent:
                 self.proc = subprocess.Popen([self.path] + self.args,
@@ -179,7 +180,7 @@ class ProcRunner(object):
                 self.started = True
                 time.sleep(self.interval)
             self.started = True
-            code = -1 if self.proc is None else self.proc.poll()
+            self.retcode = -1 if self.proc is None else self.proc.poll()
             self.proc = None
         except Exception as e:
             return
@@ -209,6 +210,12 @@ class ProcRunner(object):
         except:
             pass
         return []
+
+    @property
+    def code(self):
+        self.requireStarted()
+        return self.retcode
+
 
     @property
     def pid(self):


### PR DESCRIPTION
Catch normal tear-down related signals and allow the event factory's publisher threads time to run their `tearDown` methods. If threads are not joined within a timeout (10s) the process exits with `SIGSTOP`.

`SIGHUP` is also caught and does nothing.