### PR TITLE
[Fix #1735] Limit OPENED and access-related events

### DIFF
--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -22,6 +22,9 @@ namespace osquery {
 
 extern std::map<int, std::string> kMaskActions;
 
+extern const int kFileDefaultMasks;
+extern const int kFileAccessMasks;
+
 /**
  * @brief Subscription details for INotifyEventPublisher events.
  *

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -72,8 +72,10 @@ void FileEventSubscriber::configure() {
       // Use the filesystem globbing pattern to determine recursiveness.
       sc->recursive = 0;
       sc->path = file;
-      sc->mask = (accesses.count(category) > 0) ? IN_ALL_EVENTS
-                                                : (IN_ALL_EVENTS ^ IN_ACCESS);
+      sc->mask = kFileDefaultMasks;
+      if (accesses.count(category) > 0) {
+        sc->mask |= kFileAccessMasks;
+      }
       sc->category = category;
       subscribe(&FileEventSubscriber::Callback, sc);
     }


### PR DESCRIPTION
Using `IN_ALL_EVENTS` and restricting `IN_ACCESS` was a bad plan. Let's explicitly use event type masks for non-access categories.