### PR TITLE
Remove specific filenames from RocksDB IOErrors

### DIFF
--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -356,8 +356,7 @@ Status EventSubscriberPlugin::recordEvent(EventID& eid, EventTime time) {
       status = db->Put(
           kEvents, record_key + "." + list_key + "." + list_id, record_value);
       if (!status.ok()) {
-        LOG(ERROR) << "Could not put Event Record key: " << record_key << "."
-                   << list_key << "." << list_id;
+        LOG(ERROR) << "Could not put Event Record key: " << record_key;
       }
     }
   }


### PR DESCRIPTION
The list and ID for events errors do not matter much. The specific filenames in RocksDB IOErrors are equally noisy and require specific backend aggregation logic. It's best to have repeatable errors.