### PR TITLE
Add certificate issuer and self_signed columns

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -39,7 +39,7 @@ void genCertificate(const SecCertificateRef& SecCert, QueryData& results) {
   // Generate the common name and subject.
   // They are very similar OpenSSL API accessors so save some logic and
   // generate them using output parameters.
-  genCommonName(cert, r["subject"], r["common_name"]);
+  genCommonName(cert, r["subject"], r["common_name"], r["issuer"]);
   // Same with algorithm strings.
   genAlgorithmProperties(cert, r["key_algorithm"], r["signing_algorithm"]);
 
@@ -55,6 +55,7 @@ void genCertificate(const SecCertificateRef& SecCert, QueryData& results) {
   // X509_check_ca() populates key_usage, {authority,subject}_key_id
   // so it should be called before others.
   r["ca"] = (CertificateIsCA(cert)) ? INTEGER(1) : INTEGER(0);
+  r["self_signed"] = (CertificateIsSelfSigned(cert)) ? INTEGER(1) : INTEGER(0);
   r["key_usage"] = genKeyUsage(cert->ex_kusage);
   r["authority_key_id"] =
       (cert->akid && cert->akid->keyid)

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -55,8 +55,7 @@ const std::map<unsigned long, std::string> kKeyUsageFlags = {
     {0x0020, "Key Encipherment"},
     {0x0040, "Non Repudiation"},
     {0x0080, "Digital Signature"},
-    {0x8000, "Decipher Only"}
-};
+    {0x8000, "Decipher Only"}};
 // clang-format on
 
 void genKeychains(const std::string& path, CFMutableArrayRef& keychains);
@@ -71,11 +70,15 @@ void genAlgorithmProperties(const X509* cert,
                             std::string& sig);
 
 /// Generate common name and subject.
-void genCommonName(X509* cert, std::string& subject, std::string& common_name);
+void genCommonName(X509* cert,
+                   std::string& subject,
+                   std::string& common_name,
+                   std::string& issuer);
 time_t genEpoch(ASN1_TIME* time);
 
 std::string genSHA1ForCertificate(const CFDataRef& raw_cert);
 bool CertificateIsCA(X509* cert);
+bool CertificateIsSelfSigned(X509* cert);
 
 /// Generate a list of keychain items for a given item type.
 CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,

--- a/osquery/tables/system/darwin/tests/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/tests/certificates_tests.cpp
@@ -60,8 +60,8 @@ TEST_F(CACertsTests, test_certificate_sha1) {
 }
 
 TEST_F(CACertsTests, test_certificate_properties) {
-  std::string subject, common_name;
-  genCommonName(x_cert, subject, common_name);
+  std::string subject, common_name, issuer;
+  genCommonName(x_cert, subject, common_name, issuer);
   EXPECT_EQ("localhost.localdomain", common_name);
 
   OSX_OPENSSL(X509_check_ca(x_cert));

--- a/specs/darwin/certificates.table
+++ b/specs/darwin/certificates.table
@@ -3,7 +3,9 @@ description("Certificate Authorities installed in Keychains/ca-bundles.")
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate distinguished name"),
+    Column("issuer", TEXT, "Certificate issuer distinguished name"),
     Column("ca", INTEGER, "1 if CA: true (certificate is an authority) else 0"),
+    Column("self_signed", INTEGER, "1 if self-signed, else 0"),
     Column("not_valid_before", DATETIME, "Lower bound of valid date"),
     Column("not_valid_after", DATETIME, "Certificate expiration data"),
     Column("signing_algorithm", TEXT, "Signing algorithm used"),


### PR DESCRIPTION
Add `issuer` and `self_signed` columns to OS X's `certificates` table.