### PR TITLE
[Fix #1749] Add support for make packages on Debian

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -11,14 +11,29 @@ if(APPLE)
   )
 elseif(LINUX)
   if(DEBIAN_BASED)
+    # Set basic catch-alls for debian-based systems.
     set(PACKAGE_TYPE "deb")
-    set(PACKAGE_ITERATION "1.ubuntu")
+    set(PACKAGE_ITERATION "1.debian")
     set(PACKAGE_DEPENDENCIES
       "zlib1g"
       "libbz2-1.0"
       "libreadline6"
-      "libgcrypt11"
     )
+
+    # Improve catch-alls for debian or ubuntu.
+    if(OSQUERY_BUILD_PLATFORM STREQUAL "ubuntu")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libgcrypt11"
+      )
+    elseif(OSQUERY_BUILD_PLATFORM STREQUAL "debian")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libgcrypt20"
+      )
+    endif()
+
+    # Improve package and iterations for each specific distribution.
     if(NOT OSQUERY_BUILD_DISTRO STREQUAL "lucid")
       set(PACKAGE_ITERATION "1.ubuntu10")
       set(PACKAGE_DEPENDENCIES
@@ -27,6 +42,7 @@ elseif(LINUX)
         "libapt-pkg4.12"
       )
     endif()
+
     if(OSQUERY_BUILD_DISTRO STREQUAL "precise")
       set(PACKAGE_ITERATION "1.ubuntu12")
       set(PACKAGE_DEPENDENCIES
@@ -34,8 +50,22 @@ elseif(LINUX)
         "libstdc++6"
         "libudev0"
       )
+    elseif(OSQUERY_BUILD_DISTRO STREQUAL "wheezy")
+      set(PACKAGE_ITERATION "1.debian7")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libstdc++6"
+        "libudev0"
+      )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "trusty")
       set(PACKAGE_ITERATION "1.ubuntu14")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libstdc++6 (>= 4.8)"
+        "libudev1"
+      )
+    elseif(OSQUERY_BUILD_DISTRO STREQUAL "jessie")
+      set(PACKAGE_ITERATION "1.debian8")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
         "libstdc++6 (>= 4.8)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,10 @@ add_definitions(
 
 if(APPLE)
   LOG_PLATFORM("OS X")
+elseif(OSQUERY_BUILD_PLATFORM STREQUAL "debian")
+  set(DEBIAN_BASED TRUE)
+  set(DEBIAN TRUE)
+  LOG_PLATFORM("Debian")
 elseif(OSQUERY_BUILD_PLATFORM STREQUAL "ubuntu")
   set(DEBIAN_BASED TRUE)
   set(UBUNTU TRUE)

--- a/osquery/database/db_handle.h
+++ b/osquery/database/db_handle.h
@@ -32,7 +32,9 @@ typedef std::shared_ptr<DBHandle> DBHandleRef;
 
 class GlogRocksDBLogger : public rocksdb::Logger {
  public:
-  virtual void Logv(const char* format, va_list ap);
+  // We intend to override a virtual method that is overloaded.
+  using rocksdb::Logger::Logv;
+  void Logv(const char* format, va_list ap) override;
 };
 
 /**

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -68,8 +68,12 @@ function main_debian() {
     package libboost-all-dev
     package automake
   fi 
-  
+
   install_google_benchmark
+
+  package rubygems
+  gem_install fpm
+
   install_thrift
   install_rocksdb 
   install_yara


### PR DESCRIPTION
1. Add relevant macros to CMake for Debian 7 and 8.
2. Install fpm within the Debian provisioning scripts.
3. Silence intentional override of overloaded method (RocksDB logger facility).
