### PR TITLE
Minor de-prioritization of failed publisher logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,16 @@ package: .setup
 	cd build/$(BUILD_DIR) && PACKAGE=True cmake ../../ && \
 		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
 
+debug_package: .setup
+	cd build/debug_$(BUILD_DIR) && DEBUG=True PACKAGE=True cmake ../../ && \
+		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
+
 packages: .setup
 	cd build/$(BUILD_DIR) && PACKAGE=True cmake ../../ && \
+		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
+
+debug_packages:
+	cd build/debug_$(BUILD_DIR) && DEBUG=True PACKAGE=True cmake ../../ && \
 		$(DEFINES) $(MAKE) packages --no-print-directory $(MAKEFLAGS)
 
 sync: .setup

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -808,8 +808,8 @@ void attachEvents() {
   for (const auto& subscriber : subscribers) {
     auto status = EventFactory::registerEventSubscriber(subscriber.second);
     if (!status.ok()) {
-      LOG(WARNING) << "Error registering subscriber: " << subscriber.first
-                   << ": " << status.getMessage();
+      LOG(INFO) << "Error registering subscriber: " << subscriber.first << ": "
+                << status.getMessage();
     }
   }
 

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -21,7 +21,11 @@
 
 namespace osquery {
 
+#ifdef DEBUG
+const std::string kVersion = CONCAT(OSQUERY_BUILD_VERSION, -debug);
+#else
 const std::string kVersion = STR(OSQUERY_BUILD_VERSION);
+#endif
 const std::string kSDKVersion = OSQUERY_SDK_VERSION;
 const std::string kSDKPlatform = OSQUERY_PLATFORM;
 }

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -14,10 +14,15 @@ SOURCE_DIR="$SCRIPT_DIR/../.."
 source $SOURCE_DIR/tools/lib.sh
 distro "darwin" BUILD_VERSION
 
+BUILD_DIR="$SOURCE_DIR/build/"
+if [[ ! -z "$DEBUG" ]]; then
+  BUILD_DIR="${BUILD_DIR}debug_"
+fi
+
 if [[ "$BUILD_VERSION" == "10.11" ]]; then
-  BUILD_DIR="$SOURCE_DIR/build/darwin"
+  BUILD_DIR="${BUILD_DIR}darwin"
 else
-  BUILD_DIR="$SOURCE_DIR/build/darwin$BUILD_VERSION"
+  BUILD_DIR="${BUILD_DIR}darwin$BUILD_VERSION"
 fi
 export PATH="$PATH:/usr/local/bin"
 


### PR DESCRIPTION
Publishers/subscriptions failing their initialization is normal for kernel-based publishers. This is also assumed normal if there are no subscriptions needed. Later during runtime, after a reconfiguration, the publishers/subscribers *could* be started/stopped.

This also adds helpful macros for building debug packages on OS X.