### PR TITLE
[Fix #1583] Require osqueryd to have R/W access to RocksDB

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -418,13 +418,16 @@ void Initializer::start() {
   }
 
   // Check the backing store by allocating and exiting on error.
-  if (!DBHandle::checkDB()) {
+  if (!DBHandle::checkDB(tool_ == OSQUERY_TOOL_DAEMON)) {
     LOG(ERROR) << binary_ << " initialize failed: Could not open RocksDB";
     if (isWorker()) {
       ::exit(EXIT_CATASTROPHIC);
     } else {
       ::exit(EXIT_FAILURE);
     }
+  } else if (tool_ == OSQUERY_TOOL_DAEMON) {
+    // A daemon must always have R/W access to the database.
+    DBHandle::requireWrite();
   }
 
   // Bind to an extensions socket and wait for registry additions.

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -136,19 +136,19 @@ void DBHandle::open() {
   auto s =
       rocksdb::DB::Open(options_, path_, column_families_, &handles_, &db_);
   if (!s.ok() || db_ == nullptr) {
-#if defined(ROCKSDB_LITE)
-    // RocksDB LITE does not support readonly mode.
-    VLOG(1) << "Opening RocksDB failed: Continuing without storage support";
-#else
+    if (require_write_) {
+      // A failed open in R/W mode is a runtime error.
+      throw std::runtime_error(s.ToString());
+    }
+
     VLOG(1) << "Opening RocksDB failed: Continuing with read-only support";
+#if !defined(ROCKSDB_LITE)
+    // RocksDB LITE does not support readonly mode.
     // The database was readable but could not be opened, either (1) it is not
     // writable or (2) it is already opened by another process.
     // Try to open the database in a ReadOnly mode.
-    s = rocksdb::DB::OpenForReadOnly(
+    rocksdb::DB::OpenForReadOnly(
         options_, path_, column_families_, &handles_, &db_);
-    if (!s.ok()) {
-      throw std::runtime_error(s.ToString());
-    }
 #endif
     // Also disable event publishers.
     Flag::updateValue("disable_events", "true");
@@ -182,17 +182,20 @@ DBHandleRef DBHandle::getInstance() {
   return getInstance(FLAGS_database_path, FLAGS_database_in_memory);
 }
 
-bool DBHandle::checkDB() {
+bool DBHandle::checkDB(bool require_write) {
   // Allow database instances to check if a status/sanity check was requested.
   kCheckingDB = true;
   try {
     auto handle = DBHandle(FLAGS_database_path, FLAGS_database_in_memory);
+    kCheckingDB = false;
+    if (require_write && handle.read_only_) {
+      return false;
+    }
   } catch (const std::exception& e) {
     kCheckingDB = false;
     VLOG(1) << e.what();
     return false;
   }
-  kCheckingDB = false;
   return true;
 }
 

--- a/osquery/database/db_handle.h
+++ b/osquery/database/db_handle.h
@@ -67,7 +67,10 @@ class DBHandle {
    *
    * @return Success if a handle was created without error.
    */
-  static bool checkDB();
+  static bool checkDB(bool require_write = false);
+
+  /// Require all DBHandle accesses to open a read and write handle.
+  static void requireWrite() { getInstance()->require_write_ = true; }
 
  private:
   /////////////////////////////////////////////////////////////////////////////
@@ -234,6 +237,9 @@ class DBHandle {
 
   /// The database was opened in a ReadOnly mode.
   bool read_only_{false};
+
+  // The database must be opened in a R/W mode.
+  bool require_write_{false};
 
   /// Location of RocksDB on disk, blank if in-memory is true.
   std::string path_;

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -160,7 +160,7 @@ function install_cppnetlib() {
   TARBALL=$SOURCE.tar.gz
   URL=$DEPS_URL/$TARBALL
 
-  if provision cppnetlib /usr/local/lib/libcppnetlib-uri.a; then
+  if provision cppnetlib /usr/local/include/boost/network.hpp; then
     pushd $SOURCE
     mkdir -p build
     pushd build


### PR DESCRIPTION
This extends the `DBHandle` interface to include a concept of "required R/W" and then sets that requirement for both checking DB sanity and opening a process-global RocksDB handle for only the daemon process.