### PR TITLE
[#1702] Add config and database dumping to stdout

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -161,6 +161,7 @@ SANITIZE_THREAD=True # Add -fsanitize=thread when using "make sanitize"
 OPTIMIZED=True # Disable generic CPU optimizations
 SKIP_TESTS=True # Skip unit test building (very very not recommended!)
 SKIP_BENCHMARKS=True # Build unit tests but skip building benchmark targets
+SKIP_TABLES=True # Build platform without any table implementations or specs
 OSX_VERSION_MIN=10.11 # Override the native minimum OS X version ABI
 ```
 

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -26,9 +26,6 @@
 
 namespace osquery {
 
-/// The builder or invoker may change the default config plugin.
-DECLARE_string(config_plugin);
-
 class ConfigParserPlugin;
 
 /**

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -46,6 +46,9 @@ extern const std::string kEvents;
  */
 extern const std::string kLogs;
 
+/// An ordered list of column type names.
+extern const std::vector<std::string> kDomains;
+
 /////////////////////////////////////////////////////////////////////////////
 // Row
 /////////////////////////////////////////////////////////////////////////////
@@ -625,6 +628,9 @@ Status deleteDatabaseValue(const std::string& domain, const std::string& key);
 /// Get a list of keys for a given domain.
 Status scanDatabaseKeys(const std::string& domain,
                         std::vector<std::string>& keys);
+
+/// Allow callers to scan each column family and print each value.
+void dumpDatabase();
 
 /// Generate a specific-use registry for database access abstraction.
 CREATE_REGISTRY(DatabasePlugin, "database");

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -34,6 +34,14 @@ namespace osquery {
 /// The config plugin must be known before reading options.
 CLI_FLAG(string, config_plugin, "filesystem", "Config plugin name");
 
+CLI_FLAG(bool,
+         config_check,
+         false,
+         "Check the format of an osquery config and exit");
+
+CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration");
+
+DECLARE_string(config_plugin);
 DECLARE_string(pack_delimiter);
 
 /**
@@ -201,6 +209,16 @@ Status Config::load() {
 
   // if there was a response, parse it and update internal state
   if (response.size() > 0) {
+    if (FLAGS_config_dump) {
+      // If config checking is enabled, debug-write the raw config data.
+      for (const auto& content : response[0]) {
+        fprintf(stdout,
+                "{\"%s\": %s}\n",
+                content.first.c_str(),
+                content.second.c_str());
+      }
+      ::exit(EXIT_SUCCESS);
+    }
     return update(response[0]);
   }
 
@@ -231,6 +249,7 @@ inline void stripConfigComments(std::string& json) {
 }
 
 Status Config::updateSource(const std::string& name, const std::string& json) {
+  // Compute a 'synthesized' hash using the content before it is parsed.
   hashSource(name, json);
 
   // load the config (source.second) into a pt::ptree
@@ -281,23 +300,25 @@ Status Config::updateSource(const std::string& name, const std::string& json) {
             {"action", "genPack"}, {"name", pack.first}, {"value", value}};
         Registry::call("config", request, response);
 
-        if (response.size() > 0 && response[0].count(pack.first) > 0) {
+        if (response.size() == 0 || response[0].count(pack.first) == 0) {
+          continue;
+        }
+
+        try {
+          pt::ptree pack_tree;
           std::stringstream pack_stream;
           pack_stream << response[0][pack.first];
-          pt::ptree pack_tree;
-          try {
-            pt::read_json(pack_stream, pack_tree);
-            addPack(pack.first, name, pack_tree);
-          } catch (const pt::json_parser::json_parser_error& e) {
-            LOG(WARNING) << "Error parsing the pack JSON: " << pack.first;
-          }
+          pt::read_json(pack_stream, pack_tree);
+          addPack(pack.first, name, pack_tree);
+        } catch (const pt::json_parser::json_parser_error& e) {
+          LOG(WARNING) << "Error parsing the pack JSON: " << pack.first;
         }
       }
     }
   }
 
   for (const auto& plugin : Registry::all("config_parser")) {
-    std::shared_ptr<ConfigParserPlugin> parser;
+    std::shared_ptr<ConfigParserPlugin> parser = nullptr;
     try {
       parser = std::dynamic_pointer_cast<ConfigParserPlugin>(plugin.second);
     } catch (const std::bad_cast& e) {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -55,7 +55,7 @@ enum {
 /*
  * 8 best effort priority levels are supported
  */
-#define IOPRIO_BE_NR  (8)
+#define IOPRIO_BE_NR (8)
 
 enum {
   IOPRIO_WHO_PROCESS = 1,
@@ -150,17 +150,15 @@ namespace osquery {
 
 using chrono_clock = std::chrono::high_resolution_clock;
 
-CLI_FLAG(bool,
-         config_check,
-         false,
-         "Check the format of an osquery config and exit");
-
 #ifndef __APPLE__
 CLI_FLAG(bool, daemonize, false, "Run as daemon (osqueryd only)");
 #endif
 
 DECLARE_string(distributed_plugin);
 DECLARE_bool(disable_distributed);
+DECLARE_string(config_plugin);
+DECLARE_bool(config_check);
+DECLARE_bool(database_dump);
 
 ToolType kToolType = OSQUERY_TOOL_UNKNOWN;
 
@@ -446,6 +444,11 @@ void Initializer::start() {
     }
     // A configuration check exits the application.
     ::exit(s.getCode());
+  }
+
+  if (FLAGS_database_dump) {
+    dumpDatabase();
+    ::exit(EXIT_SUCCESS);
   }
 
   // Load the osquery config using the default/active config plugin.

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -25,6 +25,8 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
+CLI_FLAG(bool, database_dump, false, "Dump the contents of the backing store");
+
 /////////////////////////////////////////////////////////////////////////////
 // Row - the representation of a row in a set of database results. Row is a
 // simple map where individual column names are keys, which map to the Row's
@@ -571,5 +573,22 @@ Status scanDatabaseKeys(const std::string& domain,
     }
   }
   return status;
+}
+
+void dumpDatabase() {
+  for (const auto& domain : kDomains) {
+    std::vector<std::string> keys;
+    if (!scanDatabaseKeys(domain, keys)) {
+      continue;
+    }
+    for (const auto& key : keys) {
+      std::string value;
+      if (!getDatabaseValue(domain, key, value)) {
+        continue;
+      }
+      fprintf(
+          stdout, "%s[%s]: %s\n", domain.c_str(), key.c_str(), value.c_str());
+    }
+  }
 }
 }

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -50,6 +50,21 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    def test_config_dump(self):
+        '''Test that config raw output is dumped when requested'''
+        config = "%s/test_noninline_packs.conf" % test_base.SCRIPT_DIR
+        proc = test_base.TimeoutRunner([
+                self.binary,
+                "--config_dump",
+                "--config_path=%s" % config
+            ],
+            SHELL_TIMEOUT)
+        content = ""
+        with open(config, 'r') as fh: content = fh.read()
+        self.assertEqual(proc.stdout, "{\"%s\": %s}\n" % (config, content))
+        print (proc.stderr)
+        self.assertEqual(proc.proc.poll(), 0)
+
     def test_config_check_failure(self):
         '''Test that a missing config fails'''
         proc = test_base.TimeoutRunner([


### PR DESCRIPTION
From #1702:

This provides (1) and (3). The second bullet is skipped since it takes a bit more work and is not straight forward that it should even exist beyond a method for debugging. If a config fetch fails the daemon stops.