### PR TITLE
Mark flaky integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ argparse
 # needed for integration tests
 pexpect
 thrift
+flaky

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import flaky
 import glob
 import os
 import psutil
@@ -239,6 +240,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
+    @flaky.flaky(max_runs=3)
     def test_7_extensions_autoload_watchdog(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
@@ -260,6 +262,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
+    @flaky.flaky(max_runs=3)
     def test_8_external_config(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])


### PR DESCRIPTION
Reviewing a few of the annoying failed integrations tests, I find that a few (extensions) are always the culprits. It doesn't make sense to remove, skip, or retry tests if these fail so we end up merging anyway. Hopefully marking these as [flaky](http://opensource.box.com/flaky/) will help!

One way to find out!!!!