### PR TITLE
Minor nits around distributed CLIs

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -283,11 +283,11 @@ Maximum returned row value size.
 
 Distributed plugin name. The default distributed plugin is not set. You must set `--distributed_enabled=true --distributed_plugin=tls` (or whatever plugin you'd rather use instead of TLS) to use the distributed feature.
 
-`--distributed_enabled=false`
+`--disable_distributed=true`
 
 Main killswitch for distributed queries functionality. By default, this is turned off.
 
-`--distributed_poll_interval=60`
+`--distributed_interval=60`
 
 In seconds, the amount of time that osqueryd will wait between periodically checking in with a distributed query server to see if there are any queries to execute.
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -160,7 +160,7 @@ CLI_FLAG(bool, daemonize, false, "Run as daemon (osqueryd only)");
 #endif
 
 DECLARE_string(distributed_plugin);
-DECLARE_bool(distributed_enabled);
+DECLARE_bool(disable_distributed);
 
 ToolType kToolType = OSQUERY_TOOL_UNKNOWN;
 
@@ -462,7 +462,7 @@ void Initializer::start() {
   initLogger(binary_);
 
   // Initialize the distributed plugin, if necessary
-  if (FLAGS_distributed_enabled) {
+  if (!FLAGS_disable_distributed) {
     if (Registry::exists("distributed", FLAGS_distributed_plugin)) {
       initActivePlugin("distributed", FLAGS_distributed_plugin);
     }

--- a/osquery/dispatcher/distributed.cpp
+++ b/osquery/dispatcher/distributed.cpp
@@ -14,11 +14,11 @@
 namespace osquery {
 
 FLAG(uint64,
-     distributed_poll_interval,
+     distributed_interval,
      60,
-     "Seconds in between polling the server for new queries (default 60)")
+     "Seconds between polling for new queries (default 60)")
 
-DECLARE_bool(distributed_enabled);
+DECLARE_bool(disable_distributed);
 DECLARE_string(distributed_plugin);
 
 void DistributedRunner::start() {
@@ -28,12 +28,12 @@ void DistributedRunner::start() {
     if (dist.getPendingQueryCount() > 0) {
       dist.runQueries();
     }
-    ::sleep(FLAGS_distributed_poll_interval);
+    ::sleep(FLAGS_distributed_interval);
   }
 }
 
 Status startDistributed() {
-  if (FLAGS_distributed_enabled && !FLAGS_distributed_plugin.empty() &&
+  if (!FLAGS_disable_distributed && !FLAGS_distributed_plugin.empty() &&
       Registry::getActive("distributed") == FLAGS_distributed_plugin) {
     Dispatcher::addService(std::make_shared<DistributedRunner>());
     return Status(0, "OK");

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -26,9 +26,9 @@ namespace osquery {
 FLAG(string, distributed_plugin, "tls", "Distributed plugin name");
 
 FLAG(bool,
-     distributed_enabled,
-     false,
-     "Main killswitch for distributed queries. (default false");
+     disable_distributed,
+     true,
+     "Disable distributed queries (default true)");
 
 boost::shared_mutex distributed_queries_mutex_;
 boost::shared_mutex distributed_results_mutex_;


### PR DESCRIPTION
Use the `--disable_{feature}` "style". We could also support both, at the cost of a few additional strings if we used `FlagAlias`s.