### PR TITLE
Added fv2_users table

### DIFF
--- a/osquery/tables/system/darwin/fv2_users.mm
+++ b/osquery/tables/system/darwin/fv2_users.mm
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Foundation/Foundation.h>
+#import <dlfcn.h>
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genFV2Users(QueryContext& context) {
+  @autoreleasepool {
+
+    QueryData results;
+    
+    void *libCoreStorageHandle = dlopen("libCoreStorage.dylib", RTLD_LOCAL | RTLD_LAZY);
+    if (!libCoreStorageHandle) {
+        return results;
+    }
+    
+    typedef CFDictionaryRef (*CoreStorageCopyFamilyPropertiesForMount_t)(const char *);
+    CoreStorageCopyFamilyPropertiesForMount_t CoreStorageCopyFamilyPropertiesForMount =
+    (CoreStorageCopyFamilyPropertiesForMount_t) dlsym(libCoreStorageHandle, "CoreStorageCopyFamilyPropertiesForMount");
+    if (!CoreStorageCopyFamilyPropertiesForMount) {
+        return results;
+    }
+    
+    NSDictionary *properties = (__bridge NSDictionary *)CoreStorageCopyFamilyPropertiesForMount("/");
+    for (NSDictionary *user in properties[@"com.apple.corestorage.lvf.encryption.context"][@"CryptoUsers"]) {
+        if (![user[@"UserNamesData"] isKindOfClass:[NSArray class]]) {
+            continue;
+        }
+        Row r;
+        NSString *userShortName = [[NSString alloc] initWithData:[user[@"UserNamesData"] lastObject]
+                                                        encoding:NSUTF8StringEncoding];
+        r["user"] = TEXT([userShortName UTF8String]);
+        results.push_back(r);
+    }
+    
+    return results;
+
+  }
+}
+}
+}

--- a/specs/darwin/fv2_users.table
+++ b/specs/darwin/fv2_users.table
@@ -1,0 +1,9 @@
+table_name("fv2_users")
+description("Returns FV2 Users")
+schema([
+    Column("user", TEXT, "FV2 User", index=True),
+])
+implementation("system/darwin/fv2_users@genFV2Users")
+examples([
+  "select * from fv2_users;",
+])


### PR DESCRIPTION
Here is a fun example of pulling FV2 info using `libCoreStorage.dylib`. Thanks to @pudquick for pointing this out to me.

It is an undocumented library, but has an incredible amount of information. I load the lib and functions with `dlfcn` to help mitigate any crashes from changes on Apple's part.