### PR TITLE
Add and document TLS debug features

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -9,11 +9,14 @@ The most important differentiator to the **filesystem** suite of plugins is an a
 The initial step is called an "enroll step" and in the case of **tls** plugins, uses an implicit *enroll* plugin, also called **tls**. If you enable either config or logger **tls** plugins the enrollment plugin will turn on automatically. Enrollment provides an initial secret to the remote server in order to negotiate a private node secret used for future identification. The process is simple:
 
 1. Configure a target `--tls_hostname`, `--enroll_tls_endpoint`.
-2. Submit an `--enroll_secret_path`, an `--enroll_secret_env`, or use TLS-client authentication, to the enroll endpoint.
-3. Receive a **node_key** and store within RocksDB.
-4. Make config/logger requests while providing **node_key** as identification/authentication.
+2. Place your server's root certificate authority's PEM-encoded certificate into a file, for example `/path/to/server-root.pem` and configure the client to pin this root: `--tls_server_certs=`.
+3. Submit an `--enroll_secret_path`, an `--enroll_secret_env`, or use TLS-client authentication, to the enroll endpoint.
+4. Receive a **node_key** and store within RocksDB.
+5. Make config/logger requests while providing **node_key** as identification/authentication.
 
 The validity of a **node_key** is determined and implemented in the TLS server. The client only manages to ask for the content during enroll, and posts the content during subsequent requests.
+
+With osquery version 1.7.0, OS X clients **MUST** use a `--tls_server_certs` bundle since osquery is built using LibreSSL and no default certificate bundle is available on OS X.
 
 ### Simple shared secret enrollment
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -168,6 +168,16 @@ See the **tls**/[remote](../deployment/remote.md) plugin documentation. An enrol
 
 See the **tls**/[remote](../deployment/remote.md) plugin documentation. This is a number of seconds before checking for buffered logs. Results are sent to the TLS endpoint in intervals, not on demand (unless the period=0).
 
+`--logger_tls_compress=false`
+
+Optionally enable GZIP compression for request bodies when sending. This is optional, and disabled by default, as the deployment must explicitly know that the logging endpoint supports GZIP for content encoding.
+
+`--logger_tls_max=1048576`
+
+It is common for TLS/HTTPS servers to enforce a maximum request body size. The default behavior in osquery is to enforce each log line be under 1M bytes. This means each result line from a query's results cannot exceed 1M, this is very unlikely. Each log attempt will try to forward up to 1024 lines. If your service is limited request bodies, configure the client to limit the log line size.
+
+Use this only in emergency situations as size violations are dropped. It is extremely uncommon for this to occur, as the `value_max` for each column would need to be drastically larger, or the offending table would have to implement several hundred columns.
+
 `--distributed_tls_read_endpoint=/foobar`
 
 The URI path which will be used, in conjunction with `tls_hostname`, to create the remote URI for retrieving distributed queries when using the **tls** distributed plugin.

--- a/osquery/remote/CMakeLists.txt
+++ b/osquery/remote/CMakeLists.txt
@@ -2,6 +2,7 @@ ADD_OSQUERY_LIBRARY(FALSE osquery_remote
   enroll/enroll.cpp
   serializers/json.cpp
   transports/tls.cpp
+  remote.cpp
 )
 
 ADD_OSQUERY_LIBRARY(FALSE osquery_enrollment_plugins

--- a/osquery/remote/remote.cpp
+++ b/osquery/remote/remote.cpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+#include <cstring>
+
+#include <zlib.h>
+
+namespace osquery {
+
+#define MOD_GZIP_ZLIB_WINDOWSIZE 15
+#define MOD_GZIP_ZLIB_CFACTOR 9
+
+void compress(std::string& data) {
+  z_stream zs;
+  memset(&zs, 0, sizeof(zs));
+
+  if (deflateInit2(&zs,
+                   Z_BEST_COMPRESSION,
+                   Z_DEFLATED,
+                   MOD_GZIP_ZLIB_WINDOWSIZE + 16,
+                   MOD_GZIP_ZLIB_CFACTOR,
+                   Z_DEFAULT_STRATEGY) != Z_OK) {
+    return;
+  }
+
+  zs.next_in = (Bytef*)data.data();
+  zs.avail_in = data.size();
+
+  int ret = Z_OK;
+  std::string output;
+
+  {
+    char buffer[16384] = {0};
+    while (ret == Z_OK) {
+      zs.next_out = reinterpret_cast<Bytef*>(buffer);
+      zs.avail_out = sizeof(output);
+
+      ret = deflate(&zs, Z_FINISH);
+      if (output.size() < zs.total_out) {
+        output.append(buffer, zs.total_out - output.size());
+      }
+    }
+  }
+
+  deflateEnd(&zs);
+  if (ret != Z_STREAM_END) {
+    return;
+  }
+
+  data = std::move(output);
+}
+}

--- a/osquery/remote/tests/requests_tests.cpp
+++ b/osquery/remote/tests/requests_tests.cpp
@@ -77,4 +77,65 @@ TEST_F(RequestsTests, test_call_with_params) {
   expected.put<std::string>("foo", "baz");
   EXPECT_EQ(recv, expected);
 }
+
+class CopyTransport : public Transport {
+ public:
+  Status sendRequest() {
+    response_status_ = Status(0, "OK");
+    return response_status_;
+  }
+
+  Status sendRequest(const std::string& params) {
+    response_status_ = Status(0, params);
+    return response_status_;
+  }
+};
+
+class CopySerializer : public Serializer {
+ public:
+  std::string getContentType() const { return "copy"; }
+
+  Status serialize(const boost::property_tree::ptree& params,
+                   std::string& serialized) {
+    serialized = params.get("copy", "");
+    return Status(0, "OK");
+  }
+
+  Status deserialize(const std::string& serialized,
+                     boost::property_tree::ptree& params) {
+    return Status(0, "OK");
+  }
+};
+
+TEST_F(RequestsTests, test_compression) {
+  auto req = Request<CopyTransport, CopySerializer>("foobar");
+
+  // Ask the request to compress the output from serialization.
+  req.setOption("compress", true);
+
+  std::string uncompressed = "stringstringstringstring";
+  for (size_t i = 0; i < 10; i++) {
+    uncompressed += uncompressed;
+  }
+
+  // Our special 'copy' serializer copies input from the 'copy' key in params.
+  boost::property_tree::ptree params;
+  params.put<std::string>("copy", uncompressed);
+
+  // Similarly, the 'copy' transport copies the request params into the
+  // response status.
+  req.call(params);
+  auto status = req.getResponse(params);
+
+  auto compressed = status.getMessage();
+  auto expected = std::string(
+      "\x1F\x8B\b\0\0\0\0\0\x2\x3\xED\xC4\xB1\r\0\0\x4\0\xB0s\xC5"
+      "b\xC0\xFFq\x84\xB5\x1D:"
+      "\xDBY1\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xDB"
+      "\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xDB\xB6m\xFB\xF1\x1"
+      "1j\xA0\xA8\0`\0\0",
+      78);
+  EXPECT_EQ(compressed, expected);
+  EXPECT_LT(compressed.size(), uncompressed.size());
+}
 }


### PR DESCRIPTION
1. Document the 10.11 limitation/requirement for `--tls_server_certs` when using packages built using the static LibreSSL.
2. Document the optional `--logger_tls_max` for limited the max size of each transmitted log line [#1793].
3. Add helpful remote status messages to the TLSLogger verbose message logs. This helps when debugging TLS/server failures.
4. Add optional support for compression (GZIP) of POST request content.