### PR TITLE
[#1665, #1615] Refactor user-based tables to act uniformly

### DIFF
--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -298,4 +298,12 @@ void ConstraintList::unserialize(const boost::property_tree::ptree& tree) {
   }
   affinity = columnTypeName(tree.get<std::string>("affinity", "UNKNOWN"));
 }
+
+bool QueryContext::hasConstraint(const std::string& column,
+                                 ConstraintOperator op) const {
+  if (constraints.count(column) == 0) {
+    return false;
+  }
+  return constraints.at(column).exists(op);
+}
 }

--- a/osquery/tables/applications/browser_utils.h
+++ b/osquery/tables/applications/browser_utils.h
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+
 #include <boost/property_tree/json_parser.hpp>
 
 #include <osquery/filesystem.h>
@@ -18,7 +19,8 @@ namespace pt = boost::property_tree;
 namespace osquery {
 namespace tables {
 
-QueryData genChromeBasedExtensions(QueryContext& context, const fs::path sub_dir);
+QueryData genChromeBasedExtensions(QueryContext& context,
+                                   const fs::path& sub_dir);
 
 /// A helper check to rename bool-type values as 1 or 0.
 inline void jsonBoolAsInt(std::string& s) {

--- a/osquery/tables/system/authorized_keys.cpp
+++ b/osquery/tables/system/authorized_keys.cpp
@@ -14,18 +14,18 @@
 #include <osquery/core.h>
 #include <osquery/tables.h>
 #include <osquery/filesystem.h>
-#include <osquery/sql.h>
+
+#include "osquery/tables/system/system_utils.h"
 
 namespace osquery {
 namespace tables {
 
-const std::vector<std::string> kSSHAuthorizedkeys = {
-    ".ssh/authorized_keys",".ssh/authorized_keys2"
-};
+const std::vector<std::string> kSSHAuthorizedkeys = {".ssh/authorized_keys",
+                                                     ".ssh/authorized_keys2"};
 
-void genSSHkeysForUser(const std::string& username,
-                            const std::string& directory,
-                            QueryData& results) {
+void genSSHkeysForUser(const std::string& uid,
+                       const std::string& directory,
+                       QueryData& results) {
   for (const auto& kfile : kSSHAuthorizedkeys) {
     boost::filesystem::path keys_file = directory;
     keys_file /= kfile;
@@ -40,7 +40,7 @@ void genSSHkeysForUser(const std::string& username,
     for (const auto& line : split(keys_content, "\n")) {
       if (!line.empty() && line[0] != '#') {
         Row r;
-        r["username"] = username;
+        r["uid"] = uid;
         r["key"] = line;
         r["key_file"] = keys_file.string();
         results.push_back(r);
@@ -52,24 +52,11 @@ void genSSHkeysForUser(const std::string& username,
 QueryData getAuthorizedKeys(QueryContext& context) {
   QueryData results;
 
-  // Select only the home directory for this user.
-  QueryData users;
-  if (!context.constraints["username"].exists(EQUALS)) {
-    users =
-        SQL::selectAllFrom("users", "uid", EQUALS, std::to_string(getuid()));
-  } else {
-    auto usernames = context.constraints["username"].getAll(EQUALS);
-    for (const auto& username : usernames) {
-      // Use a predicated select all for each user.
-      auto user = SQL::selectAllFrom("users", "username", EQUALS, username);
-      users.insert(users.end(), user.begin(), user.end());
-    }
-  }
-
   // Iterate over each user
+  QueryData users = usersFromContext(context);
   for (const auto& row : users) {
-    if (row.count("username") > 0 && row.count("directory") > 0) {
-       genSSHkeysForUser(row.at("username"), row.at("directory"), results);
+    if (row.count("uid") > 0 && row.count("directory") > 0) {
+      genSSHkeysForUser(row.at("uid"), row.at("directory"), results);
     }
   }
 

--- a/osquery/tables/system/system_utils.cpp
+++ b/osquery/tables/system/system_utils.cpp
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/sql.h>
+
+#include "osquery/tables/system/system_utils.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData usersFromContext(const QueryContext& context, bool all) {
+  QueryData users;
+  if (context.hasConstraint("uid", EQUALS)) {
+    context.forEachConstraint(
+        "uid",
+        EQUALS,
+        ([&users](const std::string& expr) {
+          auto user = SQL::selectAllFrom("users", "uid", EQUALS, expr);
+          users.insert(users.end(), user.begin(), user.end());
+        }));
+  } else if (!all) {
+    users =
+        SQL::selectAllFrom("users", "uid", EQUALS, std::to_string(getuid()));
+  } else {
+    users = SQL::selectAllFrom("users");
+  }
+  return users;
+}
+
+QueryData pidsFromContext(const QueryContext& context, bool all) {
+  QueryData procs;
+  if (context.hasConstraint("pid", EQUALS)) {
+    context.forEachConstraint(
+        "pid",
+        EQUALS,
+        ([&procs](const std::string& expr) {
+          auto proc = SQL::selectAllFrom("processes", "pid", EQUALS, expr);
+          procs.insert(procs.end(), procs.begin(), procs.end());
+        }));
+  } else if (!all) {
+    procs = SQL::selectAllFrom(
+        "processes", "pid", EQUALS, std::to_string(getpid()));
+  } else {
+    procs = SQL::selectAllFrom("processes");
+  }
+  return procs;
+}
+}
+}

--- a/osquery/tables/system/system_utils.h
+++ b/osquery/tables/system/system_utils.h
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Get a list of users given a context.
+ *
+ * If no user is provided the current user is returned.
+ *
+ * @param context The context given to a table implementation.
+ * @param optional all Return all users regardless of context.
+ * @return A complete set of rows for each user.
+ */
+QueryData usersFromContext(const QueryContext& context, bool all = false);
+
+/**
+ * Get a list of pids given a context.
+ *
+ * If no pid is provided all pids are returned.
+ *
+ * @param context The context given to a table implementation.
+ * @param optional Return all pids regardless of context.
+ * @return A complete set of rows for each process.
+ */
+QueryData pidsFromContext(const QueryContext& context, bool all = true);
+}
+}

--- a/specs/authorized_keys.table
+++ b/specs/authorized_keys.table
@@ -1,11 +1,12 @@
 table_name("authorized_keys")
-description("A line-delimited authorized_keys table of per-user")
+description("A line-delimited authorized_keys table.")
 schema([
-    Column("username", TEXT, "authorized_keys of owner",
+    Column("uid", BIGINT, "The local owner of authorized_keys file",
       additional=True),
     Column("algorithm",TEXT,"algorithim of key"),
     Column("key", TEXT, "parsed authorized keys line"),
-    Column("key_file", TEXT, "Path to the authorized_keys for this user"),
-    ForeignKey(column="username", table="users"),
+    Column("key_file", TEXT, "Path to the authorized_keys file"),
+    ForeignKey(column="uid", table="users"),
 ])
+attributes(user_data=True)
 implementation("authorized_keys@getAuthorizedKeys")

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -1,6 +1,8 @@
 table_name("chrome_extensions")
 description("Chrome browser extensions.")
 schema([
+  Column("uid", BIGINT, "The local user that owns the extension",
+    additional=True),
   Column("name", TEXT, "Extension display name"),
   Column("identifier", TEXT, "Extension identifier"),
   Column("version", TEXT, "Extension-supplied version"),
@@ -11,6 +13,7 @@ schema([
   Column("persistent", INTEGER,
     "1 If extension is persistent across all tabs else 0"),
   Column("path", TEXT, "Path to extension folder"),
+  ForeignKey(column="uid", table="users"),
 ])
-attributes(cachable=True)
+attributes(user_data=True)
 implementation("applications/browser_chrome@genChromeExtensions")

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -1,6 +1,8 @@
 table_name("browser_plugins")
 description("All C/NPAPI browser plugin details for all users.")
 schema([
+    Column("uid", BIGINT, "The local user that owns the plugin",
+      additional=True),
     Column("name", TEXT, "Plugin display name"),
     Column("identifier", TEXT, "Plugin identifier"),
     Column("version", TEXT, "Plugin short version"),
@@ -9,6 +11,7 @@ schema([
     Column("development_region", TEXT, "Plugin language-localization"),
     Column("native", INTEGER, "Plugin requires native execution"),
     Column("path", TEXT, "Path to plugin bundle"),
+    ForeignKey(column="uid", table="users")
 ])
-attributes(cachable=True)
+attributes(user_data=True)
 implementation("applications/browser_plugins@genBrowserPlugins")

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -1,6 +1,8 @@
 table_name("safari_extensions")
 description("Safari browser extension details for all users.")
 schema([
+    Column("uid", BIGINT, "The local user that owns the extension",
+      additional=True),
     Column("name", TEXT, "Extension display name"),
     Column("identifier", TEXT, "Extension identifier"),
     Column("version", TEXT, "Extension long version"),
@@ -9,6 +11,10 @@ schema([
     Column("author", TEXT, "Optional extension author"),
     Column("description", TEXT, "Optional extension description text"),
     Column("path", TEXT, "Path to extension XAR bundle"),
+    ForeignKey(column="uid", table="users")
 ])
-attributes(cachable=True)
+attributes(user_data=True)
 implementation("applications/browser_plugins@genSafariExtensions")
+examples([
+  "select count(*) from users JOIN safari_extensions using (uid)",
+])

--- a/specs/firefox_addons.table
+++ b/specs/firefox_addons.table
@@ -1,6 +1,8 @@
 table_name("firefox_addons")
 description("Firefox browser extensions, webapps, and addons.")
 schema([
+    Column("uid", BIGINT, "The local user that owns the addon",
+        additional=True),
     Column("name", TEXT, "Addon display name"),
     Column("identifier", TEXT, "Addon identifier"),
     Column("creator", TEXT, "Addon-supported creator string"),
@@ -18,7 +20,7 @@ schema([
       "1 If the addon includes binary components else 0"),
     Column("location", TEXT, "Global, profile location"),
     Column("path", TEXT, "Path to plugin bundle"),
-
+    ForeignKey(column="uid", table="users"),
 ])
-attributes(cachable=True)
+attributes(user_data=True)
 implementation("applications/browser_firefox@genFirefoxAddons")

--- a/specs/known_hosts.table
+++ b/specs/known_hosts.table
@@ -1,10 +1,11 @@
 table_name("known_hosts")
-description("A line-delimited known_hosts table of per-user")
+description("A line-delimited known_hosts table.")
 schema([
-    Column("username", TEXT, "authorized_keys of owner",
+    Column("uid", BIGINT, "The local user that owns the known_hosts file",
       additional=True),
     Column("key", TEXT, "parsed authorized keys line"),
-    Column("key_file", TEXT, "Path to the authorized_keys for this user"),
-    ForeignKey(column="username", table="users"),
+    Column("key_file", TEXT, "Path to known_hosts file"),
+    ForeignKey(column="uid", table="users"),
 ])
+attributes(user_data=True)
 implementation("known_hosts@getKnownHostsKeys")

--- a/specs/opera_extensions.table
+++ b/specs/opera_extensions.table
@@ -1,6 +1,8 @@
 table_name("opera_extensions")
 description("Opera browser extensions.")
 schema([
+  Column("uid", BIGINT, "The local user that owns the extension",
+    additional=True),
   Column("name", TEXT, "Extension display name"),
   Column("identifier", TEXT, "Extension identifier"),
   Column("version", TEXT, "Extension-supplied version"),
@@ -11,6 +13,7 @@ schema([
   Column("persistent", INTEGER,
     "1 If extension is persistent across all tabs else 0"),
   Column("path", TEXT, "Path to extension folder"),
+  ForeignKey(column="uid", table="users"),
 ])
-attributes(cachable=True)
+attributes(user_data=True)
 implementation("applications/browser_opera@genOperaExtensions")

--- a/specs/shell_history.table
+++ b/specs/shell_history.table
@@ -1,10 +1,10 @@
 table_name("shell_history")
 description("A line-delimited (command) table of per-user .*_history data.")
 schema([
-    Column("username", TEXT, "Shell history owner",
-      additional=True),
+    Column("uid", BIGINT, "Shell history owner", additional=True),
     Column("command", TEXT, "Unparsed date/line/command history line"),
     Column("history_file", TEXT, "Path to the .*_history for this user"),
-    ForeignKey(column="username", table="users"),
+    ForeignKey(column="uid", table="users"),
 ])
+attributes(user_data=True)
 implementation("shell_history@genShellHistory")


### PR DESCRIPTION
The default expectation/policy for tables based primarily on user data is to generate content for the user running osquery only. To support listing content from all users the user data-based table must support an `additional` key and be marked with the attribute `user_data=True`. The additional key **SHOULD** be `uid` such that:

```sql
SELECT * from users join USER_DATA_TABLE using (uid)
```

Is performant.