### PR TITLE
[1576] Gate Makefile check for git to non-deps targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 PLATFORM := $(shell uname -s)
-GIT_EXISTS := $(shell which git)
 BASH_EXISTS := $(shell which bash)
-VERSION := $(shell git describe --tags HEAD --always)
 SHELL := $(shell which bash)
+
+ifneq ($(MAKECMDGOALS),deps)
+GIT_EXISTS := $(shell which git)
+endif
 
 MAKE = make
 ifeq ($(PLATFORM),FreeBSD)
@@ -96,18 +98,20 @@ ifeq ($(PLATFORM),Linux)
 endif
 
 .setup:
+ifneq ($(MAKECMDGOALS),deps)
 ifeq ($(GIT_EXISTS),)
 	@echo "Problem: cannot find 'git'"
-	false
+	@false
+endif
 endif
 ifeq ($(BASH_EXISTS),)
 	@echo "Problem: cannot find 'bash'"
-	false
+	@false
 endif
 
 ifeq ($(DISTRO),unknown_version)
 	@echo Unknown, non-Redhat, non-Ubuntu based Linux distro
-	false
+	@false
 endif
 	@mkdir -p build/docs
 	@mkdir -p build/$(BUILD_DIR)

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -4,7 +4,9 @@ We include a `make deps` command to make it easier for developers to get started
 
 WARNING: This will install or build various dependencies on the build host that are not required to "use" osquery, only build osquery binaries and packages.
 
- If you're trying to run our automatic tool on a machine that is extremely customized and configured, `make deps` may try to install software that conflicts with software you have installed. If this happens, please create an issue and/or submit a pull request with a fix. We'd like to support as many operating systems as possible.
+If you're trying to run our automatic tool on a machine that is extremely customized and configured, `make deps` may try to install software that conflicts with software you have installed. If this happens, please create an issue and/or submit a pull request with a fix. We'd like to support as many operating systems as possible.
+
+In almost all cases `git`, GNU `make`, and `bash` are required for the build. In some cases the dependencies target will attempt to pull them in.
 
 ## Building on OS X
 


### PR DESCRIPTION
For Vagrant targets, the `make deps` provisioning scripts will install `git`. A check for `git` is only needed when executing CMake proxy targets.