### PR TITLE
Fix clang-analyzer warning

### DIFF
--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -55,7 +55,7 @@ size_t splayValue(size_t original, size_t splayPercent) {
   std::default_random_engine generator;
   generator.seed(
       std::chrono::high_resolution_clock::now().time_since_epoch().count());
-  std::uniform_int_distribution<size_t> distribution(min_value, max_value);
+  std::uniform_int_distribution<uint32_t> distribution(min_value, max_value);
   return distribution(generator);
 }
 


### PR DESCRIPTION
Kept running into this clang analyzer warning with Xcode 7.1.1 and clang-700.1.76 on OS X 10.10.5

```
[ 11%] Building CXX object osquery/config/CMakeFiles/osquery_config.dir/packs.cpp.o
In file included from /Users/sbs/projects/osquery/osquery/config/packs.cpp:11:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/algorithm:2920:52: 
warning: The result of the '>>' expression is undefined
    __mask0_ = __w0_ > 0 ? _Engine_result_type(~0) >> (_EDt - __w0_) :
                           ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
1 warning generated.
```

Traced it to `std::uniform_int_distribution` which takes `IntType` as the template parameter, and is undefined if it's not one of the `IntType`. Switched it to using `uint32_t` instead of `size_t` and clang-analyzer is happy.