### PR TITLE
Additional TSK table: device_hash

### DIFF
--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -18,15 +18,15 @@
 namespace osquery {
 
 #ifdef __APPLE__
-  #import <CommonCrypto/CommonDigest.h>
-  #define __HASH_API(name) CC_##name
+#import <CommonCrypto/CommonDigest.h>
+#define __HASH_API(name) CC_##name
 #else
-  #include <openssl/sha.h>
-  #include <openssl/md5.h>
-  #define __HASH_API(name) name
+#include <openssl/sha.h>
+#include <openssl/md5.h>
+#define __HASH_API(name) name
 
-  #define SHA1_DIGEST_LENGTH SHA_DIGEST_LENGTH
-  #define SHA1_CTX SHA_CTX
+#define SHA1_DIGEST_LENGTH SHA_DIGEST_LENGTH
+#define SHA1_CTX SHA_CTX
 #endif
 
 #define HASH_CHUNK_SIZE 4096
@@ -86,7 +86,9 @@ std::string Hash::digest() {
   return digest.str();
 }
 
-std::string hashFromBuffer(HashType hash_type, const void* buffer, size_t size) {
+std::string hashFromBuffer(HashType hash_type,
+                           const void* buffer,
+                           size_t size) {
   Hash hash(hash_type);
   hash.update(buffer, size);
   return hash.digest();

--- a/specs/device_hash.table
+++ b/specs/device_hash.table
@@ -1,0 +1,11 @@
+table_name("device_hash")
+description("Similar to the hash table, but use TSK and allow block address access.")
+schema([
+    Column("device", TEXT, "Absolute file path to device node", required=True),
+    Column("partition", TEXT, "A partition number", required=True),
+    Column("inode", BIGINT, "Filesystem inode number", required=True),
+    Column("md5", TEXT, "MD5 hash of provided inode data"),
+    Column("sha1", TEXT, "SHA1 hash of provided inode data"),
+    Column("sha256", TEXT, "SHA256 hash of provided inode data"),
+])
+implementation("forensic/sleuthkit@genDeviceHash")

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -17,7 +17,6 @@ import os
 import subprocess
 import sys
 import time
-import utils
 
 try:
     import argparse
@@ -27,6 +26,8 @@ except ImportError:
 
 # Import the testing utils
 sys.path.append(os.path.dirname(os.path.realpath(__file__)) + "/tests/")
+
+import utils
 
 KB = 1024 * 1024
 RANGES = {
@@ -306,7 +307,7 @@ if __name__ == "__main__":
             profile1 = json.loads(fh.read())
 
     if not os.path.exists(args.shell):
-        print("Cannot find --daemon: %s" % (args.shell))
+        print("Cannot find --shell: %s" % (args.shell))
         exit(1)
     if args.config is None and not os.path.exists(args.tables):
         print("Cannot find --tables: %s" % (args.tables))


### PR DESCRIPTION
1. Clean up sleuthkit tables.
2. Add `device_hash` table that takes a `device`, `partition`, and `inode` tuple to calculate hashes.