### PR TITLE
[#1487] Add osquery_events table to track pubsub stats

### DIFF
--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -27,9 +27,12 @@ namespace osquery {
 
 int kMaxEventLatency = 3000;
 
+DECLARE_bool(verbose);
+
 class FSEventsTests : public testing::Test {
  protected:
   void SetUp() {
+    FLAGS_verbose = true;
     trigger_path = kTestWorkingDirectory + "fsevents" +
                    std::to_string(rand() % 10000 + 10000);
   }

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/test_util.h"
 
 int main(int argc, char* argv[]) {

--- a/specs/utility/osquery_events.table
+++ b/specs/utility/osquery_events.table
@@ -1,0 +1,16 @@
+table_name("osquery_events")
+description("Information about the event publishers and subscribers.")
+schema([
+    Column("name", TEXT, "Event publisher or subscriber name"),
+    Column("publisher", TEXT, "Name of the associated publisher"),
+    Column("type", TEXT, "Either publisher or subscriber"),
+    Column("subscriptions", INTEGER,
+      "Number of subscriptions the publisher received or subscriber used"),
+    Column("events", INTEGER,
+      "Number of events emitted or received since osquery started"),
+    Column("restarts", INTEGER, "Publisher only: number of runloop restarts"),
+    Column("active", INTEGER,
+      "1 if the publisher or subscriber is active else 0"),
+])
+attributes(utility=True)
+implementation("osquery@genOsqueryEvents")

--- a/tools/tests/stress.py
+++ b/tools/tests/stress.py
@@ -86,7 +86,7 @@ def audit(args):
 
 def single(args):
     start_time = time.time()
-    proc = subprocess.Popen(test,
+    proc = subprocess.Popen(args,
                             shell=True,
                             stderr=subprocess.PIPE,
                             stdout=subprocess.PIPE)
@@ -107,7 +107,7 @@ def stress(args):
         if args["audit"]:
             times.append(audit(args))
         else:
-            times.append(single(args))
+            times.append(single(test))
         if args["stat"]:
             print ("%6.4f" % (times[-1]))
         else:


### PR DESCRIPTION
This adds tracking data to subscribers and publishers. A scheduled query to `osquery_events` allows one to determine if any publishers are trashing or if their subscriptions are generating too many uncaught events.