### PR TITLE
[Fix #1814] Various fixes for Linux inotify

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -38,7 +38,7 @@ FLAG(uint64, read_user_max, 10 * 1024 * 1024, "Maximum non-su read size");
 HIDDEN_FLAG(bool, allow_unsafe, false, "Allow unsafe executable permissions");
 
 /// Disable forensics (atime/mtime preserving) file reads.
-HIDDEN_FLAG(bool, disable_forensic, false, "Disable atime/mtime preservation");
+HIDDEN_FLAG(bool, disable_forensic, true, "Disable atime/mtime preservation");
 
 static const size_t kMaxRecursiveGlobs = 64;
 


### PR DESCRIPTION
1. The `forensic`  capability on Linux to preserve `atime` between hashing has an adverse effect of causing additional inotify events. We should opt for variable `atimes` over variable `ctimes` as the access event for hashing is gated to an explicit opt-in.
2. The daemon will create duplicate `file_events` if it is torn-down before an expiration event occurs. This adds a persistent `optimize` key to RocksDB to restore optimization times, which is the default.