### PR TITLE
Fix segfault on interfaces tables

### DIFF
--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -134,6 +134,9 @@ QueryData genInterfaceAddresses(QueryContext &context) {
   }
 
   for (if_addr = if_addrs; if_addr != nullptr; if_addr = if_addr->ifa_next) {
+    if (if_addr->ifa_addr == nullptr) {
+      continue;
+    }
     if (if_addr->ifa_addr->sa_family == AF_INET ||
         if_addr->ifa_addr->sa_family == AF_INET6) {
       genAddressesFromAddr(if_addr, results);
@@ -153,7 +156,8 @@ QueryData genInterfaceDetails(QueryContext &context) {
   }
 
   for (if_addr = if_addrs; if_addr != nullptr; if_addr = if_addr->ifa_next) {
-    if (if_addr->ifa_addr->sa_family != AF_INTERFACE) {
+    if (if_addr->ifa_addr != nullptr &&
+        if_addr->ifa_addr->sa_family != AF_INTERFACE) {
       // This interface entry does not describe the link details.
       continue;
     }


### PR DESCRIPTION
getifaddrs(3) states that ifa_addr can be null. Check to make sure they are not null before accessing them