### PR TITLE
Add platform_info table for UEFI/ROM details

### DIFF
--- a/osquery/tables/system/darwin/iokit_registry.cpp
+++ b/osquery/tables/system/darwin/iokit_registry.cpp
@@ -22,12 +22,6 @@ void genIOKitDevice(const io_service_t& device,
                     int depth,
                     QueryData& results) {
   Row r;
-
-  // Get the device details
-  CFMutableDictionaryRef details;
-  IORegistryEntryCreateCFProperties(
-      device, &details, kCFAllocatorDefault, kNilOptions);
-
   io_name_t name, device_class;
   auto kr = IORegistryEntryGetName(device, name);
   if (kr == KERN_SUCCESS) {
@@ -86,7 +80,6 @@ void genIOKitDevice(const io_service_t& device,
   r["retain_count"] = INTEGER(retain_count);
 
   results.push_back(r);
-  CFRelease(details);
 }
 
 void genIOKitDeviceChildren(const io_registry_entry_t& service,

--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -8,12 +8,18 @@
  *
  */
 
+#include <iomanip>
+#include <sstream>
+
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
+
+#include <boost/algorithm/string.hpp>
 
 #include <osquery/tables.h>
 
 #include "osquery/tables/system/smbios_utils.h"
+#include "osquery/tables/system/darwin/iokit_utils.h"
 
 namespace osquery {
 namespace tables {
@@ -67,9 +73,9 @@ QueryData genSMBIOSTables(QueryContext& context) {
 
   // Parse structures.
   DarwinSMBIOSParser parser;
-  parser.setData(smbios_data, length);
-  parser.tables(([&results](size_t index, const SMBStructHeader* hdr,
-                            uint8_t* address, size_t size) {
+  parser.setData(const_cast<uint8_t*>(smbios_data), length);
+  parser.tables(([&results](
+      size_t index, const SMBStructHeader* hdr, uint8_t* address, size_t size) {
     genSMBIOSTable(index, hdr, address, size, results);
   }));
 
@@ -78,6 +84,61 @@ QueryData genSMBIOSTables(QueryContext& context) {
   return results;
 }
 
-QueryData genPlatformInfo(QueryContext& context) { return {}; }
+QueryData genPlatformInfo(QueryContext& context) {
+  auto entry =
+      IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/rom@0");
+  if (entry == MACH_PORT_NULL) {
+    return {};
+  }
+
+  // Get the device details
+  CFMutableDictionaryRef details = nullptr;
+  IORegistryEntryCreateCFProperties(
+      entry, &details, kCFAllocatorDefault, kNilOptions);
+
+  QueryData results;
+  if (details != nullptr) {
+    Row r;
+    r["vendor"] = getIOKitProperty(details, "vendor");
+    r["volume_size"] = getIOKitProperty(details, "fv-main-size");
+    r["size"] = getIOKitProperty(details, "rom-size");
+    r["date"] = getIOKitProperty(details, "release-date");
+    r["version"] = getIOKitProperty(details, "version");
+
+    {
+      auto address = getIOKitProperty(details, "fv-main-address");
+      auto value = boost::lexical_cast<size_t>(address);
+
+      std::stringstream hex_id;
+      hex_id << std::hex << std::setw(8) << std::setfill('0') << value;
+      r["address"] = "0x" + hex_id.str();
+    }
+
+    {
+      std::vector<std::string> extra_items;
+      auto info = getIOKitProperty(details, "apple-rom-info");
+      std::vector<std::string> info_lines;
+      iter_split(info_lines, info, boost::algorithm::first_finder("%0a"));
+      for (const auto& line : info_lines) {
+        std::vector<std::string> details;
+        iter_split(details, line, boost::algorithm::first_finder(": "));
+        if (details.size() > 1) {
+          boost::trim(details[1]);
+          if (details[0].find("Revision") != std::string::npos) {
+            r["revision"] = details[1];
+          }
+          extra_items.push_back(details[1]);
+        }
+      }
+      r["extra"] = osquery::join(extra_items, "; ");
+    }
+
+    results.push_back(r);
+    CFRelease(details);
+  }
+
+  IOObjectRelease(entry);
+  return results;
+}
 }
 }

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -8,6 +8,11 @@
  *
  */
 
+#include <iomanip>
+#include <sstream>
+
+#include <boost/noncopyable.hpp>
+
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
@@ -24,27 +29,40 @@ namespace tables {
 
 const std::string kLinuxEFISystabPath = "/sys/firmware/efi/systab";
 
-void genSMBIOSFromDMI(size_t base, size_t length, QueryData& results) {
-  // Linux will expose the SMBIOS/DMI entry point structures, which contain
-  // a member variable with the DMI tables start address and size.
-  // This applies to both the EFI-variable and physical memory search.
-  uint8_t* data = nullptr;
-  auto status = osquery::readRawMem(base, length, (void**)&data);
-  if (!status.ok() || data == nullptr) {
-    VLOG(1) << "Could not read DMI tables memory";
-    return;
+class LinuxSMBIOSParser : public SMBIOSParser {
+ public:
+  /// Attempt to read the system table and SMBIOS from an address.
+  void readFromAddress(size_t address, size_t length);
+
+  /// Parse the SMBIOS address from an EFI systab file.
+  void readFromSystab(const std::string& systab);
+
+  /// Cross version/boot read initializer.
+  bool discover();
+
+  /// Check if the read was successful.
+  bool valid() { return (data_ != nullptr && table_data_ != nullptr); }
+
+ public:
+  virtual ~LinuxSMBIOSParser() {
+    if (data_ != nullptr) {
+      free(data_);
+    }
+    if (table_data_ != nullptr) {
+      free(table_data_);
+    }
   }
 
-  // Attempt to parse tables from allocated data.
-  genSMBIOSTables(data, length, results);
-  free(data);
-}
+ private:
+  void discoverTables(size_t address, size_t length);
 
-void genRawSMBIOSTables(size_t address, size_t length, QueryData& results) {
-  uint8_t* data = nullptr;
-  auto status = osquery::readRawMem(address, length, (void**)&data);
-  if (!status.ok() || data == nullptr) {
-    VLOG(1) << "Could not read SMBIOS memory";
+  /// Hold the raw SMBIOS memory read.
+  uint8_t* data_{nullptr};
+};
+
+void LinuxSMBIOSParser::readFromAddress(size_t address, size_t length) {
+  auto status = osquery::readRawMem(address, length, (void**)&data_);
+  if (!status.ok() || data_ == nullptr) {
     return;
   }
 
@@ -53,41 +71,123 @@ void genRawSMBIOSTables(size_t address, size_t length, QueryData& results) {
   for (offset = 0; offset <= 0xFFF0; offset += 16) {
     // Could look for "_SM_" for the SMBIOS header, but the DMI header exists
     // in both SMBIOS and the legacy DMI spec.
-    if (memcmp(data + offset, "_DMI_", 5) == 0) {
-      auto dmi_data = (DMIEntryPoint*)(data + offset);
-      genSMBIOSFromDMI(dmi_data->tableAddress, dmi_data->tableLength, results);
+    if (memcmp(data_ + offset, "_DMI_", 5) == 0) {
+      auto dmi_data = (DMIEntryPoint*)(data_ + offset);
+      discoverTables(dmi_data->tableAddress, dmi_data->tableLength);
     }
   }
-  free(data);
 }
 
-void genEFISystabTables(QueryData& results) {
-  std::string systab;
-  if (!readFile(kLinuxEFISystabPath, systab).ok()) {
+void LinuxSMBIOSParser::readFromSystab(const std::string& systab) {
+  std::string content;
+  if (!readFile(kLinuxEFISystabPath, content).ok()) {
     return;
   }
 
-  for (const auto& line : osquery::split(systab, "\n")) {
+  for (const auto& line : osquery::split(content, "\n")) {
     if (line.find("SMBIOS") == 0) {
       auto details = osquery::split(line, "=");
       if (details.size() == 2 && details[1].size() > 2) {
         long long int address;
         safeStrtoll(details[1], 16, address);
-        genRawSMBIOSTables(address, kLinuxSMBIOSRawLength_, results);
+        readFromAddress(address, kLinuxSMBIOSRawLength_);
       }
     }
   }
 }
 
-QueryData genSMBIOSTables(QueryContext& context) {
-  QueryData results;
-
-  if (osquery::isReadable(kLinuxEFISystabPath).ok()) {
-    genEFISystabTables(results);
-  } else {
-    genRawSMBIOSTables(kLinuxSMBIOSRawAddress_, kLinuxSMBIOSRawLength_,
-                       results);
+void LinuxSMBIOSParser::discoverTables(size_t address, size_t length) {
+  // Linux will expose the SMBIOS/DMI entry point structures, which contain
+  // a member variable with the DMI tables start address and size.
+  // This applies to both the EFI-variable and physical memory search.
+  auto status = osquery::readRawMem(address, length, (void**)&table_data_);
+  if (!status.ok() || table_data_ == nullptr) {
+    return;
   }
+
+  // The read was successful, save the size and wait for requests to parse.
+  table_size_ = length;
+}
+
+bool LinuxSMBIOSParser::discover() {
+  if (osquery::isReadable(kLinuxEFISystabPath)) {
+    readFromSystab(kLinuxEFISystabPath);
+  } else {
+    readFromAddress(kLinuxSMBIOSRawAddress_, kLinuxSMBIOSRawLength_);
+  }
+  return valid();
+}
+
+QueryData genSMBIOSTables(QueryContext& context) {
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    VLOG(1) << "Could not read SMBIOS memory";
+    return {};
+  }
+
+  QueryData results;
+  parser.tables(([&results](size_t index, const SMBStructHeader* hdr,
+                            uint8_t* address, size_t size) {
+    genSMBIOSTable(index, hdr, address, size, results);
+  }));
+
+  return results;
+}
+
+/// Read a string using the index that is offset-bytes within address.
+std::string dmi_string(uint8_t* data, uint8_t* address, size_t offset) {
+  auto index = (uint8_t)(*(address + offset));
+  auto bp = (char*)data;
+  while (index > 1) {
+    while (*bp != 0) {
+      bp++;
+    }
+    bp++;
+    index--;
+  }
+
+  return std::string(bp);
+}
+
+QueryData genPlatformInfo(QueryContext& context) {
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    VLOG(1) << "Could not read SMBIOS memory";
+    return {};
+  }
+
+  QueryData results;
+  parser.tables(([&results](size_t index, const SMBStructHeader* hdr,
+                            uint8_t* address, size_t size) {
+    if (hdr->type != kSMBIOSTypeBIOS || size < 0x12) {
+      return;
+    }
+
+    Row r;
+    // The DMI string data uses offsets (indexes) into a data section that
+    // trails the header and structure offsets.
+    uint8_t* data = address + hdr->length;
+    r["vendor"] = dmi_string(data, address, 0x04);
+    r["version"] = dmi_string(data, address, 0x05);
+    r["date"] = dmi_string(data, address, 0x08);
+
+    // Firmware load address as a WORD.
+    size_t firmware_address = (address[0x07] << 8) + address[0x06];
+    std::stringstream hex_id;
+    hex_id << std::hex << std::setw(4) << std::setfill('0') << firmware_address;
+    r["address"] = "0x" + hex_id.str();
+
+    // Firmware size as a count of 64k blocks.
+    size_t firmware_size = (address[0x09] + 1) << 6;
+    r["size"] = std::to_string(firmware_size * 1024);
+
+    // Minor and major BIOS revisions.
+    r["revision"] = std::to_string((size_t)address[0x14]) + "." +
+                    std::to_string((size_t)address[0x15]);
+    r["volume_size"] = "0";
+    r["extra"] = "";
+    results.push_back(r);
+  }));
 
   return results;
 }

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -28,8 +28,40 @@ typedef struct DMIEntryPoint {
   uint8_t bcdRevision;
 } __attribute__((packed)) DMIEntryPoint;
 
-extern const std::map<int, std::string> kSMBIOSTypeDescriptions;
+/// Get friendly names for each SMBIOS table/section type.
+extern const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions;
 
-void genSMBIOSTables(const uint8_t* tables, size_t length, QueryData& results);
+constexpr uint8_t kSMBIOSTypeBIOS = 0;
+
+/**
+ * @brief A generic parser for SMBIOS tables.
+ *
+ * This generic class does not provide interfaces for finding tables only
+ * parsing data once it has been provided.
+ */
+class SMBIOSParser : private boost::noncopyable {
+ public:
+  /// Walk the tables and apply a predicate.
+  virtual void tables(std::function<void(
+      size_t index, const SMBStructHeader* hdr, uint8_t* address, size_t size)>
+                          predicate);
+
+ public:
+  virtual ~SMBIOSParser() {}
+
+ protected:
+  /// This protected data member is used during table parsing and must be set.
+  uint8_t* table_data_{nullptr};
+
+  /// Table size discovered from SMBIOS.
+  size_t table_size_{0};
+};
+
+/// Helper, cross platform, table row generator.
+void genSMBIOSTable(size_t index,
+                    const SMBStructHeader* hdr,
+                    uint8_t* address,
+                    size_t size,
+                    QueryData& results);
 }
 }

--- a/specs/platform_info.table
+++ b/specs/platform_info.table
@@ -1,0 +1,13 @@
+table_name("platform_info")
+description("Information about EFI/UEFI/ROM and platform/boot.")
+schema([
+    Column("vendor", TEXT, "Platform code vendor"),
+    Column("version", TEXT, "Platform code version"),
+    Column("date", TEXT, "Self-reported platform code update date"),
+    Column("revision", TEXT, "BIOS major and minor revision"),
+    Column("address", TEXT, "Relative address of firmware mapping"),
+    Column("size", TEXT, "Size in bytes of firmware"),
+    Column("volume_size", INTEGER, "(Optional) size of firmware volume"),
+    Column("extra", TEXT, "Platform-specific additional information"),
+])
+implementation("system@genPlatformInfo")


### PR DESCRIPTION
This is a WIP implementation of the `platform_info` table that reports DMI BIOS information about the platform on Linux and (will) IOKit's platform-related ROM information on Darwin.