### PR TITLE
Fix -A/.all contention via do_meta_command

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -941,6 +941,7 @@ static int shell_exec(
     struct callback_data *pArg, /* Pointer to struct callback_data */
     char **pzErrMsg /* Error msg written here */
     ) {
+
   // Grab a lock on the managed DB instance.
   auto dbc = osquery::SQLiteDBManager::get();
   auto db = dbc->db();
@@ -1286,10 +1287,6 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
   int rc = 0;
   char *azArg[50];
 
-  // A meta command may act on the database, grab a lock and instance.
-  auto dbc = osquery::SQLiteDBManager::get();
-  auto db = dbc->db();
-
   /* Parse the input line into tokens.
   */
   while (zLine[i] && nArg < ArraySize(azArg)) {
@@ -1341,8 +1338,15 @@ static int do_meta_command(char *zLine, struct callback_data *p) {
     if (rc != SQLITE_OK) {
       fprintf(stderr, "Error querying table: %s\n", azArg[1]);
     }
-  } else if (c == 'b' && n >= 3 && strncmp(azArg[0], "bail", n) == 0 &&
-             nArg > 1 && nArg < 3) {
+    return rc;
+  }
+
+  // A meta command may act on the database, grab a lock and instance.
+  auto dbc = osquery::SQLiteDBManager::get();
+  auto db = dbc->db();
+
+  if (c == 'b' && n >= 3 && strncmp(azArg[0], "bail", n) == 0 && nArg > 1 &&
+      nArg < 3) {
     bail_on_error = booleanValue(azArg[1]);
   } else if (c == 'e' && strncmp(azArg[0], "echo", n) == 0 && nArg > 1 &&
              nArg < 3) {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -155,12 +155,6 @@ void SQLiteSQLPlugin::detach(const std::string& name) {
   detachTableInternal(name, dbc->db());
 }
 
-SQLiteDBInstance::SQLiteDBInstance() {
-  primary_ = false;
-  sqlite3_open(":memory:", &db_);
-  attachVirtualTables(db_);
-}
-
 SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, std::mutex& mtx)
     : db_(db), lock_(mtx, std::try_to_lock) {
   if (lock_.owns_lock()) {
@@ -168,8 +162,14 @@ SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, std::mutex& mtx)
   } else {
     db_ = nullptr;
     VLOG(1) << "DBManager contention: opening transient SQLite database";
-    SQLiteDBInstance();
+    init();
   }
+}
+
+void SQLiteDBInstance::init() {
+  primary_ = false;
+  sqlite3_open(":memory:", &db_);
+  attachVirtualTables(db_);
 }
 
 SQLiteDBInstance::~SQLiteDBInstance() {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -38,12 +38,15 @@ namespace osquery {
  */
 class SQLiteDBInstance : private boost::noncopyable {
  public:
-  SQLiteDBInstance();
+  SQLiteDBInstance() { init(); }
   SQLiteDBInstance(sqlite3*& db, std::mutex& mtx);
   ~SQLiteDBInstance();
 
   /// Check if the instance is the osquery primary.
   bool isPrimary() const { return primary_; }
+
+  /// Generate a new 'transient' connection.
+  void init();
 
   /**
    * @brief Accessor to the internal `sqlite3` object, do not store references

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -363,6 +363,9 @@ Status attachTableInternal(const std::string &name,
       nullptr, /* Rollback */
       nullptr, /* FindFunction */
       nullptr, /* Rename */
+      nullptr, /* Savepoint */
+      nullptr, /* Release */
+      nullptr, /* RollbackTo */
   };
   // clang-format on
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -181,6 +181,12 @@ class OsqueryiTest(unittest.TestCase):
         self.assertTrue(0 <= int(row['seconds']) <= 60)
 
     @test_base.flaky
+    def test_time_using_all(self):
+        self.osqueryi.run_command(' ')
+        result = self.osqueryi.run_command('.all time')
+        self.assertNotEqual(result.rstrip(), "Error querying table: time")
+
+    @test_base.flaky
     def test_config_bad_json(self):
         self.osqueryi = test_base.OsqueryWrapper(self.binary,
                                                  args={"config_path": "/"})


### PR DESCRIPTION
A recent regression prevented transient connections to the DB. This fixes the bug, allowing multiple DB connections (using distinct DBs/virtual table modules) and improves the speed of `-A` or `.all` shell meta commands. The `do_meta_command` command switch does not need to hold a lock for the database. It does so to help future commands, assuming they'll want to change options/modes for the database. There is one custom-command that trampolines into `shell_exec` (the all command) and this should run before the secondary lock is needed.