### PR TITLE
Fixes for various build/sanitize/deps nice-to-haves

### DIFF
--- a/CMake/FindRocksDB.cmake
+++ b/CMake/FindRocksDB.cmake
@@ -25,7 +25,6 @@ SET(_rocksdb_LIBRARIES_SEARCH_DIRS
   /opt/rocksdb
 )
 
-##
 if( "${ROCKSDB_HOME}" STREQUAL "")
   if("" MATCHES "$ENV{ROCKSDB_HOME}")
     set (ROCKSDB_HOME ${_rocksdb_HOME})
@@ -35,7 +34,6 @@ if( "${ROCKSDB_HOME}" STREQUAL "")
 else( "${ROCKSDB_HOME}" STREQUAL "")
   message(STATUS "ROCKSDB_HOME is not empty: \"${ROCKSDB_HOME}\"")
 endif( "${ROCKSDB_HOME}" STREQUAL "")
-##
 
 IF( NOT ${ROCKSDB_HOME} STREQUAL "" )
   SET(_rocksdb_INCLUDE_SEARCH_DIRS ${ROCKSDB_HOME}/include ${_rocksdb_INCLUDE_SEARCH_DIRS})
@@ -100,7 +98,7 @@ if (NOT DEFINED ROCKSDB_FOUND)
     HINTS ${_rocksdb_LIBRARIES_SEARCH_DIRS}
   )
 
-  find_library(ROCKSDB_SNAPPY_LIBRARY NAMES libsnappy.a
+  find_library(ROCKSDB_SNAPPY_LIBRARY NAMES snappy
     HINTS ${_rocksdb_LIBRARIES_SEARCH_DIRS}
   )
 

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -57,7 +57,7 @@ void FSEventsSubscriptionContext::requireAction(const std::string& action) {
 void FSEventsEventPublisher::restart() {
   if (paths_.empty()) {
     // There are no paths to watch.
-    paths_.insert("/dev/null/");
+    paths_.insert("/dev/null");
   }
 
   if (run_loop_ == nullptr) {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -764,7 +764,8 @@ void attachEvents() {
   for (const auto& subscriber : subscribers) {
     auto status = EventFactory::registerEventSubscriber(subscriber.second);
     if (!status.ok()) {
-      LOG(WARNING) << "Error registering subscriber: " << status.getMessage();
+      LOG(WARNING) << "Error registering subscriber: " << subscriber.first
+                   << ": " << status.getMessage();
     }
   }
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -181,7 +181,7 @@ Status readFile(const fs::path& path,
                     if (buffer.size() == size) {
                       content += std::move(buffer);
                     } else {
-                      content += std::move(std::string(buffer, size));
+                      content += buffer.substr(0, size);
                     }
                   }));
 }

--- a/osquery/tables/events/process_file_events.cpp
+++ b/osquery/tables/events/process_file_events.cpp
@@ -23,7 +23,7 @@ class ProcessFileEventSubscriber
   Status init() override {
     auto pubref = EventFactory::getEventPublisher("kernel");
     if (pubref == nullptr || !pubref->hasStarted() || pubref->isEnding()) {
-      return Status(1);
+      return Status(1, "No kernel event publisher");
     }
 
     configure();

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -27,6 +27,12 @@ const std::string kLinuxOSRelease = "/etc/redhat-release";
 const std::string kLinuxOSRegex =
     "(?P<name>[\\w+\\s]+) .* "
     "(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)\\.?(?P<patch>\\w+)?";
+#elif defined(DEBIAN)
+const std::string kLinuxOSRelease = "/etc/os-release";
+const std::string kLinuxOSRegex =
+    "PRETTY_NAME=\"(?P<name>[\\w \\/]*) "
+    "(?P<major>[0-9]+)[\\.]{0,1}(?P<minor>[0-9]*)[\\.]{0,1}(?P<patch>[0-9]*).*"
+    "\"";
 #else
 const std::string kLinuxOSRelease = "/etc/os-release";
 const std::string kLinuxOSRegex =

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -24,7 +24,8 @@
 namespace osquery {
 namespace tables {
 
-inline std::string getProcAttr(const std::string& attr, const std::string& pid) {
+inline std::string getProcAttr(const std::string& attr,
+                               const std::string& pid) {
   return "/proc/" + pid + "/" + attr;
 }
 
@@ -43,7 +44,8 @@ inline std::string readProcCMDLine(const std::string& pid) {
   return content;
 }
 
-inline std::string readProcLink(const std::string& attr, const std::string& pid) {
+inline std::string readProcLink(const std::string& attr,
+                                const std::string& pid) {
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
 
@@ -154,7 +156,7 @@ struct SimpleProcStat {
   std::string saved_gid; // Gid: - - * -
 
   std::string resident_size; // VmRSS:
-  std::string phys_footprint;  // VmSize:
+  std::string phys_footprint; // VmSize:
 
   // Output from sring parsing /proc/<pid>/stat.
   std::string state;
@@ -254,8 +256,10 @@ void genProcess(const std::string& pid, QueryData& results) {
   r["root"] = readProcLink("root", pid);
   r["uid"] = proc_stat.real_uid;
   r["euid"] = proc_stat.effective_uid;
+  r["suid"] = proc_stat.saved_uid;
   r["gid"] = proc_stat.real_gid;
   r["egid"] = proc_stat.effective_gid;
+  r["sgid"] = proc_stat.saved_gid;
 
   // If the path of the executable that started the process is available and
   // the path exists on disk, set on_disk to 1. If the path is not

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <osquery/logger.h>
 #include <osquery/tables.h>
+#include <osquery/sql.h>
 
 #include "osquery/core/test_util.h"
 
@@ -29,10 +30,24 @@ TEST_F(SystemsTablesTests, test_os_version) {
 
   // Make sure major and minor contain data (a missing value of -1 is an error).
   EXPECT_FALSE(result[0]["major"].empty());
+
+// Debian does not define a minor.
+#if !defined(DEBIAN)
   EXPECT_FALSE(result[0]["minor"].empty());
+#endif
 
   // The OS name should be filled in too.
   EXPECT_FALSE(result[0]["name"].empty());
+}
+
+TEST_F(SystemsTablesTests, test_process_info) {
+  auto results = SQL("select * from osquery_info join processes using (pid)");
+  ASSERT_EQ(results.rows().size(), 1U);
+
+  // Make sure there is a valid UID and parent.
+  EXPECT_EQ(results.rows()[0].count("uid"), 1U);
+  EXPECT_NE(results.rows()[0].at("uid"), "-1");
+  EXPECT_NE(results.rows()[0].at("parent"), "-1");
 }
 }
 }

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -8,7 +8,7 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 function main_fedora() {
-  sudo yum update -y
+  sudo dnf update -y
 
   package texinfo
   package wget
@@ -34,15 +34,22 @@ function main_fedora() {
   package clang
   package clang-devel
 
-  install_cmake
-
   set_cc clang
   set_cxx clang++
 
-  install_boost
-
-  install_gflags
-  install_iptables_dev
+  if [[ $DISTRO -lt "22" ]]; then
+    install_cmake
+    install_boost
+    install_gflags
+    install_iptables_dev
+  else
+    package cmake
+    package boost-devel
+    package boost-static
+    package gflags
+    package gflags-devel
+    package iptables-devel
+  fi
 
   package doxygen
   package byacc
@@ -52,9 +59,17 @@ function main_fedora() {
   package automake
   package libtool
 
-  install_snappy
+  if [[ $DISTRO -lt "22" ]]; then
+    install_snappy
+    install_thrift
+  else
+    package snappy
+    package snappy-devel
+    package thrift
+    package thrift-devel
+  fi
+
   install_rocksdb
-  install_thrift
   install_yara
   install_cppnetlib
   install_google_benchmark
@@ -62,6 +77,7 @@ function main_fedora() {
   package device-mapper-devel
   package libgcrypt-devel
   package gettext-devel
+
   install_libcryptsetup
   install_sleuthkit
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -129,12 +129,13 @@ function install_thrift() {
 }
 
 function install_rocksdb() {
-  TARBALL=rocksdb-3.10.2.tar.gz
+  VERSION=4.1
+  TARBALL=rocksdb-$VERSION.tar.gz
   URL=$DEPS_URL/$TARBALL
-  SOURCE=rocksdb-rocksdb-3.10.2
+  SOURCE=rocksdb-rocksdb-$VERSION
 
   if provision rocksdb /usr/local/lib/librocksdb_lite.a; then
-    if [[ ! -f rocksdb-rocksdb-3.10.2/librocksdb_lite.a ]]; then
+    if [[ ! -f rocksdb-rocksdb-$VERSION/librocksdb_lite.a ]]; then
       if [[ $FAMILY = "debian" ]]; then
         CLANG_INCLUDE="-I/usr/include/clang/3.4/include"
       elif [[ $FAMILY = "redhat" ]]; then
@@ -153,8 +154,8 @@ function install_rocksdb() {
         $MAKE -j $THREADS static_lib CFLAGS="$CLANG_INCLUDE $CFLAGS"
       popd
     fi
-    sudo cp rocksdb-rocksdb-3.10.2/librocksdb_lite.a /usr/local/lib
-    sudo cp -R rocksdb-rocksdb-3.10.2/include/rocksdb /usr/local/include
+    sudo cp rocksdb-rocksdb-$VERSION/librocksdb_lite.a /usr/local/lib
+    sudo cp -R rocksdb-rocksdb-$VERSION/include/rocksdb /usr/local/include
   fi
 }
 
@@ -466,7 +467,11 @@ function package() {
       log "$1 is already installed. skipping."
     else
       log "installing $1"
-      sudo yum install $1 -y
+      if [[ $OS = "fedora" ]]; then
+        sudo dnf install $1 -y
+      else
+        sudo yum install $1 -y
+      fi
     fi
   elif [[ $OS = "darwin" ]]; then
     if [[ -n "$(brew list | grep $1)" ]]; then

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -90,7 +90,7 @@ function install_sleuthkit() {
   TARBALL=$SOURCE.tar.gz
   URL=$DEPS_URL/$TARBALL
 
-  if provision sleuthkid /usr/local/lib/libtsk.a; then
+  if provision sleuthkit /usr/local/lib/libtsk.a; then
     pushd $SOURCE
     ./bootstrap
     ./configure --prefix=/usr/local --without-afflib \

--- a/tools/tests/asan.supp
+++ b/tools/tests/asan.supp
@@ -1,0 +1,2 @@
+interceptor_via_fun:google::SetArgv
+interceptor_via_lib:gflags

--- a/tools/tests/sanitize_blacklist.txt
+++ b/tools/tests/sanitize_blacklist.txt
@@ -4,3 +4,9 @@
 # ASIO 0-lookups
 fun:*get_io_service*
 src:*asio/impl/*
+
+# GFlags
+fun:*SetArgv*
+
+# RocksDB
+fun:*ColumnFamilyOptions*


### PR DESCRIPTION
1. Bump RocksDB to 4.1 for Linux, `brew` will reflect the update too for OS X.
2. Fix an allocation error for sleuthkit-based tables.
3. Update provision for Fedora.
4. The `process_file_events` subscriber would fail without the `kernel` publisher and say "OK".
