### PR TITLE
Config MD5 a bit more deterministic

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -91,7 +91,7 @@ class Schedule {
  */
 class Config {
  private:
-  Config() : schedule_(Schedule()){};
+  Config() : schedule_(Schedule()), valid_(false){};
 
  protected:
   typedef boost::unique_lock<boost::shared_mutex> WriteLock;
@@ -171,6 +171,17 @@ class Config {
    * @return The MD5 of the osquery config
    */
   Status getMD5(std::string& hash);
+
+  /**
+   * @brief Hash a source's config data
+   *
+   * @param source is the place where the config content came from
+   * @param content is the content of the config data for a given source
+   */
+  void hashSource(const std::string& source, const std::string& content);
+
+  /// Whether or not the last loaded config was valid
+  bool isValid();
 
   /**
    * @brief Add a pack to the osquery schedule
@@ -270,7 +281,8 @@ class Config {
   Schedule schedule_;
   std::map<std::string, QueryPerformance> performance_;
   std::map<std::string, std::vector<std::string> > files_;
-  std::string hash_;
+  std::map<std::string, std::string> hash_;
+  bool valid_;
 
  private:
   friend class ConfigTests;

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -365,7 +365,10 @@ void Initializer::start() {
   }
 
   // Load the osquery config using the default/active config plugin.
-  Config::getInstance().load();
+  auto s = Config::getInstance().load();
+  if (!s.ok()) {
+    LOG(ERROR) << "Error reading config: " << s.toString();
+  }
 
   // Initialize the status and result plugin logger.
   initActivePlugin("logger", FLAGS_logger_plugin);

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -144,6 +144,8 @@ QueryData genOsqueryInfo(QueryContext& context) {
     VLOG(1) << "Could not retrieve config hash: " << s.toString();
   }
 
+  r["config_valid"] = Config::getInstance().isValid() ? INTEGER(1) : INTEGER(0);
+
   r["config_path"] = Flag::getValue("config_path");
   r["extensions"] =
       (pingExtension(FLAGS_extensions_socket).ok()) ? "active" : "inactive";

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -3,13 +3,12 @@ description("Top level information about the running version of osquery.")
 schema([
     Column("pid", INTEGER, "Process (or thread) ID"),
     Column("version", TEXT, "osquery toolkit version"),
-    Column("config_md5", TEXT, "md5 hash of the working configuration"),
-    Column("config_path", TEXT,
-      "Optional: path to filesystem config plugin content"),
+    Column("config_md5", TEXT, "md5 hash of the working configuration state"),
+    Column("config_valid", INTEGER, "1 if the config was loaded and considered valid, else 0"),
+    Column("config_path", TEXT, "Optional: path to filesystem config plugin content"),
     Column("extensions", TEXT, "osquery extensions status"),
     Column("build_platform", TEXT, "osquery toolkit build platform"),
-    Column("build_distro", TEXT,
-      "osquery toolkit platform distribution name (os version)"),
+    Column("build_distro", TEXT, "osquery toolkit platform distribution name (os version)"),
 ])
 attributes(utility=True)
 implementation("osquery@genOsqueryInfo")


### PR DESCRIPTION
```
$ ./build/darwin/osquery/osqueryi --config_path=/asdfasdfadfs
E0903 11:45:02.050308 1990836992 init.cpp:370] Error reading config: config file does not exist
Using a virtual database. Need help, type '.help'
osquery> .mode line
osquery> .all osquery_info
           pid = 33700
       version = 1.5.2-43-gb06fa92
    config_md5 =
  config_valid = 0
   config_path = /asdfasdfadfs
    extensions = active
build_platform = darwin
  build_distro = 10.10
osquery> .exit

$ ./build/darwin/osquery/osqueryi
osquery> .mode line
osquery> .all osquery_info
           pid = 33781
       version = 1.5.2-43-gb06fa92
    config_md5 = 8a432ac93d3de080c62d77ba99b89783
  config_valid = 1
   config_path = /var/osquery/osquery.conf
    extensions = active
build_platform = darwin
  build_distro = 10.10
osquery> .exit
```

#1486