### PR TITLE
Fixed bug when checking if config is valid

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -299,7 +299,7 @@ void Config::hashSource(const std::string& source, const std::string& content) {
 }
 
 Status Config::getMD5(std::string& hash) {
-  if (valid_) {
+  if (!valid_) {
     return Status(1, "Current config is not valid");
   }
 


### PR DESCRIPTION
This fixes a bug that was incorrectly checking the `valid_` flag, causing the `getMD5` function to return a bad status and not compute a hash, which would in turn cause `genOsqueryInfo` to set the hash to an empty string.

https://github.com/facebook/osquery/blob/master/osquery/config/config.cpp#L302

https://github.com/facebook/osquery/blob/64c18a70a9eb6030405bb0253ed0ee8ee9928d82/osquery/tables/utility/osquery.cpp#L193