### PR TITLE
RHEL os_version fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,12 +5,11 @@ targets = {
   "debian8" => {
     "box" => "deb/jessie-amd64"
   },
-
   "centos6.5" => {
-    "box" => "chef/centos-6.5"
+    "box" => "bento/centos-6.7"
   },
   "centos7.1"   => {
-    "box" => "chef/centos-7.1"
+    "box" => "bento/centos-7.1"
   },
   "ubuntu14"  => {
     "box" => "ubuntu/trusty64"
@@ -19,7 +18,7 @@ targets = {
     "box" => "ubuntu/precise64"
   },
   "freebsd10" => {
-    "box" => "chef/freebsd-10.0"
+    "box" => "bento/freebsd-10.2"
   },
   "aws-amazon2015.03" => {
     "box" => "andytson/aws-dummy",

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -25,8 +25,9 @@ namespace tables {
 #if defined(REDHAT_BASED)
 const std::string kLinuxOSRelease = "/etc/redhat-release";
 const std::string kLinuxOSRegex =
-    "(?P<name>\\w+) .* "
-    "(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)[\\.]{0,1}(?P<patch>[0-9]+).*";
+    "(?P<name>[\\w+\\s]+) .* "
+    "(?P<major>[0-9]+)\\.(?P<minor>[0-9]+) "
+    "(?P<patch>\\(\\w+\\))";
 #else
 const std::string kLinuxOSRelease = "/etc/os-release";
 const std::string kLinuxOSRegex =


### PR DESCRIPTION
* There is an issue with the regex for os_version in the `/etc/redhat-release` file, this change properly 
parses version on RHEL6/RHEL7.  
* I also included a new Vagrant box link as chef/centos-6.5 doesn't show up anymore as a valid remote box. 

```
osquery> SELECT * FROM os_version;
+---------------------------------+-------+-------+-------+-------+
| name                            | major | minor | patch | build |
+---------------------------------+-------+-------+-------+-------+
| Red Hat Enterprise Linux Server | 7     | 1     | -1    |       |
+---------------------------------+-------+-------+-------+-------+
```