### PR TITLE
Fixing build for Ubuntu 10.04 Lucid

### DIFF
--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -188,6 +188,34 @@ function install_yara() {
   fi
 }
 
+function install_openssl() {
+  SOURCE=openssl-1.0.2d
+  TARBALL=$SOURCE.tar.gz
+  URL=http://openssl.org/source/$TARBALL
+
+  if provision openssl /usr/local/lib/libssl.so.1.0.0; then
+    pushd $SOURCE
+    CC="$CC" CXX="$CXX" ./config --prefix=/usr/local --openssldir=/etc/ssl --libdir=lib shared zlib-dynamic enable-shared
+    make -j $THREADS
+    sudo make install
+    popd
+  fi
+}
+
+function install_bison() {
+  SOURCE=bison-2.5
+  TARBALL=$SOURCE.tar.gz
+  URL=http://ftp.gnu.org/gnu/bison/$TARBALL
+
+  if provision bison /usr/local/bin/bison; then
+    pushd $SOURCE
+    CC="$CC" CXX="$CXX" ./configure --prefix=/usr/local --with-libiconv-prefix=/usr/local/libiconv/
+    make -j $THREADS
+    sudo make install
+    popd
+  fi
+}
+
 function install_boost() {
   SOURCE=boost_1_55_0
   TARBALL=$SOURCE.tar.gz

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -36,7 +36,6 @@ function main_ubuntu() {
   package wget
   package unzip
   package build-essential
-  package bison
   package flex
   package devscripts
   package debhelper
@@ -133,6 +132,13 @@ function main_ubuntu() {
     gem_install fpm
   fi
 
+  if [[ $DISTRO = "lucid" ]]; then
+    install_openssl
+    install_bison
+  else
+    package bison
+  fi
+
   install_thrift
   install_rocksdb
   install_yara
@@ -148,4 +154,9 @@ function main_ubuntu() {
 
   # Audit facility (kautitd) and netlink APIs
   package libaudit-dev
+  if [[ $DISTRO = "lucid" ]]; then
+    package python-argparse
+    package python-jinja2
+    package python-psutil
+  fi
 }


### PR DESCRIPTION
The build was failing at 2 points:
1) Building Thrift:
    - required newer OpenSSL 1.0.0+. The latest available in lucid repositories is OpenSSL 0.9.8
    - required Bison >=2.5. The latest available in lucid repositories is Bison 2.4.8
2) Python packages were failing to install with pip, because they required python >=2.7, but the latest python for lucid is python 2.6. These packages are - argparse, jinja2, psutil.

After fixing these two points the build became successful. 

For testing if build is working I was using Docker with this Dockerfile:
```
FROM ubuntu:lucid

RUN apt-get update
RUN apt-get -y install git-core
RUN git clone https://github.com/jajce/osquery.git
RUN cd osquery/ && make deps
RUN cd osquery/ && make
RUN cd osquery/ && make packages
```