### PR TITLE
[Fix #1822] adjust smc parsing fpe2 values

### DIFF
--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -373,8 +373,6 @@ void genSMCKey(const std::string &key,
   r["size"] = INTEGER(value.dataSize);
   if (r["type"] == "ui8" || r["type"] == "ui16" || r["type"] == "ui32") {
     r["value"] = std::to_string(strtoul(value.bytes.bytes, value.dataSize, 10));
-  } else if (r["type"] == "fpe2") {
-    r["value"] = std::to_string(strtof(value.bytes.bytes, value.dataSize, 10));
   } else {
     std::stringstream hex;
     for (size_t i = 0; i < value.dataSize; i++) {


### PR DESCRIPTION
Lumping parsing of smc fpe2 values in with the else case, which is also
used for parsing sp78 values, seems to have it show correct values that
match those outputted by `./smc -l | grep -i fpe2` via the smc-fuzzer
tool.

resolves #1822