### PR TITLE
Use key_strength to support ECC

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -42,7 +42,7 @@ void genCertificate(const SecCertificateRef& SecCert, QueryData& results) {
   genCommonName(cert, r["subject"], r["common_name"], r["issuer"]);
   // Same with algorithm strings.
   genAlgorithmProperties(
-      cert, r["key_algorithm"], r["signing_algorithm"], r["key_size"]);
+      cert, r["key_algorithm"], r["signing_algorithm"], r["key_strength"]);
 
   // Most certificate field accessors return strings.
   r["not_valid_before"] = INTEGER(genEpoch(X509_get_notBefore(cert)));

--- a/specs/darwin/certificates.table
+++ b/specs/darwin/certificates.table
@@ -10,7 +10,7 @@ schema([
     Column("not_valid_after", DATETIME, "Certificate expiration data"),
     Column("signing_algorithm", TEXT, "Signing algorithm used"),
     Column("key_algorithm", TEXT, "Key algorithm used"),
-    Column("key_size", INTEGER, "Key size used"),
+    Column("key_strength", TEXT, "Key size used for RSA/DSA, or curve name"),
     Column("key_usage", TEXT, "Certificate key usage and extended key usage"),
     Column("subject_key_id", TEXT, "SKID an optionally included SHA1"),
     Column("authority_key_id", TEXT, "AKID an optionally included SHA1"),


### PR DESCRIPTION
Call `key_size` `key_strength` to support labels for curves for ECC as well as key sizes for RSA/DSA.