### PR TITLE
Support for newer versions of libdpkg

### DIFF
--- a/CMake/FindLibdpkg.cmake
+++ b/CMake/FindLibdpkg.cmake
@@ -1,0 +1,21 @@
+# - Find libdpkg
+# This module defines
+# LIBPKG_VERSION, string representation of libpkg version
+# LIBPKG_VERSION_MAJOR, major version number
+# LIBPKG_VERSION_MINOR, minor version number
+# LIBPKG_VERSION_PATCH, patch version number
+# LIBPKG_VERSION_NUMBER, version as a compariable integer
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_LIBDPKG QUIET libdpkg)
+
+MESSAGE("LOG" ${PC_LIBDPKG_LIBRARY_DIRS})
+
+set(LIBDPKG_VERSION ${PC_LIBDPKG_VERSION})
+string(REGEX REPLACE "([0-9]+).[0-9]+.[0-9]+" "\\1" LIBDPKG_VERSION_MAJOR ${LIBDPKG_VERSION})
+string(REGEX REPLACE "[0-9]+.([0-9]+).[0-9]+" "\\1" LIBDPKG_VERSION_MINOR ${LIBDPKG_VERSION})
+string(REGEX REPLACE "[0-9]+.[0-9]+.([0-9]+)" "\\1" LIBDPKG_VERSION_PATCH ${LIBDPKG_VERSION})
+math(EXPR LIBDPKG_VERSION_NUMBER "${LIBDPKG_VERSION_MAJOR} * 1000000 + ${LIBDPKG_VERSION_MINOR} * 1000 + ${LIBDPKG_VERSION_PATCH}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libdpkg DEFAULT_MSG LIBDPKG_VERSION)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,9 @@ targets = {
   "centos7.1"   => {
     "box" => "bento/centos-7.1"
   },
+	"ubuntu15.04"  => {
+    "box" => "ubuntu/vivid64"
+  },
   "ubuntu14"  => {
     "box" => "ubuntu/trusty64"
   },

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -56,6 +56,11 @@ else()
       ${OSQUERY_UBUNTU_TABLES}
     )
 
+	# libdpkg API is volitile and suffers breaking changes. We need to find and pass in the libdpkg
+	# version via pkg-config
+	find_package(Libdpkg REQUIRED)
+	add_definitions(-DLIBDPKG_VERSION=${LIBDPKG_VERSION_NUMBER})
+
     ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg")
   endif()
 

--- a/osquery/tables/system/ubuntu/deb_packages.cpp
+++ b/osquery/tables/system/ubuntu/deb_packages.cpp
@@ -17,34 +17,54 @@
 extern "C" {
 #include <dpkg/dpkg-db.h>
 
+#if LIBDPKG_VERSION < 1017010
 // copy pasted from dpkg-db.h
-// these enums are inside struct pkginfo and are not visible for other headers
+// Prior to libdpkg 1.7.10 these enums are inside struct pkginfo and are not
+// visible for other headers
 enum pkgwant {
-  want_unknown,
-  want_install,
-  want_hold,
-  want_deinstall,
-  want_purge,
-  // Not allowed except as special sentinel value in some places.
-  want_sentinel,
-} want;
+	PKG_WANT_UNKNOWN,
+	PKG_WANT_INSTALL,
+	PKG_WANT_HOLD,
+	PKG_WANT_DEINSTALL,
+	PKG_WANT_PURGE,
+	/** Not allowed except as special sentinel value in some places. */
+	PKG_WANT_SENTINEL,
+};
 
-// The error flag bitmask.
 enum pkgeflag {
-  eflag_ok = 0,
-  eflag_reinstreq = 1,
-} eflag;
+	PKG_EFLAG_OK		= 0,
+	PKG_EFLAG_REINSTREQ	= 1,
+};
 
 enum pkgstatus {
-  stat_notinstalled,
-  stat_configfiles,
-  stat_halfinstalled,
-  stat_unpacked,
-  stat_halfconfigured,
-  stat_triggersawaited,
-  stat_triggerspending,
-  stat_installed
-} status;
+	PKG_STAT_NOTINSTALLED,
+	PKG_STAT_CONFIGFILES,
+	PKG_STAT_HALFINSTALLED,
+	PKG_STAT_UNPACKED,
+	PKG_STAT_HALFCONFIGURED,
+	PKG_STAT_TRIGGERSAWAITED,
+	PKG_STAT_TRIGGERSPENDING,
+	PKG_STAT_INSTALLED,
+};
+
+enum pkgpriority {
+	PKG_PRIO_REQUIRED,
+	PKG_PRIO_IMPORTANT,
+	PKG_PRIO_STANDARD,
+	PKG_PRIO_OPTIONAL,
+	PKG_PRIO_EXTRA,
+	PKG_PRIO_OTHER,
+	PKG_PRIO_UNKNOWN,
+	PKG_PRIO_UNSET = -1,
+};
+#endif
+
+#if LIBDPKG_VERSION < 1017023
+// libdpkg versions 1.17.23 and newer defines a size_t for fieldinfo which is
+// automatically expanded using the FIELD macro found in dpkg/parsedump.h. For
+// versions prior we just need the name
+#define FIELD(name) name
+#endif
 
 #include <dpkg/dpkg.h>
 #include <dpkg/pkg-array.h>
@@ -135,12 +155,12 @@ const std::map<std::string, std::string> kFieldMappings = {
 * as needed.
 */
 const struct fieldinfo fieldinfos[] = {
-    {"Package", f_name, w_name},
-    {"Installed-Size", f_charfield, w_charfield, PKGIFPOFF(installedsize)},
-    {"Architecture", f_architecture, w_architecture},
-    {"Source", f_charfield, w_charfield, PKGIFPOFF(source)},
-    {"Version", f_version, w_version, PKGIFPOFF(version)},
-    {"Revision", f_revision, w_revision},
+    {FIELD("Package"), f_name, w_name},
+    {FIELD("Installed-Size"), f_charfield, w_charfield, PKGIFPOFF(installedsize)},
+    {FIELD("Architecture"), f_architecture, w_architecture},
+    {FIELD("Source"), f_charfield, w_charfield, PKGIFPOFF(source)},
+    {FIELD("Version"), f_version, w_version, PKGIFPOFF(version)},
+    {FIELD("Revision"), f_revision, w_revision},
     {NULL}};
 
 void extractDebPackageInfo(const struct pkginfo *pkg, QueryData &results) {
@@ -179,7 +199,9 @@ QueryData genDebs(QueryContext &context) {
   dpkg_setup(&packages);
   for (int i = 0; i < packages.n_pkgs; i++) {
     struct pkginfo *pkg = packages.pkgs[i];
-    if (pkg->status == pkg->stat_notinstalled) {
+	// Casted to int to allow the older enums that were embeded in the packages
+	// struct to be compared
+	if (static_cast<int>(pkg->status) == static_cast<int>(PKG_STAT_NOTINSTALLED)) {
       continue;
     }
 


### PR DESCRIPTION
Libdpkg has some breaking changes in newer versions which prevented
compiling the deb_packages table on Ubuntu 15.04.  This change looks for
the libpkg version user pkg-config and adds some preprocessor magic to
support the newer versions.