### PR TITLE
Do not add (self) events for FSEvents

### DIFF
--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -82,16 +82,24 @@ void FSEventsEventPublisher::restart() {
   // Remove any existing stream.
   stop();
 
-  // Create the FSEvent stream
+  // Set stream flags.
+  auto flags =
+      kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagWatchRoot;
+  if (no_defer_) {
+    flags |= kFSEventStreamCreateFlagNoDefer;
+  }
+  if (no_self_) {
+    flags |= kFSEventStreamCreateFlagIgnoreSelf;
+  }
+
+  // Create the FSEvent stream.
   stream_ = FSEventStreamCreate(nullptr,
                                 &FSEventsEventPublisher::Callback,
                                 nullptr,
                                 watch_list,
                                 kFSEventStreamEventIdSinceNow,
                                 1,
-                                kFSEventStreamCreateFlagFileEvents |
-                                    kFSEventStreamCreateFlagNoDefer |
-                                    kFSEventStreamCreateFlagWatchRoot);
+                                flags);
   if (stream_ != nullptr) {
     // Schedule the stream on the run loop.
     FSEventStreamScheduleWithRunLoop(stream_, run_loop_, kCFRunLoopDefaultMode);

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -144,7 +144,15 @@ class FSEventsEventPublisher
   /// Set of paths to monitor, determined by a configure step.
   std::set<std::string> paths_;
 
+  /// Reference to the run loop for this thread.
   CFRunLoopRef run_loop_{nullptr};
+
+ private:
+  /// For testing only, ask the event stream to publish events immediately.
+  bool no_defer_{false};
+
+  /// For testing only, allow the event stream to publish its own events.
+  bool no_self_{true};
 
  private:
   friend class FSEventsTests;

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -40,6 +40,8 @@ class FSEventsTests : public testing::Test {
 
   void StartEventLoop() {
     event_pub_ = std::make_shared<FSEventsEventPublisher>();
+    event_pub_->no_defer_ = true;
+    event_pub_->no_self_ = false;
     EventFactory::registerEventPublisher(event_pub_);
     FILE* fd = fopen(trigger_path.c_str(), "w");
     fclose(fd);


### PR DESCRIPTION
Reporting FS events from osquery causes duplicate `ATTRIBUTES_MODIFIED` lines when the event handler `stat`s and reads the content for hashing.

Also, removing the defer option increases performance at the cost of lagging events slightly. In our cases this lag will not be noticed as in almost all cases the query schedule is much more request-latent.