### PR TITLE
Only emit process events for 0-status execve

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -156,6 +156,10 @@ Status ProcessEventSubscriber::Callback(const AuditEventContextRef& ec,
                                         const void* user_data) {
   // Check and set the valid state change.
   // If this is an unacceptable change reset the state and clear row data.
+  if (ec->fields.count("success") && ec->fields.at("success") == "no") {
+    return Status(0, "OK");
+  }
+
   if (!validAuditState(ec->type, state_).ok()) {
     state_ = STATE_SYSCALL;
     Row().swap(row_);


### PR DESCRIPTION
The `exec` family may emit non-0 return statuses, opaque to the caller, we do _not_ want to audit these. 