### PR TITLE
Refactor a bit of config and add socket_events table to Linux

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -781,16 +781,35 @@ class EventSubscriber : public EventSubscriberPlugin {
   /// Set the subscriber state.
   void state(EventSubscriberState state) { state_ = state; }
 
-  EventSubscriber() : EventSubscriberPlugin(), state_(SUBSCRIBER_NONE) {}
+  EventSubscriber(bool enabled = true)
+      : EventSubscriberPlugin(), disabled(!enabled), state_(SUBSCRIBER_NONE) {}
+
+ protected:
+  /**
+   * @brief Allow subscriber implementations to default disable themselves.
+   *
+   * A subscriber may induce latency on a system within the callback routines.
+   * Before the initialization and set up is performed the EventFactory can
+   * choose to exclude a subscriber if it is not explicitly enabled within
+   * the config.
+   *
+   * EventSubscriber%s that should be default-disabled should set this flag
+   * in their constructor or worst case before EventSubsciber::init.
+   */
+  bool disabled{false};
 
  private:
   /// The event subscriber's run state.
   EventSubscriberState state_;
 
  private:
+  friend class EventFactory;
+
+ private:
   FRIEND_TEST(EventsTests, test_event_sub);
   FRIEND_TEST(EventsTests, test_event_sub_subscribe);
   FRIEND_TEST(EventsTests, test_event_sub_context);
+  FRIEND_TEST(EventsTests, test_event_toggle_subscribers);
 };
 
 /**

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include <boost/property_tree/ptree.hpp>
@@ -36,14 +35,13 @@ typedef struct {
  */
 class Pack {
  public:
-  Pack(const std::string& name, const boost::property_tree::ptree& tree);
-  Pack(const std::string& name, const std::string& json);
+  Pack(const std::string& name, const boost::property_tree::ptree& tree)
+      : Pack(name, "", tree) {}
   Pack(const std::string& name,
        const std::string& source,
-       const boost::property_tree::ptree& tree);
-  Pack(const std::string& name,
-       const std::string& source,
-       const std::string& json);
+       const boost::property_tree::ptree& tree) {
+    initialize(name, source, tree);
+  }
 
   void initialize(const std::string& name,
                   const std::string& source,

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -138,7 +138,7 @@ if(APPLE)
     kernel-configure-target
     COMMAND
     COMMAND echo ""
-    COMMAND echo 'WARNING: Configuring kernel to break/debug (BE CAREFUL)...'
+    COMMAND echo "WARNING: Configuring kernel to break/debug..."
     COMMAND echo "WARNING: nvram boot-args=\"kext-dev-mode=1 kcsuffix=kernel -v pmuflags=1\""
     COMMAND sudo nvram boot-args="kext-dev-mode=1 kcsuffix=kernel -v pmuflags=1"
     COMMAND echo "WARNING: Reboot required."

--- a/osquery/config/parsers/events.cpp
+++ b/osquery/config/parsers/events.cpp
@@ -21,10 +21,7 @@ class EventsConfigParserPlugin : public ConfigParserPlugin {
  public:
   std::vector<std::string> keys() { return {"events"}; }
 
-  Status setUp() {
-    data_.put_child("events", pt::ptree());
-    return Status(0, "OK");
-  }
+  EventsConfigParserPlugin() { data_.put_child("events", pt::ptree()); }
 
   Status update(const std::map<std::string, pt::ptree>& config) {
     if (config.count("events") > 0) {

--- a/osquery/config/parsers/tests/events_tests.cpp
+++ b/osquery/config/parsers/tests/events_tests.cpp
@@ -35,7 +35,7 @@ TEST_F(EventsConfigParserPluginTests, test_get_event) {
 
   auto plugin = Config::getInstance().getParser("events");
   EXPECT_TRUE(plugin != nullptr);
-  auto data = plugin->getData();
+  const auto& data = plugin->getData();
 
   EXPECT_EQ(data.count("events"), 1U);
   EXPECT_GT(data.get_child("events").count("environment_variables"), 0U);

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -10,6 +10,8 @@
 #include <memory>
 #include <vector>
 
+#include <boost/property_tree/json_parser.hpp>
+
 #include <gtest/gtest.h>
 
 #include <osquery/config.h>
@@ -139,7 +141,7 @@ TEST_F(ConfigTests, test_parse) {
   auto tree = getExamplePacksConfig();
   auto packs = tree.get_child("packs");
   for (const auto& pack : packs) {
-    c.addPack(Pack(pack.first, pack.second));
+    c.addPack(pack.first, "", pack.second);
   }
   for (Pack& p : c.schedule_) {
     EXPECT_TRUE(p.shouldPackExecute());
@@ -148,7 +150,7 @@ TEST_F(ConfigTests, test_parse) {
 
 TEST_F(ConfigTests, test_remove) {
   auto c = Config();
-  c.addPack(Pack("kernel", getUnrestrictedPack()));
+  c.addPack("kernel", "", getUnrestrictedPack());
   c.removePack("kernel");
   for (Pack& pack : c.schedule_) {
     EXPECT_NE("kernel", pack.getName());
@@ -161,7 +163,7 @@ TEST_F(ConfigTests, test_add_remove_pack) {
   auto last = c.schedule_.end();
   EXPECT_EQ(std::distance(first, last), 0);
 
-  c.addPack(Pack("kernel", getUnrestrictedPack()));
+  c.addPack("kernel", "", getUnrestrictedPack());
   first = c.schedule_.begin();
   last = c.schedule_.end();
   EXPECT_EQ(std::distance(first, last), 1);
@@ -175,7 +177,7 @@ TEST_F(ConfigTests, test_add_remove_pack) {
 TEST_F(ConfigTests, test_get_scheduled_queries) {
   std::vector<ScheduledQuery> queries;
   auto c = Config();
-  c.addPack(Pack("kernel", getUnrestrictedPack()));
+  c.addPack("kernel", "", getUnrestrictedPack());
   c.scheduledQueries(
       ([&queries](const std::string&, const ScheduledQuery& query) {
         queries.push_back(query);
@@ -198,7 +200,7 @@ TEST_F(ConfigTests, test_get_parser) {
 
   const auto& parser =
       std::dynamic_pointer_cast<TestConfigParserPlugin>(plugin);
-  auto data = parser->getData();
+  const auto& data = parser->getData();
 
   EXPECT_EQ(data.count("list"), 1U);
   EXPECT_EQ(data.count("dictionary"), 1U);

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -7,6 +7,9 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+
+#include <boost/property_tree/json_parser.hpp>
+
 #include <gtest/gtest.h>
 
 #include <osquery/core.h>
@@ -123,14 +126,8 @@ TEST_F(PacksTests, test_schedule) {
 }
 
 TEST_F(PacksTests, test_discovery_cache) {
-  auto pack = Pack("kernel", getPackWithValidDiscovery());
-  auto& stats = pack.getStats();
-  EXPECT_EQ(stats.total, 0);
-  EXPECT_EQ(stats.hits, 0);
-  EXPECT_EQ(stats.misses, 0);
-
   auto c = Config();
-  c.addPack(pack);
+  c.addPack("kernel", "", getPackWithValidDiscovery());
   size_t query_count = 0;
   for (size_t i = 0; i < 5; i++) {
     c.scheduledQueries(

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -252,7 +252,7 @@ TEST_F(FSEventsTests, test_fsevents_fire_event) {
 
   // Simulate registering an event subscriber.
   auto sub = std::make_shared<TestFSEventsEventSubscriber>();
-  auto status = sub->init();
+  EventFactory::registerEventSubscriber(sub);
 
   // Create a subscriptioning context, note the added Event to the symbol
   auto sc = sub->GetSubscription(0);
@@ -277,6 +277,7 @@ TEST_F(FSEventsTests, test_fsevents_event_action) {
 
   auto sc = sub->GetSubscription(0);
   EventFactory::registerEventSubscriber(sub);
+
   sub->subscribe(&TestFSEventsEventSubscriber::Callback, sc, nullptr);
   CreateEvents();
   sub->WaitForEvents(kMaxEventLatency, 1);

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -260,7 +260,7 @@ TEST_F(INotifyTests, test_inotify_fire_event) {
   // Assume event type is registered.
   StartEventLoop();
   auto sub = std::make_shared<TestINotifyEventSubscriber>();
-  sub->init();
+  EventFactory::registerEventSubscriber(sub);
 
   // Create a subscriptioning context, note the added Event to the symbol
   auto sc = sub->GetSubscription(real_test_path, 0);
@@ -278,7 +278,7 @@ TEST_F(INotifyTests, test_inotify_event_action) {
   // Assume event type is registered.
   StartEventLoop();
   auto sub = std::make_shared<TestINotifyEventSubscriber>();
-  sub->init();
+  EventFactory::registerEventSubscriber(sub);
 
   auto sc = sub->GetSubscription(real_test_path, 0);
   sub->subscribe(&TestINotifyEventSubscriber::Callback, sc, nullptr);
@@ -315,7 +315,7 @@ TEST_F(INotifyTests, test_inotify_recursion) {
   StartEventLoop();
 
   auto sub = std::make_shared<TestINotifyEventSubscriber>();
-  sub->init();
+  EventFactory::registerEventSubscriber(sub);
 
   boost::filesystem::create_directory(real_test_dir);
   boost::filesystem::create_directory(real_test_sub_dir);

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -20,18 +20,16 @@
 
 namespace osquery {
 
-//const std::string kTestingEventsDBPath = "/tmp/rocksdb-osquery-testevents";
-
 class EventsDatabaseTests : public ::testing::Test {};
 
-class FakeEventPublisher
+class DBFakeEventPublisher
     : public EventPublisher<SubscriptionContext, EventContext> {
-  DECLARE_PUBLISHER("FakePublisher");
+  DECLARE_PUBLISHER("DBFakePublisher");
 };
 
-class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
+class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
  public:
-  FakeEventSubscriber() { setName("FakeSubscriber"); }
+  DBFakeEventSubscriber() { setName("DBFakeSubscriber"); }
   /// Add a fake event at time t
   Status testAdd(int t) {
     Row r;
@@ -41,7 +39,7 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
 };
 
 TEST_F(EventsDatabaseTests, test_event_module_id) {
-  auto sub = std::make_shared<FakeEventSubscriber>();
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
   sub->doNotExpire();
 
   // Not normally available outside of EventSubscriber->Add().
@@ -52,13 +50,13 @@ TEST_F(EventsDatabaseTests, test_event_module_id) {
 }
 
 TEST_F(EventsDatabaseTests, test_event_add) {
-  auto sub = std::make_shared<FakeEventSubscriber>();
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
   auto status = sub->testAdd(1);
   EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsDatabaseTests, test_record_indexing) {
-  auto sub = std::make_shared<FakeEventSubscriber>();
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
   auto status = sub->testAdd(2);
   status = sub->testAdd(11);
   status = sub->testAdd(61);
@@ -99,7 +97,7 @@ TEST_F(EventsDatabaseTests, test_record_indexing) {
 }
 
 TEST_F(EventsDatabaseTests, test_record_range) {
-  auto sub = std::make_shared<FakeEventSubscriber>();
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
 
   // Search within a specific record range.
   auto indexes = sub->getIndexes(0, 10);
@@ -124,7 +122,7 @@ TEST_F(EventsDatabaseTests, test_record_range) {
 }
 
 TEST_F(EventsDatabaseTests, test_record_expiration) {
-  auto sub = std::make_shared<FakeEventSubscriber>();
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
 
   // No expiration
   auto indexes = sub->getIndexes(0, 5000);

--- a/osquery/tables/events/darwin/process_events.cpp
+++ b/osquery/tables/events/darwin/process_events.cpp
@@ -75,7 +75,7 @@ Status ProcessEventSubscriber::Callback(
     if (plugin == nullptr || plugin.get() == nullptr) {
       LOG(ERROR) << "Could not load events config parser";
     } else {
-      auto data = plugin->getData();
+      const auto &data = plugin->getData();
       if (data.get_child("events").count("environment_variables") > 0) {
         use_whitelist = true;
         whitelist = data.get_child("events.environment_variables");

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/sql.h>
+
+#include "osquery/events/linux/audit.h"
+
+namespace osquery {
+
+#define AUDIT_SYSCALL_BIND 49
+#define AUDIT_SYSCALL_CONNECT 42
+
+// Depend on the external getUptime table method.
+namespace tables {
+extern long getUptime();
+}
+
+class SocketEventSubscriber : public EventSubscriber<AuditEventPublisher> {
+ public:
+  /// Decorating syscall events with socket information on Linux is expensive.
+  SocketEventSubscriber() : EventSubscriber(false) {}
+
+  /// The process event subscriber declares an audit event type subscription.
+  Status init();
+
+  /// Kernel events matching the event type will fire.
+  Status Callback(const AuditEventContextRef& ec, const void* user_data);
+};
+
+REGISTER(SocketEventSubscriber, "event_subscriber", "socket_events");
+
+Status SocketEventSubscriber::init() {
+  auto sc = createSubscriptionContext();
+
+  // Monitor for bind and connect syscalls.
+  sc->rules.push_back({AUDIT_SYSCALL_BIND, ""});
+  sc->rules.push_back({AUDIT_SYSCALL_CONNECT, ""});
+
+  // Drop events if they are encountered outside of the expected state.
+  // sc->types = {AUDIT_SYSCALL};
+  subscribe(&SocketEventSubscriber::Callback, sc, nullptr);
+
+  return Status(0, "OK");
+}
+
+Status SocketEventSubscriber::Callback(const AuditEventContextRef& ec,
+                                       const void* user_data) {
+  Row r;
+  r["pid"] = ec->fields["pid"];
+  r["path"] = ec->fields["exe"];
+  r["fd"] = ec->fields["a0"];
+
+  if (ec->syscall == AUDIT_SYSCALL_CONNECT) {
+    r["action"] = "connect";
+    // The connect syscall must exit with EINPROGRESS
+    if (ec->fields.count("exit") && ec->fields.at("exit") != "-115") {
+      return Status(0, "Not recording socket event");
+    }
+
+  } else if (ec->syscall == AUDIT_SYSCALL_BIND) {
+    r["action"] = "bind";
+  }
+
+  // The open/bind success status.
+  r["success"] = (ec->fields["success"] == "yes") ? "1" : "0";
+
+  auto qd = SQL::selectAllFrom("process_open_sockets", "pid", EQUALS, r["pid"]);
+  for (const auto& row : qd) {
+    if (row.at("fd") == r["fd"]) {
+      // For the socket event that happens before a bind.
+      if (row.at("socket").empty()) {
+        return Status(0, "No socket information");
+      }
+
+      r["socket"] = row.at("socket");
+      r["family"] = row.at("family");
+      r["protocol"] = row.at("protocol");
+      r["remote_address"] = row.at("remote_address");
+      r["local_address"] = row.at("local_address");
+      r["remote_port"] = row.at("remote_port");
+      r["local_port"] = row.at("local_port");
+      break;
+    }
+  }
+
+  if (r.count("socket") == 0) {
+    return Status(0, "No socket found");
+  }
+
+  r["uptime"] = std::to_string(tables::getUptime());
+  add(r, getUnixTime());
+  return Status(0, "OK");
+}
+} // namespace osquery

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -157,8 +157,7 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
   // Use the category as a lookup into the yara file_paths. The value will be
   // a list of signature groups to scan with.
   auto category = r.at("category");
-  pt::ptree yara_config;
-  yara_config = parser->getData();
+  const auto& yara_config = parser->getData();
   const auto& yara_paths = yara_config.get_child("file_paths");
   const auto& sig_groups = yara_paths.find(category);
   for (const auto& rule : sig_groups->second) {

--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -108,7 +108,8 @@ void genSocketDescriptor(int pid, int descriptor, QueryData &results) {
     Row r;
 
     r["pid"] = INTEGER(pid);
-    r["socket"] = INTEGER(descriptor);
+    r["fd"] = BIGINT(descriptor);
+    r["socket"] = BIGINT(si.psi.soi_so);
     r["path"] = "";
 
     // Darwin/OSX SOCKINFO_TCP is not IPPROTO_TCP

--- a/specs/linux/socket_events.table
+++ b/specs/linux/socket_events.table
@@ -1,0 +1,20 @@
+table_name("socket_events")
+description("Track network socket opens and closes.")
+schema([
+    Column("action", TEXT, "The socket action (bind, listen, close)"),
+    Column("pid", BIGINT, "Process (or thread) ID"),
+    Column("path", TEXT, "Path of executed file"),
+    Column("fd", INTEGER, "The file description for the process socket"),
+    Column("success", INTEGER, "The socket open attempt status"),
+    Column("socket", BIGINT, "The operating system socket ID"),
+    Column("family", BIGINT, "The Internet protocol family ID"),
+    Column("protocol", BIGINT, "The network protocol ID"),
+    Column("local_address", TEXT, "Local address associated with socket"),
+    Column("remote_address", TEXT, "Remote address associated with socket"),
+    Column("local_port", INTEGER, "Local network protocol port number"),
+    Column("remote_port", INTEGER, "Remote network protocol port number"),
+    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("uptime", BIGINT, "Time of execution in system uptime"),
+])
+attributes(event_subscriber=True)
+implementation("socket_events@socket_events::genTable")

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -2,7 +2,8 @@ table_name("process_open_sockets")
 description("Processes which have open network sockets on the system.")
 schema([
     Column("pid", INTEGER, "Process (or thread) ID", index=True),
-    Column("socket", INTEGER, "Socket descriptor number"),
+    Column("fd", BIGINT, "Socket file descriptor number"),
+    Column("socket", BIGINT, "Socket handle or inode number"),
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),
     Column("protocol", INTEGER, "Transport protocol (TCP/UDP)"),
     Column("local_address", TEXT, "Socket local address"),


### PR DESCRIPTION
The refactor of config/packs was initiated because event subscribers needed a method for toggling `::init` based on some configurable option. In the case of auditd, turning on the support with `--disable_audit=false` used to start auditing the EXECVE syscall. It was understandable that this would cause latency based on the number of processes executing per measure of time.

A new `socket_events` table will do the same but for `bind` and `connect`. These are less-obvious and for now, require a scan of /proc for socket tuples. In the future this file descriptor to socket tuple will be faster.

A config may now contain:
```json
{
  "events": {
    "enabled_subscribers": [ "socket_events" ],
    "disabled_subscribers": [ "process_events" ]
  }
}
```

By default the `socket_events` table is disabled. This means auditd support needs to be turned on as an option and the above `enable_subscribers` line must exist within the config.