### PR TITLE
[#1636] Add simple sharding to packs and pack queries

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -233,6 +233,15 @@ consist of pack name to pack content JSON data structures.
           "description": "Check each user's active directory cached settings."
         }
       }
+    },
+    "testing": {
+      "shard": "10",
+      "queries": {
+        "suid_bins": {
+          "query": "select * from suid_bins;",
+          "interval": "3600",
+        }
+      }
     }
   }
 }
@@ -342,17 +351,16 @@ When osquery's config parser is provided a string instead of inline dictionary t
 
 ### Options
 
-In addition to discovery and queries, a pack may contain a **platform** key
-and a **version** key. Specifying platform allows you to specify that the pack
-should only be executed on "linux", "darwin", etc.
+In addition to discovery and queries, a pack may contain a **platform**, **shard**, or **version** key. Specifying platform allows you to specify that the pack should only be executed on "linux", "darwin", etc. The shard key applies Chef-style percentage sharding. Appropriate values range from 1 - 100 and represent a percentage of hosts that should use this pack. Values over 100 are equivalent to 100%, 0 discounts the shard option. The hosts that fall into the range are a deterministic 10%. The version key can set a minimum supported version for this query.
 
 In practice, this looks like:
 
 ```json
 {
-	"platform": "any",
-	"version": "1.5.0",
-	"queries": {}
+  "platform": "any",
+  "version": "1.5.0",
+  "shard": "10",
+  "queries": {}
 }
 ```
 

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -21,11 +21,11 @@
 namespace osquery {
 
 /// Statistics about Pack discovery query actions.
-typedef struct {
-  size_t total;
-  size_t hits;
-  size_t misses;
-} PackStats;
+struct PackStats {
+  size_t total{0};
+  size_t hits{0};
+  size_t misses{0};
+};
 
 /**
  * @brief The programmatic representation of a query pack
@@ -75,6 +75,8 @@ class Pack {
   /// Returns the minimum version that the pack is configured to run on
   const std::string& getVersion() const;
 
+  size_t getShard() const { return shard_; }
+
   /// Returns the schedule dictated by the pack
   const std::map<std::string, ScheduledQuery>& getSchedule() const;
 
@@ -96,14 +98,31 @@ class Pack {
   const PackStats& getStats() const;
 
  protected:
+  /// List of query strings.
   std::vector<std::string> discovery_queries_;
+
+  /// Map of query names to the scheduled query details.
   std::map<std::string, ScheduledQuery> schedule_;
+
+  /// Platform requirement for pack.
   std::string platform_;
+
+  /// Minimum version requirement for pack.
   std::string version_;
+
+  /// Optional shard requirement for pack.
+  size_t shard_{0};
+
+  /// Pack canonicalized name.
   std::string name_;
+
+  /// Name of config source that created/added this pack.
   std::string source_;
-  bool should_execute_;
+
+  /// Cached time and result from previous discovery step.
   std::pair<size_t, bool> discovery_cache_;
+
+  /// Pack discovery statistics.
   PackStats stats_;
 
  private:
@@ -113,6 +132,9 @@ class Pack {
    * Initialization must include pack content
    */
   Pack(){};
+
+ private:
+  FRIEND_TEST(PacksTests, test_check_platform);
 };
 
 /**

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -16,6 +16,7 @@
 
 #include <osquery/events.h>
 #include <osquery/filesystem.h>
+#include <osquery/flags.h>
 #include <osquery/tables.h>
 
 #include "osquery/events/darwin/fsevents.h"

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -14,6 +14,7 @@
 #include <osquery/events.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
+#include <osquery/packs.h>
 #include <osquery/registry.h>
 #include <osquery/sql.h>
 #include <osquery/tables.h>
@@ -82,6 +83,7 @@ QueryData genOsqueryPacks(QueryContext& context) {
     r["name"] = pack.getName();
     r["version"] = pack.getVersion();
     r["platform"] = pack.getPlatform();
+    r["shard"] = INTEGER(pack.getShard());
 
     auto stats = pack.getStats();
     r["discovery_cache_hits"] = INTEGER(stats.hits);
@@ -217,11 +219,11 @@ QueryData genOsquerySchedule(QueryContext& context) {
         r["user_time"] = "0";
         r["system_time"] = "0";
         r["average_memory"] = "0";
+        r["last_executed"] = "0";
 
         // Report optional performance information.
         Config::getInstance().getPerformanceStats(
-            name,
-            [&r](const QueryPerformance& perf) {
+            name, [&r](const QueryPerformance& perf) {
               r["executions"] = BIGINT(perf.executions);
               r["last_executed"] = BIGINT(perf.last_executed);
               r["output_size"] = BIGINT(perf.output_size);
@@ -235,6 +237,5 @@ QueryData genOsquerySchedule(QueryContext& context) {
       });
   return results;
 }
-
 }
 }

--- a/specs/utility/osquery_packs.table
+++ b/specs/utility/osquery_packs.table
@@ -4,6 +4,7 @@ schema([
     Column("name", TEXT, "The given name for this query pack"),
     Column("platform", TEXT, "Platforms this query is supported on"),
     Column("version", TEXT, "Minimum osquery version that this query will run on"),
+    Column("shard", INTEGER, "Shard restriction limit, 1-100, 0 meaning no restriction"),
     Column("discovery_cache_hits", INTEGER, "The number of times that the discovery query used cached values since the last time the config was reloaded"),
     Column("discovery_executions", INTEGER, "The number of times that the discovery queries have been executed since the last time the config was reloaded"),
 ])

--- a/tools/tests/test_inline_pack.conf
+++ b/tools/tests/test_inline_pack.conf
@@ -15,7 +15,7 @@
       }
     },
     "discovery_pack": {
-      "platform": "darwin",
+      "platform": "all",
       "version": "1.5.0",
       "discovery": [
         "select pid from processes where name = 'foobar';"


### PR DESCRIPTION
1. Packs can now include a `"shard"` key that applies Chef-style machine sharding. If a machine's shard (first character of hostname MD5 / 255) is below the required shard, the logic applies. These shards can be applied to the embedded queries within a pack too.
2. Pack discovery checking for version/platform now occurs once. If the platform/version does not apply at a pack level the query addition is skipped.