### PR TITLE
Adding strict codesigning checks

### DIFF
--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -42,7 +42,7 @@ Status getVerifyFlags(SecCSFlags& flags) {
       return Status(-1, "Couldn't determine OS X version");
     }
 
-    sFlags = kSecCSDefaultFlags |  kSecCSCheckAllArchitectures;
+    sFlags = kSecCSStrictValidate |  kSecCSCheckAllArchitectures;
     if (minorVersion > 8) {
       sFlags |= kSecCSCheckNestedCode;
     }


### PR DESCRIPTION
Hi,

Simple change - replaced kSecCSStrictValidate vs kSecCSDefaultFlags.

Reason is that strict code signing checks insure that no data is being hidden on a macho/fat file. No increased performance overhead from my testing.

This coincides with my ShmooCon talk next Friday.

http://shmoocon.org/speakers/#hidedata

Let me know if you have any questions.

Thanks!

