### PR TITLE
Extend fields of file_events

### DIFF
--- a/osquery/tables/events/event_utils.cpp
+++ b/osquery/tables/events/event_utils.cpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/events.h>
+#include <osquery/hash.h>
+#include <osquery/sql.h>
+
+namespace osquery {
+
+const std::set<std::string> kCommonFileColumns = {
+    "inode", "uid", "gid", "mode", "size", "atime", "mtime", "ctime",
+};
+
+void decorateFileEvent(const std::string& path, bool hash, Row& r) {
+  auto results = SQL::selectAllFrom("file", "path", EQUALS, path);
+  if (results.size() == 1) {
+    auto& row = results.at(0);
+    for (const auto& key : kCommonFileColumns) {
+      if (row.count(key) > 0) {
+        r[key] = row.at(key);
+      }
+    }
+  }
+
+  if (hash) {
+    auto hashes = hashMultiFromFile(
+        HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256, path);
+    r["md5"] = std::move(hashes.md5);
+    r["sha1"] = std::move(hashes.sha1);
+    r["sha256"] = std::move(hashes.sha256);
+    // Hashed determines the success/status of hashing, -1 failed, 1 success.
+    r["hashed"] = (r.at("md5").empty()) ? "-1" : "1";
+  } else {
+    // Alternatively if hashing wasn't needed hashed is a 0.
+    r["hashed"] = "0";
+  }
+}
+}

--- a/osquery/tables/events/event_utils.h
+++ b/osquery/tables/events/event_utils.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+
+#include <osquery/tables.h>
+
+namespace osquery {
+
+/**
+ * @brief A helper function for each platform's implementation of file_events.
+ *
+ * Given an action and path, this Row decorator assures a common implementation
+ * of hashing and common columns from the `file` table.
+ *
+ * @param path The target path from the file event.
+ * @param hash Should the target path be read and hashed.
+ * @param r The output parameter row structure.
+ */
+void decorateFileEvent(const std::string& path, bool hash, Row& r);
+}

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -15,9 +15,9 @@
 #include <osquery/config.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/hash.h>
 
 #include "osquery/events/linux/inotify.h"
+#include "osquery/tables/events/event_utils.h"
 
 namespace osquery {
 
@@ -81,25 +81,23 @@ void FileEventSubscriber::configure() {
 }
 
 Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
+  if (ec->action.empty()) {
+    return Status(0);
+  }
+
   Row r;
   r["action"] = ec->action;
   r["target_path"] = ec->path;
   r["category"] = sc->category;
   r["transaction_id"] = INTEGER(ec->event->cookie);
 
-  if (ec->action == "CREATED" || ec->action == "UPDATED") {
-    auto hashes = hashMultiFromFile(
-        HASH_TYPE_MD5 | HASH_TYPE_SHA1 | HASH_TYPE_SHA256, ec->path);
-    r["md5"] = std::move(hashes.md5);
-    r["sha1"] = std::move(hashes.sha1);
-    r["sha256"] = std::move(hashes.sha256);
-  }
+  // Add hashing and 'join' against the file table for stat-information.
+  decorateFileEvent(
+      ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
 
-  if (ec->action != "" && ec->action != "OPENED") {
-    // A callback is somewhat useless unless it changes the EventSubscriber
-    // state or calls `add` to store a marked up event.
-    add(r, ec->time);
-  }
+  // A callback is somewhat useless unless it changes the EventSubscriber
+  // state or calls `add` to store a marked up event.
+  add(r, ec->time);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -171,7 +171,7 @@ void genApplicationsFromPath(const fs::path& path,
   }
 
   for (const auto& app : new_apps) {
-    if (fs::exists(app + "/Contents/Info.plist")) {
+    if (pathExists(app + "/Contents/Info.plist")) {
       apps.insert(app + "/Contents/Info.plist");
     }
   }
@@ -187,14 +187,14 @@ void genApplication(const pt::ptree& tree,
   // Loop through each column and its mapped Info.plist key name.
   for (const auto& item : kAppsInfoPlistTopLevelStringKeys) {
     r[item.second] = tree.get<std::string>(item.first, "");
-      // Change boolean values into integer 1, 0.
-      if (r[item.second] == "true" || r[item.second] == "YES" ||
-          r[item.second] == "Yes") {
-        r[item.second] = INTEGER(1);
-      } else if (r[item.second] == "false" || r[item.second] == "NO" ||
-                 r[item.second] == "No") {
-        r[item.second] = INTEGER(0);
-      }
+    // Change boolean values into integer 1, 0.
+    if (r[item.second] == "true" || r[item.second] == "YES" ||
+        r[item.second] == "Yes") {
+      r[item.second] = INTEGER(1);
+    } else if (r[item.second] == "false" || r[item.second] == "NO" ||
+               r[item.second] == "No") {
+      r[item.second] = INTEGER(0);
+    }
   }
   results.push_back(std::move(r));
 }
@@ -221,7 +221,7 @@ Status genAppsFromLaunchServices(std::set<std::string>& apps) {
   }
 
   @autoreleasepool {
-    for (id app in (__bridge NSArray*)ls_apps) {
+    for (id app in(__bridge NSArray*)ls_apps) {
       if (app != nil && [app isKindOfClass:[NSURL class]]) {
         apps.insert(std::string([[app path] UTF8String]) +
                     "/Contents/Info.plist");

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -33,10 +33,7 @@ const std::map<fs::file_type, std::string> kTypeNames{
     {fs::status_error, "error"},
 };
 
-void genFileInfo(/*const std::string& path,
-                 const std::string& filename,
-                 const std::string& dir,*/
-                 const fs::path& path,
+void genFileInfo(const fs::path& path,
                  const fs::path& parent,
                  const std::string& pattern,
                  QueryData& results) {

--- a/specs/file_events.table
+++ b/specs/file_events.table
@@ -1,13 +1,23 @@
 table_name("file_events")
 description("Track time/action changes to files specified in configuration data.")
 schema([
-    Column("target_path", TEXT, "The path changed"),
-    Column("category", TEXT, "The category of the file"),
+    Column("target_path", TEXT, "The path associated with the event"),
+    Column("category", TEXT, "The category of the file defined in the config"),
     Column("action", TEXT, "Change action (UPDATE, REMOVE, etc)"),
     Column("transaction_id", BIGINT, "ID used during bulk update"),
+    Column("inode", BIGINT, "Filesystem inode number"),
+    Column("uid", BIGINT, "Owning user ID"),
+    Column("gid", BIGINT, "Owning group ID"),
+    Column("mode", TEXT, "Permission bits"),
+    Column("size", BIGINT, "Size of file in bytes"),
+    Column("atime", BIGINT, "Last access time"),
+    Column("mtime", BIGINT, "Last modification time"),
+    Column("ctime", BIGINT, "Creation time"),
     Column("md5", TEXT, "The MD5 of the file after change"),
     Column("sha1", TEXT, "The SHA1 of the file after change"),
     Column("sha256", TEXT, "The SHA256 of the file after change"),
+    Column("hashed", INTEGER,
+      "1 if the file was hashed, 0 if not, -1 if hashing failed"),
     Column("time", BIGINT, "Time of file event"),
 ])
 attributes(event_subscriber=True)


### PR DESCRIPTION
This adds helpful fields to the `file_events` table that are nice to query at the time of event, rather than a subsequent JOIN at query time.