### PR TITLE
Documentation updates for TLS client-auth and FIM

### DIFF
--- a/docs/wiki/development/pubsub-framework.md
+++ b/docs/wiki/development/pubsub-framework.md
@@ -26,7 +26,7 @@ The pubsub runflow is exposed as a publisher `setUp()`, a series of `addSubscrip
 
 Filesystem events are the simplest example, let's consider Linux's inotify framework. [osquery/events/linux/inotify.cpp](https://github.com/facebook/osquery/blob/master/osquery/events/linux/inotify.cpp) is exposed as an osquery publisher.
 
-There's an array of yet-to-be-implemented uses of the inotify publisher, but a simple example includes querying for every change to "/etc/passwd". The [osquery/tables/events/linux/passwd_changes.cpp](https://github.com/facebook/osquery/blob/master/osquery/tables/events/linux/passwd_changes.cpp) table uses a pubsub subscription and implements a subscriber.
+There's an array of yet-to-be-implemented uses of the inotify publisher, but a simple example includes querying for every change to "/etc/passwd". The [osquery/tables/events/linux/file_events.cpp](https://github.com/facebook/osquery/blob/master/osquery/tables/events/linux/file_events.cpp) table uses a pubsub subscription and implements a subscriber. The subscriptions are constructed from the configuration. See the file [integrity monitoring deployment](../deployment/file-integrity-monitoring.md) guide for details.
 
 ## Event Subscribers
 

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -29,7 +29,7 @@ FLAG(string,
      "/var/log/osquery/",
      "Directory path for ERROR/WARN/INFO and results logging");
 
-FLAG(int32, logger_mode, 0640, "Mode for log files (default '0640')");
+FLAG(int32, logger_mode, 0640, "Decimal mode for log files (default '0640')");
 
 /// Legacy, backward compatible "osquery_log_dir" CLI option.
 FLAG_ALIAS(std::string, osquery_log_dir, logger_path);


### PR DESCRIPTION
1. Remove references to the `passwd_changes` table.
2. Add a reference to the expected enrollment experience when using TLS client-auth.