### PR TITLE
[#1488] Shutdown Linux event publishers responsibly

### DIFF
--- a/osquery/events/linux/audit.cpp
+++ b/osquery/events/linux/audit.cpp
@@ -43,6 +43,8 @@ enum AuditStatus {
   AUDIT_IMMUTABLE = 2,
 };
 
+static const int kAuditMLatency = 1000;
+
 Status AuditEventPublisher::setUp() {
   handle_ = audit_open();
   if (handle_ <= 0) {
@@ -293,8 +295,8 @@ Status AuditEventPublisher::run() {
   }
 
   // Only apply a cool down if the reply request failed.
-  osquery::publisherSleep(200);
-  return Status(0, "Continue");
+  osquery::publisherSleep(kAuditMLatency);
+  return Status(0, "OK");
 }
 
 bool AuditEventPublisher::shouldFire(const AuditSubscriptionContextRef& sc,

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -24,9 +24,8 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-int kINotifyMLatency = 200;
-
-static const uint32_t BUFFER_SIZE =
+static const int kINotifyMLatency = 200;
+static const uint32_t kINotifyBufferSize =
     (10 * ((sizeof(struct inotify_event)) + NAME_MAX + 1));
 
 std::map<int, std::string> kMaskActions = {
@@ -115,13 +114,13 @@ Status INotifyEventPublisher::restartMonitoring(){
 
 Status INotifyEventPublisher::run() {
   // Get a while wrapper for free.
-  char buffer[BUFFER_SIZE];
+  char buffer[kINotifyBufferSize];
   fd_set set;
 
   FD_ZERO(&set);
   FD_SET(getHandle(), &set);
 
-  struct timeval timeout = {3, 3000};
+  struct timeval timeout = {1, 0};
   int selector = ::select(getHandle() + 1, &set, nullptr, nullptr, &timeout);
   if (selector == -1) {
     LOG(ERROR) << "Could not read inotify handle";
@@ -132,7 +131,7 @@ Status INotifyEventPublisher::run() {
     // Read timeout.
     return Status(0, "Continue");
   }
-  ssize_t record_num = ::read(getHandle(), buffer, BUFFER_SIZE);
+  ssize_t record_num = ::read(getHandle(), buffer, kINotifyBufferSize);
   if (record_num == 0 || record_num == -1) {
     return Status(1, "INotify read failed");
   }
@@ -166,7 +165,7 @@ Status INotifyEventPublisher::run() {
   }
 
   osquery::publisherSleep(kINotifyMLatency);
-  return Status(0, "Continue");
+  return Status(0, "OK");
 }
 
 INotifyEventContextRef INotifyEventPublisher::createEventContextFrom(

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -16,7 +16,7 @@
 
 namespace osquery {
 
-int kUdevMLatency = 200;
+static const int kUdevMLatency = 200;
 
 REGISTER(UdevEventPublisher, "event_publisher", "udev");
 
@@ -53,7 +53,7 @@ Status UdevEventPublisher::run() {
   FD_ZERO(&set);
   FD_SET(fd, &set);
 
-  struct timeval timeout = {3, 3000};
+  struct timeval timeout = {1, 0};
   int selector = ::select(fd + 1, &set, nullptr, nullptr, &timeout);
   if (selector == -1) {
     LOG(ERROR) << "Could not read udev monitor";
@@ -62,7 +62,7 @@ Status UdevEventPublisher::run() {
 
   if (selector == 0 || !FD_ISSET(fd, &set)) {
     // Read timeout.
-    return Status(0, "Timeout");
+    return Status(0, "Finished");
   }
 
   struct udev_device *device = udev_monitor_receive_device(monitor_);
@@ -77,7 +77,7 @@ Status UdevEventPublisher::run() {
   udev_device_unref(device);
 
   osquery::publisherSleep(kUdevMLatency);
-  return Status(0, "Continue");
+  return Status(0, "OK");
 }
 
 std::string UdevEventPublisher::getValue(struct udev_device* device,

--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -89,7 +89,16 @@ stop() {
     RETVAL=0
   else
     PID=$(cat $PIDFILE)
-    pkill -P $PID && kill -9 $PID
+    # Terminate the daemon and watchers
+    pkill -g $PID
+    # Allow the event threads to tear down
+    ( while kill -0 $PID >/dev/null 2>&1; do sleep 0.2; done ) & DPID=$!
+    # If the event threads are still running after 5 seconds, kill them
+    ( sleep 5 && pkill -9 -g $PID && kill -9 $DPID ) 2>/dev/null & WPID=$!
+    if wait $DPID 2>/dev/null; then
+      pkill -9 -P $WPID
+      wait $WPID
+    fi
     rm -f $PIDFILE
   fi
 }


### PR DESCRIPTION
Each linux publisher should shutdown within a second when the service is turned down or a terminate signal is received. 

1. Enforce a max of 1-second blocking periods for each Linux publisher.
2. Make the Linux init script smarter, it should wait for workers and worker threads to stop.