### PR TITLE
[Fix #1854] Unify power sensor tables

### DIFF
--- a/osquery/tables/system/darwin/tests/smc_tests.cpp
+++ b/osquery/tables/system/darwin/tests/smc_tests.cpp
@@ -18,14 +18,8 @@
 namespace osquery {
 namespace tables {
 
-void genTemperature(const Row &row,
-                    QueryData &results);
-void genVoltage(const Row &row,
-                QueryData &results);
-void genCurrent(const Row &row,
-                QueryData &results);
-void genPower(const Row &row,
-              QueryData &results);
+void genTemperature(const Row &row, QueryData &results);
+void genPower(const Row &row, QueryData &results);
 
 class SmcTests : public testing::Test {};
 
@@ -33,11 +27,8 @@ TEST_F(SmcTests, test_gen_temperature) {
   QueryData results;
   // Generate a set of results/single row using an example smc temperature key.
   Row param = {
-    {"key", "TC0E"},
-    {"type", "sp78"},
-    {"size", "2"},
-    {"value", "3dd0"},
-    {"hidden", "0"},
+      {"key", "TC0E"},   {"type", "sp78"}, {"size", "2"},
+      {"value", "3dd0"}, {"hidden", "0"},
   };
   genTemperature(param, results);
 
@@ -50,57 +41,7 @@ TEST_F(SmcTests, test_gen_temperature) {
 
   // We could compare the entire map, but iterating the columns will produce
   // better error text as most likely parsing for a certain column/type changed.
-  for (const auto& column : expected) {
-    EXPECT_EQ(results[0][column.first], column.second);
-  }
-}
-
-TEST_F(SmcTests, test_gen_voltage) {
-  QueryData results;
-  // Generate a set of results/single row using an example smc voltage key.
-  Row param = {
-    {"key", "VC0C"},
-    {"type", "sp5a"},
-    {"size", "2"},
-    {"value", "035b"},
-    {"hidden", "0"},
-  };
-  genVoltage(param, results);
-
-  Row expected = {
-      {"key", "VC0C"},
-      {"name", "CPU Core 1"},
-      {"value", "0.84"},
-  };
-
-  // We could compare the entire map, but iterating the columns will produce
-  // better error text as most likely parsing for a certain column/type changed.
-  for (const auto& column : expected) {
-    EXPECT_EQ(results[0][column.first], column.second);
-  }
-}
-
-TEST_F(SmcTests, test_gen_current) {
-  QueryData results;
-  // Generate a set of results/single row using an example smc current key.
-  Row param = {
-    {"key", "IC0C"},
-    {"type", "sp78"},
-    {"size", "2"},
-    {"value", "026a"},
-    {"hidden", "0"},
-  };
-  genCurrent(param, results);
-
-  Row expected = {
-      {"key", "IC0C"},
-      {"name", "CPU Core"},
-      {"value", "2.41"},
-  };
-
-  // We could compare the entire map, but iterating the columns will produce
-  // better error text as most likely parsing for a certain column/type changed.
-  for (const auto& column : expected) {
+  for (const auto &column : expected) {
     EXPECT_EQ(results[0][column.first], column.second);
   }
 }
@@ -109,26 +50,20 @@ TEST_F(SmcTests, test_gen_power) {
   QueryData results;
   // Generate a set of results/single row using an example smc power key.
   Row param = {
-    {"key", "PC1R"},
-    {"type", "sp78"},
-    {"size", "2"},
-    {"value", "05a9"},
-    {"hidden", "0"},
+      {"key", "PC1R"},   {"type", "sp78"}, {"size", "2"},
+      {"value", "05a9"}, {"hidden", "0"},
   };
   genPower(param, results);
 
   Row expected = {
-      {"key", "PC1R"},
-      {"name", "CPU Rail"},
-      {"value", "4.66"},
+      {"key", "PC1R"}, {"name", "CPU Rail"}, {"value", "4.66"},
   };
 
   // We could compare the entire map, but iterating the columns will produce
   // better error text as most likely parsing for a certain column/type changed.
-  for (const auto& column : expected) {
+  for (const auto &column : expected) {
     EXPECT_EQ(results[0][column.first], column.second);
   }
 }
-
 }
 }

--- a/specs/darwin/fan_speed_sensors.table
+++ b/specs/darwin/fan_speed_sensors.table
@@ -1,4 +1,4 @@
-table_name("sensor_fan_speeds")
+table_name("fan_speed_sensors")
 description("Fan speeds.")
 schema([
     Column("fan", TEXT, "Fan number"),
@@ -7,4 +7,4 @@ schema([
     Column("max", INTEGER, "Maximum speed"),
     Column("target", INTEGER, "Target speed"),
 ])
-implementation("smc_keys@getFanSpeeds")
+implementation("smc_keys@genFanSpeedSensors")

--- a/specs/darwin/power_sensors.table
+++ b/specs/darwin/power_sensors.table
@@ -1,0 +1,13 @@
+table_name("power_sensors")
+description("Machine power (currents, voltages, wattages, etc) sensors.")
+schema([
+    Column("key", TEXT, "The SMC key on OS X", index=True),
+    Column("category", TEXT, "The sensor category: currents, voltage, wattage"),
+    Column("name", TEXT, "Name of power source"),
+    Column("value", TEXT, "Power in Watts"),
+    ForeignKey(column="key", table="smc_keys"),
+])
+examples([
+  "select * from power_sensors where category = 'voltage'"
+])
+implementation("smc_keys@genPowerSensors")

--- a/specs/darwin/sensor_currents.table
+++ b/specs/darwin/sensor_currents.table
@@ -1,9 +1,0 @@
-table_name("sensor_currents")
-description("Current sensors.")
-schema([
-    Column("key", TEXT, "The SMC key on OS X", index=True),
-    Column("name", TEXT, "Name of current source"),
-    Column("value", TEXT, "Current in Amps"),
-    ForeignKey(column="key", table="smc_keys"),
-])
-implementation("smc_keys@getCurrents")

--- a/specs/darwin/sensor_powers.table
+++ b/specs/darwin/sensor_powers.table
@@ -1,9 +1,0 @@
-table_name("sensor_powers")
-description("Power sensors.")
-schema([
-    Column("key", TEXT, "The SMC key on OS X", index=True),
-    Column("name", TEXT, "Name of power source"),
-    Column("value", TEXT, "Power in Watts"),
-    ForeignKey(column="key", table="smc_keys"),
-])
-implementation("smc_keys@getPowers")

--- a/specs/darwin/sensor_voltages.table
+++ b/specs/darwin/sensor_voltages.table
@@ -1,9 +1,0 @@
-table_name("sensor_voltages")
-description("Voltage sensors.")
-schema([
-    Column("key", TEXT, "The SMC key on OS X", index=True),
-    Column("name", TEXT, "Name of voltage source"),
-    Column("value", TEXT, "Voltage in Volts"),
-    ForeignKey(column="key", table="smc_keys"),
-])
-implementation("smc_keys@getVoltages")

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -1,5 +1,5 @@
 table_name("signature")
-description("File signature status.  Note: verifying a signature can be an expensive operation!")
+description("File (executable, bundle, installer, disk) code signing status.")
 schema([
     Column("path", TEXT, "Must provide a path or directory", required=True),
     Column("signed", INTEGER, "1 If the file is signed else 0"),

--- a/specs/darwin/temperature_sensors.table
+++ b/specs/darwin/temperature_sensors.table
@@ -1,5 +1,5 @@
-table_name("sensor_temperatures")
-description("Temperature sensors.")
+table_name("temperature_sensors")
+description("Machine's temperature sensors.")
 schema([
     Column("key", TEXT, "The SMC key on OS X", index=True),
     Column("name", TEXT, "Name of temperature source"),
@@ -7,4 +7,4 @@ schema([
     Column("fahrenheit", TEXT, "Temperature in Fahrenheit"),
     ForeignKey(column="key", table="smc_keys"),
 ])
-implementation("smc_keys@getTemperatures")
+implementation("smc_keys@genTemperatureSensors")


### PR DESCRIPTION
1. Rename `sensor_temperatures` -> `temperature_sensors`, `sensor_powers` -> `power_sensors`, and `sensor_fan_speeds` -> `fan_speed_sensors`.
2. Remove `sensor_currents` and `sensor_voltages`, and replicate their data within `sensor_powers`.
3. Add a `category` to `power_sensors` (the new mega-power-related sensors table) indicating what "type" of sensor this key/value reports.
4. Create some inline predicate parsing to minimize duplicate code.