### PR TITLE
Promote 10.11 to default darwin package builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 DISTRO := $(shell . ./tools/lib.sh; _platform)
 DISTRO_VERSION := $(shell . ./tools/lib.sh; _distro $(DISTRO))
 ifeq ($(DISTRO),darwin)
-	ifeq ($(DISTRO_VERSION), 10.10)
+	ifeq ($(DISTRO_VERSION), 10.11)
 		BUILD_DIR = darwin
 	else
 		BUILD_DIR = darwin$(DISTRO_VERSION)

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -351,6 +351,13 @@ Status attachTableInternal(const std::string &name,
       tables::sqlite::xEof,
       tables::sqlite::xColumn,
       tables::sqlite::xRowid,
+      nullptr, /* Update */
+      nullptr, /* Begin */
+      nullptr, /* Sync */
+      nullptr, /* Commit */
+      nullptr, /* Rollback */
+      nullptr, /* FindFunction */
+      nullptr, /* Rename */
   };
   // clang-format on
 

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -23,7 +23,7 @@ import test_base
 
 
 class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
-
+    @test_base.flaky
     def test_1_daemon_without_watchdog(self):
         daemon = self._run_daemon({
             "disable_watchdog": True,
@@ -32,6 +32,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(daemon.isAlive())
         daemon.kill()
 
+    @test_base.flaky
     def test_2_daemon_with_option(self):
         logger_path = os.path.join(test_base.CONFIG_DIR, "logger-tests")
         os.makedirs(logger_path)

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -24,7 +24,6 @@ SHELL_TIMEOUT = 10
 
 
 class OsqueryiTest(unittest.TestCase):
-
     def setUp(self):
         self.binary = os.path.join(test_base.ARGS.build, "osquery", "osqueryi")
         self.osqueryi = test_base.OsqueryWrapper(self.binary)
@@ -38,6 +37,7 @@ class OsqueryiTest(unittest.TestCase):
         self.assertRaises(test_base.OsqueryException,
                           self.osqueryi.run_query, 'foo')
 
+    @test_base.flaky
     def test_config_check_success(self):
         '''Test that a 0-config passes'''
         proc = test_base.TimeoutRunner([
@@ -52,6 +52,7 @@ class OsqueryiTest(unittest.TestCase):
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    @test_base.flaky
     def test_config_dump(self):
         '''Test that config raw output is dumped when requested'''
         config = "%s/test_noninline_packs.conf" % test_base.SCRIPT_DIR
@@ -67,6 +68,7 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    @test_base.flaky
     def test_config_check_failure(self):
         '''Test that a missing config fails'''
         proc = test_base.TimeoutRunner([
@@ -103,6 +105,7 @@ class OsqueryiTest(unittest.TestCase):
         self.assertNotEqual(proc.stderr, "")
         self.assertNotEqual(proc.proc.poll(), 0)
 
+    @test_base.flaky
     def test_config_check_example(self):
         '''Test that the example config passes'''
         example_path = "deployment/osquery.example.conf"


### PR DESCRIPTION
This will effect those to develop or perform custom builds for OS X on 10.10 and 10.11!

| Version | Current Target  | New Target | 
| --- | --- | --- |
| 10.10 | `./build/darwin/osquery` | `./build/darwin10.10/osquery` |
| 10.11 | `./build/darwin10.11/osquery` | `./build/darwin/osquery` |

This change will cause the package-related jobs to use the 10.11 build as the distribution build.
