### PR TITLE
Add a `signature` table on Darwin

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -12,6 +12,7 @@ if(APPLE)
   file(GLOB OSQUERY_DARWIN_TABLES_TESTS "*/darwin/tests/*.cpp" "*/darwin/tests/*.mm")
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_DARWIN_TABLES_TESTS})
 
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework Cocoa")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreFoundation")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework Security")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework OpenDirectory")

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/filesystem.hpp>
+#include <Cocoa/Cocoa.h>                /* For NSAppKitVersionNumber */
+#include <Foundation/Foundation.h>
+#include <Security/CodeSigning.h>
+
+#include <osquery/core.h>
+#include <osquery/core/conversions.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+void genSignatureForFile(const std::string& path,
+                         QueryData& results) {
+  Row r;
+  OSStatus result;
+
+  // Defaults
+  r["path"] = path;
+  r["signed"] = INTEGER(0);
+  r["identifier"] = "";
+
+  // Create a URL that points to this file.
+  auto url = (__bridge CFURLRef)[NSURL fileURLWithPath:@(path.c_str())];
+  if (url == nullptr) {
+    VLOG(1) << "Could not create URL from file: " << path;
+    return;
+  }
+
+  // Create the static code object.
+  SecStaticCodeRef staticCode;
+  result = SecStaticCodeCreateWithPath(url, kSecCSDefaultFlags, &staticCode);
+  if (result != 0) {
+    VLOG(1) << "Could not create static code object for file: " << path;
+    return;
+  }
+
+  // Set up the flags - some of them aren't present on 10.8.
+  SecCSFlags csFlags;
+  if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_8) {
+    csFlags = kSecCSDefaultFlags | kSecCSCheckNestedCode;
+  } else {
+    csFlags = kSecCSBasicValidateOnly;
+  }
+
+  // Actually validate.
+  result = SecStaticCodeCheckValidityWithErrors(staticCode, csFlags, NULL, NULL);
+  if (result == 0) {
+    CFDictionaryRef codeInfo;
+
+    result = SecCodeCopySigningInformation(
+      staticCode,
+      kSecCSSigningInformation | kSecCSRequirementInformation,
+      &codeInfo);
+    if (result == 0) {
+      // If we don't get an identifier for this file, then it's not signed.
+      CFStringRef ident = (CFStringRef)CFDictionaryGetValue(codeInfo, kSecCodeInfoIdentifier);
+      if (ident != nullptr) {
+        // We have an identifier - this indicates that the file is signed, and, since
+        // it didn't error above, it's *also* a valid signature.
+        r["signed"] = INTEGER(1);
+        r["identifier"] = stringFromCFString(ident);
+
+        // TODO(andrew-d): can get more information from the signature here?
+      } else {
+        VLOG(1) << "No identifier found for file: " << path;
+      }
+
+      CFRelease(codeInfo);
+    } else {
+      VLOG(1) << "Could not get signing information for file: " << path;
+    }
+  } else {
+    // If this errors, then we either don't have a signature, or it's malformed.
+    VLOG(1) << "Static code validity check failed for file: " << path;
+  }
+
+  results.push_back(r);
+  CFRelease(staticCode);
+}
+
+QueryData genSignature(QueryContext& context) {
+  QueryData results;
+
+  // The query must provide a predicate with constraints including path or
+  // directory. We search for the parsed predicate constraints with the equals
+  // operator.
+  auto paths = context.constraints["path"].getAll(EQUALS);
+  for (const auto& path_string : paths) {
+    boost::filesystem::path path = path_string;
+
+    // Note: we are explicitly *not* using is_regular_file here, since you can
+    // pass a directory path to the verification functions (e.g. for app
+    // bundles, etc.)
+    if (!pathExists(path).ok()) {
+      continue;
+    }
+
+    genSignatureForFile(path_string, results);
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/darwin/tests/signature_tests.mm
+++ b/osquery/tables/system/darwin/tests/signature_tests.mm
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#include <gtest/gtest.h>
+#include <boost/filesystem/operations.hpp>
+#include <boost/make_unique.hpp>
+#include <mach-o/dyld.h>
+
+#include "osquery/core/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+void genSignatureForFile(const std::string& path, QueryData& results);
+
+// Gets the full path to the current executable (only works on Darwin)
+std::string getExecutablePath() {
+  uint32_t size = 1024;
+
+  while (true) {
+    auto buf = boost::make_unique<char[]>(size);
+
+    if (_NSGetExecutablePath(buf.get(), &size) == 0) {
+      return std::string(buf.get());
+    }
+
+    // If we get here, the buffer wasn't large enough, and we need to
+    // reallocate.  We just continue the loop and will reallocate above.
+  }
+}
+
+// Get the full, real path to the current executable (only works on Darwin).
+std::string getRealExecutablePath() {
+  auto path = getExecutablePath();
+  return fs::canonical(path).string();
+}
+
+class SignatureTest : public testing::Test {
+ protected:
+  void SetUp() {
+    tempFile = kTestWorkingDirectory + "darwin-signature";
+  }
+
+  void TearDown() {
+    // End the event loops, and join on the threads.
+    fs::remove_all(tempFile);
+  }
+
+ protected:
+  std::string tempFile;
+};
+
+/*
+ * Ensures that the signature for a signed binary is correct.
+ *
+ * We use `/bin/ls` as the test binary, since it should be present "everywhere".
+ */
+TEST_F(SignatureTest, test_get_valid_signature) {
+  std::string path = "/bin/ls";
+
+  QueryData results;
+  genSignatureForFile(path, results);
+
+  Row expected = {
+      {"path", path},
+      {"signed", "1"},
+      {"identifier", "com.apple.ls"},
+  };
+
+  for (const auto& column : expected) {
+    EXPECT_EQ(results.front()[column.first], column.second);
+  }
+}
+
+/*
+ * Ensures that the results for an unsigned binary are correct.
+ *
+ * We use the currently-running binary as the 'unsigned binary', rather than
+ * relying on a particular binary to be present.
+ */
+TEST_F(SignatureTest, test_get_unsigned) {
+  std::string path = getRealExecutablePath();
+
+  QueryData results;
+  genSignatureForFile(path, results);
+
+  Row expected = {
+      {"path", path},
+      {"signed", "0"},
+      {"identifier", ""},
+  };
+
+  for (const auto& column : expected) {
+    EXPECT_EQ(results.front()[column.first], column.second);
+  }
+}
+
+/*
+ * Ensures that the results for a signed but invalid binary are correct.
+ *
+ * This test is a bit of a hack - we copy an existing signed binary (/bin/ls,
+ * like above), and then modify one byte in the middle of the file by XORing it
+ * with 0xBA.  This should ensure that it differs from whatever the original
+ * byte was, and should thus invalidate the signature.
+ */
+TEST_F(SignatureTest, test_get_invalid_signature) {
+  std::string originalPath = "/bin/ls";
+  std::string newPath = tempFile;
+
+  // Create a buffer to hold the entire file.
+  std::vector<uint8_t> binary;
+  binary.resize(fs::file_size(originalPath));
+  ASSERT_TRUE(binary.size() > 0);
+
+  // Open existing file
+  FILE* f = fopen(originalPath.c_str(), "rb");
+  ASSERT_TRUE(f != nullptr);
+
+  // Read it to memory
+  auto nread = fread(&binary[0], sizeof(uint8_t), binary.size(), f);
+  fclose(f);
+  ASSERT_EQ(nread, binary.size());
+
+  // Actually modify a byte.
+  size_t offset = binary.size() / 2;
+  binary[offset] = binary[offset] ^ 0xBA;
+
+  // Write it back to a file.
+  f = fopen(newPath.c_str(), "wb");
+  ASSERT_TRUE(f != nullptr);
+  fwrite(&binary[0], sizeof(uint8_t), binary.size(), f);
+  fclose(f);
+
+  // Get the signature of this new file.
+  QueryData results;
+  genSignatureForFile(newPath, results);
+
+  Row expected = {
+      {"path", newPath},
+      {"signed", "0"},
+      {"identifier", ""},
+  };
+
+  for (const auto& column : expected) {
+    EXPECT_EQ(results.front()[column.first], column.second);
+  }
+}
+
+}
+}
+

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -1,0 +1,11 @@
+table_name("signature")
+description("File signature status.  Note: verifying a signature can be an expensive operation!")
+schema([
+    Column("path", TEXT, "Must provide a path or directory", required=True),
+    Column("signed", INTEGER, "1 If the file is signed else 0"),
+    Column("identifier", TEXT, "The signing identifier sealed into the signature"),
+])
+implementation("signature@genSignature")
+examples([
+  "select * from signature where path = '/bin/ls'",
+])


### PR DESCRIPTION
This table allows verifying the signature of files (or bundles) on
Darwin.  It also provides the signing identifier that is a part of the
signature.

I've made a couple of possibly-controversial changes here, most important of which is adding a dependency on the Cocoa framework in order to get access to NSAppKitVersionNumber.  If this is something you'd rather not support, let me know and I'd be happy to strip that portion out.