### PR TITLE
[#1810] Allow extensions autoloading in osqueryi

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -117,7 +117,7 @@ class Initializer : private boost::noncopyable {
    *
    * @param name The name of the worker process.
    */
-  void initWorkerWatcher(const std::string& name) const;
+  void initWorkerWatcher(const std::string& name = "") const;
 
   /// Assume initialization finished, start work.
   void start() const;

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -231,7 +231,7 @@ struct ConstraintList {
   std::set<std::string> getAll(ConstraintOperator op) const;
 
   /// See ConstraintList::getAll, but as a selected literal type.
-  template<typename T>
+  template <typename T>
   std::set<T> getAll(ConstraintOperator op) const {
     std::set<T> literal_matches;
     auto matches = getAll(op);
@@ -399,7 +399,7 @@ class TablePlugin : public Plugin {
   std::string columnDefinition() const;
 
   /// Return the name and column pairs for attaching virtual tables.
-  PluginResponse routeInfo() const;
+  PluginResponse routeInfo() const override;
 
   /**
    * @brief Check if there are fresh cache results for this table.
@@ -471,7 +471,7 @@ class TablePlugin : public Plugin {
    * @param request The plugin request, must include an action key.
    * @param response A plugin response, for generation this contains the rows.
    */
-  Status call(const PluginRequest& request, PluginResponse& response);
+  Status call(const PluginRequest& request, PluginResponse& response) override;
 
  public:
   /// Helper data structure transformation methods.

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -132,6 +132,15 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
   // Additional index for flag values.
   max += 6;
 
+  // Show a reference to the flags documentation.
+
+  // Show the Gflags-specific 'flagfile'.
+  if (!shell && cli) {
+    fprintf(stdout, "    --flagfile PATH");
+    fprintf(stdout, "%s", std::string(max - 8 - 5, ' ').c_str());
+    fprintf(stdout, "  Line-delimited file of additional flags\n");
+  }
+
   auto& aliases = instance().aliases_;
   for (const auto& flag : info) {
     if (details.count(flag.name) > 0) {

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -69,6 +69,12 @@ int profile(int argc, char *argv[]) {
 int main(int argc, char *argv[]) {
   // Parse/apply flags, start registry, load logger/config plugins.
   osquery::Initializer runner(argc, argv, osquery::OSQUERY_TOOL_SHELL);
+
+  // The shell will not use a worker process.
+  // It will initialize a watcher thread for potential auto-loaded extensions.
+  runner.initWorkerWatcher();
+
+  // Check for shell-specific switches and positional arguments.
   if (argc > 1 || !isatty(fileno(stdin)) || osquery::FLAGS_A.size() > 0 ||
       osquery::FLAGS_L || osquery::FLAGS_profile > 0) {
     // A query was set as a positional argument, via stdin, or profiling is on.

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -156,14 +156,14 @@ QueryData genOsqueryExtensions(QueryContext& context) {
 
   ExtensionList extensions;
   if (getExtensions(extensions).ok()) {
-    for (const auto& extenion : extensions) {
+    for (const auto& extension : extensions) {
       Row r;
-      r["uuid"] = TEXT(extenion.first);
-      r["name"] = extenion.second.name;
-      r["version"] = extenion.second.version;
-      r["sdk_version"] = extenion.second.sdk_version;
-      r["path"] = getExtensionSocket(extenion.first);
-      r["type"] = "extension";
+      r["uuid"] = TEXT(extension.first);
+      r["name"] = extension.second.name;
+      r["version"] = extension.second.version;
+      r["sdk_version"] = extension.second.sdk_version;
+      r["path"] = getExtensionSocket(extension.first);
+      r["type"] = (extension.first == 0) ? "core" : "extension";
       results.push_back(r);
     }
   }


### PR DESCRIPTION
The osquery shell can autoload extensions. The only difference between the daemon and the shell, with respect to extensions autoloading, is the daemon expects to fork a worker process and continue only as a watch dog (a loop to check sanity of a single worker). If the shell implicitly disable watchdog features it can offer the same extension loading and monitoring as the daemon.