### PR TITLE
freebsd process table: Fix EUID/EGID to not use saved IDs

### DIFF
--- a/osquery/tables/system/freebsd/processes.cpp
+++ b/osquery/tables/system/freebsd/processes.cpp
@@ -124,9 +124,9 @@ void genProcess(struct procstat* pstat,
   r["parent"] = INTEGER(proc->ki_ppid);
   r["name"] = TEXT(proc->ki_comm);
   r["uid"] = INTEGER(proc->ki_ruid);
-  r["euid"] = INTEGER(proc->ki_svuid);
+  r["euid"] = INTEGER(proc->ki_uid);
   r["gid"] = INTEGER(proc->ki_rgid);
-  r["egid"] = INTEGER(proc->ki_svgid);
+  r["egid"] = INTEGER(proc->ki_groups[0]);
 
   if (procstat_getpathname(pstat, proc, path, sizeof(path)) == 0) {
     r["path"] = TEXT(path);


### PR DESCRIPTION
It's not totally clear why saved IDs were used here. There is some precident in
sigar (https://github.com/hyperic/sigar), where they also use the saved UID,
but me and @wxsBSD are not really sure why. Maybe it's because kinfo_proc feels
different than similar structs on other Unices.

Fixes #1662.