### PR TITLE
[Fix #1694] Expire results for 'old' scheduled queries

### DIFF
--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -103,7 +103,7 @@ class Pack {
   std::string name_;
   std::string source_;
   bool should_execute_;
-  std::pair<int, bool> discovery_cache_;
+  std::pair<size_t, bool> discovery_cache_;
   PackStats stats_;
 
  private:

--- a/osquery/dispatcher/CMakeLists.txt
+++ b/osquery/dispatcher/CMakeLists.txt
@@ -2,12 +2,16 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_dispatcher
   dispatcher.cpp
 )
 
+ADD_OSQUERY_TEST(TRUE
+  dispatcher/tests/dispatcher_tests.cpp
+)
+
+# The following dispatcher ("runner") implementations are additional.
 ADD_OSQUERY_LIBRARY(FALSE osquery_dispatcher_runners
   scheduler.cpp
   distributed.cpp
 )
 
-# Note: if there are ever scheduler tests this needs to set the
-# test files manually.
-file(GLOB OSQUERY_DISPATCHER_TESTS "tests/*.cpp")
-ADD_OSQUERY_TEST(TRUE ${OSQUERY_DISPATCHER_TESTS})
+ADD_OSQUERY_TEST(FALSE
+  dispatcher/tests/scheduler_tests.cpp
+)

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "osquery/core/test_util.h"
+#include "osquery/sql/sqlite_util.h"
+#include "osquery/dispatcher/scheduler.h"
+
+namespace osquery {
+
+extern SQL monitor(const std::string& name, const ScheduledQuery& query);
+
+class SchedulerTests : public testing::Test {};
+
+TEST_F(SchedulerTests, test_monitor) {
+  std::string name = "pack_test_test_query";
+
+  // This query has never run so it will not have a timestamp.
+  std::string timestamp;
+  getDatabaseValue(kPersistentSettings, "timestamp." + name, timestamp);
+  ASSERT_TRUE(timestamp.empty());
+
+  // Fill in a scheduled query and execute it via the query monitor wrapper.
+  ScheduledQuery query;
+  query.interval = 10;
+  query.splayed_interval = 11;
+  query.query = "select * from time";
+  auto results = monitor(name, query);
+  EXPECT_EQ(results.rows().size(), 1U);
+
+  // Ask the config instance for the monitored performance.
+  QueryPerformance perf;
+  Config::getInstance().getPerformanceStats(
+      name, ([&perf](const QueryPerformance& r) { perf = r; }));
+  // Make sure it was recorded query ran.
+  // There is no pack for this query within the config, that is fine as these
+  // performance stats are tracked independently.
+  EXPECT_EQ(perf.executions, 1U);
+  EXPECT_GT(perf.output_size, 0U);
+
+  // A bit more testing, potentially redundant, check the database results.
+  // Since we are only monitoring, no 'actual' results are stored.
+  std::string content;
+  getDatabaseValue(kQueries, name, content);
+  EXPECT_TRUE(content.empty());
+
+  // Finally, make sure there is a recorded timestamp for the execution.
+  // We are not concerned with the APPROX value, only that it was recorded.
+  getDatabaseValue(kPersistentSettings, "timestamp." + name, timestamp);
+  EXPECT_FALSE(timestamp.empty());
+}
+
+TEST_F(SchedulerTests, test_config_results_purge) {
+  // Set a query time for now (time is only important relative to a week ago).
+  auto query_time = osquery::getUnixTime();
+  setDatabaseValue(
+      kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
+  // Store a meaningless saved query interval splay.
+  setDatabaseValue(kPersistentSettings, "interval.test_query", "11");
+  // Store meaningless query differential results.
+  setDatabaseValue(kQueries, "test_query", "{}");
+
+  // We do not need "THE" config instance.
+  // We only need to trigger a 'purge' event, this occurs when configuration
+  // content is updated by a plugin or on load.
+  Config::getInstance().purge();
+
+  // Nothing should have been purged.
+  {
+    std::string content;
+    getDatabaseValue(kPersistentSettings, "timestamp.test_query", content);
+    EXPECT_FALSE(content.empty());
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kPersistentSettings, "interval.test_query", content);
+    EXPECT_FALSE(content.empty());
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kQueries, "test_query", content);
+    EXPECT_FALSE(content.empty());
+  }
+
+  // Update the timestamp to have run a week and a day ago.
+  query_time -= (84600 * (7 + 1));
+  setDatabaseValue(
+      kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
+
+  // Trigger another purge.
+  Config::getInstance().purge();
+  // Now ALL 'test_query' related storage will have been purged.
+  {
+    std::string content;
+    getDatabaseValue(kPersistentSettings, "timestamp.test_query", content);
+    EXPECT_TRUE(content.empty());
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kPersistentSettings, "interval.test_query", content);
+    EXPECT_TRUE(content.empty());
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kQueries, "test_query", content);
+    EXPECT_TRUE(content.empty());
+  }
+}
+}

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/algorithm/string/trim.hpp>
 
+#include <osquery/core.h>
 #include <osquery/database.h>
 #include <osquery/enroll.h>
 #include <osquery/flags.h>
@@ -64,7 +65,7 @@ std::string getNodeKey(const std::string& enroll_plugin) {
   }
 
   // The node key request time is recorded before the enroll request occurs.
-  auto request_time = std::to_string(std::time(nullptr));
+  auto request_time = std::to_string(getUnixTime());
 
   // Request the enroll plugin's node secret.
   PluginResponse response;


### PR DESCRIPTION
1. Change interval restrictions to include a max of 1 week. Anything over a week will not be added to the schedule and will emit a log.
2. Every time the configuration content is updated check for results/intervals that have not been used/updated for a week. Expire results older than a week if the related scheduled query no longer exists in the schedule.