### PR TITLE
Only discovery SMBIOS tables once on Linux

### DIFF
--- a/osquery/filesystem/linux/mem.cpp
+++ b/osquery/filesystem/linux/mem.cpp
@@ -96,6 +96,7 @@ Status readRawMem(size_t base, size_t length, void** buffer) {
     if (!readMem(fd, base, length, (uint8_t*)*buffer).ok()) {
       close(fd);
       free(*buffer);
+      *buffer = nullptr;
       return Status(1, "Cannot memory map or seek/read memory");
     }
   } else {

--- a/osquery/tables/system/smbios_utils.cpp
+++ b/osquery/tables/system/smbios_utils.cpp
@@ -96,7 +96,7 @@ void SMBIOSParser::tables(std::function<void(
     }
 
     auto table_length = next_table - table;
-    predicate(index, header, table, table_length);
+    predicate(index++, header, table, table_length);
     table = next_table;
   }
 }


### PR DESCRIPTION
When reading from the SMBIOS offset from the systab hint, only discover the tables (ala "_DMI_") once if the memory read succeeds.