### PR TITLE
[Fix #1418] Add developer_id to safari_extensions

### DIFF
--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -50,6 +50,7 @@ const std::map<std::string, std::string> kSafariExtensionKeys = {
     {"CFBundleInfoDictionaryVersion", "sdk"},
     {"Description", "description"},
     {"Update Manifest URL", "update_url"},
+    {"DeveloperIdentifier", "developer_id"},
 };
 
 void genBrowserPlugin(const std::string& uid,

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -9,6 +9,7 @@ schema([
     Column("sdk", TEXT, "Bundle SDK used to compile extension"),
     Column("update_url", TEXT, "Extension-supplied update URI"),
     Column("author", TEXT, "Optional extension author"),
+    Column("developer_id", TEXT, "Optional developer identifier"),
     Column("description", TEXT, "Optional extension description text"),
     Column("path", TEXT, "Path to extension XAR bundle"),
     ForeignKey(column="uid", table="users")


### PR DESCRIPTION
This was missed from the original `safari_extensions` refactor since it is an optional key.