### PR TITLE
[Fix #1559] Allow boost.filesystem incorrect LC_CTYPE

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -200,6 +200,14 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
       binary_(fs::path(std::string(argv[0])).filename().string()) {
   std::srand(chrono_clock::now().time_since_epoch().count());
 
+  // Handled boost filesystem locale problems fixes in 1.56.
+  // See issue #1559 for the discussion and upstream boost patch.
+  try {
+    boost::filesystem::path::codecvt();
+  } catch(std::runtime_error &e) {
+    setenv("LC_ALL", "C", 1);
+  }
+
   // osquery implements a custom help/usage output.
   for (int i = 1; i < *argc_; i++) {
     auto help = std::string((*argv_)[i]);


### PR DESCRIPTION
Reset `LC_ALL` to "C" if `boost::filesystem` cannot handle the system/user-configured `LC_CTYPE`