### PR TITLE
Cleanup/stabilize file_events-related APIs

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -456,6 +456,19 @@ class RegistryHelper : public RegistryHelperCore {
     return ditems;
   }
 
+ protected:
+  /**
+   * @brief Add an existing plugin to this registry, used for testing only.
+   *
+   * @param item A PluginType-cased registry item.
+   * @param item_name An identifier for this registry plugin.
+   * @return A success/failure status.
+   */
+  Status add(const std::shared_ptr<RegistryType>& item) {
+    items_[item->getName()] = item;
+    return RegistryHelperCore::add(item->getName(), true);
+  }
+
  public:
   RegistryHelper(RegistryHelper const&) = delete;
   void operator=(RegistryHelper const&) = delete;
@@ -463,6 +476,9 @@ class RegistryHelper : public RegistryHelperCore {
  private:
   AddExternalCallback add_;
   RemoveExternalCallback remove_;
+
+ private:
+  FRIEND_TEST(EventsTests, test_event_subscriber_configure);
 };
 
 /// Helper definition for a shared pointer to a Plugin.
@@ -782,5 +798,5 @@ class RegistryFactory : private boost::noncopyable {
  * The actual plugins must add themselves to a registry type and should
  * implement the Plugin and RegistryType interfaces.
  */
-class Registry : public RegistryFactory {};
+using Registry = RegistryFactory;
 }

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -31,6 +31,9 @@ DECLARE_bool(verbose);
 class FSEventsTests : public testing::Test {
  protected:
   void SetUp() override {
+    // FSEvents will use data from the config and config parsers.
+    Registry::registry("config_parser")->setUp();
+
     FLAGS_verbose = true;
     trigger_path = kTestWorkingDirectory + "fsevents" +
                    std::to_string(rand() % 10000 + 10000);

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -131,17 +131,18 @@ class INotifyEventPublisher
   Status run() override;
 
   /// Remove all monitors and subscriptions.
-  void removeSubscriptions() override;
+  void removeSubscriptions(const std::string& subscriber) override;
 
  private:
   /// Helper/specialized event context creation.
-  INotifyEventContextRef createEventContextFrom(struct inotify_event* event);
+  INotifyEventContextRef createEventContextFrom(
+      struct inotify_event* event) const;
 
   /// Check if the application-global `inotify` handle is alive.
-  bool isHandleOpen() { return inotify_handle_ > 0; }
+  bool isHandleOpen() const { return inotify_handle_ > 0; }
 
   /// Check all added Subscription%s for a path.
-  bool isPathMonitored(const std::string& path);
+  bool isPathMonitored(const std::string& path) const;
 
   /**
    * @brief Add an INotify watch (monitor) on this path.
@@ -176,10 +177,10 @@ class INotifyEventPublisher
                   const INotifyEventContextRef& ec) const override;
 
   /// Get the INotify file descriptor.
-  int getHandle() { return inotify_handle_; }
+  int getHandle() const { return inotify_handle_; }
 
   /// Get the number of actual INotify active descriptors.
-  size_t numDescriptors() { return descriptors_.size(); }
+  size_t numDescriptors() const { return descriptors_.size(); }
 
   /// If we overflow, try and restart the monitor
   Status restartMonitoring();
@@ -194,10 +195,13 @@ class INotifyEventPublisher
   DescriptorPathMap descriptor_paths_;
 
   /// The inotify file descriptor handle.
-  int inotify_handle_{-1};
+  std::atomic<int> inotify_handle_{-1};
 
   /// Time in seconds of the last inotify restart.
-  int last_restart_{-1};
+  std::atomic<int> last_restart_{-1};
+
+  /// Access to path and descriptor mappings.
+  mutable boost::shared_mutex mutex_;
 
  public:
   friend class INotifyTests;

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -32,6 +32,9 @@ const int kMaxEventLatency = 3000;
 class INotifyTests : public testing::Test {
  protected:
   void SetUp() override {
+    // INotify will use data from the config and config parsers.
+    Registry::registry("config_parser")->setUp();
+
     real_test_path = kTestWorkingDirectory + "inotify-trigger";
     real_test_dir = kTestWorkingDirectory + "inotify-triggers";
     real_test_dir_path = real_test_dir + "/1";
@@ -287,7 +290,7 @@ TEST_F(INotifyTests, test_inotify_run) {
   auto sub = std::make_shared<TestINotifyEventSubscriber>();
   EventFactory::registerEventSubscriber(sub);
 
-  // Create a subscriptioning context
+  // Create a subscription context
   auto mc = std::make_shared<INotifySubscriptionContext>();
   mc->path = real_test_path;
   mc->mask = IN_ALL_EVENTS;

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -188,7 +188,7 @@ void RegistryHelperCore::setUp() {
 }
 
 void RegistryHelperCore::configure() {
-  if (active_.size() != 0 && exists(active_, true)) {
+  if (!active_.empty() && exists(active_, true)) {
     items_.at(active_)->configure();
   } else {
     for (auto& item : items_) {

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -62,8 +62,7 @@ REGISTER(FileEventSubscriber, "event_subscriber", "file_events");
 void FileEventSubscriber::configure() {
   // Clear all paths from FSEvents.
   // There may be a better way to find the set intersection/difference.
-  auto pub = getPublisher();
-  pub->removeSubscriptions();
+  removeSubscriptions();
 
   Config::getInstance().files([this](const std::string& category,
                                      const std::vector<std::string>& files) {

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -59,8 +59,7 @@ REGISTER(FileEventSubscriber, "event_subscriber", "file_events");
 void FileEventSubscriber::configure() {
   // Clear all monitors from INotify.
   // There may be a better way to find the set intersection/difference.
-  auto pub = getPublisher();
-  pub->removeSubscriptions();
+  removeSubscriptions();
 
   auto parser = Config::getParser("file_paths");
   auto& accesses = parser->getData().get_child("file_accesses");
@@ -95,8 +94,8 @@ Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   if ((sc->mask & kFileAccessMasks) != kFileAccessMasks) {
     // Add hashing and 'join' against the file table for stat-information.
-    decorateFileEvent(
-        ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
+    decorateFileEvent(ec->path,
+                      (ec->action == "CREATED" || ec->action == "UPDATED"), r);
   } else {
     // The access event on Linux would generate additional events if stated.
     for (const auto& column : kCommonFileColumns) {

--- a/osquery/tables/events/process_file_events.cpp
+++ b/osquery/tables/events/process_file_events.cpp
@@ -40,10 +40,8 @@ class ProcessFileEventSubscriber
 REGISTER(ProcessFileEventSubscriber, "event_subscriber", "process_file_events");
 
 void ProcessFileEventSubscriber::configure() {
-
   // There may be a better way to find the set intersection/difference.
-  auto pub = getPublisher();
-  pub->removeSubscriptions();
+  removeSubscriptions();
 
   Config::getInstance().files([this](const std::string &category,
                                      const std::vector<std::string> &files) {

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/property_tree/json_parser.hpp>
+
+#include <osquery/config.h>
+#include <osquery/events.h>
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+#include <osquery/sql.h>
+
+#include "osquery/core/test_util.h"
+#include "osquery/tables/events/event_utils.h"
+
+namespace osquery {
+
+DECLARE_bool(registry_exceptions);
+
+class FileEventSubscriber;
+
+class FileEventsTableTests : public testing::Test {
+ public:
+  void SetUp() override {
+    Config::getInstance().reset();
+
+    // Promote registry access exceptions when testing tables and SQL.
+    exceptions_ = FLAGS_registry_exceptions;
+    FLAGS_registry_exceptions = true;
+
+    // Setup configuration parsers for file paths accesses.
+    Registry::registry("config_parser")->setUp();
+  }
+
+  void TearDown() override { FLAGS_registry_exceptions = exceptions_; }
+
+ protected:
+  Status load() { return Config::getInstance().load(); }
+
+ private:
+  bool exceptions_{false};
+};
+
+TEST_F(FileEventsTableTests, test_subscriber_exists) {
+  ASSERT_TRUE(Registry::exists("event_subscriber", "file_events"));
+
+  // Note: do not perform a reinterpret cast like this.
+  auto plugin = Registry::get("event_subscriber", "file_events");
+  auto* subscriber =
+      reinterpret_cast<std::shared_ptr<FileEventSubscriber>*>(&plugin);
+  EXPECT_NE(subscriber, nullptr);
+}
+
+TEST_F(FileEventsTableTests, test_table_empty) {
+  // Attach/create the publishers.
+  attachEvents();
+
+  auto results = SQL::selectAllFrom("file_events");
+  EXPECT_EQ(results.size(), 0U);
+}
+
+class FileEventsTestsConfigPlugin : public ConfigPlugin {
+ public:
+  Status genConfig(std::map<std::string, std::string>& config) override {
+    std::stringstream ss;
+    pt::write_json(ss, getUnrestrictedPack(), false);
+    config["data"] = ss.str();
+    return Status(0);
+  }
+};
+
+TEST_F(FileEventsTableTests, test_configure_subscriptions) {
+  // Attach/create the publishers.
+  attachEvents();
+
+  // Load a configuration with file paths, verify subscriptions.
+  Registry::add<FileEventsTestsConfigPlugin>("config", "file_events_tests");
+  Registry::setActive("config", "file_events_tests");
+  this->load();
+
+  // Explicitly request a configure for subscribers.
+  Registry::registry("event_subscriber")->configure();
+
+  std::string q = "select * from osquery_events where name = 'file_events'";
+  auto results = SQL::SQL(q);
+  ASSERT_EQ(results.rows().size(), 1U);
+  auto& row = results.rows()[0];
+  // Expect the paths within "unrestricted_pack" to be created as subscriptions.
+  EXPECT_EQ(row.at("subscriptions"), "2");
+
+  // The most important part, make sure a reconfigure removes the subscriptions.
+  Config::getInstance().update({{"data", "{}"}});
+  results = SQL::SQL(q);
+  auto& row2 = results.rows()[0];
+  EXPECT_EQ(row2.at("subscriptions"), "0");
+}
+}

--- a/tools/tests/test_noninline_packs.conf
+++ b/tools/tests/test_noninline_packs.conf
@@ -1,6 +1,8 @@
 {
   "packs": {
+    // This pack is "non-inline", meaning it should trigger genPack.
     "tester": "lester",
+    // This pack is "inlined", the content is a JSON dictionary.
     "foobar": {
       "version": "1.5.0",
       "queries": {


### PR DESCRIPTION
This is a bit of clean and some additional testing around the `file_events` lifecycle. This goes from configuration to registry to event factory to the related publishers and finally adds a new small set of tests around the "user"-facing `file_events` API (so to speak).

We make sure of a meta-table that reports details about the pubsub system. While this does not report on the publisher internal details, it reports on the data that publishers use during `configure`.