### PR TITLE
Add pack_delimiter option

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -238,6 +238,23 @@ consist of pack name to pack content JSON data structures.
 }
 ```
 
+The pack value may also be a string, such as:
+
+```json
+{
+  "packs": {
+    "external_pack": "/path/to/external_pack.conf",
+    "internal_stuff": {
+      [...]
+    }
+  }
+}
+```
+
+If using a string instead of an inline JSON dictionary the configuration plugin will be asked to "generate" that resource. In the case of the default **filesystem** plugin, these strings are considered paths.
+
+Queries added to the schedule from packs inherit the pack name as part of the scheduled query name identifier. For example, consider the embedded `active_directory` query above, it is in the `internal_stuff` pack so the scheduled query name becomes: `pack_internal_stuff_active_directory`. The delimiter can be changed using the `--pack_delimiter=_`, see the [CLI Options](../installation/cli-flags.md) for more details.
+
 ### Discovery queries
 
 Discovery queries are a feature of query packs that make it much easier to monitor services at scale. Consider that there are some groups of scheduled

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -197,6 +197,10 @@ Osquery will natively re-run the discovery queries from time to time, to make
 sure that all of the correct packs are executing. This flag allows you to
 specify that interval.
 
+`--pack_delimiter=_`
+
+Control the delimiter between pack name and pack query names. When queries are added to the daemon's schedule they inherit the name of the pack. A query named "info" within the "general_info" pack will become "pack_general_info_info". Changing the delimiter to "/" turned the scheduled name into: "pack/general_info/info".
+
 `--schedule_default_interval=3600`
 
 Optionally set the default interval value. This is used if you schedule a query

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -31,6 +31,8 @@ namespace osquery {
 /// The config plugin must be known before reading options.
 CLI_FLAG(string, config_plugin, "filesystem", "Config plugin name");
 
+DECLARE_string(pack_delimiter);
+
 /**
  * @brief The backing store key name for the executing query.
  *
@@ -84,7 +86,8 @@ void Config::scheduledQueries(std::function<
     for (const auto& it : pack.getSchedule()) {
       std::string name = it.first;
       if (pack.getName() != "main" && pack.getName() != "legacy_main") {
-        name = "pack_" + pack.getName() + "_" + it.first;
+        name = "pack" + FLAGS_pack_delimiter + pack.getName() +
+               FLAGS_pack_delimiter + it.first;
       }
       predicate(name, it.second);
     }

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -29,6 +29,8 @@ FLAG(int32,
      3600,
      "Cache expiration for a packs discovery queries");
 
+FLAG(string, pack_delimiter, "_", "Delimiter for pack and query names");
+
 FLAG(int32, schedule_splay_percent, 10, "Percent to splay config times");
 
 FLAG(int32,


### PR DESCRIPTION
Allow configurations to override the pack query name limiter. It makes sense to eventually make the default delimiter "/" since "_" is often used within query names.