### PR TITLE
Making distributed tests more awesome and less flaky

### DIFF
--- a/include/osquery/enroll.h
+++ b/include/osquery/enroll.h
@@ -75,6 +75,13 @@ class EnrollPlugin : public Plugin {
 std::string getNodeKey(const std::string& enroll_plugin, bool force = false);
 
 /**
+ * @brief Delete the existing node key from the persistant storage
+ *
+ * @return a Status indicating the success or failure of the operation
+ */
+Status clearNodeKey();
+
+/**
  * @brief Read the enrollment secret from disk.
  *
  * We suspect multiple enrollment types may require an apriori, and enterprise
@@ -83,7 +90,7 @@ std::string getNodeKey(const std::string& enroll_plugin, bool force = false);
  *
  * @return enroll_secret The trimmed content read from FLAGS_enroll_secret_path.
  */
-const std::string& getEnrollSecret();
+const std::string getEnrollSecret();
 
 /**
  * @brief Enroll plugin registry.

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -35,6 +35,20 @@ CLI_FLAG(string,
          "",
          "Name of environment variable holding enrollment-auth secret");
 
+Status clearNodeKey() {
+  std::string node_key;
+  auto s = getDatabaseValue(kPersistentSettings, "nodeKey", node_key);
+  if (!s.ok()) {
+    return s;
+  }
+
+  if (node_key.size() > 0) {
+    return deleteDatabaseValue(kPersistentSettings, "nodeKey");
+  }
+
+  return Status(0, "OK");
+}
+
 std::string getNodeKey(const std::string& enroll_plugin, bool force) {
   std::string node_key;
   getDatabaseValue(kPersistentSettings, "nodeKey", node_key);
@@ -61,19 +75,16 @@ std::string getNodeKey(const std::string& enroll_plugin, bool force) {
   return node_key;
 }
 
-const std::string& getEnrollSecret() {
-  static std::string enrollment_secret;
+const std::string getEnrollSecret() {
+  std::string enrollment_secret;
 
-  if (enrollment_secret.size() == 0) {
-    // Secret has not been read yet.
-    if (FLAGS_enroll_secret_path != "") {
-      osquery::readFile(FLAGS_enroll_secret_path, enrollment_secret);
-      boost::trim(enrollment_secret);
-    } else {
-      const char* env_secret = std::getenv(FLAGS_enroll_secret_env.c_str());
-      if (env_secret != nullptr) {
-        enrollment_secret = std::string(env_secret);
-      }
+  if (FLAGS_enroll_secret_path != "") {
+    osquery::readFile(FLAGS_enroll_secret_path, enrollment_secret);
+    boost::trim(enrollment_secret);
+  } else {
+    const char* env_secret = std::getenv(FLAGS_enroll_secret_env.c_str());
+    if (env_secret != nullptr) {
+      enrollment_secret = std::string(env_secret);
     }
   }
 

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -59,14 +59,6 @@ TEST_F(EnrollTests, test_enroll_secret_retrieval) {
   // Make sure the file content was read and trimmed.
   auto secret = getEnrollSecret();
   EXPECT_EQ(secret, "test_secret");
-
-  // Now change the file path.
-  FLAGS_enroll_secret_path = kTestWorkingDirectory + "not_a_secret.txt";
-  // And for good measure, write some content.
-  writeTextFile(FLAGS_enroll_secret_path, "test_not_a_secret", 0600, false);
-  // The enrollment key should not update.
-  secret = getEnrollSecret();
-  EXPECT_EQ(secret, "test_secret");
 }
 
 TEST_F(EnrollTests, test_enroll_key_retrieval) {


### PR DESCRIPTION
Distributed tests were failing every now and then because the test
plugin didn't implement retry's and the test server wasn't always
starting up fast enough. I fixed this by refactoring the tests to use
the real TLS plugin, which has retry logic. This required some mangling
of the configuration options, which should serve as a good reference as
well.