### PR TITLE
[#1488] Stop OS X event publishers with SIGINT

### DIFF
--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -246,7 +246,7 @@ void DiskArbitrationEventPublisher::stop() {
     session_ = nullptr;
   }
 
-  if (run_loop_ == nullptr) {
+  if (run_loop_ != nullptr) {
     CFRunLoopStop(run_loop_);
   }
 }

--- a/osquery/events/darwin/diskarbitration.h
+++ b/osquery/events/darwin/diskarbitration.h
@@ -75,13 +75,13 @@ class DiskArbitrationEventPublisher
                   const DiskArbitrationEventContextRef &ec) const;
   Status run();
 
+  // Callin for stopping the streams/run loop.
+  void end() { stop(); }
+
   static void DiskAppearedCallback(DADiskRef disk, void *context);
   static void DiskDisappearedCallback(DADiskRef disk, void *context);
 
  private:
-  DASessionRef session_;
-  CFRunLoopRef run_loop_;
-
   void restart();
   void stop();
   static std::string getProperty(const CFStringRef &property,
@@ -90,5 +90,9 @@ class DiskArbitrationEventPublisher
   static void fire(const std::string &action,
                    const DiskArbitrationEventContextRef &ec,
                    const CFDictionaryRef &dict);
+
+ private:
+  DASessionRef session_{nullptr};
+  CFRunLoopRef run_loop_{nullptr};
 };
 }

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -189,8 +189,6 @@ Status FSEventsEventPublisher::run() {
   return Status(0, "OK");
 }
 
-void FSEventsEventPublisher::end() { stop(); }
-
 void FSEventsEventPublisher::Callback(
     ConstFSEventStreamRef stream,
     void* callback_info,

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -101,7 +101,7 @@ class FSEventsEventPublisher
   // Entrypoint to the run loop
   Status run();
   // Callin for stopping the streams/run loop.
-  void end();
+  void end() { stop(); }
 
  public:
   /// FSEvents registers a client callback instead of using a select/poll loop.

--- a/osquery/events/darwin/iokit_hid.h
+++ b/osquery/events/darwin/iokit_hid.h
@@ -83,6 +83,9 @@ class IOKitHIDEventPublisher
   // Entrypoint to the run loop
   Status run();
 
+  // The event factory may end, stopping the IOKit runloop.
+  void end() { stop(); }
+
  public:
   /// IOKit HID hotplugged event.
   static void MatchingCallback(void *context,

--- a/osquery/events/darwin/scnetwork.h
+++ b/osquery/events/darwin/scnetwork.h
@@ -62,6 +62,9 @@ class SCNetworkEventPublisher
   // Entrypoint to the run loop
   Status run();
 
+  // The event factory may end, stopping the SCNetwork runloop.
+  void end() { stop(); }
+
  public:
   /// SCNetwork registers a client callback instead of using a select/poll loop.
   static void Callback(const SCNetworkReachabilityRef target,


### PR DESCRIPTION
When CTRL+C, SIGINT, SIGTERM, or SIGABRT is sent to osqueryd, the event publishers should stop gracefully within 4 seconds. A secondary signal will cause the application to stop immediately. 