### PR TITLE
Fixing kernel-configure-target syntax error

### DIFF
--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -138,7 +138,7 @@ if(APPLE)
     kernel-configure-target
     COMMAND
     COMMAND echo ""
-    COMMAND echo "WARNING: Configuring kernel to break/debug (BE CAREFUL)..."
+    COMMAND echo 'WARNING: Configuring kernel to break/debug (BE CAREFUL)...'
     COMMAND echo "WARNING: nvram boot-args=\"kext-dev-mode=1 kcsuffix=kernel -v pmuflags=1\""
     COMMAND sudo nvram boot-args="kext-dev-mode=1 kcsuffix=kernel -v pmuflags=1"
     COMMAND echo "WARNING: Reboot required."


### PR DESCRIPTION
`kernel-make-target` cmake target fails due to a syntax error because of the parentheses. 