### PR TITLE
Improve TLS logging memory

### DIFF
--- a/osquery/database/db_handle.cpp
+++ b/osquery/database/db_handle.cpp
@@ -128,9 +128,9 @@ DBHandle::DBHandle(const std::string& path, bool in_memory)
   options_.arena_block_size = (4 * 1024);
   options_.write_buffer_size = (4 * 1024) * 100; // 100 blocks.
   options_.max_write_buffer_number = 2;
-  options_.min_write_buffer_number_to_merge = 2;
-  options_.max_background_compactions = 1;
-  options_.max_background_flushes = 1;
+  options_.min_write_buffer_number_to_merge = 1;
+  options_.max_background_compactions = 2;
+  options_.max_background_flushes = 2;
 
   // Create an environment to replace the default logger.
   if (logger_ == nullptr) {

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -8,7 +8,7 @@
  *
  */
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/chrono.hpp>
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -24,14 +24,14 @@ namespace osquery {
 FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
 
 void interruptableSleep(size_t milli) {
-  boost::this_thread::sleep(boost::posix_time::milliseconds(milli));
+  boost::this_thread::sleep_for(boost::chrono::milliseconds(milli));
 }
 
 Dispatcher::~Dispatcher() { join(); }
 
 void Dispatcher::init() {
   thread_manager_ = InternalThreadManager::newSimpleThreadManager(
-          (size_t)FLAGS_worker_threads, 0);
+      (size_t)FLAGS_worker_threads, 0);
   auto thread_factory = ThriftThreadFactory(new PosixThreadFactory());
   thread_manager_->threadFactory(thread_factory);
   thread_manager_->start();


### PR DESCRIPTION
This minimizes the max memory needed for TLS loggers. When the logger thread wake up it will discover the log items in RocksDB. Those will be constructed into a property tree and passed to the remote API's serializer/deserializer. This adds a spurious JSON encode/decode step. We should try to avoid keeping multiple copies of this content in memory simultaneously.