### PR TITLE
Fixing default configuration syntax, trailing comma

### DIFF
--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -44,7 +44,7 @@
     "verbose": "false",
 
     // The number of threads for concurrent query schedule execution.
-    "worker_threads": "2",
+    "worker_threads": "2"
 
     // Enable schedule profiling, this will fill in averages and totals for
     // system/user CPU time and memory for every query in the schedule.


### PR DESCRIPTION
This trailing comma was making the default config to fail since the last one is commented.