### PR TITLE
Remove boolean type-columns from file in favor of 'type'

### DIFF
--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -15,11 +15,7 @@ schema([
     Column("mtime", BIGINT, "Last modification time"),
     Column("ctime", BIGINT, "Creation time"),
     Column("hard_links", INTEGER, "Number of hard links"),
-    Column("is_file", INTEGER, "1 If a file node else 0"),
-    Column("is_dir", INTEGER, "1 If a directory (not file) else 0"),
-    Column("is_link", INTEGER, "1 If a symlink else 0"),
-    Column("is_char", INTEGER, "1 If a character special device else 0"),
-    Column("is_block", INTEGER, "1 If a block special device else 0"),
+    Column("type", TEXT, "File status"),
     Column("pattern", TEXT, "A pattern which can be used to match file paths"),
 ])
 attributes(utility=True)


### PR DESCRIPTION
To support <i>many-more</i> file types we should deprecate the `is_type`-style columns in the `file` table and use a somewhat catchall-style `type` that reports the textual file type. 