### PR TITLE
[#1648] Support multiple loggers

### DIFF
--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -49,9 +49,9 @@ Status SyslogLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
       severity = LOG_CRIT;
     }
 
-    std::string line = "severity=" + std::to_string(item.severity)
-                    + " location=" + item.filename + ":" + std::to_string(item.line) +
-                      " message=" + item.message;
+    std::string line = "severity=" + std::to_string(item.severity) +
+                       " location=" + item.filename + ":" +
+                       std::to_string(item.line) + " message=" + item.message;
 
     syslog(severity, "%s", line.c_str());
   }
@@ -63,8 +63,7 @@ Status SyslogLoggerPlugin::init(const std::string& name,
   closelog();
 
   // Define the syslog/target's application name.
-  if (FLAGS_logger_syslog_facility < 0 ||
-      FLAGS_logger_syslog_facility > 23) {
+  if (FLAGS_logger_syslog_facility < 0 || FLAGS_logger_syslog_facility > 23) {
     FLAGS_logger_syslog_facility = LOG_LOCAL3 >> 3;
   }
   openlog(name.c_str(), LOG_PID | LOG_CONS, FLAGS_logger_syslog_facility << 3);

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -174,4 +174,29 @@ TEST_F(LoggerTests, test_logger_snapshots) {
   logHealthStatus(item);
   EXPECT_EQ(LoggerTests::health_status_rows, 1);
 }
+
+class SecondTestLoggerPlugin : public TestLoggerPlugin {};
+
+TEST_F(LoggerTests, test_multiple_loggers) {
+  Registry::add<SecondTestLoggerPlugin>("logger", "second_test");
+  EXPECT_TRUE(Registry::setActive("logger", "test,second_test").ok());
+
+  // With two active loggers, the string should be added twice.
+  logString("this is a test", "added");
+  EXPECT_EQ(LoggerTests::log_lines.size(), 2U);
+
+  LOG(WARNING) << "Logger test is generating a warning status (4)";
+  // Refer to the above notes about status logs not emitting until the logger
+  // it initialized. We do a 0-test to check for dead locks around attempting
+  // to forward Glog-based sinks recursively into our sinks.
+  EXPECT_EQ(LoggerTests::statuses_logged, 0);
+
+  // Now try to initialize multiple loggers (1) forwards, (2) does not.
+  Registry::setActive("logger", "test,filesystem");
+  initLogger("logger_test");
+  LOG(WARNING) << "Logger test is generating a warning status (5)";
+  // Now that the "test" logger is initialized, the status log will be
+  // forwarded.
+  EXPECT_EQ(LoggerTests::statuses_logged, 1);
+}
 }

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -210,6 +210,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = test_base.EXClient(extension.options["extensions_socket"])
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open(timeout=EXTENSION_TIMEOUT))
         em = client.getEM()
 
@@ -307,6 +308,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client to the manager and extension.
         client = test_base.EXClient(extension.options["extensions_socket"])
+        test_base.expectTrue(client.open)
         self.assertTrue(client.open(timeout=EXTENSION_TIMEOUT))
         em = client.getEM()
 
@@ -316,6 +318,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         ex_uuid = result.keys()[0]
         client2 = test_base.EXClient(extension.options["extensions_socket"],
             uuid=ex_uuid)
+        test_base.expectTrue(client2.open)
         self.assertTrue(client2.open(timeout=EXTENSION_TIMEOUT))
         ex = client2.getEX()
 


### PR DESCRIPTION
This is mostly a PoC for multiple "active" plugins. Setting a comma-separated list of loggers on start should turn them both on and send all messages to both simultaneously, serially.