### PR TITLE
[Fix #1861] Add newline to all filesystem logger writes

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -365,7 +365,7 @@ Status logQueryLogItem(const QueryLogItem& results,
   }
 
   for (auto& json : json_items) {
-    if (!json.empty()) {
+    if (!json.empty() && json.back() == '\n') {
       json.pop_back();
       status = logString(json, "event", receiver);
     }
@@ -378,7 +378,7 @@ Status logSnapshotQuery(const QueryLogItem& item) {
   if (!serializeQueryLogItemJSON(item, json)) {
     return Status(1, "Could not serialize snapshot");
   }
-  if (!json.empty()) {
+  if (!json.empty() && json.back() == '\n') {
     json.pop_back();
   }
   return Registry::call("logger", {{"snapshot", json}});
@@ -389,7 +389,7 @@ Status logHealthStatus(const QueryLogItem& item) {
   if (!serializeQueryLogItemJSON(item, json)) {
     return Status(1, "Could not serialize health");
   }
-  if (!json.empty()) {
+  if (!json.empty() && json.back() == '\n') {
     json.pop_back();
   }
   return Registry::call("logger", {{"health", json}});

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -72,7 +72,7 @@ Status FilesystemLoggerPlugin::setUp() {
 }
 
 Status FilesystemLoggerPlugin::logString(const std::string& s) {
-  return logStringToFile(s + "\n", kFilesystemLoggerFilename);
+  return logStringToFile(s, kFilesystemLoggerFilename);
 }
 
 Status FilesystemLoggerPlugin::logStringToFile(const std::string& s,
@@ -80,7 +80,7 @@ Status FilesystemLoggerPlugin::logStringToFile(const std::string& s,
   std::lock_guard<std::mutex> lock(filesystemLoggerPluginMutex);
   try {
     auto status = writeTextFile(
-        (log_path_ / filename).string(), s, FLAGS_logger_mode, true);
+        (log_path_ / filename).string(), s + '\n', FLAGS_logger_mode, true);
     if (!status.ok()) {
       return status;
     }


### PR DESCRIPTION
Add a newline to snapshot and health filesystem writes.

Previously, **only** the `logString` interface for the Filesystem logger plugin was "re" appending a newline. This is a bug, writes to files should always include a newline.