### PR TITLE
eliminated some warnings from Clang 3.7 analyze mode

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -210,7 +210,7 @@ Status Config::update(const std::map<std::string, std::string>& config) {
     for (const auto& plugin : Registry::all("config_parser")) {
       std::shared_ptr<ConfigParserPlugin> parser;
       try {
-        parser = std::dynamic_pointer_cast<ConfigParserPlugin>(plugin.second);
+	parser = std::dynamic_pointer_cast<ConfigParserPlugin>(plugin.second);
       } catch (const std::bad_cast& e) {
         LOG(ERROR) << "Error casting config parser plugin: " << plugin.first;
       }

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -33,7 +33,7 @@ std::string base64Decode(const std::string& encoded) {
   is = encoded;
   boost::replace_all(is, "\r\n", "");
   boost::replace_all(is, "\n", "");
-  uint32_t size = is.size();
+  size_t size = is.size();
 
   // Remove the padding characters
   if (size && is[size - 1] == '=') {
@@ -61,7 +61,7 @@ std::string base64Encode(const std::string& unencoded) {
     return std::string();
   }
 
-  unsigned int writePaddChars = (3-unencoded.length()%3)%3;
+  size_t writePaddChars = (3U-unencoded.length()%3U)%3U;
   std::string base64(it_base64(unencoded.begin()), it_base64(unencoded.end()));
   base64.append(writePaddChars,'=');
   os << base64;

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -185,6 +185,6 @@ DistributedQueryRequest Distributed::popRequest() {
   WriteLock wlock_queries(distributed_queries_mutex_);
   auto q = queries_[0];
   queries_.erase(queries_.begin());
-  return std::move(q);
+  return q;
 }
 }

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -307,7 +307,7 @@ std::vector<EventRecord> EventSubscriberPlugin::getRecords(
     }
   }
 
-  return std::move(records);
+  return records;
 }
 
 Status EventSubscriberPlugin::recordEvent(EventID& eid, EventTime time) {
@@ -438,7 +438,7 @@ QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
     // Index retrieval will apply the constraints checking and auto-expire.
     expire_time_ = getUnixTime() - FLAGS_events_expiry;
   }
-  return std::move(results);
+  return results;
 }
 
 Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -120,7 +120,7 @@ Status readFile(const fs::path& path, std::string& content, bool dry_run) {
     if (is.bad()) {
       return Status(1, "Error reading special file: " + path.string());
     }
-    content.assign(std::move(buffer.str()));
+    content.assign(buffer.str());
   } else {
     content = std::string(size, '\0');
     is.read(&content[0], size);

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -56,7 +56,7 @@ class TLSRequestHelper {
       uri += ((uri.find("?") != std::string::npos) ? "&" : "?") +
              FLAGS_tls_enroll_override + "=" + getEnrollSecret();
     }
-    return std::move(uri);
+    return uri;
   }
 
   /**

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -23,7 +23,7 @@ const std::map<std::string, std::string> kExtensionKeys = {
     {"default_locale", "locale"},
     {"update_url", "update_url"},
     {"author", "author"},
-    {"background.persistent", "persistent"},
+    {"background.persistent", "persistent"}
 };
 
 void genExtension(const std::string& path, QueryData& results) {

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -41,7 +41,7 @@ typedef FSEventsEventContextRef FileEventContextRef;
 typedef EventSubscriber<INotifyEventPublisher> FileEventSubscriber;
 typedef INotifyEventContextRef FileEventContextRef;
 #define FILE_CHANGE_MASK \
-  IN_CREATE | IN_CLOSE_WRITE | IN_MODIFY
+  ( (IN_CREATE) | (IN_CLOSE_WRITE) | (IN_MODIFY) )
 #endif
 
 /**

--- a/osquery/tables/networking/interfaces.cpp
+++ b/osquery/tables/networking/interfaces.cpp
@@ -30,9 +30,14 @@
 namespace osquery {
 namespace tables {
 
-// Macros for safe sign-extension
-#define INTEGER_FROM_UCHAR(x) INTEGER((uint16_t)x);
-#define BIGINT_FROM_UINT32(x) BIGINT((uint64_t)x);
+// Functions for safe sign-extension
+  std::basic_string<char> INTEGER_FROM_UCHAR(unsigned char x) {
+    return INTEGER(static_cast<uint16_t>(x));
+  }
+
+  std::basic_string<char> BIGINT_FROM_UINT32(uint32_t x) {
+    return BIGINT(static_cast<uint64_t>(x));
+  }
 
 void genAddressesFromAddr(const struct ifaddrs *addr, QueryData &results) {
   std::string dest_address;
@@ -41,16 +46,16 @@ void genAddressesFromAddr(const struct ifaddrs *addr, QueryData &results) {
 
   // Address and mask will appear every time.
   if (addr->ifa_addr != nullptr) {
-    r["address"] = ipAsString((struct sockaddr *)addr->ifa_addr);
+    r["address"] = ipAsString(static_cast<struct sockaddr *>(addr->ifa_addr));
   }
 
   if (addr->ifa_netmask != nullptr) {
-    r["mask"] = ipAsString((struct sockaddr *)addr->ifa_netmask);
+    r["mask"] = ipAsString(static_cast<struct sockaddr *>(addr->ifa_netmask));
   }
 
   // The destination address is used for either a broadcast or PtP address.
   if (addr->ifa_dstaddr != nullptr) {
-    dest_address = ipAsString((struct sockaddr *)addr->ifa_dstaddr);
+    dest_address = ipAsString(static_cast<struct sockaddr *>(addr->ifa_dstaddr));
     if ((addr->ifa_flags & IFF_BROADCAST) == IFF_BROADCAST) {
       r["broadcast"] = dest_address;
     } else {
@@ -73,7 +78,7 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
   if (addr->ifa_data != nullptr && addr->ifa_name != nullptr) {
 #ifdef __linux__
     // Linux/Netlink interface details parsing.
-    auto ifd = (struct rtnl_link_stats *)addr->ifa_data;
+    auto ifd = static_cast<struct rtnl_link_stats *>(addr->ifa_data);
     r["mtu"] = "0";
     r["metric"] = "0";
     r["type"] = "0";
@@ -128,7 +133,8 @@ void genDetailsFromAddr(const struct ifaddrs *addr, QueryData &results) {
 QueryData genInterfaceAddresses(QueryContext &context) {
   QueryData results;
 
-  struct ifaddrs *if_addrs = nullptr, *if_addr = nullptr;
+  struct ifaddrs *if_addrs = nullptr;
+  struct ifaddrs *if_addr = nullptr;
   if (getifaddrs(&if_addrs) != 0 || if_addrs == nullptr) {
     return {};
   }
@@ -150,7 +156,8 @@ QueryData genInterfaceAddresses(QueryContext &context) {
 QueryData genInterfaceDetails(QueryContext &context) {
   QueryData results;
 
-  struct ifaddrs *if_addrs = nullptr, *if_addr = nullptr;
+  struct ifaddrs *if_addrs = nullptr;
+  struct ifaddrs *if_addr = nullptr;
   if (getifaddrs(&if_addrs) != 0 || if_addrs == nullptr) {
     return {};
   }

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -30,7 +30,7 @@ const char MAP[] = {'0','1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', '
 const int HIGH_BITS = 4;
 const int LOW_BITS = 15;
 
-void parseIpEntry(ipt_ip *ip, Row &r) {
+void parseIpEntry(const ipt_ip *ip, Row &r) {
   r["protocol"] = INTEGER(ip->proto);
   if (strlen(ip->iniface)) {
     r["iniface"] = TEXT(ip->iniface);
@@ -44,10 +44,10 @@ void parseIpEntry(ipt_ip *ip, Row &r) {
    r["outiface"] = "all";
   }
 
-  r["src_ip"] = ipAsString((struct in_addr *)&ip->src);
-  r["dst_ip"] = ipAsString((struct in_addr *)&ip->dst);
-  r["src_mask"] = ipAsString((struct in_addr *)&ip->smsk);
-  r["dst_mask"] = ipAsString((struct in_addr *)&ip->dmsk);
+  r["src_ip"] = ipAsString(&ip->src);
+  r["dst_ip"] = ipAsString(&ip->dst);
+  r["src_mask"] = ipAsString(&ip->smsk);
+  r["dst_mask"] = ipAsString(&ip->dmsk);
 
   char aux_char[2] = {0};
   std::string iniface_mask;
@@ -97,11 +97,11 @@ void genIPTablesRules(const std::string &filter, QueryData &results) {
       r["bytes"] = "0";
     }
 
-    struct ipt_entry *prev_rule = nullptr;
+    const struct ipt_entry * prev_rule = nullptr;
     // Iterating through all the rules per chain
-    for (auto chain_rule = iptc_first_rule(chain, handle); chain_rule;
+    for (const struct ipt_entry * chain_rule = iptc_first_rule(chain, handle); chain_rule;
          chain_rule = iptc_next_rule(prev_rule, handle)) {
-      prev_rule = (struct ipt_entry *)chain_rule;
+      prev_rule = chain_rule; 
 
       auto target = iptc_get_target(chain_rule, handle);
       if (target != nullptr) {
@@ -116,13 +116,13 @@ void genIPTablesRules(const std::string &filter, QueryData &results) {
         r["match"] = "no";
       }
 
-      struct ipt_ip *ip = (struct ipt_ip *)&chain_rule->ip;
+      const struct ipt_ip *ip = &chain_rule->ip;
       parseIpEntry(ip, r);
 
       results.push_back(r);
     } // Rule iteration
     results.push_back(r);
-  } // Chain iteration
+  } // Chain iteration 
 
   iptc_free(handle);
 }

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -44,7 +44,7 @@ Status readNetlink(int socket_fd, int seq, char* output, size_t* size) {
   size_t message_size = 0;
   do {
     int latency = 0;
-    int bytes = 0;
+    ssize_t bytes = 0;
     while (bytes == 0) {
       bytes = recv(socket_fd, output, MAX_NETLINK_SIZE - message_size, 0);
       if (bytes < 0) {
@@ -58,7 +58,7 @@ Status readNetlink(int socket_fd, int seq, char* output, size_t* size) {
     }
 
     // Assure valid header response, and not an error type.
-    nl_hdr = (struct nlmsghdr*)output;
+    nl_hdr = (struct nlmsghdr *)output;
     if (NLMSG_OK(nl_hdr, bytes) == 0 || nl_hdr->nlmsg_type == NLMSG_ERROR) {
       return Status(1, "Read invalid NETLINK message");
     }
@@ -84,9 +84,9 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   int mask = 0;
   char interface[IF_NAMESIZE];
 
-  struct rtmsg* message = (struct rtmsg*)NLMSG_DATA(netlink_msg);
-  struct rtattr* attr = (struct rtattr*)RTM_RTA(message);
-  int attr_size = RTM_PAYLOAD(netlink_msg);
+  struct rtmsg* message = static_cast<struct rtmsg *>(NLMSG_DATA(netlink_msg));
+  struct rtattr* attr = static_cast<struct rtattr*>(RTM_RTA(message));
+  uint32_t attr_size = RTM_PAYLOAD(netlink_msg);
 
   Row r;
 

--- a/osquery/tables/networking/linux/tests/iptables_tests.cpp
+++ b/osquery/tables/networking/linux/tests/iptables_tests.cpp
@@ -20,7 +20,7 @@
 namespace osquery {
 namespace tables {
 
-void parseIpEntry(ipt_ip *ip, Row &row);
+void parseIpEntry(const ipt_ip *ip, Row &row);
 
 ipt_ip* getIpEntryContent() {
   static ipt_ip ip_entry;

--- a/osquery/tables/other/yara.cpp
+++ b/osquery/tables/other/yara.cpp
@@ -154,7 +154,7 @@ QueryData genYara(QueryContext& context) {
     }
   }
 
-  return std::move(results);
+  return results;
 }
 }
 }

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -52,7 +52,7 @@ QueryData genMounts(QueryContext &context) {
   }
   endmntent(mounts);
 
-  return std::move(results);
+  return results;
 }
 }
 }

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -45,13 +45,13 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 {% if class_name != "" %}\
     if (EventFactory::exists("{{class_name}}")) {
       auto subscriber = EventFactory::getEventSubscriber("{{class_name}}");
-      return std::move(subscriber->{{function}}(request));
+      return subscriber->{{function}}(request);
     } else {
       LOG(ERROR) << "Subscriber table: {{class_name}} missing.";
       return QueryData();
     }
 {% else %}\
-    return std::move(tables::{{function}}(request));
+    return tables::{{function}}(request);
 {% endif %}\
   }
 };


### PR DESCRIPTION
Removed calls to std::move (mostly in return statements) that would prevent copy elision. 