### PR TITLE
Scheduled query success tracking

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -35,6 +35,15 @@ DECLARE_string(config_plugin);
 class ConfigParserPlugin;
 
 /**
+ * @brief The backing store key name for the executing query.
+ *
+ * The config maintains schedule statistics and tracks failed executions.
+ * On process or worker resume an initializer or config may check if the
+ * resume was the result of a failure during an executing query.
+ */
+extern const std::string kExecutingQuery;
+
+/**
  * The schedule is an iterable collection of Packs. When you iterate through
  * a schedule, you only get the packs that should be running on the host that
  * you're currently operating on.
@@ -161,6 +170,19 @@ class Config {
                               size_t size,
                               const Row& r0,
                               const Row& r1);
+
+  /**
+   * @brief Record a query 'initialization', meaning the query will run.
+   *
+   * Recording initializations if queries helps to identify when queries do not
+   * complete. The Config::recordQueryPerformance method will clear a dirty
+   * status set by this method. This status is saved in the backing database
+   * store. On process start, or worker state, if any dirty bit is set then
+   * it is assumed that the current start is a result of a previous abort.
+   *
+   * @param name THe unique name of the scheduled item
+   */
+  void recordQueryStart(const std::string& name);
 
   /**
    * @brief Calculate the hash of the osquery config

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -26,11 +26,13 @@ FLAG(bool, enable_monitor, false, "Enable the schedule monitor");
 
 FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit")
 
-inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
+static inline SQL monitor(const std::string& name,
+                          const ScheduledQuery& query) {
   // Snapshot the performance and times for the worker before running.
   auto pid = std::to_string(getpid());
   auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   auto t0 = time(nullptr);
+  Config::getInstance().recordQueryStart(name);
   auto sql = SQLInternal(query.query);
   // Snapshot the performance after, and compare.
   auto t1 = time(nullptr);


### PR DESCRIPTION
If a scheduled query fails to complete it will be recorded within the backing store (RockDB). On the next daemon, or worker, load: a `WARNING` log message will be generated. This can be used to monitor failing queries across a fleet but aggregating status logs.