### PR TITLE
[Fix #1828] Remove inline include from distributed

### DIFF
--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -14,11 +14,8 @@
 #include <vector>
 
 #include <osquery/database.h>
-#include <osquery/flags.h>
 #include <osquery/registry.h>
 #include <osquery/status.h>
-
-#include <osquery/dispatcher/dispatcher.h>
 
 namespace osquery {
 

--- a/osquery/dispatcher/distributed.cpp
+++ b/osquery/dispatcher/distributed.cpp
@@ -8,8 +8,10 @@
  *
  */
 
+#include <osquery/flags.h>
+#include <osquery/distributed.h>
+
 #include "osquery/dispatcher/distributed.h"
-#include "osquery/distributed.h"
 
 namespace osquery {
 


### PR DESCRIPTION
A small refactor to prevent the publish SDK from depending on inline-included headers.