### PR TITLE
don't reinvent the recursive wheel

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -123,6 +123,20 @@ Status listDirectoriesInDirectory(const boost::filesystem::path& path,
                                   bool ignore_error = 1);
 
 /**
+ * @brief List all of the directories in a specific directory, recursively.
+ *
+ * @param path the path which you would like to list
+ * @param results a non-const reference to a vector which will be populated
+ * with the directory listing of the path param, assuming that all operations
+ * completed successfully.
+ *
+ * @return an instance of Status, indicating success or failure.
+ */
+Status listDirectoriesInDirectoryRecursively(const boost::filesystem::path& path,
+                                  std::vector<std::string>& results,
+                                  bool ignore_error = 1);
+
+/**
  * @brief Given a filesystem globbing patten, resolve all matching paths.
  *
  * @code{.cpp}

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -241,10 +241,10 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
   if (recursive && isDirectory(path).ok()) {
     std::vector<std::string> children;
     // Get a list of children of this directory (requested recursive watches).
-    listDirectoriesInDirectory(path, children);
+    listDirectoriesInDirectoryRecursively(path, children);
 
     for (const auto& child : children) {
-      addMonitor(child, recursive);
+      addMonitor(child, false);
     }
   }
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -304,6 +304,12 @@ Status listDirectoriesInDirectory(const fs::path& path,
   return listInAbsoluteDirectory((path / "*"), results, GLOB_FOLDERS);
 }
 
+Status listDirectoriesInDirectoryRecursively(const fs::path& path,
+                                  std::vector<std::string>& results,
+                                  bool ignore_error) {
+  return listInAbsoluteDirectory((path / "**"), results, GLOB_FOLDERS);
+}
+
 Status getDirectory(const fs::path& path, fs::path& dirpath) {
   if (!isDirectory(path).ok()) {
     dirpath = fs::path(path).parent_path().string();


### PR DESCRIPTION
Fixes #1611.  See comments there for the details.  I ended up adding a new function in `filesystem.cpp` to find folders recursively since that seemed like the cleanest way to handle it.  Could perhaps be refactored into a flag argument for recursion.

After this fix, osquery no longer spins the CPU and eventually blows its stack on startup.