### PR TITLE
Add an events_max limit for event buffering

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -269,6 +269,10 @@ Timeout to expire [eventing publish subscribe](../development/pubsub-framework.m
 
 Since event rows are only "added" it does not make sense to emit "removed" results. An optimization can occur within the osquery daemon's query schedule. Every time the select query runs on a subscriber the current time is saved. Subsequent selects will use the previously saved time as the lower bound. This optimization is removed if any constraints on the "time" column are included.
 
+`--events_max=1000`
+
+Maximum number of events to buffer in the backing store while waiting for a query to 'drain' or trigger an expiration. If the expiration (`events_expiry`) is set to 1 day, this max value indicates that only 1000 events will be stored before dropping each day. In this case the limiting time is almost always the scheduled query. If a scheduled query that select from events-based tables occurs sooner than the expiration time that interval becomes the limit.
+
 ### Logging/results flags
 
 `--logger_plugin=filesystem`

--- a/osquery/database/db_handle.h
+++ b/osquery/database/db_handle.h
@@ -90,62 +90,68 @@ class DBHandle {
   /////////////////////////////////////////////////////////////////////////////
 
   /**
-   * @brief Get data from the database
+   * @brief Get data from the database for a given domain and key.
    *
-   * @param domain the "domain" or "column family" that you'd like to retrieve
-   * the data from
-   * @param key the string key that you'd like to get
-   * @param value a non-const string reference where the result of the
-   * operation will be stored
+   * @param domain the "domain" or "column family"
+   * @param key the string key
+   * @param value the output string container, will be populated with data
    *
-   * @return an instance of osquery::Status indicating the success or failure
-   * of the operation.
+   * @return operation success or failure
    */
   Status Get(const std::string& domain,
              const std::string& key,
              std::string& value) const;
 
   /**
-   * @brief Put data into the database
+   * @brief Put data into the database identified by a domain and key.
    *
-   * @param domain the "domain" or "column family" that you'd like to insert
-   * data into
-   * @param key the string key that you'd like to put
-   * @param value the data that you'd like to put into RocksDB
+   * @param domain the "domain" or "column family"
+   * @param key the string key
+   * @param value the data in a string container
    *
-   * @return an instance of osquery::Status indicating the success or failure
-   * of the operation.
+   * @return operation success or failure
    */
   Status Put(const std::string& domain,
              const std::string& key,
              const std::string& value) const;
 
   /**
-   * @brief Delete data from the database
+   * @brief Delete data from the database given a domain and key.
    *
-   * @param domain the "domain" or "column family" that you'd like to delete
-   * data from
-   * @param key the string key that you'd like to delete
+   * @param domain the "domain" or "column family"
+   * @param key the string key
    *
-   * @return an instance of osquery::Status indicating the success or failure
-   * of the operation.
+   * @return operation success or failure
    */
   Status Delete(const std::string& domain, const std::string& key) const;
 
   /**
-   * @brief List the data in a "domain"
+   * @brief List the keys in a "domain"
    *
-   * @param domain the "domain" or "column family" that you'd like to list
-   * data from
-   * @param results a non-const reference to a vector which will be populated
-   * with all of the keys from the supplied domain.
+   * @param domain the "domain" or "column family"
+   * @param results an output list of all keys within the domain
+   * @param optional max limit the number of result keys to a max
    *
-   * @return an instance of osquery::Status indicating the success or failure
-   * of the operation.
+   * @return operation success or failure
    */
   Status Scan(const std::string& domain,
               std::vector<std::string>& results,
               size_t max = 0) const;
+
+  /**
+   * @brief List the data in a "domain"
+   *
+   * @param domain the "domain" or "column family"
+   * @param results an output list of all keys with the given prefix
+   * @param prefix require each key to contain this string prefix
+   * @param optional max limit the number of result keys to a max
+   *
+   * @return operation success or failure
+   */
+  Status ScanPrefix(const std::string& domain,
+                    std::vector<std::string>& results,
+                    const std::string& prefix,
+                    size_t max = 0) const;
 
  private:
   /**
@@ -215,7 +221,7 @@ class DBHandle {
 
   /**
    * @brief Private helper around accessing the column family handle for a
-   * specific column family, based on it's name
+   * specific column family, based on its name
    */
   rocksdb::ColumnFamilyHandle* getHandleForColumnFamily(
       const std::string& cf) const;

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -213,17 +213,15 @@ static int xBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   // the consecutive sets of terms each of the constraint sets are applied onto.
   // Subsequent attempts from failed (unusable) constraints replace the set,
   // while new sets of terms append.
-  int term = -1;
   if (pIdxInfo->nConstraint > 0) {
     for (size_t i = 0; i < static_cast<size_t>(pIdxInfo->nConstraint); ++i) {
       // Record the term index (this index exists across all expressions).
       const auto &constraint_info = pIdxInfo->aConstraint[i];
-      term = constraint_info.iTermOffset;
 #if defined(DEBUG)
       plan("Evaluating constraints for table: " + pVtab->content->name +
            " [index=" + std::to_string(i) + " column=" +
            std::to_string(constraint_info.iColumn) + " term=" +
-           std::to_string((int)term) + " usable=" +
+           std::to_string((int)constraint_info.iTermOffset) + " usable=" +
            std::to_string((int)constraint_info.usable) + "]");
 #endif
       if (!constraint_info.usable) {


### PR DESCRIPTION
This adds a new CLI flag: `--events_max` that assists subscriber tables from buffering an excess number of events in RocksDB. The max value will be applied regularly when events are added to the backing store, while they wait for a query to select results. If the maximum number of events occurs within a scheduled period, events will drop.

In practice, dropped events never occur. This assist is focused on draining buffers that have no scheduled query.