### PR TITLE
Allow packs to add file_path categories

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -216,6 +216,25 @@ class Config : private boost::noncopyable {
   static const std::shared_ptr<ConfigParserPlugin> getParser(
       const std::string& parser);
 
+  /**
+   * @brief Apply each ConfigParser to an input property tree.
+   *
+   * This iterates each discovered ConfigParser Plugin and the plugin's keys
+   * to match keys within the input property tree. If a key matches then the
+   * associated value is passed to the parser.
+   *
+   * Use this utility method for both the top-level configuration tree and
+   * the content of each configuration pack. There is an optional black list
+   * parameter to differentiate pack content.
+   *
+   * @param source The input configuration source name.
+   * @param tree The input configuration tree.
+   * @param pack True if the tree was built from pack data, otherwise false.
+   */
+  static void applyParsers(const std::string& source,
+                           const boost::property_tree::ptree& tree,
+                           bool pack = false);
+
  protected:
   /**
    * @brief Call the genConfig method of the config retriever plugin.
@@ -272,10 +291,11 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
   FRIEND_TEST(ConfigTests, test_get_parser);
   FRIEND_TEST(ConfigTests, test_add_remove_pack);
+  FRIEND_TEST(ConfigTests, test_update_clear);
   FRIEND_TEST(ConfigTests, test_noninline_pack);
 
+  friend class FilePathsConfigParserPluginTests;
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
-  FRIEND_TEST(FilePathsConfigParserPluginTests, test_get_files);
   FRIEND_TEST(PacksTests, test_discovery_cache);
   FRIEND_TEST(SchedulerTests, test_monitor);
   FRIEND_TEST(SchedulerTests, test_config_results_purge);

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -109,20 +109,26 @@ void Pack::initialize(const std::string& name,
                       const pt::ptree& tree) {
   name_ = name;
   source_ = source;
+  // Check the shard limitation, shards falling below this value are included.
   if (tree.count("shard") > 0) {
     shard_ = tree.get<size_t>("shard", 0);
   }
 
+  // Check for a platform restriction.
   platform_.clear();
   if (tree.count("platform") > 0) {
     platform_ = tree.get<std::string>("platform", "");
   }
 
+  // Check for a version restriction.
   version_.clear();
   if (tree.count("version") > 0) {
     version_ = tree.get<std::string>("version", "");
   }
 
+  // Apply the shard, platform, and version checking.
+  // It is important to set each value such that the packs meta-table can report
+  // each of the restrictions.
   if ((shard_ > 0 && shard_ < getMachineShard()) || !checkPlatform() ||
       !checkVersion()) {
     return;

--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -17,26 +17,66 @@
 
 namespace osquery {
 
-class FilePathsConfigParserPluginTests : public testing::Test {};
+class FilePathsConfigParserPluginTests : public testing::Test {
+ public:
+  void SetUp() override {
+    // Read config content manually.
+    readFile(kTestDataPath + "test_parse_items.conf", content_);
+
+    // Construct a config map, the typical output from `Config::genConfig`.
+    config_data_["awesome"] = content_;
+  }
+
+  size_t numFiles() {
+    size_t count = 0;
+    Config::getInstance().files(([&count](
+        const std::string&, const std::vector<std::string>&) { count++; }));
+    return count;
+  }
+
+ protected:
+  std::string content_;
+  std::map<std::string, std::string> config_data_;
+};
 
 TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
-  // Read config content manually.
-  std::string content;
-  auto s = readFile(kTestDataPath + "test_parse_items.conf", content);
-  EXPECT_TRUE(s.ok());
+  std::vector<std::string> expected_categories = {
+      "config_files", "logs", "logs"};
+  std::vector<std::string> categories;
+  std::vector<std::string> expected_values = {
+      "/dev", "/dev/zero", "/dev/null", "/dev/random", "/dev/urandom"};
+  std::vector<std::string> values;
 
-  // Construct a config map, the typical output from `Config::genConfig`.
-  std::map<std::string, std::string> config;
-  config["awesome"] = content;
+  Config::getInstance().update(config_data_);
+  Config::getInstance().files(([&categories, &values](
+      const std::string& category, const std::vector<std::string>& files) {
+    categories.push_back(category);
+    for (const auto& file : files) {
+      values.push_back(file);
+    }
+  }));
 
-  Config c;
-  s = c.update(config);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(s.toString(), "OK");
-  c.files(
-      ([](const std::string& category, const std::vector<std::string>& files) {
-        std::vector<std::string> value = {"/usr"};
-        EXPECT_EQ(value, files);
-      }));
+  EXPECT_EQ(categories, expected_categories);
+  EXPECT_EQ(values, expected_values);
+}
+
+TEST_F(FilePathsConfigParserPluginTests, test_get_file_accesses) {
+  // Assume config data has been added.
+  auto parser = Config::getParser("file_paths");
+  auto& accesses = parser->getData().get_child("file_accesses");
+  EXPECT_EQ(accesses.size(), 2U);
+}
+
+TEST_F(FilePathsConfigParserPluginTests, test_remove_source) {
+  EXPECT_GT(numFiles(), 0U);
+  Config::getInstance().removeFiles("awesome");
+  // Expect the pack's set to persist.
+  // Do not call removeFiles, instead only update the pack/config content.
+  EXPECT_EQ(numFiles(), 1U);
+
+  // This will clear all source data for 'awesome'.
+  config_data_["awesome"] = "";
+  Config::getInstance().update(config_data_);
+  EXPECT_EQ(numFiles(), 0U);
 }
 }

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -176,6 +176,7 @@ TEST_F(ConfigTests, test_parse) {
       // Although this is a valid discovery query, there is no SQL plugin in
       // the core tests.
       {"valid_discovery_pack", false},
+      {"restricted_pack", true},
   };
 
   c.packs(([&results](Pack& pack) {
@@ -211,6 +212,31 @@ TEST_F(ConfigTests, test_add_remove_pack) {
   c.removePack("unrestricted_pack");
   c.packs(([&pack_count](Pack& pack) { pack_count++; }));
   EXPECT_EQ(pack_count, 0U);
+}
+
+TEST_F(ConfigTests, test_update_clear) {
+  // Read config content manually.
+  std::string content;
+  readFile(kTestDataPath + "test_parse_items.conf", content);
+
+  // Create the output of a `genConfig`.
+  std::map<std::string, std::string> config_data;
+  config_data["awesome"] = content;
+
+  // Update, then clear, packs should have been cleared.
+  Config c;
+  c.update(config_data);
+  size_t count = 0;
+  auto packCounter = [&count](Pack& pack) { count++; };
+  c.packs(packCounter);
+  EXPECT_GT(count, 0U);
+
+  // Now clear.
+  config_data["awesome"] = "";
+  c.update(config_data);
+  count = 0;
+  c.packs(packCounter);
+  EXPECT_EQ(count, 0U);
 }
 
 TEST_F(ConfigTests, test_get_scheduled_queries) {

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -106,6 +106,17 @@ TEST_F(PacksTests, test_check_version) {
   EXPECT_TRUE(fpack.checkVersion());
 }
 
+TEST_F(PacksTests, test_restriction_population) {
+  // Require that all potential restrictions are populated before being checked.
+  auto tree = getExamplePacksConfig();
+  auto packs = tree.get_child("packs");
+  auto fpack = Pack("fake_pack", packs.get_child("restricted_pack"));
+
+  ASSERT_FALSE(fpack.getPlatform().empty());
+  ASSERT_FALSE(fpack.getVersion().empty());
+  ASSERT_EQ(fpack.getShard(), 1U);
+}
+
 TEST_F(PacksTests, test_schedule) {
   auto fpack = Pack("discovery_pack", getPackWithDiscovery());
   // Expect a single query in the schedule since one query has an explicit

--- a/tools/tests/test_inline_pack.conf
+++ b/tools/tests/test_inline_pack.conf
@@ -46,6 +46,11 @@
           "interval": 3600
         }
       }
+    },
+    "restricted_pack": {
+      "version": "9.9.9",
+      "platform": "none",
+      "shard": "1"
     }
   },
   "schedule": {

--- a/tools/tests/test_parse_items.conf
+++ b/tools/tests/test_parse_items.conf
@@ -17,6 +17,18 @@
           "interval": 3600
         }
       }
+    },
+    "foobar_with_files": {
+      "file_paths": {
+        "logs": [
+          "/dev/random",
+          "/dev/urandom"
+        ]
+      },
+      "file_accesses": [
+        "logs",
+        "bar"
+      ]
     }
   },
   "schedule": {
@@ -26,13 +38,17 @@
     }
   },
   "file_paths": {
-    "foo": [
-      "/usr"
+    "logs": [
+      "/dev/null"
     ],
-    "bar": [
-      "/usr"
+    "config_files": [
+      "/dev",
+      "/dev/zero"
     ]
   },
+  "file_accesses": [
+    "logs"
+  ],
   "events": {
     "environment_variables": [
       "foo",


### PR DESCRIPTION
From some testing I saw that `file_paths` was not recognized when within paths. This was an original design decision that doesn't have to be as limiting now that we manage config state from multiple sources.

The concept is simple! Paths and other things from packs are tracked by their source. For things in the config that do not recognize indexing by an additional pack name, or where something would be over-complicated by an additional 'name' the source becomes the source + DELIMITER + name. When a config source is updated the packs from that source are removed. This triggers a removal of the file paths originally added by the pack.