### PR TITLE
[Fix #1531] Use libarchive finish for safari_extension parsing

### DIFF
--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -109,7 +109,7 @@ inline void genSafariExtension(const std::string& path, QueryData& results) {
   // Use open_file, instead of the preferred open_filename for OS X 10.9.
   archive_read_support_format_xar(ext);
   if (archive_read_open_file(ext, path.c_str(), 10240) != ARCHIVE_OK) {
-    archive_read_close(ext);
+    archive_read_finish(ext);
     return;
   }
 
@@ -143,6 +143,7 @@ inline void genSafariExtension(const std::string& path, QueryData& results) {
   }
 
   archive_read_close(ext);
+  archive_read_finish(ext);
   results.push_back(std::move(r));
 }
 


### PR DESCRIPTION
The libarchive API seems to still leak with XAR header entry parsing, be careful!