### PR TITLE
[#1518] Only emit a single line for each logString

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -56,7 +56,7 @@ extern const std::vector<std::string> kDomains;
 /**
  * @brief A variant type for the SQLite type affinities.
  */
-typedef std::string RowData;
+using RowData = std::string;
 
 /**
  * @brief A single row from a database query
@@ -64,7 +64,7 @@ typedef std::string RowData;
  * Row is a simple map where individual column names are keys, which map to
  * the Row's respective value
  */
-typedef std::map<std::string, RowData> Row;
+using Row = std::map<std::string, RowData>;
 
 /**
  * @brief Serialize a Row into a property tree
@@ -116,7 +116,7 @@ Status deserializeRowJSON(const std::string& json, Row& r);
  * QueryData is the canonical way to represent the results of SQL queries in
  * osquery. It's just a vector of Row's.
  */
-typedef std::vector<Row> QueryData;
+using QueryData = std::vector<Row>;
 
 /**
  * @brief Serialize a QueryData object into a property tree
@@ -392,7 +392,7 @@ Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
  * @return Status indicating the success or failure of the operation
  */
 Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& i,
-                                         std::string& json);
+                                         std::vector<std::string>& items);
 
 /////////////////////////////////////////////////////////////////////////////
 // DistributedQueryRequest

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -341,22 +341,22 @@ Status serializeQueryLogItemAsEvents(const QueryLogItem& i, pt::ptree& tree) {
 }
 
 Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& i,
-                                         std::string& json) {
+                                         std::vector<std::string>& items) {
   pt::ptree tree;
   auto status = serializeQueryLogItemAsEvents(i, tree);
   if (!status.ok()) {
     return status;
   }
 
-  std::ostringstream output;
   for (auto& event : tree) {
+    std::ostringstream output;
     try {
       pt::write_json(output, event.second, false);
     } catch (const pt::json_parser::json_parser_error& e) {
       return Status(1, e.what());
     }
+    items.push_back(output.str());
   }
-  json = output.str();
   return Status(0, "OK");
 }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -53,7 +53,7 @@ inline SQL monitor(const std::string& name, const ScheduledQuery& query) {
   return sql;
 }
 
-void launchQuery(const std::string& name, const ScheduledQuery& query) {
+inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // Execute the scheduled query and create a named query object.
   VLOG(1) << "Executing query: " << query.query;
   auto sql =

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -34,7 +34,7 @@ class SchedulerRunner : public InternalRunnable {
   unsigned long int timeout_;
 };
 
-/// Start quering according to the config's schedule
+/// Start querying according to the config's schedule
 Status startScheduler();
 
 /// Helper scheduler start with variable settings for testing.

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -29,10 +29,7 @@ FLAG(string,
      "/var/log/osquery/",
      "Directory path for ERROR/WARN/INFO and results logging");
 
-FLAG(int32,
-     logger_mode,
-     0640,
-     "Mode for log files (default '0640')");
+FLAG(int32, logger_mode, 0640, "Mode for log files (default '0640')");
 
 /// Legacy, backward compatible "osquery_log_dir" CLI option.
 FLAG_ALIAS(std::string, osquery_log_dir, logger_path);
@@ -75,14 +72,15 @@ Status FilesystemLoggerPlugin::setUp() {
 }
 
 Status FilesystemLoggerPlugin::logString(const std::string& s) {
-  return logStringToFile(s, kFilesystemLoggerFilename);
+  return logStringToFile(s + "\n", kFilesystemLoggerFilename);
 }
 
 Status FilesystemLoggerPlugin::logStringToFile(const std::string& s,
                                                const std::string& filename) {
   std::lock_guard<std::mutex> lock(filesystemLoggerPluginMutex);
   try {
-    auto status = writeTextFile((log_path_ / filename).string(), s, FLAGS_logger_mode, true);
+    auto status = writeTextFile(
+        (log_path_ / filename).string(), s, FLAGS_logger_mode, true);
     if (!status.ok()) {
       return status;
     }

--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -30,9 +30,7 @@ class SyslogLoggerPlugin : public LoggerPlugin {
 REGISTER(SyslogLoggerPlugin, "logger", "syslog");
 
 Status SyslogLoggerPlugin::logString(const std::string& s) {
-  for (const auto& line : osquery::split(s, "\n")) {
-    syslog(LOG_INFO, "%s", line.c_str());
-  }
+  syslog(LOG_INFO, "%s", s.c_str());
   return Status(0, "OK");
 }
 

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -199,4 +199,19 @@ TEST_F(LoggerTests, test_multiple_loggers) {
   // forwarded.
   EXPECT_EQ(LoggerTests::statuses_logged, 1);
 }
+
+TEST_F(LoggerTests, test_logger_scheduled_query) {
+  QueryLogItem item;
+  item.name = "test_query";
+  item.identifier = "unknown_test_host";
+  item.time = 0;
+  item.calendar_time = "no_time";
+  item.results.added.push_back({{"test_column", "test_value"}});
+  logQueryLogItem(item);
+  EXPECT_EQ(LoggerTests::log_lines.size(), 1U);
+
+  item.results.removed.push_back({{"test_column", "test_new_value\n"}});
+  logQueryLogItem(item);
+  EXPECT_EQ(LoggerTests::log_lines.size(), 3U);
+}
 }


### PR DESCRIPTION
Hopefully this improves logger plugin performance by not requiring another JSON encode within the TLS logger. It should also make the API a bit clearer, `logString` logs a single line of string data, this is an event in most cases. Previously the logger plugin would have to deduce how to split and emit multiple events.