### PR TITLE
Unify build script and fix EVENTS benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PLATFORM := $(shell uname -s)
+GIT_EXISTS := $(shell which git)
+BASH_EXISTS := $(shell which bash)
 VERSION := $(shell git describe --tags HEAD --always)
 SHELL := $(shell which bash)
 
@@ -10,11 +12,11 @@ endif
 DISTRO := $(shell . ./tools/lib.sh; _platform)
 DISTRO_VERSION := $(shell . ./tools/lib.sh; _distro $(DISTRO))
 ifeq ($(DISTRO),darwin)
-  ifeq ($(DISTRO_VERSION), 10.10)
-    BUILD_DIR = darwin
-  else
-    BUILD_DIR = darwin$(DISTRO_VERSION)
-  endif
+	ifeq ($(DISTRO_VERSION), 10.10)
+		BUILD_DIR = darwin
+	else
+		BUILD_DIR = darwin$(DISTRO_VERSION)
+	endif
 else ifeq ($(DISTRO),freebsd)
 	BUILD_DIR = freebsd$(DISTRO_VERSION)
 else
@@ -34,7 +36,7 @@ docs: .setup
 
 debug: .setup
 	cd build/debug_$(BUILD_DIR) && DEBUG=True cmake ../../ && \
-	  $(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)
+		$(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)
 
 test_debug: .setup
 	cd build/debug_$(BUILD_DIR) && DEBUG=True cmake ../../ && \
@@ -94,6 +96,15 @@ ifeq ($(PLATFORM),Linux)
 endif
 
 .setup:
+ifeq ($(GIT_EXISTS),)
+	@echo "Problem: cannot find 'git'"
+	false
+endif
+ifeq ($(BASH_EXISTS),)
+	@echo "Problem: cannot find 'bash'"
+	false
+endif
+
 ifeq ($(DISTRO),unknown_version)
 	@echo Unknown, non-Redhat, non-Ubuntu based Linux distro
 	false
@@ -102,8 +113,8 @@ endif
 	@mkdir -p build/$(BUILD_DIR)
 	@mkdir -p build/debug_$(BUILD_DIR)
 ifeq ($(PLATFORM),Linux)
-		@ln -snf $(BUILD_DIR) build/linux
-		@ln -snf debug_$(BUILD_DIR) build/debug_linux
+	@ln -snf $(BUILD_DIR) build/linux
+	@ln -snf debug_$(BUILD_DIR) build/debug_linux
 endif
 
 package: .setup

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -10,6 +10,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include <osquery/config.h>
 #include <osquery/events.h>
 #include <osquery/tables.h>
 
@@ -66,6 +67,10 @@ class BenchmarkEventSubscriber
 };
 
 static void EVENTS_subscribe_fire(benchmark::State& state) {
+  // Setup the event config parser plugin.
+  auto plugin = Config::getInstance().getParser("events");
+  plugin->setUp();
+
   // Register a publisher.
   auto pub = std::make_shared<BenchmarkEventPublisher>();
   EventFactory::registerEventPublisher(pub);

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -12,59 +12,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/lib.sh
 
-threads THREADS
-platform PLATFORM
-distro $PLATFORM DISTRO
-
-# Build kernel extension/module and tests.
-BUILD_KERNEL=0
-if [[ "$PLATFORM" = "darwin" ]]; then
-  if [[ "$DISTRO" = "10.10" ]]; then
-    BUILD_KERNEL=1
-  fi
-fi
-
-MAKE=make
-if [[ "$PLATFORM" = "freebsd" ]]; then
-  MAKE=gmake
-fi
-
-cd $SCRIPT_DIR/../
-
-function cleanUp() {
-  # Cleanup kernel
-  $MAKE kernel-unload || sudo reboot
-}
-
-# Run build host provisions and install library dependencies.
-$MAKE deps
-
-# Clean previous build artifacts.
-$MAKE clean
-
-# Build osquery.
-$MAKE -j$THREADS
-
-if [[ $BUILD_KERNEL = 1 ]]; then
-  # Build osquery kernel (optional).
-  $MAKE kernel-build
-
-  # Setup cleanup code for catastrophic test failures.
-  trap cleanUp EXIT INT TERM
-
-  # Load osquery kernel (optional).
-  $MAKE kernel-load
-fi
-
-# Request that tests include addition 'release' or 'package' units.
-export RUN_RELEASE_TESTS=1
-
-# Run code unit and integration tests.
-$MAKE test/fast
-
-if [[ $BUILD_KERNEL = 1 ]]; then
-  # Run kernel unit and integration tests (optional).
-  $MAKE kernel-test/fast
-fi
+# Run the build function and the tests
+build true
 
 exit 0

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -126,3 +126,64 @@ function in_ec2() {
     return 1
   fi
 }
+
+function build_kernel_cleanup() {
+  # Cleanup kernel
+  $MAKE kernel-unload || sudo reboot
+}
+
+function build() {
+  threads THREADS
+  platform PLATFORM
+  distro $PLATFORM DISTRO
+
+  # Build kernel extension/module and tests.
+  BUILD_KERNEL=0
+  if [[ "$PLATFORM" = "darwin" ]]; then
+    if [[ "$DISTRO" = "10.10" ]]; then
+      BUILD_KERNEL=1
+    fi
+  fi
+
+  MAKE=make
+  if [[ "$PLATFORM" = "freebsd" ]]; then
+    MAKE=gmake
+  fi
+
+  RUN_TESTS=$1
+
+  cd $SCRIPT_DIR/../
+
+  # Run build host provisions and install library dependencies.
+  $MAKE deps
+
+  # Clean previous build artifacts.
+  $MAKE clean
+
+  # Build osquery.
+  $MAKE -j$THREADS
+
+  if [[ $BUILD_KERNEL = 1 ]]; then
+    # Build osquery kernel (optional).
+    $MAKE kernel-build
+
+    # Setup cleanup code for catastrophic test failures.
+    trap build_kernel_cleanup EXIT INT TERM
+
+    # Load osquery kernel (optional).
+    $MAKE kernel-load
+  fi
+
+  if [[ $RUN_TESTS = true ]]; then
+    # Request that tests include addition 'release' or 'package' units.
+    export RUN_RELEASE_TESTS=1
+
+    # Run code unit and integration tests.
+    $MAKE test/fast
+
+    if [[ $BUILD_KERNEL = 1 ]]; then
+      # Run kernel unit and integration tests (optional).
+      $MAKE kernel-test/fast
+    fi
+  fi
+}


### PR DESCRIPTION
1. Detecting git/bash in the `Makefile` will help identify CMake problems where the version/build info is not formatted well.
2. Unifying the build logic for build/test and benchmarking should help preventing breakage of less-watched build paths. Previously the nightly benchmark generation was failing due to exceptions in the benchmark code and regressions in the build flow.