### PR TITLE
Add timezone field to time table

### DIFF
--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -25,6 +25,9 @@ QueryData genTime(QueryContext& context) {
   char weekday[10] = {0};
   strftime(weekday, sizeof(weekday), "%A", now);
 
+  char timezone[5] = {0};
+  strftime(timezone, sizeof(timezone), "%Z", now);
+
   std::string timestamp;
   timestamp = asctime(gmt);
   boost::algorithm::trim(timestamp);
@@ -40,6 +43,7 @@ QueryData genTime(QueryContext& context) {
   r["hour"] = INTEGER(now->tm_hour);
   r["minutes"] = INTEGER(now->tm_min);
   r["seconds"] = INTEGER(now->tm_sec);
+  r["timezone"] = TEXT(timezone);
   r["unix_time"] = INTEGER(_time);
   r["timestamp"] = TEXT(timestamp);
   r["iso_8601"] = TEXT(iso_8601);

--- a/specs/utility/time.table
+++ b/specs/utility/time.table
@@ -8,6 +8,7 @@ schema([
     Column("hour", INTEGER, "Current hour in the system"),
     Column("minutes", INTEGER, "Current minutes in the system"),
     Column("seconds", INTEGER, "Current seconds in the system"),
+    Column("timezone", TEXT, "Current timezone in the system"),
     Column("unix_time", INTEGER, "Current UNIX time in the system"),
     Column("timestamp", TEXT, "Current timestamp in the system"),
     Column("iso_8601", TEXT, "Current time (iso format) in the system"),


### PR DESCRIPTION
So, this is the minimum version of what is necessary.  In an ideal world, we could pull in [ICU](http://site.icu-project.org/) and use that [to get the Olson timezone](http://userguide.icu-project.org/datetime/timezone).  That does pull in another dependency, so I'm not going to do that for now.

However, for future reference, this does more-or-less the right thing:

```
#include <unicode/timezone.h>
#include <iostream>

using namespace U_ICU_NAMESPACE;

std::string getTimezone() {
  TimeZone* tz = TimeZone::createDefault();
  UnicodeString us;
  tz->getID(us);

  std::string s;
  us.toUTF8String(s);

  delete tz;
  return s;
}

int main() {
  auto tz = getTimezone();
  std::cout << "Current timezone ID: " << tz << std::endl;
  return 0;
}
```