### PR TITLE
Add hardware/internal (monitoring) packs and reduce FPs, duplicates

### DIFF
--- a/packs/hardware-monitoring.conf
+++ b/packs/hardware-monitoring.conf
@@ -1,0 +1,88 @@
+{
+  "queries": {
+    "acpi_tables": {
+      "query": "select * from acpi_tables;",
+      "interval": 86400,
+      "description": "General reporting and heuristics monitoring."
+    },
+    "cpuid": {
+      "query": "select feature, value, output_register, output_bit, input_eax from cpuid;",
+      "interval": 86400,
+      "description": "General reporting and heuristics monitoring."
+    },
+    "smbios_tables": {
+      "query": "select * from smbios_tables;",
+      "interval": 86400,
+      "description": "General reporting and heuristics monitoring."
+    },
+    "nvram": {
+      "query": "select * from nvram where name not in ('backlight-level', 'SystemAudioVolumeDB', 'SystemAudioVolume');",
+      "interval": 1200,
+      "platform": "darwin",
+      "description": "Report on crashes, alternate boots, and boot arguments."
+    },
+    "kernel_info": {
+      "query": "select * from kernel_info join hash using (path);",
+      "interval": 7200,
+      "description": "Report the booted kernel, potential arguments, and the device."
+    },
+    "pci_devices": {
+      "query": "select * from pci_devices;",
+      "interval": 7200,
+      "description": "Report an inventory of PCI devices. Attaches and detaches will show up in hardware_events."
+    },
+    "usb_devices": {
+      "query": "select * from usb_devices;",
+      "interval": 7200,
+      "description": "Report an inventory of USB devices. Attaches and detaches will show up in hardware_events."
+    },
+    "hardware_events": {
+      "query" : "select * from hardware_events where path <> '' or model <> '';",
+      "interval" : 7200,
+      "removed": false,
+      "version" : "1.4.5",
+      "description" : "Retrieves all the hardware related events in the target OSX system.",
+      "value" : "Determine if a third party device was attached to the system."
+    },
+    "darwin_kernel_system_controls": {
+      "query": "select * from system_controls where subsystem = 'kern' and (name like '%boot%' or name like '%secure%' or name like '%single%');",
+      "interval": 7200,
+      "platform": "darwin",
+      "description": "Double check the information reported in kernel_info and report the kernel signature."
+    },
+    "iokit_devicetree": {
+      "query": "select * from iokit_devicetree;",
+      "interval": 86400,
+      "platform": "darwin",
+      "descriptor": "General inventory of IOKit's devices on OS X."
+    },
+    "efi_file_hashes": {
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, md5, sha1, sha256 from (select * from file where pattern = '/System/Library/CoreServices/*.efi' union select * from file where pattern = '/System/Library/LaunchDaemons/com.apple*{EFI,efi}*') file join hash using (path);",
+      "interval": 7200,
+      "removed": false,
+      "version": "1.6.1",
+      "platform": "darwin",
+      "description": "Hash files related to EFI platform updates and EFI bootloaders on primary boot partition. This does not hash bootloaders on the EFI/boot partition."
+    },
+    "kernel_extensions": {
+      "query" : "select * from kernel_extensions;",
+      "interval" : "3600",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information about the current kernel extensions for the target OSX system."
+    },
+    "kernel_modules": {
+      "query" : "select * from kernel_modules;",
+      "interval" : "3600",
+      "platform" : "linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves all the information for the current kernel modules in the target Linux system."
+    },
+    "device_nodes": {
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, mode, type from file where directory = '/dev/';",
+      "interval": "600",
+      "version": "1.6.0",
+      "description": "Inventory all 'device' nodes in /dev/."
+    }
+  }
+}

--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -147,19 +147,11 @@
       "value" : "Useful for intrusion detection and incident response. Verify assumptions of what accounts should be accessing what systems and identify machines accessed during a compromise."
     },
     "ip_forwarding": {
-      "query" : "select * from system_controls where name = 'net.inet.ip.forwarding';",
+      "query" : "select * from system_controls where oid = '4.30.41.1' union select * from system_controls where oid = '4.2.0.1';",
       "interval" : "3600",
       "version" : "1.4.5",
-      "description" : "Retrieves the current status of IP forwarding.",
-      "value" : "Identify if a machine is being used as relay"
-    },
-    "startup_items": {
-      "query" : "select * from startup_items;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieve all the items that will load when the target OSX system starts.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+      "description" : "Retrieves the current status of IP/IPv6 forwarding.",
+      "value" : "Identify if a machine is being used as relay."
     },
     "process_env": {
       "query" : "select * from process_envs;",
@@ -218,21 +210,6 @@
       "version" : "1.4.5",
       "description" : "Retrieves all the files in the target system that are setuid enabled.",
       "value" : "Detect backdoor binaries (attacker may drop a copy of /bin/sh). Find potential elevation points / vulnerabilities in the standard build."
-    },
-    "keychain_items": {
-      "query" : "select * from keychain_items;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the items contained in the keychain in the target OSX system.",
-      "value" : "Determine what access the user had, identify accounts to be remediated."
-    },
-    "hardware_events": {
-      "query" : "select distinct * from hardware_events where path <> '' or model <> '';",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the hardware related events in the target OSX system.",
-      "value" : "Determine if a third party device was attached to the system, include in scope for identification/mitigation/future detection."
     },
     "passwd_changes": {
       "query" : "select * from passwd_changes;",

--- a/packs/osquery-monitoring.conf
+++ b/packs/osquery-monitoring.conf
@@ -1,0 +1,23 @@
+{
+  "queries": {
+    "schedule": {
+      "query": "select name, interval, executions, output_size, wall_time, (user_time/executions) as avg_user_time, (system_time/executions) as avg_system_time, average_memory, last_executed from osquery_schedule;",
+      "interval": 7200,
+      "removed": false,
+      "version": "1.6.0",
+      "description": "Report performance for every query within packs and the general schedule."
+    },
+    "events": {
+      "query": "select name, publisher, type, subscriptions, events, active from osquery_events;",
+      "interval": 86400,
+      "removed": false,
+      "description": "Report event publisher health and track event counters."
+    },
+    "osquery_info": {
+      "query": "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter from osquery_info i, processes p, time where p.pid = i.pid;",
+      "interval": 600,
+      "removed": false,
+      "description": "A heartbeat counter that reports general performance (CPU, memory) and version."
+    }
+  }
+}

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -164,12 +164,6 @@
       "description" : "New version of Genieo",
       "value" : "Artifact used by this malware"
     },
-    "KeychainACLCollisions": {
-      "query" : "select label, description, authorizations, path, count(path) as collisions from keychain_acls where label != '' and path != '' group by label having collisions > 1;",
-      "interval" : "86400",
-      "description" : "Detect OS X keychain items with ACLs permitting multiple application access.",
-      "value" : "Potential information stealing/leakage."
-    },
     "HackingTeam_Mac_RAT1": {
       "query" : "select * from file where path = '/dev/ptmx0';",
       "interval" : "86400",
@@ -177,16 +171,23 @@
       "value" : "Artifact used by this malware"
     },
     "HackingTeam_Mac_RAT2": {
-      "query" : "select * from apps where bundle_identifier = 'com.ht.RCSMac' or bundle_package_type like 'OSAX';",
+      "query" : "select * from apps where bundle_identifier = 'com.ht.RCSMac';",
       "interval" : "86400",
       "description" : "Detect RAT used by Hacking Team",
       "value" : "Artifact used by this malware"
     },
     "HackingTeam_Mac_RAT3": {
-      "query" : "select * from launchd where label = 'com.ht.RCSMac' or label like 'com.yourcompany.%' or name = 'com.apple.loginStoreagent.plist' or name = 'com.apple.mdworker.plist' or name = 'com.apple.UIServerLogin.plist';",
+      "query" : "select * from launchd where label = 'com.ht.RCSMac' or name = 'com.apple.loginStoreagent.plist' or name = 'com.apple.mdworker.plist' or name = 'com.apple.UIServerLogin.plist';",
       "interval" : "86400",
       "description" : "Detect RAT used by Hacking Team",
       "value" : "Artifact used by this malware"
+    },
+    "xprotect_reports": {
+      "query": "select * from xprotect_reports;",
+      "interval": 1200,
+      "removed": false,
+      "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
+      "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally."
     }
   }
 }

--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -1,12 +1,5 @@
 {
   "queries": {
-    "osquery_info": {
-      "query" : "select * from osquery_info;",
-      "interval" : "86400",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current version of the running osquery in the target system and where the configuration was loaded from.",
-      "value" : "osquery version will provide information about potential vulnerabilities and available tables and functionality, tied to version."
-    },
     "kernel_info": {
       "query" : "select * from kernel_info;",
       "interval" : "86400",
@@ -46,36 +39,36 @@
       "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
     },
     "browser_plugins": {
-      "query" : "select * from browser_plugins;",
+      "query" : "select browser_plugins.* from users join browser_plugins using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+      "value" : "General security posture."
     },
     "safari_extensions": {
-      "query" : "select * from safari_extensions;",
+      "query" : "select safari_extensions.* from users join safari_extensions using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves the list of extensions for Safari in the target system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+      "value" : "General security posture."
     },
     "chrome_extensions": {
-      "query" : "select * from chrome_extensions;",
+      "query" : "select chrome_extensions.* from users join chrome_extensions using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves the list of extensions for Chrome in the target system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+      "value" : "General security posture."
     },
     "firefox_addons": {
-      "query" : "select * from firefox_addons;",
+      "query" : "select firefox_addons.* from users join firefox_addons using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves the list of addons for Firefox in the target system.",
-      "value" : "This, with the help of a vulnerability feed, can help tell if a vulnerable application is installed."
+      "value" : "General security posture."
     },
     "homebrew_packages": {
       "query" : "select * from homebrew_packages;",

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -54,22 +54,12 @@
 
   /* Define a schedule of queries */
   "schedule": {
-    // This is a simple example query that outputs information about osquery.
-    "info": {
+    // This is a simple example query that outputs basic system information.
+    "system_info": {
       // The exact query to run.
-      "query": "SELECT * FROM osquery_info",
+      "query": "SELECT hostname, cpu_brand, physical_memory FROM system_info;",
       // The interval in seconds to run this query, not an exact interval.
       "interval": 3600
-    },
-
-    // Another simple query that outputs information about the schedule.
-    // This can be used to collect performance metrics.
-    "schedule": {
-      "query": "SELECT name, interval, executions, output_size, wall_time, (user_time/executions) AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory FROM osquery_schedule",
-      "interval": 7200,
-      // We are only concerned with updates to the schedule, so we can ignore
-      // when items drop out.
-      "removed": false
     }
   },
 
@@ -85,9 +75,11 @@
    * make install: {PREFIX}/share/osquery/packs
    */
   "packs": {
+    // "osquery-monitoring": "/usr/share/osquery/packs/osquery-monitoring.conf",
     // "incident-response": "/usr/share/osquery/packs/incident-response.conf",
     // "it-compliance": "/usr/share/osquery/packs/it-compliance.conf",
     // "osx-attacks": "/usr/share/osquery/packs/osx-attacks.conf",
-    // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf"
+    // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
+    // "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf"
   }
 }

--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -59,6 +59,11 @@ class AdditionalFeatureTests(test_base.ProcessGenerator, unittest.TestCase):
         em = client.getEM()
 
         # Every query from the pack(s) is added to the packs table.
+        def get_packs():
+            result = em.query("select * from osquery_packs")
+            return len(result.response) == 2
+        # Allow the daemon some lag to parse the pack content.
+        test_base.expectTrue(get_packs)
         result = em.query("select * from osquery_packs")
         self.assertEqual(len(result.response), 2)
 


### PR DESCRIPTION
1. Recent changes to user-data-based tables will only return data for the current user unless you set a value for the `additional` field (`uid`). These scheduled queries need to join against `users`.
2. Add helpful internal monitoring queries.
3. Add potentially noisy inventory-based device and hardware monitoring packs.