### PR TITLE
Add currently authenticated FileVault user

### DIFF
--- a/specs/disk_encryption.table
+++ b/specs/disk_encryption.table
@@ -5,6 +5,7 @@ schema([
     Column("uuid", TEXT, "Disk Universally Unique Identifier"),
     Column("encrypted", INTEGER, "1 If encrypted: true (disk is encrypted), else 0"),
     Column("type", TEXT, "Description of cipher type and mode if available"),
+    Column("uid", TEXT, "Currently authenticated user if available"),
     ForeignKey(column="name", table="block_devices"),
     ForeignKey(column="uuid", table="block_devices"),
 ])


### PR DESCRIPTION
From the discussion in #1752, this adds currently authenticated FileVault user to `disk_encryption` table on Darwin.

```
osquery> select de.name, de.encrypted, de.type, de.uid, users.shell
    ...> from disk_encryption as de join users
    ...> where de.uid == users.uid;
+------------+-----------+---------+-----+--------------------+
| name       | encrypted | type    | uid | shell              |
+------------+-----------+---------+-----+--------------------+
| /dev/disk1 | 1         | AES-XTS | 501 | /usr/local/bin/zsh |
+------------+-----------+---------+-----+--------------------+
```