### PR TITLE
[#1546] Add computer_name to system_info and extend to Linux

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -78,7 +78,6 @@ endif()
 # Construct a set of all object files, starting with third-party and all
 # of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
 set(OSQUERY_OBJECTS $<TARGET_OBJECTS:osquery_sqlite>)
-add_compile_options(-Werror)
 
 # Add subdirectories
 add_subdirectory(config)

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -55,9 +55,14 @@ FLAG(string,
      "Field used to identify the host running osquery (hostname, uuid)");
 
 std::string getHostname() {
-  char hostname[256] = {0}; // Linux max should be 64.
-  gethostname(hostname, sizeof(hostname) - 1);
+  static long max_hostname = sysconf(_SC_HOST_NAME_MAX);
+  long size = (max_hostname > 255) ? max_hostname + 1 : 256;
+  char* hostname = (char*)malloc(size);
+  memset((void*)hostname, 0, size);
+  gethostname(hostname, size - 1);
   std::string hostname_string = std::string(hostname);
+  free(hostname);
+
   boost::algorithm::trim(hostname_string);
   return hostname_string;
 }

--- a/osquery/main/run.cpp
+++ b/osquery/main/run.cpp
@@ -15,6 +15,7 @@
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 
+#include "osquery/database/db_handle.h"
 #include "osquery/sql/sqlite_util.h"
 
 DEFINE_string(query, "", "query to execute");
@@ -40,6 +41,8 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  osquery::DBHandle::setAllowOpen(true);
+  osquery::FLAGS_database_path = "/dev/null";
   osquery::Registry::setUp();
   osquery::FLAGS_disable_events = true;
   osquery::FLAGS_registry_exceptions = true;

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <stdio.h>
+
+#include <osquery/filesystem.h>
+#include <osquery/tables.h>
+#include <osquery/sql.h>
+
+namespace osquery {
+namespace tables {
+
+QueryData genSystemInfo(QueryContext &context) {
+  Row r;
+  r["hostname"] = osquery::getHostname();
+  r["computer_name"] = r["hostname"];
+
+  std::string uuid;
+  r["uuid"] = (osquery::getHostUUID(uuid)) ? uuid : "";
+
+  auto qd = SQL::selectAllFrom("cpuid");
+  for (const auto& row : qd) {
+    if (row.at("feature") == "product_name") {
+      r["cpu_brand"] = row.at("value");
+    }
+  }
+
+  // Can parse /proc/cpuinfo or /proc/meminfo for this data.
+  static long cores = sysconf(_SC_NPROCESSORS_CONF);
+  if (cores > 0) {
+    r["cpu_logical_cores"] = INTEGER(cores);
+    r["cpu_physical_cores"] = INTEGER(cores);
+  } else {
+    r["cpu_logical_cores"] = "-1";
+    r["cpu_physical_cores"] = "-1";
+  }
+
+  static long pages = sysconf(_SC_PHYS_PAGES);
+  static long pagesize = sysconf(_SC_PAGESIZE);
+
+  if (pages > 0 && pagesize > 0) {
+    r["physical_memory"] = BIGINT((long long)pages * (long long)pagesize);
+  } else {
+    r["physical_memory"] = "-1";
+  }
+
+  r["cpu_type"] = "0";
+  r["cpu_subtype"] = "0";
+  // Read the types from CPU info within proc.
+  std::string content;
+  if (readFile("/proc/cpuinfo", content)) {
+    for (const auto& line : osquery::split(content, "\n")) {
+      // Iterate each line and look for labels (there is also a model type).
+      if (line.find("cpu family") == 0 || line.find("model\t") == 0) {
+        auto details = osquery::split(line, ":");
+        if (details.size() == 2) {
+          // Not the most elegant but prevents us from splitting each line.
+          r[(line[0] == 'c') ? "cpu_type" : "cpu_subtype"] = details[1];
+        }
+      }
+    }
+  }
+
+  // Will require parsing DMI/SMBIOS data.
+  r["hardware_model"] = "";
+  r["hardware_serial"] = "";
+  return {r};
+}
+}
+}

--- a/specs/system_info.table
+++ b/specs/system_info.table
@@ -3,7 +3,6 @@ description("System information for identification.")
 schema([
     Column("hostname", TEXT, "Network hostname including domain"),
     Column("uuid", TEXT, "Unique ID provided by the system"),
-    Column("cpu_serial", TEXT, "System serial number frequently used for asset tracking"),
     Column("cpu_type", TEXT, "CPU type"),
     Column("cpu_subtype", TEXT, "CPU subtype"),
     Column("cpu_brand", TEXT, "CPU brand string"),
@@ -11,5 +10,8 @@ schema([
     Column("cpu_logical_cores", INTEGER, "Max number of CPU logical cores"),
     Column("physical_memory", BIGINT, "Total physical memory in bytes"),
     Column("hardware_model", TEXT, "Hardware model string"),
+    Column("hardware_serial", TEXT,
+        "System serial number frequently used for asset tracking"),
+    Column("computer_name", TEXT, "Friendly computer name (optional)"),
 ])
 implementation("system/system_info@genSystemInfo")

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -140,7 +140,6 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
                                 shell=shell,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-
     p = psutil.Process(pid=proc.pid)
 
     delay = 0
@@ -170,6 +169,8 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
     else:
         avg_utilization = sum(utilization) / len(utilization)
 
+    if len(stats.keys()) == 0:
+        raise Exception("No stats recorded, perhaps binary returns -1?")
     return {
         "utilization": avg_utilization,
         "duration": duration,


### PR DESCRIPTION
As of now, this is a WIP since the Linux version of `system_info` is fairly incomplete. I'm debating parsing structures in /proc.