### PR TITLE
Update system_info table to include CPU type, CPU cores and total memory

### DIFF
--- a/osquery/tables/system/darwin/sysctl_utils.cpp
+++ b/osquery/tables/system/darwin/sysctl_utils.cpp
@@ -36,7 +36,7 @@ namespace tables {
 #define MAX_CONTROLS 1024
 
 const std::vector<std::string> kControlNames{
-    "", "kern", "vm", "vfs", "net", "debug", "hw", "macdep", "user"};
+    "", "kern", "vm", "vfs", "net", "debug", "hw", "machdep", "user"};
 
 const std::vector<std::string> kControlTypes{
     "", "node", "int", "string", "quad", "opaque", "struct"};

--- a/specs/darwin/system_info.table
+++ b/specs/darwin/system_info.table
@@ -4,5 +4,12 @@ schema([
     Column("hostname", TEXT, "Network hostname including domain"),
     Column("uuid", TEXT, "Unique ID provided by the system"),
     Column("cpu_serial", TEXT, "System serial number frequently used for asset tracking"),
+    Column("cpu_type", TEXT, "CPU type"),
+    Column("cpu_subtype", TEXT, "CPU subtype"),
+    Column("cpu_brand", TEXT, "CPU brand string"),
+    Column("cpu_physical_cores", INTEGER, "Max number of CPU physical cores"),
+    Column("cpu_logical_cores", INTEGER, "Max number of CPU logical cores"),
+    Column("physical_memory", BIGINT, "Total physical memory in bytes"),
+    Column("hardware_model", TEXT, "Hardware model string"),
 ])
 implementation("system/system_info@genSystemInfo")


### PR DESCRIPTION
This change adds:
* `cpu_type` 
* `cpu_subtype`
* `cpu_brand`
* `cpu_physical_cores`
* `cpu_logical_cores`
* `physical_memory`
* `hardware_model` 

columns to `system_info` table.

Here's how it looks:
```
osquery> .mode line
osquery> .all system_info;
          hostname = <redacted>
              uuid = <redacted>
        cpu_serial = <redacted>
          cpu_type = x86_64h
       cpu_subtype = Intel x86-64h Haswell
         cpu_brand = Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
cpu_physical_cores = 4
 cpu_logical_cores = 8
   physical_memory = 17179869184
    hardware_model = MacBookPro11,3
```

I don't think there is a (public) IOKit API to get human readable strings for cpu info, so this relies on two mach calls: `host_info` and `sysctlbyname`.

I also briefly looked at `ioreg`, but didn't find a way (yet) to get IO/PCH chipset model/version. Maybe @theopolis has some pointers on it.