### PR TITLE
Remove RHEL builds, silence SQLite warnings, add systemd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,7 @@ elseif(CLANGXX_EXISTS)
 endif()
 
 add_compile_options(
-  -Wall
-  -Wextra
   -Wstrict-aliasing
-  -Wno-unused-parameter
   -Wno-missing-field-initializers
   -Wno-unused-local-typedef
   -Wno-unknown-warning-option

--- a/README.md
+++ b/README.md
@@ -10,14 +10,12 @@ The tools make low-level operating system analytics and monitoring both performa
 
 | Platform | Build status  | | | |
 |----------|---------------|---|---|---|
-RHEL 6.5   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildRHEL6/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildRHEL6/) | | **Homepage:** | https://osquery.io
-RHEL 7.0   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildRHEL7/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildRHEL7/) | | **Downloads:** | https://osquery.io/downloads
+OS X 10.9    | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/) | | **Homepage:** | https://osquery.io
+OS X 10.10/11| [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/) | | **Downloads:** | https://osquery.io/downloads
 CentOS 6.5   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/) | | **Tables:** | https://osquery.io/tables
 CentOS 7.0   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/) | | **Packs:** | https://osquery.io/packs
 Ubuntu 12.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/) | | **Guide:** | https://osquery.readthedocs.org
 Ubuntu 14.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/) | | [![Slack Status](https://osquery-slack.herokuapp.com/badge.svg)](https://osquery-slack.herokuapp.com) | https://osquery.slack.com
-OS X 10.9   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/) | | |
-OS X 10.10  | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX/) | | |
 
 #### What is osquery?
 
@@ -98,4 +96,4 @@ Facebook has a [bug bounty](https://www.facebook.com/whitehat/) program that inc
 #### Learn more
 
 Read the [launch blog post](https://code.facebook.com/posts/844436395567983/introducing-osquery/) for background on the project.
-If you're interested in learning more about osquery, visit the [users guide](https://osquery.readthedocs.org/) and browse our RFC-labeled Github issues.
+If you're interested in learning more about osquery, visit the [users guide](https://osquery.readthedocs.org/) and browse our RFC-labeled Github issues. Development and usage discussion is happing in the osquery Slack, grab an invite automatically: [https://osquery-slack.herokuapp.com/](https://osquery-slack.herokuapp.com/badge.sv)!

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -30,6 +30,13 @@ set(OSQUERY_LIBS
   z
 )
 
+# Add all and extra for osquery code.
+add_compile_options(
+  -Wall
+  -Wextra
+  -Wno-unused-parameter
+)
+
 if(NOT FREEBSD)
   set(OSQUERY_LIBS ${OSQUERY_LIBS} dl)
 else()

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -30,6 +30,10 @@ OUTPUT_PKG_PATH="$BUILD_DIR/$PACKAGE_NAME-$PACKAGE_VERSION."
 # Config files
 INITD_SRC="$SCRIPT_DIR/osqueryd.initd"
 INITD_DST="/etc/init.d/osqueryd"
+SYSTEMD_SERVICE_SRC="$SCRIPT_DIR/osqueryd.service"
+SYSTEMD_SERVICE_DST="/usr/lib/systemd/system/osqueryd.service"
+SYSTEMD_SYSCONFIG_SRC="$SCRIPT_DIR/osqueryd.sysconfig"
+SYSTEMD_SYSCONFIG_DST="/etc/sysconfig/osqueryd"
 CTL_SRC="$SCRIPT_DIR/osqueryctl"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/usr/share/osquery/packs/"
@@ -83,6 +87,7 @@ function main() {
   check_parsed_args
 
   platform OS
+  distro $OS DISTRO
 
   rm -rf $WORKING_DIR
   rm -f $OUTPUT_PKG_PATH
@@ -106,8 +111,16 @@ function main() {
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
   cp $PACKS_SRC/* $INSTALL_PREFIX/$PACKS_DST
 
-  mkdir -p `dirname $INSTALL_PREFIX$INITD_DST`
-  cp $INITD_SRC $INSTALL_PREFIX$INITD_DST
+  if [[ $OS = "centos" && $DISTRO = "centos7" ]]; then
+    # Install the systemd service and sysconfig
+    mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SERVICE_DST`
+    mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST`
+    cp $SYSTEMD_SERVICE_SRC $INSTALL_PREFIX$SYSTEMD_SERVICE_DST
+    cp $SYSTEMD_SYSCONFIG_SRC $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST
+  else
+    mkdir -p `dirname $INSTALL_PREFIX$INITD_DST`
+    cp $INITD_SRC $INSTALL_PREFIX$INITD_DST
+  fi
 
   log "creating package"
   IFS=',' read -a deps <<< "$PACKAGE_DEPENDENCIES"

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=The osquery Daemon
+After=network.service syslog.service
+
+[Service]
+Type=forking
+TimeoutStartSec=0
+PIDFile=/var/run/osqueryd.pid
+EnvironmentFile=/etc/sysconfig/osqueryd
+ExecStartPre=/bin/sh -c "if [[ ! -f $FLAG_FILE ]]; then touch $FLAG_FILE; fi"
+ExecStart=/usr/bin/osqueryd \
+  --force \
+  --daemonize \
+  --pidfile /var/run/osqueryd.pid \
+  --flagfile $FLAG_FILE \
+  --config_path $CONFIG_FILE
+Restart=on-abort
+KillMode=process
+KillSignal=SIGTERM
+SendSIGKILL=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/deployment/osqueryd.sysconfig
+++ b/tools/deployment/osqueryd.sysconfig
@@ -1,0 +1,2 @@
+FLAG_FILE="/etc/osquery/osquery.flags"
+CONFIG_FILE="/etc/osquery/osquery.conf"


### PR DESCRIPTION
1. We do not produce packages for RHEL and our subscriptions are expiring. Unless someone shows renewed interest, let's punt on restarting those since they are a royal PITA.
2. The SQLite code has annoying uninitialized constants. A part of me dies when I see these warnings, so I'm squashing them and limiting `-Wall -Wextra` to only osquery code.
3. CentOS7 users have asked for a systemd service. CentOS 7 package builds will now include such a service and it will up to the administrator to enable/start the service.