### PR TITLE
Allow setting the mode of log files

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -266,6 +266,12 @@ Enable verbose informational messages.
 
 Directory path for ERROR/WARN/INFO and results logging.
 
+`--logger_mode=640`
+
+File mode for output log files (provided as an octal string).  Note that this
+affects both the query result log and the status logs.
+**Warning**: If run as root, log files may contain sensitive information!
+
 `--value_max=512`
 
 Maximum returned row value size.

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -93,5 +93,39 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         acceptable_retcodes = [-1, -2, -1 * signal.SIGINT]
         self.assertTrue(daemon.retcode in acceptable_retcodes)
 
+    def test_6_logger_mode(self):
+        logger_path = os.path.join(test_base.CONFIG_DIR, "logger-mode-tests")
+        os.makedirs(logger_path)
+
+        test_mode = 0754        # Strange mode that should never exist
+        daemon = self._run_daemon({
+            "disable_watchdog": True,
+            "disable_extensions": True,
+            "disable_logging": False,
+        },
+        options_only={
+            "logger_path": logger_path,
+            "logger_mode": test_mode,
+            "verbose": True,
+        })
+        info_path = os.path.join(logger_path, "osqueryd.INFO")
+        self.assertTrue(daemon.isAlive())
+
+        def info_exists():
+            return os.path.exists(info_path)
+        # Wait for the daemon to flush to GLOG.
+        test_base.expectTrue(info_exists)
+
+        # Both log files should exist and have the given mode.
+        for fname in ['osqueryd.INFO', 'osqueryd.results.log']:
+            pth = os.path.join(logger_path, fname)
+            self.assertTrue(os.path.exists(pth))
+
+            rpath = os.path.realpath(info_path)
+            mode = os.stat(rpath).st_mode & 0777
+            self.assertEqual(mode, test_mode)
+
+        daemon.kill()
+
 if __name__ == '__main__':
     test_base.Tester().run()


### PR DESCRIPTION
This is useful in cases where you want an external process (e.g. a log forwarder running with dropped privs) to be able to read the log files, but still want to run `osqueryd` as root in order to gather information.

Quick note: I'm not sure why, but the test isn't working as expected.  Any idea why that might be?  This is the only actual mode I was able to find in the codebase.