### PR TITLE
Require Thrift 0.9.3

### DIFF
--- a/CMake/FindThrift.cmake
+++ b/CMake/FindThrift.cmake
@@ -50,3 +50,8 @@ if(NOT DEFINED THRIFT_FOUND)
     THRIFT_INCLUDE_DIR
   )
 endif()
+
+if (NOT "${THRIFT_VERSION}" STREQUAL "Thrift version 0.9.3")
+  WARNING_LOG("[Ref #1830] Cannot use thrift versions <0.9.3 (found ${THRIFT_VERSION})")
+  message(FATAL_ERROR "[Ref #1830] Need thrift version 0.9.3")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ find_package(Gflags REQUIRED)
 find_package(Gtest REQUIRED)
 find_package(RocksDB REQUIRED)
 find_package(Sqlite3 REQUIRED)
-find_package(Thrift 0.9.1 REQUIRED)
+find_package(Thrift 0.9.3 REQUIRED)
 
 # If using the RocksDB LITE version our code must also define ROCKSDB_LITE=1
 if(ROCKSDB_LITE_FOUND)


### PR DESCRIPTION
It is no longer feasible to run with thrift versions less than 0.9.3, see #1830. Let's stop people from building if CMake can detect the thrift version.