### PR TITLE
Rollup of several docs and build fixes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,13 @@ Visit https://github.com/facebook/osquery and use the web UI to create a Pull Re
 
 ## Pull Request workflow
 
-In most cases your PR should represent a single body of work. It is find to change unrelated small-things like nits or code-format issues but make every effort to submit isolated changes. This makes documentation, references, regression tracking and if needed, a revert, easier.
+In most cases your PR should represent a single body of work. It is fine to change unrelated small-things like nits or code-format issues but make every effort to submit isolated changes. This makes documentation, references, regression tracking and if needed, a revert, easier.
 
 ## Updating Pull Requests
 
-Pull requests will often need revision most likely after the required code review from the friendly core development team. :D
+Pull requests will often need revision, most likely after the required code review from the friendly core development team. :D
 
-Our preference is to minimize the number of commits in a pull request and represent each body of change as a single, concise, commit. To do this we ask you to [squash](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) your git commits before we merge changes. There are two basic workflows for squashing, let's run through some examples of each.
+Our preference is to minimize the number of commits in a pull request and represent each body of change as a single, concise, commit. To do this we ask you to [squash](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) your git commits before we merge changes. There are two basic workflows for squashing, let's run through examples of each.
 
 **You create a pull request with several commits**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,97 @@ Visit https://github.com/facebook/osquery and use the web UI to create a Pull Re
 
 ## Pull Request workflow
 
+In most cases your PR should represent a single body of work. It is find to change unrelated small-things like nits or code-format issues but make every effort to submit isolated changes. This makes documentation, references, regression tracking and if needed, a revert, easier.
+
+## Updating Pull Requests
+
+Pull requests will often need revision most likely after the required code review from the friendly core development team. :D
+
+Our preference is to minimize the number of commits in a pull request and represent each body of change as a single, concise, commit. To do this we ask you to [squash](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) your git commits before we merge changes. There are two basic workflows for squashing, let's run through some examples of each.
+
+**You create a pull request with several commits**
+
+If you open a pull request from a branch with 'stacked commits' the request will ask us to merge the lot of them into our master. That is no fun, and we will promptly ask you to squash! If you have 5 commits in the pull request you can squash these into 1 using:
+
+```
+$ git rebase -i HEAD~5
+```
+
+This tells git to perform an interactive rebase onto the `HEAD-5` commit. The interactive part means your favorite editor will prompt you for actions. To turn 5 commits into 1 we'll `pick` the first, then `squash` the remaining, in this case 4. The 'squashed' 4 will be squashed into the commit we 'pick'. Within the interactive editor, change the last 4 'picks' to an `s`, shorthand for squash.
+
+For example here are my 5 commits while editing this guide:
+
+```
+pick dc849a9 Update contributing with squash instructions
+pick 8b1fa6b Minor change to contributing
+pick 45baf1a Delete whitespace in contributing
+pick bded8d7 Delete more whitespace
+pick ab49a55 Fix small mistake
+```
+
+I can squash these into a single commit by updating and saving:
+
+```
+pick dc849a9 Update contributing with squash instructions
+s 8b1fa6b Minor change to contributing
+s 45baf1a Delete whitespace in contributing
+s bded8d7 Delete more whitespace
+s ab49a55 Fix small mistake
+```
+
+The next prompt allows us to amend the commit message:
+
+```
+# This is a combination of 5 commits.
+# The first commit's message is:
+Update contributing with squash instructions
+# This is the 2nd commit message:
+Minor change to contributing
+# This is the 3rd commit message:
+Delete whitespace in contributing
+# This is the 4th commit message:
+Delete more whitespace
+# This is the 5th commit message:
+Fix small mistake
+```
+
+I will remove everything except for the first line, as that is the thesis for all 5 commits, and save:
+
+```
+# This is a combination of 5 commits.
+# The first commit's message is:
+Update contributing with squash instructions
+```
+
+When you save you can verify your 5 commits are now 1 by inspecting the `git log`. To update your pull request you'll need to force-push since you just rewrote your local history:
+
+```
+$ git push -f
+```
+
+**You make updates to your pull request**
+
+If the pull request needs changes, or you decide to update the content, please 'amend' your previous commit:
+
+```
+$ git commit --amend
+```
+
+Like squashing, this changes the branch history so you'll need to force push the changes to update the pull request:
+
+```
+$ git push -f
+```
+
+In all cases, if the pull request is triggering automatic build/integration tests, the tests will rerun reflecting your changes.
+
 ### Linking issues
 
 Once you submit your pull request, link the GitHub issue which your Pull Request implements. To do this, if the relevant issue is #7, then simply type "#7" somewhere in the Pull Request description or comments. This links the Pull Request with the issue, which makes things easier to track down later on.
 
 ### Adding the appropriate labels
 
-To facilitate development, osquery developers adhere to a particular label workflow.
+To facilitate development, osquery developers adhere to a particular label workflow. The core development team will assign labels as appropriate.
 
 #### "ready for review" vs "in progress"
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -2,7 +2,17 @@ The osquery shell and daemon use optional command line (CLI) flags to control
 initialization, disable/enable features, and select plugins.
 
 Most of these flag-based parameters apply to both tools. Flags that do not
-control startup settings may be included as "options" to the daemon within its [configuration](../deployment/configuration.md).
+control startup settings may be included as "options" to the daemon within its [configuration](../deployment/configuration.md). To see a full list of flags for your osquery version use `--help` or select from the flags table:
+
+```
+osquery> select * from osquery_flags;
+```
+
+To see the flags that have been updated by your configuration, flagfile, or by the shell consider:
+
+```
+osquery> select * from osquery_flags where default_value <> value;
+```
 
 ## CLI-only (initialization) flags
 
@@ -38,6 +48,10 @@ If you want to read from multiple configuration paths create a directory: **/etc
 
 Check the format of an osquery config and exit. Arbitrary config plugins may be used. osquery will return a non-0 exit if the parsing failed.
 
+`--config_dump=false`
+
+Request that the configuration JSON be printed to standard out before it is updated. In this case "updated" means applied to the active config. When osquery starts it performs an initial update from the config plugin. To quickly debug the content retrieved by custom config plugins use this in tandem with `--config_check`.
+
 ### osquery daemon control flags
 
 `--force=false`
@@ -66,6 +80,10 @@ Keep osquery backing-store in memory. This has a number of performance implicati
 `--database_path=/var/osquery/osquery.db`
 
 If using a disk-based backing store, specify a path. osquery will keep state using a "backing store" using RocksDB by default. This state holds event information such that it may be queried later according to a schedule. It holds the results of the most recent query for each query within the schedule. This last-queried result allows query-differential logging.
+
+`--database_dump=false`
+
+Helpful for debugging database problems. This will print a line for each key in the backing store. Note: There could be MBs worth of data in the backing store.
 
 ### Extensions control flags
 
@@ -301,4 +319,12 @@ In seconds, the amount of time that osqueryd will wait between periodically chec
 
 Most of the shell flags are self-explanatory and are adapted from the SQLite shell. Refer to the shell's ".help" command for details and explanations.
 
-We have added the `--json` switch to output rows as a JSON list.
+There are several flags that control the shell's output format: `--json`, `--list`, `--line`, `--csv`. For all of the output types there is `--nullvalue` and `--separator` that can be used appropriately.
+
+`--planner=false`
+
+When prototyping new queries the planner enables verbose decisions made by the SQLites virtual table API module. This module is implemented by osquery code so it is very helpful to learn what predicate constraints are selected and what full table scans are required for JOINs and nested queries.
+
+`--header=true`
+
+Set this value to `false` to disable column name (header) output. If using the shell in an automation or script the header line in `line` or `csv` mode may not be needed.

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -33,7 +33,7 @@ if(APPLE)
   include_directories("${CMAKE_SOURCE_DIR}/kernel/src")
   include_directories("/System/Library/Frameworks/Kernel.framework/Headers")
   include_directories("/Applications/Xcode.app/Contents/Developer/Platforms/\
-MacOSX.platform/Developer/SDKs/MacOSX${APPLE_MIN_ABI}.sdk\
+MacOSX.platform/Developer/SDKs/MacOSX${OSQUERY_BUILD_DISTRO}.sdk\
 /System/Library/Frameworks/Kernel.framework/Headers")
   set(KERNEL_TYPE "darwin")
 elseif(LINUX)

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -111,7 +111,7 @@ function main() {
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
   cp $PACKS_SRC/* $INSTALL_PREFIX/$PACKS_DST
 
-  if [[ $OS = "centos" && $DISTRO = "centos7" ]]; then
+  if [[ $DISTRO = "centos7" || $DISTRO = "rhel7" ]]; then
     # Install the systemd service and sysconfig
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SERVICE_DST`
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST`

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
 source $SOURCE_DIR/tools/lib.sh
 distro "darwin" BUILD_VERSION
+
 if [[ "$BUILD_VERSION" == "10.11" ]]; then
   BUILD_DIR="$SOURCE_DIR/build/darwin"
 else
@@ -29,7 +30,7 @@ KERNEL_APP_IDENTIFIER="com.facebook.osquery.kernel"
 LD_IDENTIFIER="com.facebook.osqueryd"
 LD_INSTALL="/Library/LaunchDaemons/$LD_IDENTIFIER.plist"
 OUTPUT_PKG_PATH="$BUILD_DIR/osquery-$APP_VERSION.pkg"
-KERNEL_OUTPUT_PKG_PATH="$BUILD_DIR/osquery-kernel-$APP_VERSION.pkg"
+KERNEL_OUTPUT_PKG_PATH="$BUILD_DIR/osquery-kernel-${BUILD_VERSION}-${APP_VERSION}.pkg"
 AUTOSTART=false
 CLEAN=false
 
@@ -240,10 +241,10 @@ function main() {
     fi
 
     log "creating kernel package"
-    pkgbuild --root $KERNEL_INSTALL_PREFIX       \
-             --scripts $KERNEL_SCRIPT_ROOT       \
-             --identifier $KERNEL_APP_IDENTIFIER \
-             --version $APP_VERSION              \
+    pkgbuild --root $KERNEL_INSTALL_PREFIX             \
+             --scripts $KERNEL_SCRIPT_ROOT             \
+             --identifier $KERNEL_APP_IDENTIFIER       \
+             --version ${BUILD_VERSION}-${APP_VERSION} \
              $KERNEL_OUTPUT_PKG_PATH 2>&1  1>/dev/null
     log "kernel package created at $KERNEL_OUTPUT_PKG_PATH"
   fi

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -10,8 +10,8 @@ EnvironmentFile=/etc/sysconfig/osqueryd
 ExecStartPre=/bin/sh -c "if [[ ! -f $FLAG_FILE ]]; then touch $FLAG_FILE; fi"
 ExecStart=/usr/bin/osqueryd \
   --force \
-  --daemonize \
   --pidfile /var/run/osqueryd.pid \
+  --daemonize \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE
 Restart=on-abort


### PR DESCRIPTION
1. Update contributing with examples on rebasing/squashing.
2. Add some missing CLI flags to the wiki.
3. Add the OS X version to the kernel extension package. To be safe from a feature-enablement perspective, encourage folks to use the package version corresponding to their OS. In practice the worst that has been observed is losing feature capability (e.g., no more MAC auth).
4. Include the systemd service for RHEL7 systems too.