### PR TITLE
restrict getTemperatures to smc temp keys

### DIFF
--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -479,14 +479,14 @@ QueryData getTemperatures(QueryContext &context) {
     context.forEachConstraint("key",
                               EQUALS,
                               ([&smc, &results](const std::string &expr) {
-                                if (kSMCKeyDescriptions.count(expr) > 0) {
+                                if (kSMCTemperatureKeys.count(expr) > 0) {
                                   genTemperature(expr, smc, results);
                                 }
                               }));
   } else {
     // Perform a full scan of temperature keys.
-    for (const auto &smcTempKey : kSMCKeyDescriptions) {
-      genTemperature(smcTempKey.first, smc, results);
+    for (const auto &smcTempKey : kSMCTemperatureKeys) {
+      genTemperature(smcTempKey, smc, results);
     }
   }
 


### PR DESCRIPTION
Restrict getTemperatures() to smc temperature keys.

I might be overlooking something. Right now it's functionally equivalent since there's a one to one mapping between kSMCKeyDescriptions.keys() and kSMCTemperatureKeys, but shouldn't it be restricted to kSMCTemperatureKeys?