### PR TITLE
[Fix #1736] Do not cache TLS node key within enroll plugin

### DIFF
--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -43,17 +43,7 @@ CLI_FLAG(bool,
          "Disable re-enrollment attempts if related plugins return invalid");
 
 Status clearNodeKey() {
-  std::string node_key;
-  auto s = getDatabaseValue(kPersistentSettings, "nodeKey", node_key);
-  if (!s.ok()) {
-    return s;
-  }
-
-  if (node_key.size() > 0) {
-    return deleteDatabaseValue(kPersistentSettings, "nodeKey");
-  }
-
-  return Status(0, "OK");
+  return deleteDatabaseValue(kPersistentSettings, "nodeKey");
 }
 
 std::string getNodeKey(const std::string& enroll_plugin) {

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -100,13 +100,16 @@ class TLSRequestHelper : private boost::noncopyable {
     }
 
     // Receive config or key rejection
-    if (output.count("node_invalid") > 0) {
-      if (!FLAGS_disable_reenrollment) {
-        clearNodeKey();
-      }
-      return Status(1, "Request failed: Invalid node key");
-    } else if (output.count("error") > 0) {
+    if (output.count("error") > 0) {
       return Status(1, "Request failed: " + output.get("error", "<unknown>"));
+    } else if (output.count("node_invalid") > 0) {
+      auto invalid = output.get("node_invalid", "");
+      if (invalid == "1" || invalid == "true" || invalid == "True") {
+        if (!FLAGS_disable_reenrollment) {
+          clearNodeKey();
+        }
+        return Status(1, "Request failed: Invalid node key");
+      }
     }
     return Status(0, "OK");
   }


### PR DESCRIPTION
Using the following flags:
```
--config_plugin=tls
--config_tls_endpoint=/config
--tls_hostname=localhost:9090
--verbose
--disable_logging
--config_tls_refresh=3
--tls_allow_unsafe
--enroll_tls_endpoint=/enroll
--enroll_secret_path=./tools/tests/test_enroll_secret.txt
```

The `test_http_server.py` API strawman will return an "invalid" every 3 requests.