### PR TITLE
Table results caching

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -201,6 +201,13 @@ specify that interval.
 
 Control the delimiter between pack name and pack query names. When queries are added to the daemon's schedule they inherit the name of the pack. A query named "info" within the "general_info" pack will become "pack_general_info_info". Changing the delimiter to "/" turned the scheduled name into: "pack/general_info/info".
 
+`--disable_caching=false`
+
+"Caching" refers to short cutting the table implementation and returning the same results from the previous query against the table.
+This is not related to differential results from scheduled queries, but does affect the performance of the schedule.
+Results are cached when different scheduled queries in a schedule use the same table, without providing query constraints.
+Caching should NOT affect data freshness since the cache life is determined as the minimum interval of all queries against a table.
+
 `--schedule_default_interval=3600`
 
 Optionally set the default interval value. This is used if you schedule a query

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -130,4 +130,40 @@ TEST_F(TablesTests, test_constraint_map) {
   EXPECT_TRUE(cm["path"].exists());
   EXPECT_TRUE(cm["path"].existsAndMatches("some"));
 }
+
+class TestTablePlugin : public TablePlugin {
+ public:
+  void testSetCache(size_t step, size_t interval) {
+    QueryData r;
+    setCache(step, interval, r);
+  }
+
+  bool testIsCached(size_t interval) { return isCached(interval); }
+};
+
+TEST_F(TablesTests, test_caching) {
+  TestTablePlugin test;
+  // By default the interval and step is 0, so a step of 5 will not be cached.
+  EXPECT_FALSE(test.testIsCached(5));
+
+  TablePlugin::kCacheInterval = 5;
+  TablePlugin::kCacheStep = 1;
+  EXPECT_FALSE(test.testIsCached(5));
+  // Set the current time to 1, and the interval at 5.
+  test.testSetCache(TablePlugin::kCacheStep, TablePlugin::kCacheInterval);
+  // Time at 1 is cached for an interval of 5, so at time 5 the cache is fresh.
+  EXPECT_TRUE(test.testIsCached(5));
+  // 6 is the end of the cache, it is not fresh.
+  EXPECT_FALSE(test.testIsCached(6));
+  // 7 is past the cache, it is not fresh.
+  EXPECT_FALSE(test.testIsCached(7));
+
+  // Set the time at now to 2.
+  TablePlugin::kCacheStep = 2;
+  test.testSetCache(TablePlugin::kCacheStep, TablePlugin::kCacheInterval);
+  EXPECT_TRUE(test.testIsCached(5));
+  // Now 6 is within the freshness of 2 + 5.
+  EXPECT_TRUE(test.testIsCached(6));
+  EXPECT_FALSE(test.testIsCached(7));
+}
 }

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -69,7 +69,7 @@ TEST_F(TablesTests, test_constraint_matching) {
   EXPECT_FALSE(cl.notExistsOrMatches("not_some"));
 
   struct ConstraintList cl2;
-  cl2.affinity = "INTEGER";
+  cl2.affinity = INTEGER_TYPE;
   constraint = Constraint(LESS_THAN);
   constraint.expr = "1000";
   cl2.add(constraint);

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -121,6 +121,8 @@ void SchedulerRunner::start() {
     Config::getInstance().scheduledQueries(
         ([&i](const std::string& name, const ScheduledQuery& query) {
           if (query.splayed_interval > 0 && i % query.splayed_interval == 0) {
+            TablePlugin::kCacheInterval = query.splayed_interval;
+            TablePlugin::kCacheStep = i;
             launchQuery(name, query);
           }
         }));

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -28,7 +28,7 @@ class ExampleConfigPlugin : public ConfigPlugin {
 class ExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
-    return {{"example_text", "TEXT"}, {"example_integer", "INTEGER"}};
+    return {{"example_text", TEXT_TYPE}, {"example_integer", INTEGER_TYPE}};
   }
 
   QueryData generate(QueryContext& request) {

--- a/osquery/examples/example_module.cpp
+++ b/osquery/examples/example_module.cpp
@@ -15,7 +15,7 @@ using namespace osquery;
 class ExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
-    return {{"example_text", "TEXT"}, {"example_integer", "INTEGER"}};
+    return {{"example_text", TEXT_TYPE}, {"example_integer", INTEGER_TYPE}};
   }
 
   QueryData generate(QueryContext& request) {

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -397,8 +397,8 @@ Status getQueryColumnsExternal(const std::string& manager_path,
 
   // Translate response map: {string: string} to a vector: pair(name, type).
   for (const auto& column : response.response) {
-    for (const auto& column_detail : column) {
-      columns.push_back(make_pair(column_detail.first, column_detail.second));
+    for (const auto& col : column) {
+      columns.push_back(make_pair(col.first, columnTypeName(col.second)));
     }
   }
 

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -138,8 +138,8 @@ void ExtensionManagerHandler::getQueryColumns(ExtensionResponse& _return,
   _return.status.uuid = uuid_;
 
   if (status.ok()) {
-    for (const auto& column : columns) {
-      _return.response.push_back({{column.first, column.second}});
+    for (const auto& col : columns) {
+      _return.response.push_back({{col.first, columnTypeName(col.second)}});
     }
   }
 }

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -22,7 +22,7 @@ namespace osquery {
 class BenchmarkTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
-    return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
+    return {{"test_int", INTEGER_TYPE}, {"test_text", TEXT_TYPE}};
   }
 
   QueryData generate(QueryContext& ctx) {
@@ -65,7 +65,7 @@ BENCHMARK(SQL_virtual_table_internal);
 class BenchmarkLongTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
-    return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
+    return {{"test_int", INTEGER_TYPE}, {"test_text", TEXT_TYPE}};
   }
 
   QueryData generate(QueryContext& ctx) {
@@ -99,7 +99,7 @@ class BenchmarkWideTablePlugin : public TablePlugin {
   TableColumns columns() const {
     TableColumns cols;
     for (int i = 0; i < 20; i++) {
-      cols.push_back({"test_" + std::to_string(i), "INTEGER"});
+      cols.push_back({"test_" + std::to_string(i), INTEGER_TYPE});
     }
     return cols;
   }

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -123,7 +123,8 @@ Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
     auto status = this->getQueryColumns(request.at("query"), columns);
     // Convert columns to response
     for (const auto& column : columns) {
-      response.push_back({{"n", column.first}, {"t", column.second}});
+      response.push_back(
+          {{"n", column.first}, {"t", columnTypeName(column.second)}});
     }
     return status;
   } else if (request.at("action") == "attach") {
@@ -148,7 +149,7 @@ Status getQueryColumns(const std::string& q, TableColumns& columns) {
 
   // Convert response to columns
   for (const auto& item : response) {
-    columns.push_back(make_pair(item.at("n"), item.at("t")));
+    columns.push_back(make_pair(item.at("n"), columnTypeName(item.at("t"))));
   }
   return status;
 }

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -224,7 +224,7 @@ Status getQueryColumnsInternal(const std::string& q,
       // (https://www.sqlite.org/c3ref/column_decltype.html).
       col_type = "UNKNOWN";
     }
-    results.push_back({col_name, col_type});
+    results.push_back({col_name, columnTypeName(col_type)});
   }
 
   if (status.ok()) {

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -31,7 +31,7 @@ TEST_F(SQLTests, test_raw_access) {
 class TestTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
-    return {{"test_int", "INTEGER"}, {"test_text", "TEXT"}};
+    return {{"test_int", INTEGER_TYPE}, {"test_text", TEXT_TYPE}};
   }
 
   QueryData generate(QueryContext& ctx) {

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -116,18 +116,15 @@ TEST_F(SQLiteUtilTests, test_get_query_columns) {
   auto status = getQueryColumnsInternal(query, results, dbc.db());
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(2U, results.size());
-  EXPECT_EQ(std::make_pair(std::string("seconds"), std::string("INTEGER")),
-            results[0]);
-  EXPECT_EQ(std::make_pair(std::string("version"), std::string("TEXT")),
-            results[1]);
+  EXPECT_EQ(std::make_pair(std::string("seconds"), INTEGER_TYPE), results[0]);
+  EXPECT_EQ(std::make_pair(std::string("version"), TEXT_TYPE), results[1]);
 
   query = "SELECT hour + 1 AS hour1, minutes + 1 FROM time";
   status = getQueryColumnsInternal(query, results, dbc.db());
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(2U, results.size());
-  EXPECT_EQ(std::make_pair(std::string("hour1"), std::string("UNKNOWN")),
-            results[0]);
-  EXPECT_EQ(std::make_pair(std::string("minutes + 1"), std::string("UNKNOWN")),
+  EXPECT_EQ(std::make_pair(std::string("hour1"), UNKNOWN_TYPE), results[0]);
+  EXPECT_EQ(std::make_pair(std::string("minutes + 1"), UNKNOWN_TYPE),
             results[1]);
 
   query = "SELECT * FROM foo";

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -25,7 +25,7 @@ class sampleTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-        {"foo", "INTEGER"}, {"bar", "TEXT"},
+        {"foo", INTEGER_TYPE}, {"bar", TEXT_TYPE},
     };
   }
 };

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -245,7 +245,7 @@ Status attachTableInternal(const std::string &name,
                            const std::string &statement,
                            sqlite3 *db) {
   if (SQLiteDBManager::isDisabled(name)) {
-    VLOG(0) << "Table " << name << " is disabled, not attaching";
+    VLOG(1) << "Table " << name << " is disabled, not attaching";
     return Status(0, getStringForSQLiteReturnCode(0));
   }
 

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -106,7 +106,7 @@ int xCreate(sqlite3 *db,
 
   for (const auto &column : response) {
     pVtab->content->columns.push_back(
-        std::make_pair(column.at("name"), column.at("type")));
+        std::make_pair(column.at("name"), columnTypeName(column.at("type"))));
   }
 
   *ppVtab = (sqlite3_vtab *)pVtab;
@@ -131,9 +131,9 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
 
   // Attempt to cast each xFilter-populated row/column to the SQLite type.
   const auto &value = pVtab->content->data[pCur->row][column_name];
-  if (type == "TEXT") {
+  if (type == TEXT_TYPE) {
     sqlite3_result_text(ctx, value.c_str(), value.size(), SQLITE_STATIC);
-  } else if (type == "INTEGER") {
+  } else if (type == INTEGER_TYPE) {
     long afinite;
     if (!safeStrtol(value, 10, afinite) || afinite < INT_MIN ||
         afinite > INT_MAX) {
@@ -142,7 +142,7 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
       afinite = -1;
     }
     sqlite3_result_int(ctx, (int)afinite);
-  } else if (type == "BIGINT") {
+  } else if (type == BIGINT_TYPE || UNSIGNED_BIGINT_TYPE) {
     long long afinite;
     if (!safeStrtoll(value, 10, afinite)) {
       VLOG(1) << "Error casting " << column_name << " (" << value
@@ -150,7 +150,7 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
       afinite = -1;
     }
     sqlite3_result_int64(ctx, afinite);
-  } else if (type == "DOUBLE") {
+  } else if (type == DOUBLE_TYPE) {
     char *end = nullptr;
     double afinite = strtod(value.c_str(), &end);
     if (end == nullptr || end == value.c_str() || *end != '\0') {

--- a/specs/centos/rpm_package_files.table
+++ b/specs/centos/rpm_package_files.table
@@ -1,7 +1,7 @@
 table_name("rpm_package_files")
 description("RPM packages that are currently installed on the host system.")
 schema([
-    Column("package", TEXT, "RPM package name"),
+    Column("package", TEXT, "RPM package name", index=True),
     Column("path", TEXT, "Path name"),
     Column("username", TEXT, "File default username from info DB"),
     Column("groupname", TEXT, "File default groupname from info DB"),

--- a/specs/centos/rpm_packages.table
+++ b/specs/centos/rpm_packages.table
@@ -9,4 +9,5 @@ schema([
     Column("sha1", TEXT, "SHA1 hash of the package contents"),
     Column("arch", TEXT, "Architecture(s) supported"),
 ])
+attributes(cachable=True)
 implementation("@genRpmPackages")

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -12,4 +12,5 @@ schema([
     "1 If extension is persistent across all tabs else 0"),
   Column("path", TEXT, "Path to extension folder"),
 ])
+attributes(cachable=True)
 implementation("applications/browser_chrome@genChromeExtensions")

--- a/specs/crontab.table
+++ b/specs/crontab.table
@@ -10,4 +10,5 @@ schema([
     Column("command", TEXT, "Raw command string"),
     Column("path", TEXT, "File parsed"),
 ])
+attributes(cachable=True)
 implementation("crontab@genCronTab")

--- a/specs/darwin/apps.table
+++ b/specs/darwin/apps.table
@@ -28,4 +28,5 @@ schema([
         "Info properties NSAppleScriptEnabled label"),
     Column("copyright", TEXT, "Info properties NSHumanReadableCopyright label"),
 ])
+attributes(cachable=True)
 implementation("apps@genApps")

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -10,4 +10,5 @@ schema([
     Column("native", INTEGER, "Plugin requires native execution"),
     Column("path", TEXT, "Path to plugin bundle"),
 ])
+attributes(cachable=True)
 implementation("applications/browser_plugins@genBrowserPlugins")

--- a/specs/darwin/certificates.table
+++ b/specs/darwin/certificates.table
@@ -13,4 +13,5 @@ schema([
     Column("path", TEXT, "Path to Keychain or PEM bundle"),
 
 ])
+attributes(cachable=True)
 implementation("certificates@genCerts")

--- a/specs/darwin/homebrew_packages.table
+++ b/specs/darwin/homebrew_packages.table
@@ -5,4 +5,5 @@ schema([
     Column("path", TEXT, "Package install path"),
     Column("version", TEXT, "Current 'linked' version"),
 ])
+attributes(cachable=True)
 implementation("system/homebrew_packages@genHomebrewPackages")

--- a/specs/darwin/iokit_devicetree.table
+++ b/specs/darwin/iokit_devicetree.table
@@ -11,4 +11,5 @@ schema([
     Column("retain_count", INTEGER, "The device reference count"),
     Column("depth", INTEGER, "Device nested depth"),
 ])
+attributes(cachable=True)
 implementation("system/iokit_registry@genIOKitDeviceTree")

--- a/specs/darwin/iokit_registry.table
+++ b/specs/darwin/iokit_registry.table
@@ -9,4 +9,5 @@ schema([
     Column("retain_count", INTEGER, "The node reference count"),
     Column("depth", INTEGER, "Node nested depth"),
 ])
+attributes(cachable=True)
 implementation("system/iokit_registry@genIOKitRegistry")

--- a/specs/darwin/keychain_acls.table
+++ b/specs/darwin/keychain_acls.table
@@ -7,6 +7,7 @@ schema([
     Column("description", TEXT, "The description included with the ACL entry"),
     Column("label", TEXT, "An optional label tag that may be included with the keychain entry"),
 ])
+attributes(cachable=True)
 implementation("keychain_acl@genKeychainACLApps")
 examples([
   "select label, description, authorizations, path, count(path) as c from keychain_acls where label != '' and path != '' group by label having c > 1;",

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -9,4 +9,5 @@ schema([
     Column("type", TEXT, "Keychain item type (class)"),
     Column("path", TEXT, "Path to keychain containing item"),
 ])
+attributes(cachable=True)
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/launchd.table
+++ b/specs/darwin/launchd.table
@@ -31,4 +31,5 @@ schema([
     Column("process_type", TEXT,
         "Key describes the intended purpose of the job"),
 ])
+attributes(cachable=True)
 implementation("launchd@genLaunchd")

--- a/specs/darwin/launchd_overrides.table
+++ b/specs/darwin/launchd_overrides.table
@@ -7,4 +7,5 @@ schema([
     Column("uid", BIGINT, "User ID applied to the override, 0 applies to all"),
     Column("path", TEXT, "Path to daemon or agent plist"),
 ])
+attributes(cachable=True)
 implementation("launchd@genLaunchdOverrides")

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -10,4 +10,5 @@ schema([
     Column("description", TEXT, "Optional extension description text"),
     Column("path", TEXT, "Path to extension XAR bundle"),
 ])
+attributes(cachable=True)
 implementation("applications/browser_plugins@genSafariExtensions")

--- a/specs/darwin/sandboxes.table
+++ b/specs/darwin/sandboxes.table
@@ -8,4 +8,5 @@ schema([
     Column("bundle_path", TEXT, "Application bundle used by the sandbox"),
     Column("path", TEXT, "Path to sandbox container directory"),
 ])
+attributes(cachable=True)
 implementation("sandboxes@genSandboxContainers")

--- a/specs/darwin/startup_items.table
+++ b/specs/darwin/startup_items.table
@@ -6,4 +6,5 @@ schema([
     Column("type", TEXT, "Startup Item or Login Item"),
     Column("source", TEXT, "Directory or plist containing startup item"),
 ])
+attributes(cachable=True)
 implementation("startup_items@genStartupItems")

--- a/specs/darwin/wifi_networks.table
+++ b/specs/darwin/wifi_networks.table
@@ -14,4 +14,5 @@ schema([
     Column("temporarily_disabled", INTEGER, "1 if this network is temporarily disabled, 0 otherwise"),
     Column("disabled", INTEGER, "1 if this network is disabled, 0 otherwise"),
 ])
+attributes(cachable=True)
 implementation("networking/wifi@genKnownWifiNetworks")

--- a/specs/darwin/xprotect_entries.table
+++ b/specs/darwin/xprotect_entries.table
@@ -9,4 +9,5 @@ schema([
     Column("optional", INTEGER, "Match any of the identities/patterns for this XProtect name"),
     Column("uses_pattern", INTEGER, "Uses a match pattern instead of identity"),
 ])
+attributes(cachable=True)
 implementation("xprotect@genXProtectEntries")

--- a/specs/darwin/xprotect_meta.table
+++ b/specs/darwin/xprotect_meta.table
@@ -6,4 +6,5 @@ schema([
     Column("developer_id", TEXT, "Developer identity (SHA1) of extension"),
     Column("min_version", TEXT, "The minimum allowed plugin version."),
 ])
+attributes(cachable=True)
 implementation("xprotect@genXProtectMeta")

--- a/specs/etc_hosts.table
+++ b/specs/etc_hosts.table
@@ -4,4 +4,5 @@ schema([
     Column("address", TEXT, "IP address mapping"),
     Column("hostnames", TEXT, "Raw hosts mapping"),
 ])
+attributes(cachable=True)
 implementation("etc_hosts@genEtcHosts")

--- a/specs/etc_protocols.table
+++ b/specs/etc_protocols.table
@@ -6,5 +6,6 @@ schema([
     Column("alias", TEXT, "Protocol alias"),
     Column("comment", TEXT, "Comment with protocol description"),
 ])
+attributes(cachable=True)
 implementation("etc_protocols@genEtcProtocols")
 

--- a/specs/etc_services.table
+++ b/specs/etc_services.table
@@ -7,4 +7,5 @@ schema([
     Column("aliases", TEXT, "Optional space separated list of other names for a service"),
     Column("comment", TEXT, "Optional comment for a service."),
 ])
+attributes(cachable=True)
 implementation("etc_services@genEtcServices")

--- a/specs/firefox_addons.table
+++ b/specs/firefox_addons.table
@@ -20,4 +20,5 @@ schema([
     Column("path", TEXT, "Path to plugin bundle"),
 
 ])
+attributes(cachable=True)
 implementation("applications/browser_firefox@genFirefoxAddons")

--- a/specs/interface_addresses.table
+++ b/specs/interface_addresses.table
@@ -7,4 +7,5 @@ schema([
     Column("broadcast", TEXT, "Broadcast address for the interface"),
     Column("point_to_point", TEXT, "PtP address for the interface"),
 ])
+attributes(cachable=True)
 implementation("interfaces@genInterfaceAddresses")

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -14,4 +14,5 @@ schema([
     Column("oerrors", BIGINT, "Output errors"),
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
 ])
+attributes(cachable=True)
 implementation("interfaces@genInterfaceDetails")

--- a/specs/kernel_info.table
+++ b/specs/kernel_info.table
@@ -6,4 +6,5 @@ schema([
   Column("path", TEXT, "Kernel path"),
   Column("device", TEXT, "Kernel device identifier"),
 ])
+attributes(cachable=True)
 implementation("system/kernel_info@genKernelInfo")

--- a/specs/last.table
+++ b/specs/last.table
@@ -8,4 +8,5 @@ schema([
     Column("time", INTEGER, "Entry timestamp"),
     Column("host", TEXT, "Entry hostname"),
 ])
+attributes(cachable=True)
 implementation("last@genLastAccess")

--- a/specs/listening_ports.table
+++ b/specs/listening_ports.table
@@ -7,4 +7,5 @@ schema([
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),
     Column("address", TEXT, "Specific address for bind"),
 ])
+attributes(cachable=True)
 implementation("listening_ports@genListeningPorts")

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -7,4 +7,5 @@ schema([
     Column("time", INTEGER, "Time entry was made"),
     Column("pid", INTEGER, "Process (or thread) ID"),
 ])
+attributes(cachable=True)
 implementation("logged_in_users@genLoggedInUsers")

--- a/specs/opera_extensions.table
+++ b/specs/opera_extensions.table
@@ -12,4 +12,5 @@ schema([
     "1 If extension is persistent across all tabs else 0"),
   Column("path", TEXT, "Path to extension folder"),
 ])
+attributes(cachable=True)
 implementation("applications/browser_opera@genOperaExtensions")

--- a/specs/routes.table
+++ b/specs/routes.table
@@ -11,4 +11,5 @@ schema([
     Column("metric", INTEGER, "Cost of route. Lowest is preferred"),
     Column("type", TEXT, "Type of route"),
 ])
+attributes(cachable=True)
 implementation("networking/routes@genRoutes")

--- a/specs/suid_bin.table
+++ b/specs/suid_bin.table
@@ -6,4 +6,5 @@ schema([
     Column("groupname", TEXT, "Binary owner group"),
     Column("permissions", TEXT, "Binary permissions"),
 ])
+attributes(cachable=True)
 implementation("suid_bin@genSuidBin")

--- a/specs/system_controls.table
+++ b/specs/system_controls.table
@@ -1,8 +1,8 @@
 table_name("system_controls")
 description("sysctl names, values, and settings information.")
 schema([
-    Column("name", TEXT, "Full sysctl MIB name"),
-    Column("oid", TEXT, "Control MIB"),
+    Column("name", TEXT, "Full sysctl MIB name", index=True),
+    Column("oid", TEXT, "Control MIB", index=True),
     Column("subsystem", TEXT, "Subsystem ID, control type"),
     Column("current_value", TEXT, "Value of setting"),
     Column("config_value", TEXT, "The MIB value set in /etc/sysctl.conf"),

--- a/specs/ubuntu/deb_packages.table
+++ b/specs/ubuntu/deb_packages.table
@@ -8,4 +8,5 @@ schema([
     Column("arch", TEXT, "Package architecture"),
     Column("revision", TEXT, "Package revision")
 ])
+attributes(cachable=True)
 implementation("system/deb_packages@genDebs")

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -37,7 +37,6 @@ PLATFORM = platform()
 
 # Supported SQL types for spec
 class DataType(object):
-
     def __init__(self, affinity, cpp_type="std::string"):
         '''A column datatype is a pair of a SQL affinity to C++ type.'''
         self.affinity = affinity
@@ -47,13 +46,14 @@ class DataType(object):
         return self.affinity
 
 # Define column-type MACROs for the table specs
-TEXT = DataType("TEXT")
-DATE = DataType("TEXT")
-DATETIME = DataType("TEXT")
-INTEGER = DataType("INTEGER", "int")
-BIGINT = DataType("BIGINT", "long long int")
-UNSIGNED_BIGINT = DataType("UNSIGNED_BIGINT", "long long unsigned int")
-DOUBLE = DataType("DOUBLE", "double")
+TEXT = DataType("TEXT_TYPE")
+DATE = DataType("TEXT_TYPE")
+DATETIME = DataType("TEXT_TYPE")
+INTEGER = DataType("INTEGER_TYPE", "int")
+BIGINT = DataType("BIGINT_TYPE", "long long int")
+UNSIGNED_BIGINT = DataType("UNSIGNED_BIGINT_TYPE", "long long unsigned int")
+DOUBLE = DataType("DOUBLE_TYPE", "double")
+BLOB = DataType("BLOB_TYPE", "Blob")
 
 # Define table-category MACROS from the table specs
 UNKNOWN = "UNKNOWN"

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -179,8 +179,16 @@ class TableState(Singleton):
             examples=self.examples,
         )
 
+        column_options = []
+        for column in self.columns():
+            column_options += column.options
+        non_cachable = ["index", "required", "additional", "superuser"]
+        if "cachable" in self.attributes:
+            if len(set(column_options).intersection(non_cachable)) > 0:
+                print(lightred("Table cannot be marked cachable: %s" % (path)))
+                exit(1)
         if self.table_name == "" or self.function == "":
-            print (lightred("Invalid table spec: %s" % (path)))
+            print(lightred("Invalid table spec: %s" % (path)))
             exit(1)
 
         # Check for reserved column names

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -35,7 +35,7 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
   TableColumns columns() const {
     return {
 {% for column in schema %}\
-      {"{{column.name}}", "{{column.type.affinity}}"}\
+      {"{{column.name}}", {{column.type.affinity}}}\
 {% if not loop.last %}, {% endif %}
 {% endfor %}\
     };

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -43,15 +43,24 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 
   QueryData generate(QueryContext& request) {
 {% if class_name != "" %}\
-    if (EventFactory::exists("{{class_name}}")) {
-      auto subscriber = EventFactory::getEventSubscriber("{{class_name}}");
+    if (EventFactory::exists(getName())) {
+      auto subscriber = EventFactory::getEventSubscriber(getName());
       return subscriber->{{function}}(request);
     } else {
-      LOG(ERROR) << "Subscriber table: {{class_name}} missing.";
+      LOG(ERROR) << "Subscriber table missing: " << getName();
       return QueryData();
     }
 {% else %}\
-    return tables::{{function}}(request);
+{% if attributes.cachable %}\
+    if (isCached(kCacheStep)) {
+      return getCache();
+    }
+{% endif %}\
+    auto results = tables::{{function}}(request);
+{% if attributes.cachable %}\
+    setCache(kCacheStep, kCacheInterval, results);
+{% endif %}
+    return results;
 {% endif %}\
   }
 };


### PR DESCRIPTION
1. Table implementations (spec files) can mark the table as 'cachable'.
2. Cached results depend on the shortest/quickest interval of scheduled queries that act on results of the table.
3. The table API generator blocks caching on index/additional/required table column options.