### PR TITLE
[#1800] Add UUID to users and disk_encryption on Darwin

### DIFF
--- a/osquery/tables/system/darwin/disk_encryption.cpp
+++ b/osquery/tables/system/darwin/disk_encryption.cpp
@@ -67,17 +67,15 @@ Status genUnlockIdent(CFDataRef& uuid) {
   return Status(1, "Could not get unlock ident");
 }
 
-Status genUid(id_t& uid) {
+Status genUid(id_t& uid, uuid_string_t& uuid_str) {
   CFDataRef uuid = nullptr;
   if (!genUnlockIdent(uuid).ok()) {
     return Status(1, "Could not get unlock ident");
   }
 
-  char buffer[37] = {0};
-  CFDataGetBytes(uuid, CFRangeMake(0, CFDataGetLength(uuid)), (UInt8*)buffer);
-
-  uuid_t uuidT;
-  if (uuid_parse(buffer, uuidT) != 0) {
+  CFDataGetBytes(uuid, CFRangeMake(0, CFDataGetLength(uuid)), (UInt8*)uuid_str);
+  uuid_t uuidT = {0};
+  if (uuid_parse(uuid_str, uuidT) != 0) {
     return Status(1, "Could not parse UUID");
   }
 
@@ -124,8 +122,10 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
   } else {
     r["encrypted"] = encrypted;
     id_t uid;
-    if (genUid(uid).ok()) {
+    uuid_string_t uuid_string = {0};
+    if (genUid(uid, uuid_string).ok()) {
       r["uid"] = BIGINT(uid);
+      r["user_uuid"] = TEXT(uuid_string);
     }
   }
   r["type"] = (r.at("encrypted") == "1") ? kEncryptionType : std::string();

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -9,6 +9,7 @@
  */
 
 #import <OpenDirectory/OpenDirectory.h>
+#include <membership.h>
 
 #include "osquery/tables/system/user_groups.h"
 
@@ -85,6 +86,26 @@ QueryData genGroups(QueryContext &context) {
   return results;
 }
 
+void setRow(Row &r, passwd *pwd) {
+  r["gid"] = BIGINT(pwd->pw_gid);
+  r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
+  r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
+  r["description"] = TEXT(pwd->pw_gecos);
+  r["directory"] = TEXT(pwd->pw_dir);
+  r["shell"] = TEXT(pwd->pw_shell);
+
+  uuid_t uuid = {0};
+  uuid_string_t uuid_string = {0};
+
+  // From the docs: mbr_uid_to_uuid will always succeed and may return a
+  // synthesized UUID with the prefix FFFFEEEE-DDDD-CCCC-BBBB-AAAAxxxxxxxx,
+  // where 'xxxxxxxx' is a hex conversion of the UID.
+  mbr_uid_to_uuid(pwd->pw_uid, uuid);
+
+  uuid_unparse(uuid, uuid_string);
+  r["uuid"] = TEXT(uuid_string);
+}
+
 QueryData genUsers(QueryContext &context) {
   QueryData results;
   if (context.constraints["uid"].exists(EQUALS)) {
@@ -98,12 +119,7 @@ QueryData genUsers(QueryContext &context) {
       Row r;
       r["uid"] = BIGINT(uid);
       r["username"] = std::string(pwd->pw_name);
-      r["gid"] = BIGINT(pwd->pw_gid);
-      r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
-      r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
-      r["description"] = TEXT(pwd->pw_gecos);
-      r["directory"] = TEXT(pwd->pw_dir);
-      r["shell"] = TEXT(pwd->pw_shell);
+      setRow(r, pwd);
       results.push_back(r);
     }
   } else {
@@ -116,14 +132,9 @@ QueryData genUsers(QueryContext &context) {
       }
 
       Row r;
-      r["username"] = username;
       r["uid"] = BIGINT(pwd->pw_uid);
-      r["gid"] = BIGINT(pwd->pw_gid);
-      r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
-      r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
-      r["description"] = TEXT(pwd->pw_gecos);
-      r["directory"] = TEXT(pwd->pw_dir);
-      r["shell"] = TEXT(pwd->pw_shell);
+      r["username"] = username;
+      setRow(r, pwd);
       results.push_back(r);
     }
   }

--- a/specs/block_devices.table
+++ b/specs/block_devices.table
@@ -1,13 +1,13 @@
 table_name("block_devices")
 description("Block (buffered access) device file nodes: disks, ramdisks, and DMG containers.")
 schema([
-	Column("name", TEXT, "Block device name"),
-	Column("parent", TEXT, "Block device parent name"),
-	Column("vendor", TEXT, "Block device vendor string"),
-	Column("model", TEXT, "Block device model string identifier"),
-	Column("size", BIGINT, "Block device size in bytes"),
-	Column("uuid", TEXT, "Block device Universally Unique Identifier"),
-	Column("type", TEXT, "Block device type string"),
-	Column("label", TEXT, "Block device label string"),
+    Column("name", TEXT, "Block device name"),
+    Column("parent", TEXT, "Block device parent name"),
+    Column("vendor", TEXT, "Block device vendor string"),
+    Column("model", TEXT, "Block device model string identifier"),
+    Column("size", BIGINT, "Block device size in bytes"),
+    Column("uuid", TEXT, "Block device Universally Unique Identifier"),
+    Column("type", TEXT, "Block device type string"),
+    Column("label", TEXT, "Block device label string"),
 ])
 implementation("block_devices@genBlockDevs")

--- a/specs/disk_encryption.table
+++ b/specs/disk_encryption.table
@@ -5,7 +5,8 @@ schema([
     Column("uuid", TEXT, "Disk Universally Unique Identifier"),
     Column("encrypted", INTEGER, "1 If encrypted: true (disk is encrypted), else 0"),
     Column("type", TEXT, "Description of cipher type and mode if available"),
-    Column("uid", TEXT, "Currently authenticated user if available"),
+    Column("uid", TEXT, "Currently authenticated user if available (Apple)"),
+    Column("user_uuid", TEXT, "UUID of authenticated user if available (Apple)"),
     ForeignKey(column="name", table="block_devices"),
     ForeignKey(column="uuid", table="block_devices"),
 ])

--- a/specs/users.table
+++ b/specs/users.table
@@ -9,6 +9,7 @@ schema([
     Column("description", TEXT, "Optional user description"),
     Column("directory", TEXT, "User's home directory"),
     Column("shell", TEXT, "User's configured default shell"),
+    Column("uuid", TEXT, "User's UUID (Apple)"),
 ])
 implementation("users@genUsers")
 examples([


### PR DESCRIPTION
This change adds:

* `uuid` column to `users` table:

According to Apple's docs: the UUID may be a synthesized UUID (i.e. system accounts) with the prefix `FFFFEEEE-DDDD-CCCC-BBBB-AAAAxxxxxxxx`, where `xxxxxxxx` is a hex conversion of the UID

I did not notice a change in query times, but if we want to optimize further we can restrict user's UUID reporting to non-system accounts in the future.

* `user_uuid` column to `disk_encryption` table

```
osquery> select de.name, de.encrypted, de.uid, de.user_uuid, users.shell
    ...> from disk_encryption as de join users
    ...> where de.uid == users.uid and de.user_uuid == users.uuid;
+------------+-----------+-----+--------------------------------------+--------------------+
| name       | encrypted | uid | user_uuid                            | shell              |
+------------+-----------+-----+--------------------------------------+--------------------+
| /dev/disk1 | 1         | 501 | 5DDA9437-BEB6-46EB-87A0-F5DC1FF3A30E | /usr/local/bin/zsh |
+------------+-----------+-----+--------------------------------------+--------------------+
Run Time: real 0.215 user 0.061805 sys 0.039910

osquery> select count(*) from users;
+----------+
| count(*) |
+----------+
| 89       |
+----------+
Run Time: real 0.032 user 0.009014 sys 0.005743

osquery> select count(*) from disk_encryption;
+----------+
| count(*) |
+----------+
| 8        |
+----------+
Run Time: real 0.007 user 0.002207 sys 0.002506
```

Thanks for the help on this @arubdesu, can you also give this a look.

Fixes #1800