### PR TITLE
[#1778] Add hardware/board info for Linux

### DIFF
--- a/osquery/tables/system/darwin/smbios_utils.h
+++ b/osquery/tables/system/darwin/smbios_utils.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include "osquery/tables/system/smbios_utils.h"
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief A flexible SMBIOS parser for Darwin.
+ *
+ * The parsing work is within SMBIOSParser and is shared between platforms.
+ * Each OS should implement a discover and set method that implements the
+ * OS-specific SMBIOS facilities.
+ *
+ * On Darwin the SMBIOS data is kept in the DeviceTree IOKit registry.
+ */
+class DarwinSMBIOSParser : public SMBIOSParser {
+ public:
+  void setData(uint8_t* tables, size_t length) {
+    table_data_ = tables;
+    table_size_ = length;
+  }
+
+  bool discover();
+
+  ~DarwinSMBIOSParser() {
+    if (smbios_data_ != nullptr) {
+      free(smbios_data_);
+    }
+  }
+
+ private:
+  uint8_t* smbios_data_{nullptr};
+};
+}
+}

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -8,63 +8,24 @@
  *
  */
 
+#include <mach/mach.h>
+
 #include <IOKit/IOKitLib.h>
 #include <SystemConfiguration/SystemConfiguration.h>
 
-#include <mach/mach.h>
+#include <boost/algorithm/string.hpp>
 
+#include <osquery/sql.h>
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
-#include "osquery/tables/system/sysctl_utils.h"
-
-#define kIOPlatformClassName_ "IOPlatformExpertDevice"
+#include "osquery/tables/system/darwin/smbios_utils.h"
 
 namespace osquery {
 namespace tables {
 
 const std::string kMachCpuBrandStringKey = "machdep.cpu.brand_string";
 const std::string kHardwareModelNameKey = "hw.model";
-
-Status getHardwareSerial(std::string &serial) {
-  static std::string serial_cache;
-  if (!serial_cache.empty()) {
-    serial = serial_cache;
-    return Status(0, "OK");
-  }
-
-  auto matching = IOServiceMatching(kIOPlatformClassName_);
-  if (matching == nullptr) {
-    return Status(1, "Could not get service matching IOPlatformExpertDevice");
-  }
-
-  io_iterator_t it;
-  auto kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &it);
-  if (kr != KERN_SUCCESS) {
-    return Status(1, "Could not get iterator");
-  }
-
-  // There should be only one service, so just grab the first one
-  io_service_t service;
-  service = IOIteratorNext(it);
-  if (service == 0) {
-    return Status(1, "Could not iterate to get service");
-  }
-
-  CFStringRef serialNumber = (CFStringRef)IORegistryEntryCreateCFProperty(
-      service,
-      CFSTR("IOPlatformSerialNumber"),
-      kCFAllocatorDefault,
-      kNilOptions);
-  IOObjectRelease(service);
-  if (serialNumber == nullptr) {
-    return Status(1, "Could not read serial number property");
-  }
-
-  serial = serial_cache = stringFromCFString(serialNumber);
-  CFRelease(serialNumber);
-  return Status(0, "OK");
-}
 
 void genHostInfo(Row &r) {
   auto host = mach_host_self();
@@ -76,8 +37,8 @@ void genHostInfo(Row &r) {
     return;
   }
 
-  char *cpu_type;
-  char *cpu_subtype;
+  char *cpu_type = nullptr;
+  char *cpu_subtype = nullptr;
   // Get human readable strings
   slot_name(host_data.cpu_type, host_data.cpu_subtype, &cpu_type, &cpu_subtype);
 
@@ -92,9 +53,9 @@ void genHostInfo(Row &r) {
 QueryData genSystemInfo(QueryContext &context) {
   QueryData results;
   Row r;
-  r["hostname"] = osquery::getHostname();
 
-  // OS X also defines a friendly ComputerName.
+  // OS X also defines a friendly ComputerName along with a hostname.
+  r["hostname"] = osquery::getHostname();
   auto cn = SCDynamicStoreCopyComputerName(nullptr, nullptr);
   if (cn != nullptr) {
     r["computer_name"] = stringFromCFString(cn);
@@ -103,32 +64,43 @@ QueryData genSystemInfo(QueryContext &context) {
     r["computer_name"] = r["hostname"];
   }
 
+  // The UUID for Apple devices is a device identifier.
   std::string uuid;
   r["uuid"] = (osquery::getHostUUID(uuid)) ? uuid : "";
-  std::string serial;
-  r["hardware_serial"] = (getHardwareSerial(serial)) ? serial : "";
+
   genHostInfo(r);
 
-  QueryData sysctl_results;
-  // Empty config since we don't want to read sysctl.conf files
-  std::map<std::string, std::string> config;
-  genControlInfoFromName(kMachCpuBrandStringKey, sysctl_results, config);
-  genControlInfoFromName(kHardwareModelNameKey, sysctl_results, config);
-
-  if (!sysctl_results.empty()) {
-    // If genControlInfoForName() for cpu_brand and hw_model succeeds,
-    // there should be exactly two elements in sysctl_results
-    const auto &cpu_brand = sysctl_results.front();
-    const auto &hw_model = sysctl_results.back();
-
-    if (cpu_brand.count("name") > 0 &&
-        cpu_brand.at("name") == kMachCpuBrandStringKey) {
-      r["cpu_brand"] = cpu_brand.at("current_value");
+  // The CPU brand string also exists in system_controls.
+  auto qd = SQL::selectAllFrom("cpuid");
+  for (const auto &row : qd) {
+    if (row.at("feature") == "product_name") {
+      r["cpu_brand"] = row.at("value");
+      boost::trim(r["cpu_brand"]);
     }
+  }
 
-    if (hw_model.count("name") > 0 &&
-        hw_model.at("name") == kHardwareModelNameKey) {
-      r["hardware_model"] = hw_model.at("current_value");
+  {
+    DarwinSMBIOSParser parser;
+    if (!parser.discover()) {
+      r["hardware_model"] = "";
+      r["hardware_vendor"] = "";
+      r["hardware_version"] = "";
+      r["hardware_serial"] = "";
+    } else {
+      parser.tables(([&r](size_t index,
+                          const SMBStructHeader *hdr,
+                          uint8_t *address,
+                          size_t size) {
+        if (hdr->type != kSMBIOSTypeSystem || size < 0x12) {
+          return;
+        }
+
+        uint8_t *data = address + hdr->length;
+        r["hardware_vendor"] = dmiString(data, address, 0x04);
+        r["hardware_model"] = dmiString(data, address, 0x05);
+        r["hardware_version"] = dmiString(data, address, 0x06);
+        r["hardware_serial"] = dmiString(data, address, 0x07);
+      }));
     }
   }
 

--- a/osquery/tables/system/linux/smbios_utils.h
+++ b/osquery/tables/system/linux/smbios_utils.h
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include "osquery/tables/system/smbios_utils.h"
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief A flexible SMBIOS parser for Linux.
+ *
+ * The parsing work is within SMBIOSParser and is shared between platforms.
+ * Each OS should implement a discover and set method that implements the
+ * OS-specific SMBIOS facilities.
+ *
+ * On Linux SMBIOS is 'discovered' by reading from known locations in
+ * virtual memory or on newer systems, through the sysfs.
+ */
+class LinuxSMBIOSParser : public SMBIOSParser {
+ public:
+  /// Attempt to read the system table and SMBIOS from an address.
+  void readFromAddress(size_t address, size_t length);
+
+  /// Parse the SMBIOS address from an EFI systab file.
+  void readFromSystab(const std::string& systab);
+
+  /// Cross version/boot read initializer.
+  bool discover();
+
+  /// Check if the read was successful.
+  bool valid() { return (data_ != nullptr && table_data_ != nullptr); }
+
+ public:
+  virtual ~LinuxSMBIOSParser() {
+    if (data_ != nullptr) {
+      free(data_);
+    }
+    if (table_data_ != nullptr) {
+      free(table_data_);
+    }
+  }
+
+ private:
+  bool discoverTables(size_t address, size_t length);
+
+  /// Hold the raw SMBIOS memory read.
+  uint8_t* data_{nullptr};
+};
+}
+}

--- a/osquery/tables/system/smbios_utils.cpp
+++ b/osquery/tables/system/smbios_utils.cpp
@@ -123,5 +123,19 @@ void genSMBIOSTable(size_t index,
   r["md5"] = hashFromBuffer(HASH_TYPE_MD5, address, size);
   results.push_back(r);
 }
+
+std::string dmiString(uint8_t* data, uint8_t* address, size_t offset) {
+  auto index = (uint8_t)(*(address + offset));
+  auto bp = (char*)data;
+  while (index > 1) {
+    while (*bp != 0) {
+      bp++;
+    }
+    bp++;
+    index--;
+  }
+
+  return std::string(bp);
+}
 }
 }

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -32,6 +32,7 @@ typedef struct DMIEntryPoint {
 extern const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions;
 
 constexpr uint8_t kSMBIOSTypeBIOS = 0;
+constexpr uint8_t kSMBIOSTypeSystem = 1;
 
 /**
  * @brief A generic parser for SMBIOS tables.
@@ -63,5 +64,19 @@ void genSMBIOSTable(size_t index,
                     uint8_t* address,
                     size_t size,
                     QueryData& results);
+
+/**
+ * @brief Return a 0-terminated strings from an SMBIOS address and handle.
+ *
+ * SMBIOS strings are 0-terminated and 'stacked' at the end of the type
+ * structure. Each structure identifies (loosely) the type of data within.
+ * Using the structure field 'handle' or offset, the stacked data can be parsed
+ * and a string returned.
+ *
+ * @param data A pointer to the SMBIOS structure.
+ * @param address A pointer to the stacked data following the structure.
+ * @Param offset The field index into address.
+ */
+std::string dmiString(uint8_t* data, uint8_t* address, size_t offset);
 }
 }

--- a/specs/system_info.table
+++ b/specs/system_info.table
@@ -5,13 +5,14 @@ schema([
     Column("uuid", TEXT, "Unique ID provided by the system"),
     Column("cpu_type", TEXT, "CPU type"),
     Column("cpu_subtype", TEXT, "CPU subtype"),
-    Column("cpu_brand", TEXT, "CPU brand string"),
+    Column("cpu_brand", TEXT, "CPU brand string, contains vendor and model"),
     Column("cpu_physical_cores", INTEGER, "Max number of CPU physical cores"),
     Column("cpu_logical_cores", INTEGER, "Max number of CPU logical cores"),
     Column("physical_memory", BIGINT, "Total physical memory in bytes"),
-    Column("hardware_model", TEXT, "Hardware model string"),
-    Column("hardware_serial", TEXT,
-        "System serial number frequently used for asset tracking"),
+    Column("hardware_vendor", TEXT, "Hardware or board vendor"),
+    Column("hardware_model", TEXT, "Hardware or board model"),
+    Column("hardware_version", TEXT, "Hardware or board version"),
+    Column("hardware_serial", TEXT, "Device or board serial number"),
     Column("computer_name", TEXT, "Friendly computer name (optional)"),
 ])
 implementation("system/system_info@genSystemInfo")


### PR DESCRIPTION
This fills in the missing `hardware_` fields in `system_info` on Linux and adds two additional fields for both Linux and Darwin: `hardware_vendor` and `hardware_version`. These are backed by the SMBIOS/DMI System Info type (pretty appropriate).