### PR TITLE
[#1816] Refactor DB instance management

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <vector>
 #include <set>
+#include <unordered_map>
 
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -390,6 +391,29 @@ struct QueryContext : private boost::noncopyable {
 
 typedef struct QueryContext QueryContext;
 typedef struct Constraint Constraint;
+
+/**
+ * @brief osquery table content descriptor.
+ *
+ * This object is the abstracted SQLite database's virtual table descriptor.
+ * When the virtual table is created/connected the name and columns are
+ * retrieved via the TablePlugin call API. The details are kept in this context
+ * so column parsing and row walking does not require additional Registry calls.
+ *
+ * When tables are accessed as the result of an SQL statement a QueryContext is
+ * created to represent metadata that can be used by the virtual table
+ * implementation code. Thus the code that generates rows can choose to emit
+ * additional data, restrict based on constraints, or potentially yield from
+ * a cache or choose not to generate certain columns.
+ */
+struct VirtualTableContent {
+  /// Friendly name for the table.
+  TableName name;
+  /// Table column structure, retrieved once via the TablePlugin call API.
+  TableColumns columns;
+  /// Transient set of virtual table access constraints.
+  std::unordered_map<size_t, ConstraintSet> constraints;
+};
 
 /**
  * @brief The TablePlugin defines the name, types, and column information.

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1060,6 +1060,7 @@ static int shell_exec(
       }
     }
   } /* end while */
+  dbc->clearAffectedTables();
 
   if (pArg && pArg->mode == MODE_Pretty) {
     if (osquery::FLAGS_json) {
@@ -1147,16 +1148,16 @@ static sqlite3_int64 integerValue(const char *zArg) {
     char *zSuffix;
     int iMult;
   } aMult[] = {
-        {(char *)"KiB", 1024},
-        {(char *)"MiB", 1024 * 1024},
-        {(char *)"GiB", 1024 * 1024 * 1024},
-        {(char *)"KB", 1000},
-        {(char *)"MB", 1000000},
-        {(char *)"GB", 1000000000},
-        {(char *)"K", 1000},
-        {(char *)"M", 1000000},
-        {(char *)"G", 1000000000},
-    };
+      {(char *)"KiB", 1024},
+      {(char *)"MiB", 1024 * 1024},
+      {(char *)"GiB", 1024 * 1024 * 1024},
+      {(char *)"KB", 1000},
+      {(char *)"MB", 1000000},
+      {(char *)"GB", 1000000000},
+      {(char *)"K", 1000},
+      {(char *)"M", 1000000},
+      {(char *)"G", 1000000000},
+  };
   int i;
   int isNeg = 0;
   if (zArg[0] == '-') {

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -50,6 +50,7 @@ int profile(int argc, char *argv[]) {
   for (size_t i = 0; i < static_cast<size_t>(osquery::FLAGS_profile); ++i) {
     osquery::QueryData results;
     auto status = osquery::queryInternal(query, results, dbc->db());
+    dbc->clearAffectedTables();
     if (!status) {
       fprintf(stderr,
               "Query failed (%d): %s\n",

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -52,7 +52,7 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("benchmark", columnDefinition(res), dbc->db());
+  attachTableInternal("benchmark", columnDefinition(res), dbc);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -84,7 +84,7 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("long_benchmark", columnDefinition(res), dbc->db());
+  attachTableInternal("long_benchmark", columnDefinition(res), dbc);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -124,7 +124,7 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::get();
-  attachTableInternal("wide_benchmark", columnDefinition(res), dbc->db());
+  attachTableInternal("wide_benchmark", columnDefinition(res), dbc);
 
   while (state.KeepRunning()) {
     QueryData results;

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -17,7 +17,7 @@
 
 namespace osquery {
 
-extern void escapeNonPrintableBytes(std::string& data);
+extern void escapeNonPrintableBytesEx(std::string& data);
 
 class SQLTests : public testing::Test {};
 
@@ -68,25 +68,25 @@ TEST_F(SQLTests, test_raw_access_context) {
 
 TEST_F(SQLTests, test_sql_escape) {
   std::string input = "しかたがない";
-  escapeNonPrintableBytes(input);
+  escapeNonPrintableBytesEx(input);
   EXPECT_EQ(input,
             "\\xE3\\x81\\x97\\xE3\\x81\\x8B\\xE3\\x81\\x9F\\xE3\\x81\\x8C\\xE3"
             "\\x81\\xAA\\xE3\\x81\\x84");
 
   input = "悪因悪果";
-  escapeNonPrintableBytes(input);
+  escapeNonPrintableBytesEx(input);
   EXPECT_EQ(input,
             "\\xE6\\x82\\xAA\\xE5\\x9B\\xA0\\xE6\\x82\\xAA\\xE6\\x9E\\x9C");
 
   input = "モンスターハンター";
-  escapeNonPrintableBytes(input);
+  escapeNonPrintableBytesEx(input);
   EXPECT_EQ(input,
             "\\xE3\\x83\\xA2\\xE3\\x83\\xB3\\xE3\\x82\\xB9\\xE3\\x82\\xBF\\xE3"
             "\\x83\\xBC\\xE3\\x83\\x8F\\xE3\\x83\\xB3\\xE3\\x82\\xBF\\xE3\\x83"
             "\\xBC");
 
   input = "съешь же ещё этих мягких французских булок, да выпей чаю";
-  escapeNonPrintableBytes(input);
+  escapeNonPrintableBytesEx(input);
   EXPECT_EQ(
       input,
       "\\xD1\\x81\\xD1\\x8A\\xD0\\xB5\\xD1\\x88\\xD1\\x8C \\xD0\\xB6\\xD0\\xB5 "
@@ -99,7 +99,7 @@ TEST_F(SQLTests, test_sql_escape) {
       "\\xD1\\x87\\xD0\\xB0\\xD1\\x8E");
 
   input = "The quick brown fox jumps over the lazy dog.";
-  escapeNonPrintableBytes(input);
+  escapeNonPrintableBytesEx(input);
   EXPECT_EQ(input, "The quick brown fox jumps over the lazy dog.");
 }
 }

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -108,6 +108,17 @@ TEST_F(SQLiteUtilTests, test_get_test_db_result_stream) {
   }
 }
 
+TEST_F(SQLiteUtilTests, test_affected_tables) {
+  auto dbc = getTestDBC();
+  QueryData results;
+  auto status = queryInternal("SELECT * FROM time", results, dbc->db());
+
+  // Since the table scanned from "time", it should be recorded as affected.
+  EXPECT_EQ(dbc->affected_tables_.count("time"), 1U);
+  dbc->clearAffectedTables();
+  EXPECT_EQ(dbc->affected_tables_.size(), 0U);
+}
+
 TEST_F(SQLiteUtilTests, test_get_query_columns) {
   auto dbc = getTestDBC();
   TableColumns results;

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -46,8 +46,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto dbc = SQLiteDBManager::get();
 
   // Virtual tables require the registry/plugin API to query tables.
-  auto status =
-      attachTableInternal("failed_sample", "(foo INTEGER)", dbc->db());
+  auto status = attachTableInternal("failed_sample", "(foo INTEGER)", dbc);
   EXPECT_EQ(status.getCode(), SQLITE_ERROR);
 
   // The table attach will complete only when the table name is registered.
@@ -57,7 +56,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   EXPECT_TRUE(status.ok());
 
   // Use the table name, plugin-generated schema to attach.
-  status = attachTableInternal("sample", columnDefinition(response), dbc->db());
+  status = attachTableInternal("sample", columnDefinition(response), dbc);
   EXPECT_EQ(status.getCode(), SQLITE_OK);
 
   std::string q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
@@ -141,9 +140,9 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   {
     // To simplify the attach, just access the column definition directly.
     auto p = std::make_shared<pTablePlugin>();
-    attachTableInternal("p", p->columnDefinition(), dbc->db());
+    attachTableInternal("p", p->columnDefinition(), dbc);
     auto k = std::make_shared<kTablePlugin>();
-    attachTableInternal("k", k->columnDefinition(), dbc->db());
+    attachTableInternal("k", k->columnDefinition(), dbc);
   }
 
   QueryData results;
@@ -225,7 +224,7 @@ TEST_F(VirtualTableTests, test_json_extract) {
 
   {
     auto json = std::make_shared<jsonTablePlugin>();
-    attachTableInternal("json", json->columnDefinition(), dbc->db());
+    attachTableInternal("json", json->columnDefinition(), dbc);
   }
 
   QueryData results;

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -10,37 +10,12 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/sql/sqlite_util.h"
 
 namespace osquery {
-
-/**
- * @brief osquery virtual table connection.
- *
- * This object is the SQLite database's virtual table context.
- * When the virtual table is created/connected the name and columns are
- * retrieved via the TablePlugin call API. The details are kept in this context
- * so column parsing and row walking does not require additional Registry calls.
- *
- * When tables are accessed as the result of an SQL statement a QueryContext is
- * created to represent metadata that can be used by the virtual table
- * implementation code. Thus the code that generates rows can choose to emit
- * additional data, restrict based on constraints, or potentially yield from
- * a cache or choose not to generate certain columns.
- */
-struct VirtualTableContent {
-  /// Friendly name for the table.
-  TableName name;
-  /// Table column structure, retrieved once via the TablePlugin call API.
-  TableColumns columns;
-  /// Transient set of virtual table access constraints.
-  std::unordered_map<size_t, ConstraintSet> constraints;
-};
 
 /**
  * @brief osquery cursor object.
@@ -67,18 +42,24 @@ struct BaseCursor {
  * This adds each table plugin class to the state tracking in SQLite.
  */
 struct VirtualTable {
+  /// The SQLite-provided virtual table structure.
   sqlite3_vtab base;
+
+  /// Added structure: A content structure with metadata about the table.
   VirtualTableContent *content{nullptr};
+
+  /// Added structure: The thread-local DB instance associated with the query.
+  SQLiteDBInstance *instance{nullptr};
 };
 
 /// Attach a table plugin name to an in-memory SQLite database.
 Status attachTableInternal(const std::string &name,
                            const std::string &statement,
-                           sqlite3 *db);
+                           const SQLiteDBInstanceRef &instance);
 
 /// Detach (drop) a table.
 Status detachTableInternal(const std::string &name, sqlite3 *db);
 
 /// Attach all table plugins to an in-memory SQLite database.
-void attachVirtualTables(sqlite3 *db);
+void attachVirtualTables(const SQLiteDBInstanceRef &instance);
 }


### PR DESCRIPTION
This begins to refactor the use of a `DBInstance` management/contention checking abstraction into something that can communicate from within the SQLite table implementations back to the callsite. As long as the callsite does not "lose control" [1] of the database, it is possible to receive information back from the execution and decisions made within the SQLite module/virtual table code.

[1] The shell does this, but it's somewhat outside of the control of the osquery codebase.