### PR TITLE
Refactor how we determine the OS version in the signature table

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -12,7 +12,6 @@ if(APPLE)
   file(GLOB OSQUERY_DARWIN_TABLES_TESTS "*/darwin/tests/*.cpp" "*/darwin/tests/*.mm")
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_DARWIN_TABLES_TESTS})
 
-  ADD_OSQUERY_LINK_ADDITIONAL("-framework Cocoa")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreFoundation")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework Security")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework OpenDirectory")


### PR DESCRIPTION
I wasn't super happy with the new dependency on Cocoa, so I took another look at how other parts of `osquery` determined the system version and copied them.  Upside: less dependencies!  Downside: slightly more code :disappointed: 

P.S. Sorry for all the PRs today :smile: 