### PR TITLE
Bumb RocksDB to ERROR, fix OS X kernel_info, silence compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ add_compile_options(
   -Wno-unused-result
   -Wno-missing-field-initializers
   -Wno-sign-compare
+  -Wno-unused-local-typedef
+  -Wno-deprecated-register
   -Wnon-virtual-dtor
   -Wchar-subscripts
   -Wpointer-arith
@@ -300,11 +302,11 @@ CHECK_LIBRARY_EXISTS(${OPENSSL_SSL_LIBRARY} "TLSv1_client_method" "" OPENSSL_TLS
 
 # Add a define based on the highest TLS version found. Fatal if no TLS client.
 if(OPENSSL_TLSV12)
-  add_definitions(-DSSL_TXT_TLSV1_2)
+  add_definitions(-DHAS_SSL_TXT_TLSV1_2)
 elseif(OPENSSL_TLSV11)
-  add_definitions(-DSSL_TXT_TLSV1_1)
+  add_definitions(-DHAS_SSL_TXT_TLSV1_1)
 elseif(OPENSSL_TLSV10)
-  add_definitions(-DSSL_TXT_TLSV1)
+  add_definitions(-DHAS_SSL_TXT_TLSV1)
 else()
   message(FATAL_ERROR "Cannot find any TLS client methods")
 endif()

--- a/osquery/config/CMakeLists.txt
+++ b/osquery/config/CMakeLists.txt
@@ -3,18 +3,13 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_config
   packs.cpp
 )
 
-set(OSQUERY_CONFIG_PLUGINS
-  plugins/filesystem.cpp
-  plugins/tls.cpp
+file(GLOB OSQUERY_CONFIG_PLUGINS "plugins/*.cpp")
+ADD_OSQUERY_LIBRARY(FALSE osquery_config_plugins
+  ${OSQUERY_CONFIG_PLUGINS}
   update.cpp
 )
 
 file(GLOB OSQUERY_CONFIG_PARSERS "parsers/*.cpp")
-
-ADD_OSQUERY_LIBRARY(FALSE osquery_config_plugins
-  ${OSQUERY_CONFIG_PLUGINS}
-)
-
 ADD_OSQUERY_LIBRARY(TRUE osquery_config_parsers
   ${OSQUERY_CONFIG_PARSERS}
 )

--- a/osquery/database/db_handle.h
+++ b/osquery/database/db_handle.h
@@ -88,7 +88,7 @@ class DBHandle {
    */
   Status Get(const std::string& domain,
              const std::string& key,
-             std::string& value);
+             std::string& value) const;
 
   /**
    * @brief Put data into the database
@@ -103,7 +103,7 @@ class DBHandle {
    */
   Status Put(const std::string& domain,
              const std::string& key,
-             const std::string& value);
+             const std::string& value) const;
 
   /**
    * @brief Delete data from the database
@@ -115,7 +115,7 @@ class DBHandle {
    * @return an instance of osquery::Status indicating the success or failure
    * of the operation.
    */
-  Status Delete(const std::string& domain, const std::string& key);
+  Status Delete(const std::string& domain, const std::string& key) const;
 
   /**
    * @brief List the data in a "domain"
@@ -128,7 +128,8 @@ class DBHandle {
    * @return an instance of osquery::Status indicating the success or failure
    * of the operation.
    */
-  Status Scan(const std::string& domain, std::vector<std::string>& results);
+  Status Scan(const std::string& domain,
+              std::vector<std::string>& results) const;
 
  private:
   /**
@@ -187,11 +188,21 @@ class DBHandle {
    */
   static DBHandleRef getInstance(const std::string& path, bool in_memory);
 
+  /// Allow friend classes, such as unit tests, to reset the instance.
+  void resetInstance(const std::string& path, bool in_memory);
+
+  /// Perform the DB open work.
+  void open();
+
+  /// Perform the DB close work.
+  void close();
+
   /**
    * @brief Private helper around accessing the column family handle for a
    * specific column family, based on it's name
    */
-  rocksdb::ColumnFamilyHandle* getHandleForColumnFamily(const std::string& cf);
+  rocksdb::ColumnFamilyHandle* getHandleForColumnFamily(
+      const std::string& cf) const;
 
   /**
    * @brief Helper method which can be used to get a raw pointer to the
@@ -202,7 +213,7 @@ class DBHandle {
    *
    * @return a pointer to the underlying RocksDB database handle
    */
-  rocksdb::DB* getDB();
+  rocksdb::DB* getDB() const;
 
  private:
   /////////////////////////////////////////////////////////////////////////////
@@ -223,6 +234,12 @@ class DBHandle {
 
   /// The database was opened in a ReadOnly mode.
   bool read_only_{false};
+
+  /// Location of RocksDB on disk, blank if in-memory is true.
+  std::string path_;
+
+  /// True if the database was started in an in-memory only mode.
+  bool in_memory_{false};
 
  private:
   friend class RocksDatabasePlugin;

--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -7,6 +7,10 @@ add_custom_command(
   OUTPUT ${OSQUERY_THRIFT_GENERATED_FILES}
 )
 
+add_compile_options(
+  -Wno-macro-redefined
+)
+
 ADD_OSQUERY_LIBRARY(TRUE osquery_extensions
   ${OSQUERY_THRIFT_GENERATED_FILES}
   extensions.cpp

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -26,12 +26,12 @@ namespace http = boost::network::http;
 
 /// Apple's 0.9.8 OpenSSL will lack TLS protocols.
 extern "C" {
-#if !defined(SSL_TXT_TLSV1_1)
+#if !defined(HAS_SSL_TXT_TLSV1_1) and !defined(HAS_SSL_TXT_TLSV1_2)
 SSL_CTX* TLSv1_1_client_method(void) { return nullptr; }
 SSL_CTX* TLSv1_1_method(void) { return nullptr; }
 SSL_CTX* TLSv1_1_server_method(void) { return nullptr; }
 #endif
-#if !defined(SSL_TXT_TLSV1_2)
+#if !defined(HAS_SSL_TXT_TLSV1_2)
 struct CRYPTO_THREADID;
 void ERR_remove_thread_state(const CRYPTO_THREADID *tid) {}
 SSL_CTX* TLSv1_2_client_method(void) { return nullptr; }
@@ -106,7 +106,7 @@ http::client TLSTransport::getClient() {
 
   std::string ciphers = kTLSCiphers;
   // Some Ubuntu 12.04 clients exhaust their cipher suites without SHA.
-#if defined(SSL_TXT_TLSV1_2) && !defined(UBUNTU_PRECISE) && !defined(DARWIN)
+#if defined(HAS_SSL_TXT_TLSV1_2) && !defined(UBUNTU_PRECISE) && !defined(DARWIN)
   // Otherwise we prefer GCM and SHA256+
   ciphers += ":!CBC:!SHA";
 #endif

--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -118,7 +118,11 @@ QueryData genKernelInfo(QueryContext& context) {
   if (CFDictionaryGetValueIfPresent(
           properties, CFSTR("boot-file"), &property)) {
     r["path"] = stringFromCFData((CFDataRef)property);
+    std::replace(r["path"].begin(), r["path"].end(), '\\', '/');
     boost::trim(r["path"]);
+    if (!r["path"].empty() && r["path"][0] != '/') {
+      r["path"] = "/" + r["path"];
+    }
   }
   // No longer need chosen properties.
   CFRelease(properties);
@@ -136,12 +140,6 @@ QueryData genKernelInfo(QueryContext& context) {
 
       r["version"] = signature.substr(22, signature.find(":") - 22);
     }
-  }
-
-  // With the path and device, try to locate the on-disk kernel
-  if (r.count("path") > 0) {
-    // This does not use the device path, potential invalidation.
-    r["md5"] = hashFromFile(HASH_TYPE_MD5, "/" + r["path"]);
   }
 
   results.push_back(r);

--- a/osquery/tables/system/linux/kernel_info.cpp
+++ b/osquery/tables/system/linux/kernel_info.cpp
@@ -67,11 +67,6 @@ QueryData genKernelInfo(QueryContext& context) {
     VLOG(1) << "Cannot find kernel signature file: " << kKernelSignaturePath;
   }
 
-  // Using the path of the boot image, attempt to calculate a hash.
-  if (r.count("path") > 0) {
-    r["md5"] = hashFromFile(HASH_TYPE_MD5, r.at("path"));
-  }
-
   results.push_back(r);
   return results;
 }

--- a/specs/kernel_info.table
+++ b/specs/kernel_info.table
@@ -5,6 +5,5 @@ schema([
   Column("arguments", TEXT, "Kernel arguments"),
   Column("path", TEXT, "Kernel path"),
   Column("device", TEXT, "Kernel device identifier"),
-  Column("md5", TEXT, "MD5 hash of Kernel"),
 ])
 implementation("system/kernel_info@genKernelInfo")


### PR DESCRIPTION
1. RocksDB LITE is writing DB SUMMARY logs to WARN, bump the error logging to ERROR.
2. Silence OS X 10.11 compile warnings for Thrift/Boost.
3. Fix the `path` column in the `kernel_info` table on OS X, and remove `md5` from the spec, prefer a JOIN to `hash.