### PR TITLE
[Fix #1866] Emit warning log with unknown options

### DIFF
--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -47,6 +47,11 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
+    if (Flag::getType(option.first).empty()) {
+      LOG(WARNING) << "Cannot set unknown or invalid flag: " << option.first;
+      return Status(1, "Unknown flag");
+    }
+
     Flag::updateValue(option.first, value);
     // There is a special case for supported Gflags-reserved switches.
     if (option.first == "verbose" || option.first == "verbose_debug" ||


### PR DESCRIPTION
Check if a provided config options has a defined type. If no type has been recorded then this option is considered unknown.