### PR TITLE
[Fix #1788] Use an array for the 'data' key in TLS logs

### DIFF
--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -71,6 +71,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         # dies when the watcher goes away
         self.assertTrue(daemon.isDead(children[0]))
 
+    @test_base.flaky
     def test_4_daemon_sighup(self):
         # A hangup signal should not do anything to the daemon.
         daemon = self._run_daemon({
@@ -82,6 +83,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         os.kill(daemon.proc.pid, signal.SIGHUP)
         self.assertTrue(daemon.isAlive())
 
+    @test_base.flaky
     def test_5_daemon_sigint(self):
         # An interrupt signal will cause the daemon to stop.
         daemon = self._run_daemon({
@@ -96,6 +98,7 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         acceptable_retcodes = [-1, -2, -1 * signal.SIGINT]
         self.assertTrue(daemon.retcode in acceptable_retcodes)
 
+    @test_base.flaky
     def test_6_logger_mode(self):
         logger_path = os.path.join(test_base.CONFIG_DIR, "logger-mode-tests")
         os.makedirs(logger_path)

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -165,6 +165,7 @@ class OsqueryiTest(unittest.TestCase):
             result = self.osqueryi.run_command(command)
         pass
 
+    @test_base.flaky
     def test_time(self):
         '''Demonstrating basic usage of OsqueryWrapper with the time table'''
         self.osqueryi.run_command(' ')  # flush error output
@@ -176,6 +177,7 @@ class OsqueryiTest(unittest.TestCase):
         self.assertTrue(0 <= int(row['minutes']) <= 60)
         self.assertTrue(0 <= int(row['seconds']) <= 60)
 
+    @test_base.flaky
     def test_config_bad_json(self):
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
                                                  args={"config_path": "/"})


### PR DESCRIPTION
The previous change in https://github.com/facebook/osquery/pull/1771 introduced a regression by not deserializing the string JSON into a property tree.