### PR TITLE
Fix double event subscriber select

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -513,6 +513,7 @@ class EventSubscriberPlugin : public Plugin {
   FRIEND_TEST(EventsDatabaseTests, test_record_indexing);
   FRIEND_TEST(EventsDatabaseTests, test_record_range);
   FRIEND_TEST(EventsDatabaseTests, test_record_expiration);
+  FRIEND_TEST(EventsDatabaseTests, test_gentable);
   friend class BenchmarkEventSubscriber;
 };
 


### PR DESCRIPTION
When using the shell, multiple selects against an event subscriber that resulted in expired events would result in the second not returning any rows. This happened because post-expiration and event data deletion the first database get for data would fail and incorrectly fail the entire record select. 