### PR TITLE
[Fix #1570] Check for invalid apt sources

### DIFF
--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -123,7 +123,7 @@ Status INotifyEventPublisher::run() {
   struct timeval timeout = {1, 0};
   int selector = ::select(getHandle() + 1, &set, nullptr, nullptr, &timeout);
   if (selector == -1) {
-    LOG(ERROR) << "Could not read inotify handle";
+    LOG(WARNING) << "Could not read inotify handle";
     return Status(1, "INotify handle failed");
   }
 
@@ -222,7 +222,7 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
   if (!isPathMonitored(path)) {
     int watch = ::inotify_add_watch(getHandle(), path.c_str(), IN_ALL_EVENTS);
     if (watch == -1) {
-      LOG(ERROR) << "Could not add inotify watch on: " << path;
+      LOG(WARNING) << "Could not add inotify watch on: " << path;
       return false;
     }
 

--- a/osquery/tables/system/ubuntu/apt_sources.cpp
+++ b/osquery/tables/system/ubuntu/apt_sources.cpp
@@ -86,15 +86,21 @@ QueryData genAptSrcs(QueryContext& context) {
   pkgCacheFile cache_file;
   pkgCache* cache = cache_file.GetPkgCache();
   pkgSourceList* src_list = cache_file.GetSourceList();
+  if (cache == nullptr || src_list == nullptr) {
+    cache_file.Close();
+    closeConfig();
+    return results;
+  }
 
   // For each apt cache file that contains packages
-  for (pkgCache::PkgFileIterator file = cache->FileBegin(); !file.end();
+  for (pkgCache::PkgFileIterator file = cache->FileBegin(); file && !file.end();
        ++file) {
 
     // Locate the associated index files to ensure the repository is installed
     pkgIndexFile* pkgIndex;
-    if (!src_list->FindIndex(file, pkgIndex))
+    if (!src_list->FindIndex(file, pkgIndex)) {
       continue;
+    }
 
     extractAptSourceInfo(file, pkgIndex, results);
   }

--- a/osquery/tables/system/ubuntu/deb_packages.cpp
+++ b/osquery/tables/system/ubuntu/deb_packages.cpp
@@ -65,11 +65,13 @@ int pkg_sorter(const void *a, const void *b) {
   int res;
 
   res = strcmp(pa->set->name, pb->set->name);
-  if (res)
+  if (res) {
     return res;
+  }
 
-  if (pa->installed.arch == pb->installed.arch)
+  if (pa->installed.arch == pb->installed.arch) {
     return 0;
+  }
 
   return strcmp(arch_a, arch_b);
 }


### PR DESCRIPTION
This fixes a crash identified by @endrazine. When apt sources data in `/etc/apt/sources.list` or `/etc/apt/sources.list.d/{*}.list` contain invalid data/lines the `cache_file.GetPkgCache();` call will fail and `cache` will be `nullptr`. Subsequent usage results in a `SIGSEV`.

To reproduce the fault try:
```
$ zzuf -I /etc/ -r 0.01:0.1 -s 0:1000 -v \
 ./build/trusty/osquery/osqueryi --registry_exceptions=true --verbose \
 "select count(*) from apt_sources"
```

Signed-off-by: Jonathan Brossard