### PR TITLE
[#1814] Do not stat inotify access subscriptions

### DIFF
--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -40,10 +40,10 @@ std::map<int, std::string> kMaskActions = {
     {IN_OPEN, "OPENED"},
 };
 
-const int kFileDefaultMasks = IN_MOVED_TO | IN_MOVED_FROM | IN_MODIFY |
-                              IN_DELETE | IN_CREATE | IN_CLOSE_WRITE |
-                              IN_ATTRIB;
-const int kFileAccessMasks = IN_OPEN | IN_ACCESS;
+const uint32_t kFileDefaultMasks = IN_MOVED_TO | IN_MOVED_FROM | IN_MODIFY |
+                                   IN_DELETE | IN_CREATE | IN_CLOSE_WRITE |
+                                   IN_ATTRIB;
+const uint32_t kFileAccessMasks = IN_OPEN | IN_ACCESS;
 
 REGISTER(INotifyEventPublisher, "event_publisher", "inotify");
 

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -22,8 +22,8 @@ namespace osquery {
 
 extern std::map<int, std::string> kMaskActions;
 
-extern const int kFileDefaultMasks;
-extern const int kFileAccessMasks;
+extern const uint32_t kFileDefaultMasks;
+extern const uint32_t kFileAccessMasks;
 
 /**
  * @brief Subscription details for INotifyEventPublisher events.

--- a/osquery/tables/events/event_utils.cpp
+++ b/osquery/tables/events/event_utils.cpp
@@ -12,6 +12,8 @@
 #include <osquery/hash.h>
 #include <osquery/sql.h>
 
+#include "osquery/tables/events/event_utils.h"
+
 namespace osquery {
 
 const std::set<std::string> kCommonFileColumns = {

--- a/osquery/tables/events/event_utils.h
+++ b/osquery/tables/events/event_utils.h
@@ -8,11 +8,15 @@
  *
  */
 
+#include <set>
 #include <string>
 
 #include <osquery/tables.h>
 
 namespace osquery {
+
+/// List of columns decorated for file events.
+extern const std::set<std::string> kCommonFileColumns;
 
 /**
  * @brief A helper function for each platform's implementation of file_events.


### PR DESCRIPTION
If you stat an access-based event you will generate a secondary access event. This is bad. ;)