### PR TITLE
Refactor dispatcher shutdown logic

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -46,11 +46,13 @@
 
 namespace osquery {
 
-/**
- * @brief The version of osquery
- */
+/// The version of osquery, includes the git revision if not tagged.
 extern const std::string kVersion;
+
+/// The SDK version removes any git revision hash (1.6.1-g0000 becomes 1.6.1).
 extern const std::string kSDKVersion;
+
+/// Identifies the build platform of either the core extension.
 extern const std::string kSDKPlatform;
 
 /// Use a macro for the sdk/platform literal, symbols available in lib.cpp.
@@ -68,8 +70,10 @@ enum ToolType {
   OSQUERY_EXTENSION,
 };
 
-typedef boost::unique_lock<boost::shared_mutex> WriteLock;
-typedef boost::shared_lock<boost::shared_mutex> ReadLock;
+/// Helper alias for write locking a mutex.
+using WriteLock = boost::unique_lock<boost::shared_mutex>;
+/// Helper alias for read locking a mutex.
+using ReadLock = boost::shared_lock<boost::shared_mutex>;
 
 /// The osquery tool type for runtime decisions.
 extern ToolType kToolType;
@@ -95,7 +99,7 @@ class Initializer : private boost::noncopyable {
    * A daemon has additional constraints, it can use a process mutex, check
    * for sane/non-default configurations, etc.
    */
-  void initDaemon();
+  void initDaemon() const;
 
   /**
    * @brief Daemon tools may want to continually spawn worker processes
@@ -113,12 +117,13 @@ class Initializer : private boost::noncopyable {
    *
    * @param name The name of the worker process.
    */
-  void initWorkerWatcher(const std::string& name);
+  void initWorkerWatcher(const std::string& name) const;
 
   /// Assume initialization finished, start work.
-  void start();
+  void start() const;
+
   /// Turns off various aspects of osquery such as event loops.
-  void shutdown();
+  void shutdown() const;
 
   /**
    * @brief Check if a process is an osquery worker.
@@ -133,11 +138,13 @@ class Initializer : private boost::noncopyable {
 
  private:
   /// Initialize this process as an osquery daemon worker.
-  void initWorker(const std::string& name);
+  void initWorker(const std::string& name) const;
+
   /// Initialize the osquery watcher, optionally spawn a worker.
-  void initWatcher();
+  void initWatcher() const;
+
   /// Set and wait for an active plugin optionally broadcasted.
-  void initActivePlugin(const std::string& type, const std::string& name);
+  void initActivePlugin(const std::string& type, const std::string& name) const;
 
  private:
   int* argc_{nullptr};
@@ -288,6 +295,17 @@ inline size_t utf8StringSize(const std::string& str) {
  * @return A status object indicating the success or failure of the operation
  */
 Status createPidFile();
+
+/**
+ * @brief Forcefully request the application stop.
+ *
+ * Since all osquery tools may implement various 'dispatched' services in the
+ * form of event handler threads or thrift service and client pools, a stop
+ * request should behave nicely and request these services stop.
+ *
+ * Use shutdown whenever you would normally call ::exit.
+ */
+void shutdown(int recode, bool wait = false);
 
 class DropPrivileges;
 typedef std::shared_ptr<DropPrivileges> DropPrivilegesRef;

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -303,7 +303,7 @@ Status Config::load() {
                 content.first.c_str(),
                 content.second.c_str());
       }
-      ::exit(EXIT_SUCCESS);
+      osquery::shutdown(EXIT_SUCCESS);
     }
     status = update(response[0]);
   }

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -943,7 +943,7 @@ static int shell_exec(
     ) {
   // Grab a lock on the managed DB instance.
   auto dbc = osquery::SQLiteDBManager::get();
-  auto db = dbc.db();
+  auto db = dbc->db();
 
   sqlite3_stmt *pStmt = nullptr; /* Statement to execute. */
   int rc = SQLITE_OK; /* Return Code */
@@ -1144,16 +1144,16 @@ static sqlite3_int64 integerValue(const char *zArg) {
     char *zSuffix;
     int iMult;
   } aMult[] = {
-        {(char *)"KiB", 1024},
-        {(char *)"MiB", 1024 * 1024},
-        {(char *)"GiB", 1024 * 1024 * 1024},
-        {(char *)"KB", 1000},
-        {(char *)"MB", 1000000},
-        {(char *)"GB", 1000000000},
-        {(char *)"K", 1000},
-        {(char *)"M", 1000000},
-        {(char *)"G", 1000000000},
-    };
+      {(char *)"KiB", 1024},
+      {(char *)"MiB", 1024 * 1024},
+      {(char *)"GiB", 1024 * 1024 * 1024},
+      {(char *)"KB", 1000},
+      {(char *)"MB", 1000000},
+      {(char *)"GB", 1000000000},
+      {(char *)"K", 1000},
+      {(char *)"M", 1000000},
+      {(char *)"G", 1000000000},
+  };
   int i;
   int isNeg = 0;
   if (zArg[0] == '-') {
@@ -1288,7 +1288,7 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
 
   // A meta command may act on the database, grab a lock and instance.
   auto dbc = osquery::SQLiteDBManager::get();
-  auto db = dbc.db();
+  auto db = dbc->db();
 
   /* Parse the input line into tokens.
   */
@@ -1673,7 +1673,7 @@ int launchIntoShell(int argc, char **argv) {
     auto dbc = SQLiteDBManager::get();
     // Add some shell-specific functions to the instance.
     sqlite3_create_function(
-        dbc.db(), "shellstatic", 0, SQLITE_UTF8, 0, shellstaticFunc, 0, 0);
+        dbc->db(), "shellstatic", 0, SQLITE_UTF8, 0, shellstaticFunc, 0, 0);
   }
 
   stdin_is_interactive = isatty(0);

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <set>
 #include <string>
@@ -47,8 +48,8 @@ using namespace apache::thrift::concurrency;
 
 /// Create easier to reference typedefs for Thrift layer implementations.
 #define SHARED_PTR_IMPL OSQUERY_THRIFT_POINTER::shared_ptr
-typedef apache::thrift::concurrency::ThreadManager InternalThreadManager;
-typedef SHARED_PTR_IMPL<InternalThreadManager> InternalThreadManagerRef;
+using InternalThreadManager = apache::thrift::concurrency::ThreadManager;
+using InternalThreadManagerRef = SHARED_PTR_IMPL<InternalThreadManager>;
 
 /**
  * @brief Default number of threads in the thread pool.
@@ -83,15 +84,15 @@ class InternalRunnable : public Runnable {
   virtual void start() = 0;
 
  private:
-  bool run_;
+  std::atomic<bool> run_{false};
 };
 
 /// An internal runnable used throughout osquery as dispatcher services.
-typedef std::shared_ptr<InternalRunnable> InternalRunnableRef;
-typedef std::shared_ptr<boost::thread> InternalThreadRef;
+using InternalRunnableRef = std::shared_ptr<InternalRunnable>;
+using InternalThreadRef = std::shared_ptr<boost::thread>;
 /// A thrift internal runnable with variable pointer wrapping.
-typedef SHARED_PTR_IMPL<InternalRunnable> ThriftInternalRunnableRef;
-typedef SHARED_PTR_IMPL<PosixThreadFactory> ThriftThreadFactory;
+using ThriftInternalRunnableRef = SHARED_PTR_IMPL<InternalRunnable>;
+using ThriftThreadFactory = SHARED_PTR_IMPL<PosixThreadFactory>;
 
 /**
  * @brief Singleton for queuing asynchronous tasks to be executed in parallel

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -49,7 +49,7 @@ int profile(int argc, char *argv[]) {
   auto dbc = osquery::SQLiteDBManager::get();
   for (size_t i = 0; i < static_cast<size_t>(osquery::FLAGS_profile); ++i) {
     osquery::QueryData results;
-    auto status = osquery::queryInternal(query, results, dbc.db());
+    auto status = osquery::queryInternal(query, results, dbc->db());
     if (!status) {
       fprintf(stderr,
               "Query failed (%d): %s\n",

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -52,11 +52,11 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("benchmark", columnDefinition(res), dbc.db());
+  attachTableInternal("benchmark", columnDefinition(res), dbc->db());
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from benchmark", results, dbc.db());
+    queryInternal("select * from benchmark", results, dbc->db());
   }
 }
 
@@ -84,11 +84,11 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("long_benchmark", columnDefinition(res), dbc.db());
+  attachTableInternal("long_benchmark", columnDefinition(res), dbc->db());
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from long_benchmark", results, dbc.db());
+    queryInternal("select * from long_benchmark", results, dbc->db());
   }
 }
 
@@ -124,11 +124,11 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("wide_benchmark", columnDefinition(res), dbc.db());
+  attachTableInternal("wide_benchmark", columnDefinition(res), dbc->db());
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from wide_benchmark", results, dbc.db());
+    queryInternal("select * from wide_benchmark", results, dbc->db());
   }
 }
 
@@ -138,8 +138,8 @@ static void SQL_select_metadata(benchmark::State& state) {
   auto dbc = SQLiteDBManager::get();
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal(
-        "select count(*) from sqlite_temp_master;", results, dbc.db());
+    queryInternal("select count(*) from sqlite_temp_master;", results,
+                  dbc->db());
   }
 }
 

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -46,7 +46,8 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto dbc = SQLiteDBManager::get();
 
   // Virtual tables require the registry/plugin API to query tables.
-  auto status = attachTableInternal("failed_sample", "(foo INTEGER)", dbc.db());
+  auto status =
+      attachTableInternal("failed_sample", "(foo INTEGER)", dbc->db());
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -56,12 +57,12 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   EXPECT_TRUE(status.ok());
 
   // Use the table name, plugin-generated schema to attach.
-  status = attachTableInternal("sample", columnDefinition(response), dbc.db());
+  status = attachTableInternal("sample", columnDefinition(response), dbc->db());
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
   QueryData results;
-  status = queryInternal(q, results, dbc.db());
+  status = queryInternal(q, results, dbc->db());
   EXPECT_EQ(
       "CREATE VIRTUAL TABLE sample USING sample(`foo` INTEGER, `bar` TEXT)",
       results[0]["sql"]);
@@ -75,7 +76,7 @@ TEST_F(VirtualTableTests, test_sqlite3_table_joins) {
   // Run a query with a join within.
   std::string statement =
       "SELECT p.pid FROM osquery_info oi, processes p WHERE oi.pid = p.pid";
-  auto status = queryInternal(statement, results, dbc.db());
+  auto status = queryInternal(statement, results, dbc->db());
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(results.size(), 1U);
 }
@@ -140,9 +141,9 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   {
     // To simplify the attach, just access the column definition directly.
     auto p = std::make_shared<pTablePlugin>();
-    attachTableInternal("p", p->columnDefinition(), dbc.db());
+    attachTableInternal("p", p->columnDefinition(), dbc->db());
     auto k = std::make_shared<kTablePlugin>();
-    attachTableInternal("k", k->columnDefinition(), dbc.db());
+    attachTableInternal("k", k->columnDefinition(), dbc->db());
   }
 
   QueryData results;
@@ -178,7 +179,7 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
 
   for (const auto& test : constraint_tests) {
     QueryData results;
-    queryInternal(test.first, results, dbc.db());
+    queryInternal(test.first, results, dbc->db());
     EXPECT_EQ(results, test.second);
   }
 
@@ -197,7 +198,7 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   size_t index = 0;
   for (const auto& test : constraint_tests) {
     QueryData results;
-    queryInternal(test.first + " union " + test.first, results, dbc.db());
+    queryInternal(test.first + " union " + test.first, results, dbc->db());
     EXPECT_EQ(results, union_results[index++]);
   }
 }

--- a/tools/tests/sanitize_blacklist.txt
+++ b/tools/tests/sanitize_blacklist.txt
@@ -8,5 +8,13 @@ src:*asio/impl/*
 # GFlags
 fun:*SetArgv*
 
+# GLog
+# This is a confirmed race, but deemed low pri
+fun:*RawLog__SetLastTime*
+
+# Thrift
+fun:*TServerSocket*
+src:*thrift/transport/TServerSocket.cpp
+
 # RocksDB
 fun:*ColumnFamilyOptions*

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -428,6 +428,7 @@ class TimeoutRunner(object):
         self.stdout, self.stderr = self.proc.communicate()
         timer.cancel()
 
+
 def flaky(gen):
     exceptions = []
     def attempt(this):
@@ -452,6 +453,7 @@ def flaky(gen):
             i += 1
         raise exceptions[0][0]
     return wrapper
+
 
 class Tester(object):
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -104,6 +104,9 @@ class OsqueryiTest(unittest.TestCase):
             SHELL_TIMEOUT)
         self.assertNotEqual(proc.stderr, "")
         self.assertNotEqual(proc.proc.poll(), 0)
+        # Also do not accept a SIGSEG
+        # It should exit EX_CONFIG = 78
+        self.assertEqual(proc.proc.poll(), 78)
 
     @test_base.flaky
     def test_config_check_example(self):


### PR DESCRIPTION
This is a refactor of shutdown, dispatcher, and event factory concurrency logic. The results here are an attempt to minimize the number of critical sections identified by LLVM's thread sanitization.