### PR TITLE
Close socket fds when finished with them

### DIFF
--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -100,6 +100,8 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) >= 0) {
         r["type"] = INTEGER_FROM_UCHAR(ifr.ifr_hwaddr.sa_family);
       }
+
+      close(fd);
     }
 
     // Last change is not implemented in Linux.


### PR DESCRIPTION
This PR fixes an issue we saw on our machines where the osquery process would eventually exhaust the number of allowed open file descriptors on the machine. Root cause appears to be when generating the `interface_details`, the socket created for use with `ioctl` calls is not closed.


EDIT: Clearified that we saw the number of lingering file descriptors increasing on all machines, this was \*not\* an intermittent issue.