### PR TITLE
Add GID to PrivilegeDropper

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -334,6 +334,19 @@ class DropPrivileges : private boost::noncopyable {
   uid_t to_user_;
   /// The group this instance dropped privileges to.
   gid_t to_group_;
+  /// If this was a filesystem-prompted privilege drop.
+  bool fs_drop_{false};
+
+  /**
+   * @brief If dropping explicitly to a user and group also drop groups.
+   *
+   * Original process groups before explicitly dropping privileges.
+   * On restore, if there are any groups in this list, they will be added
+   * to the processes group list.
+   */
+  gid_t* original_groups_{nullptr};
+  /// The size of the original groups to backup when restoring privileges.
+  size_t group_size_{0};
 
  private:
   FRIEND_TEST(PermissionsTests, test_explicit_drop);

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -29,7 +29,7 @@ namespace osquery {
   #define SHA1_CTX SHA_CTX
 #endif
 
-#define HASH_CHUNK_SIZE 1024
+#define HASH_CHUNK_SIZE 4096
 
 Hash::~Hash() {
   if (ctx_ != nullptr) {

--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -150,7 +150,9 @@ void DBHandle::open() {
       throw std::runtime_error(s.ToString());
     }
 
-    VLOG(1) << "Opening RocksDB failed: Continuing with read-only support";
+    if (!kCheckingDB) {
+      VLOG(1) << "Opening RocksDB failed: Continuing with read-only support";
+    }
 #if !defined(ROCKSDB_LITE)
     // RocksDB LITE does not support readonly mode.
     // The database was readable but could not be opened, either (1) it is not

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ argparse
 # needed for integration tests
 pexpect
 thrift
-flaky

--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -12,7 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import flaky
 import os
 import shutil
 import time
@@ -23,7 +22,7 @@ import test_base
 import utils
 
 class AdditionalFeatureTests(test_base.ProcessGenerator, unittest.TestCase):
-    @flaky.flaky(max_runs=3)
+    @test_base.flaky
     def test_query_packs(self):
         query_pack_path = test_base.CONFIG_DIR + "/test_pack.conf"
         utils.write_config({

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -12,7 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import flaky
 import glob
 import os
 import psutil
@@ -240,7 +239,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @flaky.flaky(max_runs=3)
+    @test_base.flaky
     def test_7_extensions_autoload_watchdog(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
@@ -262,7 +261,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
-    @flaky.flaky(max_runs=3)
+    @test_base.flaky
     def test_8_external_config(self):
         loader = test_base.Autoloader(
             [test_base.ARGS.build + "/osquery/example_extension.ext"])
@@ -287,6 +286,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         client.close()
         daemon.kill(True)
 
+    @test_base.flaky
     def test_9_external_config_update(self):
         # Start an extension without a daemon, with a timeout.
         extension = self._run_extension(timeout=EXTENSION_TIMEOUT)

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -12,7 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import flaky
 import os
 import signal
 import shutil
@@ -53,7 +52,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(os.path.exists(info_path))
         daemon.kill()
     
-    @flaky.flaky(max_runs=3)
+    @test_base.flaky
     def test_3_daemon_with_watchdog(self):
         daemon = self._run_daemon({
             "disable_watchdog": False,

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -30,6 +30,7 @@ def allowed_platform(qp):
 
 
 class ReleaseTests(test_base.QueryTester):
+    @test_base.flaky
     def test_pack_queries(self):
         packs = {}
         PACKS_DIR = SOURCE_DIR + "/packs"


### PR DESCRIPTION
The previous privilege dropping logic was incorrect w.r.t to dropping group privilege. This switches the order and drops the effective group before the user.