### PR TITLE
Linux inotify should accept non-glob dirs

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -175,18 +175,6 @@ Status resolveFilePattern(const boost::filesystem::path& pattern,
  */
 void replaceGlobWildcards(std::string& pattern);
 
-/**
- * @brief Get directory portion of a path.
- *
- * @param path input path, either a filename or directory.
- * @param dirpath output path set to the directory-only path.
- *
- * @return If the input path was a directory this will indicate failure. One
- * should use `isDirectory` before.
- */
-Status getDirectory(const boost::filesystem::path& path,
-                    boost::filesystem::path& dirpath);
-
 /// Attempt to remove a directory path.
 Status remove(const boost::filesystem::path& path);
 

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -130,8 +130,28 @@ class INotifyEventPublisher
   /// Check all added Subscription%s for a path.
   bool isPathMonitored(const std::string& path);
 
-  /// Add an INotify watch (monitor) on this path.
-  bool addMonitor(const std::string& path, bool recursive);
+  /**
+   * @brief Add an INotify watch (monitor) on this path.
+   *
+   * Check if a given path is already monitored (perhaps the parent path) has
+   * and existing monitor and this is a non-directory leaf? On success the
+   * file descriptor is stored for lookup when events fire.
+   *
+   * A recursive flag will tell addMonitor to enumerate all subdirectories
+   * recursively and add monitors to them.
+   *
+   * @param path complete (non-glob) canonical path to monitor.
+   * @param recursive perform a single recursive search of subdirectories.
+   * @param add_watch (testing only) should an inotify watch be created.
+   * @return success if the inotify watch was created.
+   */
+  bool addMonitor(const std::string& path,
+                  bool recursive,
+                  bool add_watch = true);
+
+  /// Helper method to parse a subscription and add an equivalent monitor.
+  bool monitorSubscription(INotifySubscriptionContextRef& sc,
+                           bool add_watch = true);
 
   /// Remove an INotify watch (monitor) from our tracking.
   bool removeMonitor(const std::string& path, bool force = false);
@@ -145,7 +165,7 @@ class INotifyEventPublisher
   int getHandle() { return inotify_handle_; }
 
   /// Get the number of actual INotify active descriptors.
-  int numDescriptors() { return descriptors_.size(); }
+  size_t numDescriptors() { return descriptors_.size(); }
 
   /// If we overflow, try and restart the monitor
   Status restartMonitoring();
@@ -169,5 +189,6 @@ class INotifyEventPublisher
   friend class INotifyTests;
   FRIEND_TEST(INotifyTests, test_inotify_optimization);
   FRIEND_TEST(INotifyTests, test_inotify_recursion);
+  FRIEND_TEST(INotifyTests, test_inotify_match_subscription);
 };
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -301,15 +301,6 @@ Status listDirectoriesInDirectory(const fs::path& path,
       (path / ((recursive) ? "**" : "*")), results, GLOB_FOLDERS);
 }
 
-Status getDirectory(const fs::path& path, fs::path& dirpath) {
-  if (!isDirectory(path).ok()) {
-    dirpath = fs::path(path).parent_path().string();
-    return Status(0, "OK");
-  }
-  dirpath = path;
-  return Status(1, "Path is a directory: " + path.string());
-}
-
 Status isDirectory(const fs::path& path) {
   boost::system::error_code ec;
   if (fs::is_directory(path, ec)) {


### PR DESCRIPTION
The inotify event publisher needed some more tests, and was not handling `/etc` as a directory to monitor.