### PR TITLE
Add unauthenticated sparkle feeds query to vuln-mgmt pack

### DIFF
--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -109,6 +109,14 @@
       "version" : "1.4.5",
       "description" : "Retrieves all the installed RPM packages in the target Linux system.",
       "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
+    },
+    "unauthenticated_sparkle_feeds": {
+      "query" : "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, preferences p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join preferences p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.4.5",
+      "description" : "Retrieves all application bundles using unauthenticated Sparkle update feeds. See https://vulnsec.com/2016/osx-apps-vulnerabilities/ for details.",
+      "value" : "Tracking vulnerable applications updates may allow blocking of DNS or removal by BundleID."
     }
   }
 }


### PR DESCRIPTION
See https://vulnsec.com/2016/osx-apps-vulnerabilities/ for context. This will return all non-`https` update feed endpoints.