### PR TITLE
Valid bool in packs for shard/plaform/version checking

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -130,7 +130,7 @@ class Config : private boost::noncopyable {
   /**
    * @brief Iterate through all packs
    */
-  void packs(std::function<void(Pack& pack)> predicate);
+  void packs(std::function<void(std::shared_ptr<Pack>& pack)> predicate);
 
   /**
    * @brief Add a file
@@ -292,6 +292,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ConfigTests, test_get_parser);
   FRIEND_TEST(ConfigTests, test_add_remove_pack);
   FRIEND_TEST(ConfigTests, test_update_clear);
+  FRIEND_TEST(ConfigTests, test_pack_file_paths);
   FRIEND_TEST(ConfigTests, test_noninline_pack);
 
   friend class FilePathsConfigParserPluginTests;

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -10,11 +10,13 @@
 
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
 
 #include <boost/property_tree/ptree.hpp>
+#include <boost/noncopyable.hpp>
 
 #include <osquery/database.h>
 
@@ -33,7 +35,7 @@ struct PackStats {
  * Instantiating a new Pack object parses JSON and may throw a
  * boost::property_tree::json_parser::json_parser_error exception
  */
-class Pack {
+class Pack : private boost::noncopyable {
  public:
   Pack(const std::string& name, const boost::property_tree::ptree& tree)
       : Pack(name, "", tree) {}
@@ -121,6 +123,9 @@ class Pack {
 
   /// Cached time and result from previous discovery step.
   std::pair<size_t, bool> discovery_cache_;
+
+  /// Aggregate appropriateness of pack for this host.
+  std::atomic<bool> valid_{false};
 
   /// Pack discovery statistics.
   PackStats stats_;

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -134,12 +134,6 @@ void Pack::initialize(const std::string& name,
     return;
   }
 
-  schedule_.clear();
-  if (tree.count("queries") == 0) {
-    // This pack contained no queries.
-    return;
-  }
-
   discovery_queries_.clear();
   if (tree.count("discovery") > 0) {
     for (const auto& item : tree.get_child("discovery")) {
@@ -149,10 +143,17 @@ void Pack::initialize(const std::string& name,
 
   // Initialize a discovery cache at time 0.
   discovery_cache_ = std::make_pair<size_t, bool>(0, false);
+  valid_ = true;
 
   // If the splay percent is less than 1 reset to a sane estimate.
   if (FLAGS_schedule_splay_percent <= 1) {
     FLAGS_schedule_splay_percent = 10;
+  }
+
+  schedule_.clear();
+  if (tree.count("queries") == 0) {
+    // This pack contained no queries.
+    return;
   }
 
   // Iterate the queries (or schedule) and check platform/version/sanity.
@@ -207,7 +208,7 @@ const std::string& Pack::getPlatform() const { return platform_; }
 
 const std::string& Pack::getVersion() const { return version_; }
 
-bool Pack::shouldPackExecute() { return checkDiscovery(); }
+bool Pack::shouldPackExecute() { return (valid_ && checkDiscovery()); }
 
 const std::string& Pack::getName() const { return name_; }
 

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -110,6 +110,13 @@ pt::ptree getUnrestrictedPack() {
   return packs.get_child("unrestricted_pack");
 }
 
+// several restrictions (version, platform, shard)
+pt::ptree getRestrictedPack() {
+  auto tree = getExamplePacksConfig();
+  auto packs = tree.get_child("packs");
+  return packs.get_child("restricted_pack");
+}
+
 /// 1 discovery query, darwin platform restriction
 pt::ptree getPackWithDiscovery() {
   auto tree = getExamplePacksConfig();

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -51,6 +51,7 @@ std::map<std::string, std::string> getTestConfigMap();
 
 pt::ptree getExamplePacksConfig();
 pt::ptree getUnrestrictedPack();
+pt::ptree getRestrictedPack();
 pt::ptree getPackWithDiscovery();
 pt::ptree getPackWithValidDiscovery();
 pt::ptree getPackWithFakeVersion();

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -78,14 +78,14 @@ QueryData genOsqueryEvents(QueryContext& context) {
 QueryData genOsqueryPacks(QueryContext& context) {
   QueryData results;
 
-  Config::getInstance().packs([&results](Pack& pack) {
+  Config::getInstance().packs([&results](std::shared_ptr<Pack>& pack) {
     Row r;
-    r["name"] = pack.getName();
-    r["version"] = pack.getVersion();
-    r["platform"] = pack.getPlatform();
-    r["shard"] = INTEGER(pack.getShard());
+    r["name"] = pack->getName();
+    r["version"] = pack->getVersion();
+    r["platform"] = pack->getPlatform();
+    r["shard"] = INTEGER(pack->getShard());
 
-    auto stats = pack.getStats();
+    auto stats = pack->getStats();
     r["discovery_cache_hits"] = INTEGER(stats.hits);
     r["discovery_executions"] = INTEGER(stats.misses);
     results.push_back(r);

--- a/tools/tests/test_inline_pack.conf
+++ b/tools/tests/test_inline_pack.conf
@@ -12,6 +12,12 @@
           "version": "1.5.1-26",
           "removed": false
         }
+      },
+      "file_paths": {
+        "unrestricted_pack": [
+          "/unrestricted",
+          "/unrestricted/also"
+        ]
       }
     },
     "discovery_pack": {
@@ -50,7 +56,10 @@
     "restricted_pack": {
       "version": "9.9.9",
       "platform": "none",
-      "shard": "1"
+      "shard": "1",
+      "file_paths": {
+        "restricted_pack": ["/restricted"]
+      }
     }
   },
   "schedule": {


### PR DESCRIPTION
1. Record the success of pack instantiation. Validity means acceptable shard, version, and platform. If a pack is valid then discovery queries will determine appropriateness. Previously, packs did not record valid state but would fail to append to the schedule. For other (non-schedule) uses of packs this leads to undefined behavior and confusion.
2. Packs should be treated as non-copyable. There is a simple refactor here that moves pack storage into shared pointers. Pack use/scoping should still be confined to the `Config` and subsequent `Schedule` instance.