### PR TITLE
Add canary path on empty FSEvents subscription set

### DIFF
--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -57,7 +57,7 @@ void FSEventsSubscriptionContext::requireAction(const std::string& action) {
 void FSEventsEventPublisher::restart() {
   if (paths_.empty()) {
     // There are no paths to watch.
-    return;
+    paths_.insert("/dev/null/");
   }
 
   if (run_loop_ == nullptr) {
@@ -174,11 +174,6 @@ void FSEventsEventPublisher::configure() {
       }
     }
     paths_.insert(sc->discovered_);
-  }
-
-  // There were no paths in the subscriptions?
-  if (paths_.empty()) {
-    return;
   }
 
   restart();


### PR DESCRIPTION
If an osquery process starts and enables the FSEvents event publisher there should be at least 1 watched path. The alternative involves wait queues waiting for configuration updates. A single path will implement this exact queueing within the run loop for 0 extra code or CPU cost.

We call the `/var/osquery` path an FSEvents canary as it almost always exists, but that is not a requirement. Events occurring within the canary will be silently dropped since there are no matching extensions.