### PR TITLE
[#1497] Add user_events table based on audit user-type messages

### DIFF
--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -94,6 +94,9 @@ struct AuditSubscriptionContext : public SubscriptionContext {
    */
   std::set<int> types;
 
+  /// Macro for all types related to user messages.
+  bool user_types{false};
+
  private:
   friend class AuditEventPublisher;
 };

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/config.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
+
+#include "osquery/events/linux/audit.h"
+
+namespace osquery {
+
+// Depend on the external getUptime table method.
+namespace tables {
+extern long getUptime();
+}
+
+// From process_events.
+extern std::string decodeAuditValue(const std::string& s);
+
+class UserEventSubscriber : public EventSubscriber<AuditEventPublisher> {
+ public:
+  /// The user event subscriber declares an audit event type subscription.
+  Status init();
+
+  Status Callback(const AuditEventContextRef& ec, const void* user_data);
+};
+
+REGISTER(UserEventSubscriber, "event_subscriber", "user_events");
+
+Status UserEventSubscriber::init() {
+  auto sc = createSubscriptionContext();
+
+  // Request call backs for all user-related auditd events.
+  sc->user_types = true;
+  subscribe(&UserEventSubscriber::Callback, sc, nullptr);
+
+  return Status(0, "OK");
+}
+
+Status UserEventSubscriber::Callback(const AuditEventContextRef& ec,
+                                     const void* user_data) {
+  Row r;
+  r["uid"] = ec->fields["uid"];
+  r["pid"] = ec->fields["pid"];
+  r["message"] = ec->fields["msg"];
+  r["type"] = INTEGER(ec->type);
+  r["path"] = decodeAuditValue(ec->fields["exe"]);
+  r["address"] = ec->fields["addr"];
+  r["terminal"] = ec->fields["terminal"];
+  r["uptime"] = INTEGER(tables::getUptime());
+
+  add(r, getUnixTime());
+  return Status(0, "OK");
+}
+} // namespace osquery

--- a/specs/linux/user_events.table
+++ b/specs/linux/user_events.table
@@ -1,0 +1,15 @@
+table_name("user_events")
+description("Track user events from the audit framework.")
+schema([
+    Column("uid", BIGINT, "User ID"),
+    Column("pid", BIGINT, "Process (or thread) ID"),
+    Column("message", TEXT, "Path of executed file"),
+    Column("type", INTEGER, "The file description for the process socket"),
+    Column("path", TEXT, "The socket open attempt status"),
+    Column("address", TEXT, "The Internet protocol family ID"),
+    Column("terminal", TEXT, "The network protocol ID"),
+    Column("time", BIGINT, "Time of execution in UNIX time"),
+    Column("uptime", BIGINT, "Time of execution in system uptime"),
+])
+attributes(event_subscriber=True)
+implementation("user_events@user_events::genTable")


### PR DESCRIPTION
This captures the USER* related audit messages in a `user_events` table. This table is *for now* Linux only. 