### PR TITLE
Extension managers should clean extension sockets when starting

### DIFF
--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -292,6 +292,7 @@ class ExtensionRunner : public ExtensionRunnerCore {
  */
 class ExtensionManagerRunner : public ExtensionRunnerCore {
  public:
+  virtual ~ExtensionManagerRunner();
   explicit ExtensionManagerRunner(const std::string& manager_path)
       : ExtensionRunnerCore(manager_path) {}
 


### PR DESCRIPTION
If you try really hard you could mess up and delete ".*" files you do not intend. Under normal runs the extension manager path will not be changed. However, if you change the path to an existing file it will be overwritten (this artifact has existed for a while), but now that `path + ".*` will be overwritten by both extension sockets and the clean up routines. 