### PR TITLE
Reorganize file_events into process_file_events

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -85,6 +85,16 @@ fs.inotify.max_queued_events = 32768
 
 ## File Accesses
 
-It is possible to monitor for file accesses using the osquery OS X kernel module. File accesses induce a LOT of stress on the system and are more or less useless giving the context from userland monitoring systems (aka, not having the process that caused the modification).
+File accesses on Linux using inotify may induce unexpected and unwanted performance reduction. To prevent 'flooding' of access events alongside FIM, access events for `file_path` categories is an explicit opt-in. Add the following list of categories:
 
-If the kernel extension is running, the `file_access_events` table will be populated using the same **file_paths** key in the osquery config. This implementation of access monitoring includes process PIDs and should not cause CPU or memory latency outside of the normal kernel extension/module guarantees. See [../development/kernel.md](Kernel) for more information.
+```json
+{
+  "file_accesses": ["homes", "etc"]
+}
+```
+
+To enable access monitoring for the above set of directories in 'homes' and the single 'etc'.
+
+It is possible to monitor for file accesses by process using the osquery OS X kernel module. File accesses induce a LOT of stress on the system and are more or less useless giving the context from userland monitoring systems (aka, not having the process that caused the modification).
+
+If the kernel extension is running, the `process_file_events` table will be populated using the same **file_paths** key in the osquery config. This implementation of access monitoring includes process PIDs and should not cause CPU or memory latency outside of the normal kernel extension/module guarantees. See [../development/kernel.md](Kernel) for more information.

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -156,6 +156,7 @@ class INotifyEventPublisher
    * @return success if the inotify watch was created.
    */
   bool addMonitor(const std::string& path,
+                  uint32_t mask,
                   bool recursive,
                   bool add_watch = true);
 

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -66,7 +66,7 @@ void FileEventSubscriber::configure() {
   Config::getInstance().files([this](const std::string& category,
                                      const std::vector<std::string>& files) {
     for (const auto& file : files) {
-      VLOG(1) << "Added listener to: " << file;
+      VLOG(1) << "Added file event listener to: " << file;
       auto sc = createSubscriptionContext();
       sc->path = file;
       sc->category = category;

--- a/specs/darwin/process_file_events.table
+++ b/specs/darwin/process_file_events.table
@@ -1,5 +1,5 @@
-table_name("file_access_events")
-description("File access events (open and close) from kernel extension.")
+table_name("process_file_events")
+description("Process file events (open and close) from kernel extension.")
 schema([
     Column("action", TEXT,
       "The action taken on the file (OPEN, CLOSED, or CLOSED_MODIFIED)"),
@@ -13,14 +13,12 @@ schema([
     Column("owner_gid", BIGINT, "Group ID of the owner of the file"),
     Column("mode", BIGINT, "Indicates the mode of the file"),
     Column("path", TEXT, "Path of file"),
-    Column("create_time", BIGINT, "Time of creation in UNIX epoch time"),
-    Column("access_time", BIGINT, "Time of last access in UNIX epoch time"),
-    Column("modify_time", BIGINT,
+    Column("ctime", BIGINT, "Time of creation in UNIX epoch time"),
+    Column("atime", BIGINT, "Time of last access in UNIX epoch time"),
+    Column("mtime", BIGINT,
       "Time of last modification in UNIX epoch time"),
-    Column("change_time", BIGINT,
-      "Time of last metadata change in UNIX epoch time"),
     Column("time", BIGINT, "Time of event in UNIX epoch time"),
     Column("uptime", BIGINT, "Time of event in system uptime"),
 ])
 attributes(event_subscriber=True)
-implementation("file_acess_events@file_access_events::genTable")
+implementation("process_file_events@process_file_events::genTable")


### PR DESCRIPTION
This extends the config to add `file_accesses`. Adding a list of `file_paths` categories will enable access monitoring for those directories on Linux.