### PR TITLE
explicitly call out OS and requirements at top of OS X install doc

### DIFF
--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -1,4 +1,32 @@
-## Homebrew
+### Supported OS Versions
+
+Continuous integration currently tests stable release versions of osquery against 10.9 and 10.10 (as listed under the _Build_status_ column on the project [README](https://github.com/facebook/osquery/blob/master/README.md)). There are no reported issues which block expected core functionality on 10.11.  
+
+Each tagged release of osquery may be installed on all versions of OS X.
+
+## Package Installation
+
+If you plan to manage an enterprise osquery deployment, the easiest installation method is an OS X package installer. You would have to manage and deploy updates, but there are no libraries required or other dependencies.
+
+Each osquery tag (release) builds an OS X package:
+[osquery.io/downloads](https://osquery.io/downloads/).
+
+The default package creates the following structure:
+
+```sh
+/private/var/osquery/com.facebook.osqueryd.plist
+/private/var/osquery/osquery.example.conf
+/private/var/log/osquery/
+/private/var/osquery/packs/
+/usr/local/lib/osquery/
+/usr/local/bin/osqueryctl
+/usr/local/bin/osqueryd
+/usr/local/bin/osqueryi
+```
+
+This package does NOT install a LaunchDaemon to start osqueryd. You may use the `osqueryctl` script to copy the sample launch daemon job plist and associated configuration into place.
+
+## Homebrew Installation
 
 The easiest way to install osquery on OS X is via Homebrew. Check the [Homebrew](http://brew.sh/) homepage for installation instructions.
 
@@ -15,30 +43,6 @@ To update osquery:
 $ brew update
 $ brew upgrade osquery
 ```
-
-## OS X Package
-
-If you plan to manage an enterprise osquery deployment, the easiest installation method is
-an OS X package installer. You will have to manage and deploy updates.
-
-Each osquery tag (release) builds an OS X package:
-[osquery.io/downloads](https://osquery.io/downloads/).
-There are no package or library dependencies.
-
-The default package creates the following structure:
-
-```sh
-/private/var/osquery/com.facebook.osqueryd.plist
-/private/var/osquery/osquery.example.conf
-/private/var/log/osquery/
-/private/var/osquery/packs/
-/usr/local/lib/osquery/
-/usr/local/bin/osqueryctl
-/usr/local/bin/osqueryd
-/usr/local/bin/osqueryi
-```
-
-This package does NOT install a LaunchDaemon to start osqueryd. You may use the `osqueryctl` script to install the sample launch daemon script.
 
 ## Running osquery
 


### PR DESCRIPTION
Even though I’m unsure myself, since I noticed there’s no mention of 10.11 support or really any sysReqs, I added it to the docs. (May want to bump the readme with that info as well, didn’t feel like I should be making that call.) 
Pardon the presumption of accuracy 😅