### PR TITLE
Improve logging tests, add filesystem logger tests

### DIFF
--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -103,7 +103,7 @@ struct StatusLogLine {
 class LoggerPlugin : public Plugin {
  public:
   /// The LoggerPlugin PluginRequest action router.
-  Status call(const PluginRequest& request, PluginResponse& response);
+  Status call(const PluginRequest& request, PluginResponse& response) override;
 
  protected:
   /** @brief Virtual method which should implement custom logging.

--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -9,11 +9,11 @@ ADD_OSQUERY_LIBRARY(FALSE osquery_logger_plugins
   plugins/syslog.cpp
 )
 
-# Kepp the logger testing in the additional to test filesystem logging.
+# Keep the logger testing in the additional to test filesystem logging.
 # There is a significant difference between the Glog-backed filesystem plugin
 # and other, which use a Glog sink. They must be tested in tandem.
 file(GLOB OSQUERY_LOGGER_TESTS "tests/*.cpp")
-ADD_OSQUERY_TEST(FALSE ${OSQUERY_LOGGER_TESTS})
+ADD_OSQUERY_TEST(TRUE ${OSQUERY_LOGGER_TESTS})
 
 file(GLOB OSQUERY_LOGGER_PLUGIN_TESTS "plugins/tests/*.cpp")
 ADD_OSQUERY_TEST(FALSE ${OSQUERY_LOGGER_PLUGIN_TESTS})

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -189,8 +189,7 @@ static void deserializeIntermediateLog(const PluginRequest& request,
     log.push_back({
         (StatusLogSeverity)item.second.get<int>("s", O_INFO),
         item.second.get<std::string>("f", "<unknown>"),
-        item.second.get<int>("i", 0),
-        item.second.get<std::string>("m", ""),
+        item.second.get<int>("i", 0), item.second.get<std::string>("m", ""),
     });
   }
 }
@@ -292,10 +291,8 @@ void BufferedLogSink::send(google::LogSeverity severity,
       if (std::find(enabled.begin(), enabled.end(), logger) != enabled.end()) {
         // May use the logs_ storage to buffer/delay sending logs.
         std::vector<StatusLogLine> log;
-        log.push_back({(StatusLogSeverity)severity,
-                       std::string(base_filename),
-                       line,
-                       std::string(message, message_len)});
+        log.push_back({(StatusLogSeverity)severity, std::string(base_filename),
+                       line, std::string(message, message_len)});
         PluginRequest request = {{"status", "true"}};
         serializeIntermediateLog(log, request);
         if (!request["log"].empty()) {
@@ -305,10 +302,8 @@ void BufferedLogSink::send(google::LogSeverity severity,
       }
     }
   } else {
-    logs_.push_back({(StatusLogSeverity)severity,
-                     std::string(base_filename),
-                     line,
-                     std::string(message, message_len)});
+    logs_.push_back({(StatusLogSeverity)severity, std::string(base_filename),
+                     line, std::string(message, message_len)});
   }
 }
 
@@ -340,9 +335,8 @@ Status logString(const std::string& message, const std::string& category) {
 Status logString(const std::string& message,
                  const std::string& category,
                  const std::string& receiver) {
-  auto status = Registry::call(
+  return Registry::call(
       "logger", receiver, {{"string", message}, {"category", category}});
-  return Status(0, "OK");
 }
 
 Status logQueryLogItem(const QueryLogItem& results) {

--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -22,9 +22,10 @@ FLAG(int32,
 
 class SyslogLoggerPlugin : public LoggerPlugin {
  public:
-  Status logString(const std::string& s);
-  Status init(const std::string& name, const std::vector<StatusLogLine>& log);
-  Status logStatus(const std::vector<StatusLogLine>& log);
+  Status logString(const std::string& s) override;
+  Status init(const std::string& name,
+              const std::vector<StatusLogLine>& log) override;
+  Status logStatus(const std::vector<StatusLogLine>& log) override;
 };
 
 REGISTER(SyslogLoggerPlugin, "logger", "syslog");

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem/operations.hpp>
+
+#include <osquery/logger.h>
+
+#include "osquery/core/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+DECLARE_string(logger_path);
+
+class FilesystemLoggerTests : public testing::Test {
+ public:
+  void SetUp() {
+    auto logger_path = fs::path(kTestWorkingDirectory) / "unittests.logs";
+    FLAGS_logger_path = logger_path.string();
+    fs::create_directories(FLAGS_logger_path);
+
+    // Set the expected results path.
+    results_path_ = (logger_path / "osqueryd.results.log").string();
+
+    // Backup the logging status, then disable.
+    logging_status_ = FLAGS_disable_logging;
+    FLAGS_disable_logging = false;
+  }
+
+  void TearDown() { FLAGS_disable_logging = logging_status_; }
+
+  std::string getContent() { return std::string(); }
+
+ protected:
+  /// Save the status of logging before running tests, restore afterward.
+  bool logging_status_{true};
+
+  /// Results log path.
+  std::string results_path_;
+};
+
+TEST_F(FilesystemLoggerTests, test_filesystem_init) {
+  EXPECT_TRUE(Registry::exists("logger", "filesystem"));
+
+  // This will attempt to log a string (an empty string).
+  EXPECT_TRUE(Registry::setActive("logger", "filesystem"));
+  EXPECT_TRUE(Registry::get("logger", "filesystem")->setUp());
+  ASSERT_TRUE(fs::exists(results_path_));
+
+  // Make sure the content is empty.
+  std::string content;
+  EXPECT_TRUE(readFile(results_path_, content));
+  EXPECT_EQ(content, "");
+}
+
+TEST_F(FilesystemLoggerTests, test_log_string) {
+  EXPECT_TRUE(logString("{\"json\": true}", "event"));
+
+  std::string content;
+  EXPECT_TRUE(readFile(results_path_, content));
+  EXPECT_EQ(content, "{\"json\": true}\n");
+}
+
+TEST_F(FilesystemLoggerTests, test_log_snapshot) {
+  QueryLogItem item;
+  item.name = "test";
+  item.identifier = "test";
+  item.time = 0;
+  item.calendar_time = "test";
+
+  EXPECT_TRUE(logSnapshotQuery(item));
+  auto snapshot_path = fs::path(FLAGS_logger_path) / "osqueryd.snapshots.log";
+  ASSERT_TRUE(fs::exists(snapshot_path));
+
+  // Write a second snapshot item, and make sure there is a newline between
+  // the two log lines.
+  EXPECT_TRUE(logSnapshotQuery(item));
+  std::string content;
+  EXPECT_TRUE(readFile(snapshot_path.string(), content));
+
+  std::string expected =
+      "{\"snapshot\":\"\",\"name\":\"test\",\"hostIdentifier\":\"test\","
+      "\"calendarTime\":\"test\",\"unixTime\":\"0\"}\n{\"snapshot\":\"\","
+      "\"name\":\"test\",\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
+      "\"unixTime\":\"0\"}\n";
+  EXPECT_EQ(content, expected);
+}
+}

--- a/osquery/logger/plugins/tls.h
+++ b/osquery/logger/plugins/tls.h
@@ -63,8 +63,6 @@ class TLSLogForwarderRunner : public InternalRunnable {
 
 class TLSLoggerPlugin : public LoggerPlugin {
  public:
-  TLSLoggerPlugin() : log_index_(0) {}
-
   /**
    * @brief The osquery logger initialization method.
    *
@@ -93,7 +91,7 @@ class TLSLoggerPlugin : public LoggerPlugin {
    * second precision for indexing and ordering. log_index_ helps prevent
    * collisions by appending an auto-increment counter.
    */
-  size_t log_index_;
+  size_t log_index_{0};
 
  private:
   /// Allow the TLSLogForwardRunner thread to disable log buffering.


### PR DESCRIPTION
As a follow up to #1861, let's add some tests specific to the Filesystem logger plugin. These tests make sure the log lines emitted to disk are sane: for the string/result logs we expect 1 per line; for the snapshot queries, which are essentially only a different file sink, we expect the same.