### PR TITLE
Fix potential crash in disk_encryption

### DIFF
--- a/osquery/tables/system/darwin/disk_encryption.cpp
+++ b/osquery/tables/system/darwin/disk_encryption.cpp
@@ -56,7 +56,10 @@ Status genUnlockIdent(CFDataRef& uuid) {
     if (CFGetTypeID(unlock_ident) != CFDataGetTypeID()) {
       return Status(1, "Unexpected data type for unlock ident");
     }
-    uuid = (CFDataRef)unlock_ident;
+    uuid = CFDataCreateCopy(kCFAllocatorDefault, (CFDataRef)unlock_ident);
+    if (uuid == nullptr) {
+      return Status(1, "Could not get UUID");
+    }
     CFRelease(properties);
     return Status(0, "ok");
   }


### PR DESCRIPTION
1. Create a copy of UUID data so that we have the value instead of its reference before we release the properties.