### PR TITLE
[Fix #1660] Prevent spurious NETLINK recv retries

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -88,6 +88,7 @@ function main() {
 
   cd "$SCRIPT_DIR/../"
 
+  sudo pip install --upgrade pip
   sudo pip install -r requirements.txt
 
   # Reset any work or artifacts from build tests in TP.

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -75,7 +75,6 @@ function main_centos() {
   package doxygen
   package byacc
   package flex
-  package bison
 
   if [[ $DISTRO = "centos6" ]]; then
     remove_package autoconf
@@ -86,12 +85,16 @@ function main_centos() {
     install_automake
     install_libtool
 
+    install_bison
+
     package file-libs
   elif [[ $DISTRO = "centos7" ]]; then
     package autoconf
     package automake
     package libtool
     package file-devel
+
+    package bison
   fi
 
   install_snappy


### PR DESCRIPTION
The NETLINK read logic seemed incorrect. Previously this would exhaust the read latency as there are usually several `recvfrom` calls needed to read the entire NETLINK message.