### PR TITLE
Expand the scope of permissions dropping

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -112,11 +112,10 @@ set(CMAKE_SKIP_RPATH TRUE)
 
 # Create the static libosquery (everything but non-utility tables).
 add_library(libosquery STATIC main/lib.cpp ${OSQUERY_OBJECTS})
-
 target_link_libraries(libosquery ${OSQUERY_LIBS})
 set_target_properties(libosquery PROPERTIES OUTPUT_NAME osquery)
 set_target_properties(libosquery PROPERTIES COMPILE_FLAGS
-  "-DOSQUERY_BUILD_VERSION=${OSQUERY_BUILD_VERSION}")
+  "-DOSQUERY_BUILD_VERSION=${OSQUERY_BUILD_VERSION} ${CXX_COMPILE_FLAGS}")
 
 # A friendly echo printed after the library is built.
 add_custom_target(osquery_library ALL

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -98,6 +98,12 @@ std::string hashFromFile(HashType hash_type, const std::string& path) {
     return "";
   }
 
+  // Drop privileges to the user controlling the file.
+  auto dropper = DropPrivileges::get();
+  if (!dropper->dropToParent(path)) {
+    return "";
+  }
+
   Hash hash(hash_type);
   // Use the canonicalized path returned from a successful readFile dry-run.
   FILE* file = fopen(status.what().c_str(), "rb");

--- a/osquery/core/tests/permissions_tests.cpp
+++ b/osquery/core/tests/permissions_tests.cpp
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <pwd.h>
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/noncopyable.hpp>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+
+#include "osquery/core/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+class PermissionsTests : public testing::Test {
+ public:
+  PermissionsTests() : perm_path_(kTestWorkingDirectory + "lowperms/") {}
+
+  void SetUp() { fs::create_directories(perm_path_); }
+
+  void TearDown() { fs::remove_all(perm_path_); }
+
+ protected:
+  std::string perm_path_;
+};
+
+TEST_F(PermissionsTests, test_explicit_drop) {
+  {
+    auto dropper = DropPrivileges::get();
+    EXPECT_TRUE(dropper->dropTo(getuid(), getgid()));
+    // We can attempt to drop to the previously-dropped privilege.
+    EXPECT_TRUE(dropper->dropTo(getuid(), getgid()));
+  }
+
+  {
+    auto dropper = DropPrivileges::get();
+    // Make sure that an out-of-scope dropper "restore"
+    EXPECT_FALSE(dropper->dropped_);
+
+    uid_t expected_user = 0U;
+    EXPECT_EQ(dropper->to_user_, expected_user);
+
+    gid_t expected_group = 0U;
+    EXPECT_EQ(dropper->to_group_, expected_group);
+
+    // Checking if we are generally in a deprivileged mode.
+    auto dropper2 = DropPrivileges::get();
+    EXPECT_FALSE(dropper2->dropped());
+  }
+}
+
+TEST_F(PermissionsTests, test_path_drop) {
+  if (getuid() != 0) {
+    LOG(WARNING) << "Not root, skipping (path) deprivilege testing";
+    return;
+  }
+
+  // Attempt to drop to nobody based on ownership of paths.
+  auto nobody = getpwnam("nobody");
+  ASSERT_NE(nobody, nullptr);
+
+  {
+    int status = chown(perm_path_.c_str(), nobody->pw_uid, nobody->pw_gid);
+    ASSERT_EQ(status, 0);
+
+    auto dropper = DropPrivileges::get();
+    EXPECT_TRUE(dropper->dropToParent(perm_path_ + "ro"));
+    EXPECT_TRUE(dropper->dropped_);
+    EXPECT_EQ(dropper->to_user_, nobody->pw_uid);
+
+    // Even though this is possible and may make sense, it is confusing!
+    EXPECT_FALSE(dropper->dropTo(getuid(), getgid()));
+
+    // Make sure the dropper worked!
+    EXPECT_EQ(geteuid(), nobody->pw_uid);
+  }
+
+  // Now that the dropper is gone, the effective user/group should be restored.
+  EXPECT_EQ(geteuid(), getuid());
+  EXPECT_EQ(getegid(), getgid());
+}
+
+TEST_F(PermissionsTests, test_nobody_drop) {
+  if (getuid() != 0) {
+    LOG(WARNING) << "Not root, skipping (explicit) deprivilege testing";
+    return;
+  }
+
+  // Attempt to drop to nobody.
+  auto nobody = getpwnam("nobody");
+  ASSERT_NE(nobody, nullptr);
+
+  {
+    auto dropper = DropPrivileges::get();
+    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
+    EXPECT_EQ(geteuid(), nobody->pw_uid);
+  }
+
+  // Now that the dropper is gone, the effective user/group should be restored.
+  EXPECT_EQ(geteuid(), getuid());
+  EXPECT_EQ(getegid(), getgid());
+}
+}

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -106,9 +106,20 @@ inline void genSafariExtension(const std::string& path, QueryData& results) {
     return;
   }
 
+  // Perform a dry run of the file read.
+  if (!readFile(path).ok()) {
+    return;
+  }
+
+  // Finally drop privileges to the user controlling the extension.
+  auto dropper = DropPrivileges::get();
+  if (!dropper->dropToParent(path)) {
+    return;
+  }
+
   // Use open_file, instead of the preferred open_filename for OS X 10.9.
   archive_read_support_format_xar(ext);
-  if (archive_read_open_file(ext, path.c_str(), 10240) != ARCHIVE_OK) {
+  if (archive_read_open_filename(ext, path.c_str(), 10240) != ARCHIVE_OK) {
     archive_read_finish(ext);
     return;
   }


### PR DESCRIPTION
Move the `DropPrivileges` helper class into `core.h` so it can be used throughout the code base. There are several locations where the `readFile` abstraction cannot be used: plist stream parsing, archive parsing, and hashing (for some examples). It is mostly important to drop privileges before (1) operating on someone else's data, and (2) using that data within library/odd structure parsing implementations. In the case of a crash, it would be ideal if the application's effective user was non-super.