### PR TITLE
Fix build for Ubuntu Lucid

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -52,7 +52,7 @@ inline std::string decodeAuditValue(const std::string& s) {
   }
 }
 
-inline Status validAuditState(int type, AuditProcessEventState& state) {
+Status validAuditState(int type, AuditProcessEventState& state) {
   // Define some acceptable transitions outside of the default state.
   bool acceptable = (type == STATE_PATH && state == STATE_EXECVE);
   acceptable |= (type == STATE_PATH && state == STATE_CWD);


### PR DESCRIPTION
Apparently GCC prior to version 5.0 (we're using 4.8.4 on Lucid) uses the C89 semantics for dealing with "inline" functions, and it appears the linker is removing this "unused" function from the static library. The easiest fix is to simply remove the "inline" from the definition. This *should* be ok because based on my understanding, the compiler needs the source code to be able to optimize an inline function, and that isn't available when linking a static library.

As always, please let me know if you have any concerns or questions. Thanks!