### PR TITLE
[#1742] Remove deps and release from PR builds

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -183,10 +183,12 @@ The osquery package build hosts run a series of additional unit and integration 
 To mimic and follow the same build/release testing workflow use:
 
 ```
+export RUN_BUILD_DEPS=1
+export RUN_RELEASE_TESTS=1
 ./tools/build.sh
 ```
 
-Pay attention to the environment variable `RUN_RELEASE_TESTS=1`, which enables the deployment sanity tests. If you are building an optimized or distribution package manager target this will most likely fail.
+Pay attention to the environment variable `RUN_RELEASE_TESTS=1`, which enables the deployment sanity tests. If you are building an optimized or distribution package manager target this will most likely fail. The `RUN_BUILD_DEPS` variable tells the build to begin with a `make deps`.
 
 ## Notes and FAQ
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -12,6 +12,14 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/lib.sh
 
+# To request that tests run 'make deps' before building.
+# Define or uncomment the following control variable: RUN_BUILD_DEPS
+# $ export RUN_BUILD_DEPS=1
+
+# To request that tests include additional 'release' or 'package' units.
+# Define or uncomment the following control variable: RUN_RELEASE_TESTS
+# $ export RUN_RELEASE_TESTS=1
+
 # Run the build function and the tests
 build true
 

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -91,13 +91,7 @@ function main() {
   sudo pip install --upgrade pip
   sudo pip install -r requirements.txt
 
-  # Reset any work or artifacts from build tests in TP.
-  (cd third-party && git reset --hard HEAD)
-  git submodule init
-  git submodule update
-
-  # Remove any previously-cached variables
-  rm build/$OS/CMakeCache.txt >/dev/null 2>&1 || true
+  initialize $OS
 }
 
 check $1 $2


### PR DESCRIPTION
This implements part 1 of #1742.

The package and release checks are mostly dependent on the build environment. The relative environments are hosted in an isolated infrastructure that is not subject to PR trashing. It is fine if these checks are run 'nightly' or out of band with PRs, which often benefit from synchronous responses. As we grow the build and the number of platforms each PR runs on we must balance the runtime for each and the global strain each build has on the MacMini cluster.

This also removes `make deps` from the build. If developers are adding to the provision script we will need another method of triggering a specialized build that exports the associated variable to install the dependencies alongside the PR. This will be done within Jenkins and a development team member may trigger the build at their discretion during/following a code review.