### PR TITLE
[Fix #1686] Add 'subject' and 'signing_algorithm' to certificates

### DIFF
--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -19,8 +19,8 @@ namespace sqlite {
 int xOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor) {
   int rc = SQLITE_NOMEM;
   BaseCursor *pCur = new BaseCursor;
-  if (pCur) {
-    memset(pCur, 0, sizeof(BaseCursor));
+  if (pCur != nullptr) {
+    pCur->base.pVtab = nullptr;
     *ppCursor = (sqlite3_vtab_cursor *)pCur;
     rc = SQLITE_OK;
   }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -36,10 +36,16 @@ void genCertificate(const SecCertificateRef& SecCert, QueryData& results) {
     return;
   }
 
-  r["common_name"] = genCommonName(cert);
+  // Generate the common name and subject.
+  // They are very similar OpenSSL API accessors so save some logic and
+  // generate them using output parameters.
+  genCommonName(cert, r["subject"], r["common_name"]);
+  // Same with algorithm strings.
+  genAlgorithmProperties(cert, r["key_algorithm"], r["signing_algorithm"]);
+
+  // Most certificate field accessors return strings.
   r["not_valid_before"] = INTEGER(genEpoch(X509_get_notBefore(cert)));
   r["not_valid_after"] = INTEGER(genEpoch(X509_get_notAfter(cert)));
-  r["key_algorithm"] = genAlgProperty(cert);
 
   // Get the keychain for the certificate.
   r["path"] = getKeychainPath((SecKeychainItemRef)SecCert);

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -64,8 +64,14 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 
 /// Certificate property parsing functions.
 std::string genKIDProperty(const unsigned char* data, int len);
-std::string genAlgProperty(const X509* cert);
-std::string genCommonName(X509* cert);
+
+/// Generate the public key algorithm and signing algorithm.
+void genAlgorithmProperties(const X509* cert,
+                            std::string& key,
+                            std::string& sig);
+
+/// Generate common name and subject.
+void genCommonName(X509* cert, std::string& subject, std::string& common_name);
 time_t genEpoch(ASN1_TIME* time);
 
 std::string genSHA1ForCertificate(const CFDataRef& raw_cert);

--- a/osquery/tables/system/darwin/tests/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/tests/certificates_tests.cpp
@@ -60,7 +60,9 @@ TEST_F(CACertsTests, test_certificate_sha1) {
 }
 
 TEST_F(CACertsTests, test_certificate_properties) {
-  EXPECT_EQ("localhost.localdomain", genCommonName(x_cert));
+  std::string subject, common_name;
+  genCommonName(x_cert, subject, common_name);
+  EXPECT_EQ("localhost.localdomain", common_name);
 
   OSX_OPENSSL(X509_check_ca(x_cert));
   auto skid = genKIDProperty(x_cert->skid->data, x_cert->skid->length);

--- a/specs/darwin/certificates.table
+++ b/specs/darwin/certificates.table
@@ -2,9 +2,11 @@ table_name("certificates")
 description("Certificate Authorities installed in Keychains/ca-bundles.")
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
+    Column("subject", TEXT, "Certificate distinguished name"),
     Column("ca", INTEGER, "1 if CA: true (certificate is an authority) else 0"),
     Column("not_valid_before", DATETIME, "Lower bound of valid date"),
     Column("not_valid_after", DATETIME, "Certificate expiration data"),
+    Column("signing_algorithm", TEXT, "Signing algorithm used"),
     Column("key_algorithm", TEXT, "Key algorithm used"),
     Column("key_usage", TEXT, "Certificate key usage and extended key usage"),
     Column("subject_key_id", TEXT, "SKID an optionally included SHA1"),


### PR DESCRIPTION
- Some authority certificates are missing a CN so include the complete `subject` distinguished name.
- The algorithm used to sign the certificate (`signing_algorithm`) is now includes.