### PR TITLE
[fix #1536] Schedule iteration pass-by-reference

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -61,7 +61,7 @@ class Schedule {
    * next iterator element or skipped.
    */
   struct Step {
-    bool operator()(Pack pack) { return pack.shouldPackExecute(); }
+    bool operator()(Pack& pack) { return pack.shouldPackExecute(); }
   };
 
   /// Boost gives us a nice template for maintaining the state of the iterator
@@ -77,7 +77,7 @@ class Schedule {
   void remove(const std::string& pack) { remove(pack, ""); }
 
   void remove(const std::string& pack, const std::string& source) {
-    packs_.remove_if([pack, source](Pack p) {
+    packs_.remove_if([pack, source](Pack& p) {
       return (p.getName() == pack) && (p.getSource() == source);
     });
   }
@@ -304,19 +304,15 @@ class Config {
   bool valid_;
 
  private:
-  friend class ConfigTests;
   FRIEND_TEST(ConfigTests, test_parse);
   FRIEND_TEST(ConfigTests, test_remove);
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
   FRIEND_TEST(ConfigTests, test_get_parser);
   FRIEND_TEST(ConfigTests, test_add_remove_pack);
   FRIEND_TEST(ConfigTests, test_noninline_pack);
-
-  friend class OptionsConfigParserPluginTests;
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
-
-  friend class FilePathsConfigParserPluginTests;
   FRIEND_TEST(FilePathsConfigParserPluginTests, test_get_files);
+  FRIEND_TEST(PacksTests, test_discovery_cache);
 };
 
 /**

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -57,7 +57,7 @@ class Pack {
    *
    * @return A bool indicating whether or not the pack has a discovery query
    */
-  std::vector<std::string>& getDiscoveryQueries();
+  const std::vector<std::string>& getDiscoveryQueries() const;
 
   /// Utility for identifying whether or not the pack should be scheduled
   bool shouldPackExecute();
@@ -78,24 +78,24 @@ class Pack {
   const std::string& getVersion() const;
 
   /// Returns the schedule dictated by the pack
-  const std::map<std::string, ScheduledQuery>& getSchedule();
+  const std::map<std::string, ScheduledQuery>& getSchedule() const;
 
   /// Verify that the platform is compatible
-  bool checkPlatform();
+  bool checkPlatform() const;
 
   /// Verify that a given platform string is compatible
-  bool checkPlatform(const std::string& platform);
+  bool checkPlatform(const std::string& platform) const;
 
   /// Verify that the version of osquery is compatible
-  bool checkVersion();
+  bool checkVersion() const;
 
   /// Verify that a given version string is compatible
-  bool checkVersion(const std::string& version);
+  bool checkVersion(const std::string& version) const;
 
   /// Verify that a given discovery query returns the appropriate results
   bool checkDiscovery();
 
-  const PackStats& getStats();
+  const PackStats& getStats() const;
 
  protected:
   std::vector<std::string> discovery_queries_;

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -145,15 +145,15 @@ void Pack::initialize(const std::string& name,
   }
 }
 
-const std::map<std::string, ScheduledQuery>& Pack::getSchedule() {
+const std::map<std::string, ScheduledQuery>& Pack::getSchedule() const {
   return schedule_;
 }
 
-std::vector<std::string>& Pack::getDiscoveryQueries() {
+const std::vector<std::string>& Pack::getDiscoveryQueries() const {
   return discovery_queries_;
 }
 
-const PackStats& Pack::getStats() { return stats_; }
+const PackStats& Pack::getStats() const { return stats_; }
 
 const std::string& Pack::getPlatform() const { return platform_; }
 
@@ -169,9 +169,9 @@ const std::string& Pack::getSource() const { return source_; }
 
 void Pack::setName(const std::string& name) { name_ = name; }
 
-bool Pack::checkPlatform() { return checkPlatform(platform_); }
+bool Pack::checkPlatform() const { return checkPlatform(platform_); }
 
-bool Pack::checkPlatform(const std::string& platform) {
+bool Pack::checkPlatform(const std::string& platform) const {
   if (platform == "") {
     return true;
   }
@@ -189,9 +189,9 @@ bool Pack::checkPlatform(const std::string& platform) {
   return (platform.find(kSDKPlatform) != std::string::npos);
 }
 
-bool Pack::checkVersion() { return checkVersion(version_); }
+bool Pack::checkVersion() const { return checkVersion(version_); }
 
-bool Pack::checkVersion(const std::string& version) {
+bool Pack::checkVersion(const std::string& version) const {
   if (version == "") {
     return true;
   }
@@ -234,7 +234,8 @@ bool Pack::checkDiscovery() {
   for (const auto& q : discovery_queries_) {
     auto sql = SQL(q);
     if (!sql.ok()) {
-      LOG(WARNING) << "Discovery query failed: " << q;
+      LOG(WARNING) << "Discovery query failed (" << q
+                   << "): " << sql.getMessageString();
       discovery_cache_.second = false;
       break;
     }

--- a/tools/tests/test_inline_pack.conf
+++ b/tools/tests/test_inline_pack.conf
@@ -35,6 +35,17 @@
     "foobaz": {
       "version": "9.9.9",
       "queries": {}
+    },
+    "baz": {
+      "discovery": [
+        "select * from osquery_info;"
+      ],
+      "queries": {
+        "kernel_modules": {
+          "query": "select * from kernel_modules;",
+          "interval": 3600
+        }
+      }
     }
   },
   "schedule": {


### PR DESCRIPTION
There was a bug in the `osquery::Schedule` container object such that,
when the iteration through the schedule occured, pack objects were being
passed by value (copied) instead of passed by reference. Thus, the
discovery query would be executed, the object's cache would be updated,
and then the object would go out of scope and be destructed, thus
leaving the original object without ever having ran the discovery query.
This caused discovery queries to thrash. Bad times.

I added a new test so that we don't regress here as well as const'd a
few functions that should have been const in `osquery::Pack`.