### PR TITLE
Add support for Linux SMBIOS/DMI EFI structure parsing

### DIFF
--- a/osquery/tables/system/smbios_utils.cpp
+++ b/osquery/tables/system/smbios_utils.cpp
@@ -85,6 +85,8 @@ void genSMBIOSTables(const uint8_t* tables, size_t length, QueryData& results) {
     r["type"] = INTEGER((unsigned short)header->type);
     if (kSMBIOSTypeDescriptions.count(header->type) > 0) {
       r["description"] = kSMBIOSTypeDescriptions.at(header->type);
+    } else {
+      r["description"] = "Unknown";
     }
 
     r["handle"] = BIGINT((unsigned long long)header->handle);


### PR DESCRIPTION
Previously the only SMBIOS/DMI parsing support includes raw (pre/non-EFI). With an EFI boot the DMI structures are moved and the physical address is stored in the firmware sysfs.