### PR TITLE
[Fix #1693, #1527] Add osquery-specific query planner output

### DIFF
--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -55,6 +55,8 @@ struct VirtualTableContent {
 struct BaseCursor {
   /// SQLite virtual table cursor.
   sqlite3_vtab_cursor base;
+  /// Track cursors for optional planner output.
+  size_t id{0};
   /// Table data generated from last access.
   QueryData data;
   /// Current cursor position.

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -72,7 +72,6 @@ else()
   ADD_OSQUERY_LINK_ADDITIONAL("libmagic.so")
 endif()
 
-
 file(GLOB OSQUERY_CROSS_APPLICATIONS_TABLES "applications/*.cpp")
 file(GLOB OSQUERY_CROSS_SYSTEM_TABLES "system/*.cpp")
 file(GLOB OSQUERY_CROSS_NETWORKING_TABLES "networking/*.cpp")

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -15,10 +15,12 @@ def get_files_to_compile(json_data):
     files_to_compile = []
     for element in json_data:
         filename = element["file"]
-        if not filename.endswith("_tests.cpp") and \
+        if not filename.endswith("tests.cpp") and \
+                not filename.endswith("benchmarks.cpp") and \
                 "third-party" not in filename and \
                 "example" not in filename and \
-                "generated/gen" not in filename:
+                "generated/gen" not in filename and \
+                "test_util" not in filename:
             base = filename.rfind("osquery/")
             filename = filename[base + len("osquery/"):]
             base_generated = filename.rfind("generated/")
@@ -48,7 +50,7 @@ cpp_library(
 
 TARGETS_POSTSCRIPT = """  ],
   deps=[
-    "@/thrift/lib/cpp/concurrency",
+    "@/thrift/lib/cpp/concurrency:concurrency",
     ":if-cpp",
   ],
   external_deps=[


### PR DESCRIPTION
1. This fixes a constraint stacking regression that prevented UNIONS with embedded constraints from working as expected. The bug introduced would stomp constraints on subsequent selects operating on the same virtual table.

2. This adds a small "runtime" query planner that prints to `stderr` *some* actions taken by the constraint parser and filter.