### PR TITLE
[#1529] Allow DB Readonly with RocksDB lite

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -567,8 +567,6 @@ Status getDatabaseValue(const std::string& domain,
   PluginResponse response;
   auto status = Registry::call("database", "rocks", request, response);
   if (!status.ok()) {
-    VLOG(1) << "Cannot get database " << domain << "/" << key << ": "
-            << status.getMessage();
     return status;
   }
 

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -376,7 +376,7 @@ EventID EventSubscriberPlugin::getEventID() {
   {
     boost::lock_guard<boost::mutex> lock(event_id_lock_);
     status = db->Get(kEvents, eid_key, last_eid_value);
-    if (!status.ok()) {
+    if (!status.ok() || last_eid_value.empty()) {
       last_eid_value = "0";
     }
 


### PR DESCRIPTION
1. Allow osqueryi to run without a RocksDB when using RocksDB LITE.
2. Protect against malformed /proc data when processing on Linux.
