### PR TITLE
Allow user-controlled FIFOs

### DIFF
--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -295,4 +295,12 @@ TEST_F(FilesystemTests, test_safe_permissions) {
   // A root-owned file is appropriate
   EXPECT_TRUE(safePermissions("/", "/dev/zero"));
 }
+
+#ifdef __linux__
+TEST_F(FilesystemTests, test_read_proc) {
+  std::string content;
+  EXPECT_TRUE(readFile("/proc/" + std::to_string(getpid()) + "/stat", content));
+  EXPECT_GT(content.size(), 0U);
+}
+#endif
 }


### PR DESCRIPTION
This removes the check for user controlled FIFOs and instead allows reads of pseudo files up until a configuration-defined max limit. There may be ways to improve the read performance, this could use some integration tests and benchmarking.