### PR TITLE
[Fix #1611] Prevent fs links in inotify path search

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -95,18 +95,19 @@ Status isReadable(const boost::filesystem::path& path);
 Status pathExists(const boost::filesystem::path& path);
 
 /**
- * @brief List all of the files in a specific directory, non-recursively.
+ * @brief List all of the files in a specific directory.
  *
  * @param path the path which you would like to list.
  * @param results a non-const reference to a vector which will be populated
  * with the directory listing of the path param, assuming that all operations
  * completed successfully.
+ * @param recursive should the listing descend recursively into the directory.
  *
  * @return an instance of Status, indicating success or failure.
  */
 Status listFilesInDirectory(const boost::filesystem::path& path,
                             std::vector<std::string>& results,
-                            bool ignore_error = 1);
+                            bool recursive = false);
 
 /**
  * @brief List all of the directories in a specific directory, non-recursively.
@@ -115,12 +116,13 @@ Status listFilesInDirectory(const boost::filesystem::path& path,
  * @param results a non-const reference to a vector which will be populated
  * with the directory listing of the path param, assuming that all operations
  * completed successfully.
+ * @param recursive should the listing descend recursively into the directory.
  *
  * @return an instance of Status, indicating success or failure.
  */
 Status listDirectoriesInDirectory(const boost::filesystem::path& path,
                                   std::vector<std::string>& results,
-                                  bool ignore_error = 1);
+                                  bool recursive = false);
 
 /**
  * @brief Given a filesystem globbing patten, resolve all matching paths.

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -241,10 +241,12 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
   if (recursive && isDirectory(path).ok()) {
     std::vector<std::string> children;
     // Get a list of children of this directory (requested recursive watches).
-    listDirectoriesInDirectory(path, children);
+    listDirectoriesInDirectory(path, children, true);
 
+    boost::system::error_code ec;
     for (const auto& child : children) {
-      addMonitor(child, recursive);
+      auto canonicalized = fs::canonical(child, ec).string() + '/';
+      addMonitor(canonicalized, false);
     }
   }
 

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -166,6 +166,8 @@ class INotifyEventPublisher
   int last_restart_;
 
  public:
+  friend class INotifyTests;
   FRIEND_TEST(INotifyTests, test_inotify_optimization);
+  FRIEND_TEST(INotifyTests, test_inotify_recursion);
 };
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -294,14 +294,16 @@ inline Status listInAbsoluteDirectory(const fs::path& path,
 
 Status listFilesInDirectory(const fs::path& path,
                             std::vector<std::string>& results,
-                            bool ignore_error) {
-  return listInAbsoluteDirectory((path / "*"), results, GLOB_FILES);
+                            bool recursive) {
+  return listInAbsoluteDirectory(
+      (path / ((recursive) ? "**" : "*")), results, GLOB_FILES);
 }
 
 Status listDirectoriesInDirectory(const fs::path& path,
                                   std::vector<std::string>& results,
-                                  bool ignore_error) {
-  return listInAbsoluteDirectory((path / "*"), results, GLOB_FOLDERS);
+                                  bool recursive) {
+  return listInAbsoluteDirectory(
+      (path / ((recursive) ? "**" : "*")), results, GLOB_FOLDERS);
 }
 
 Status getDirectory(const fs::path& path, fs::path& dirpath) {


### PR DESCRIPTION
Based on the implementation example from #1612.