### PR TITLE
Add key_size to certificates table

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -41,7 +41,8 @@ void genCertificate(const SecCertificateRef& SecCert, QueryData& results) {
   // generate them using output parameters.
   genCommonName(cert, r["subject"], r["common_name"], r["issuer"]);
   // Same with algorithm strings.
-  genAlgorithmProperties(cert, r["key_algorithm"], r["signing_algorithm"]);
+  genAlgorithmProperties(
+      cert, r["key_algorithm"], r["signing_algorithm"], r["key_size"]);
 
   // Most certificate field accessors return strings.
   r["not_valid_before"] = INTEGER(genEpoch(X509_get_notBefore(cert)));

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -65,9 +65,10 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 std::string genKIDProperty(const unsigned char* data, int len);
 
 /// Generate the public key algorithm and signing algorithm.
-void genAlgorithmProperties(const X509* cert,
+void genAlgorithmProperties(X509* cert,
                             std::string& key,
-                            std::string& sig);
+                            std::string& sig,
+                            std::string& size);
 
 /// Generate common name and subject.
 void genCommonName(X509* cert,

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -81,13 +81,23 @@ std::string genKIDProperty(const unsigned char* data, int len) {
   return key_id.str();
 }
 
-void genAlgorithmProperties(const X509* cert,
+void genAlgorithmProperties(X509* cert,
                             std::string& key,
-                            std::string& sig) {
+                            std::string& sig,
+                            std::string& size) {
   int nid = 0;
   OSX_OPENSSL(nid = OBJ_obj2nid(cert->cert_info->key->algor->algorithm));
   if (nid != NID_undef) {
     OSX_OPENSSL(key = std::string(OBJ_nid2ln(nid)));
+
+    // Get EVP public key, to determine public key size.
+    EVP_PKEY* pkey = nullptr;
+    OSX_OPENSSL(pkey = X509_get_pubkey(cert));
+    if (pkey != nullptr) {
+      size_t key_size = 0;
+      OSX_OPENSSL(key_size = EVP_PKEY_size(pkey));
+      size = std::to_string(key_size * 8);
+    }
   }
 
   OSX_OPENSSL(nid = OBJ_obj2nid(cert->cert_info->signature->algorithm));

--- a/specs/darwin/certificates.table
+++ b/specs/darwin/certificates.table
@@ -10,6 +10,7 @@ schema([
     Column("not_valid_after", DATETIME, "Certificate expiration data"),
     Column("signing_algorithm", TEXT, "Signing algorithm used"),
     Column("key_algorithm", TEXT, "Key algorithm used"),
+    Column("key_size", INTEGER, "Key size used"),
     Column("key_usage", TEXT, "Certificate key usage and extended key usage"),
     Column("subject_key_id", TEXT, "SKID an optionally included SHA1"),
     Column("authority_key_id", TEXT, "AKID an optionally included SHA1"),


### PR DESCRIPTION
Aside: hopefully the last addition to the certificates table.

The key_size of the public key for RSA, DSA, and EC keys can be listed using the EVP APIs. This is useful for auditing potentially weak key pairs.