### PR TITLE
[Fix #1892] Build devmapper statically

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -88,45 +88,38 @@ elseif(LINUX)
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
         "libudev"
-        "device-mapper >= 1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel6")
       set(PACKAGE_ITERATION "1.rhel6")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
         "libudev"
-        "device-mapper >= 1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "oracle6")
       set(PACKAGE_ITERATION "1.oel6")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
         "libudev"
-        "device-mapper >= 1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "centos7")
       set(PACKAGE_ITERATION "1.el7")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "device-mapper >= 7:1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel7")
       set(PACKAGE_ITERATION "1.rhel7")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "device-mapper >= 7:1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "oracle7")
       set(PACKAGE_ITERATION "1.oel7")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "device-mapper >= 7:1.02.90"
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "amazon2015.03")
       set(PACKAGE_ITERATION "1.amazon2015")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
-        "device-mapper >= 7:1.02.90"
       )
     endif()
   endif()

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -52,6 +52,8 @@ else()
     )
 
     ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio")
+    ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup devmapper")
+    ADD_OSQUERY_LINK_ADDITIONAL("libselinux.so")
   elseif(UBUNTU)
     # Ubuntu specific tables
     file(GLOB OSQUERY_UBUNTU_TABLES "*/ubuntu/*.cpp")
@@ -65,11 +67,12 @@ else()
 	add_definitions(-DLIBDPKG_VERSION=${LIBDPKG_VERSION_NUMBER})
 
     ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg")
+    ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup libdevmapper.so")
   endif()
 
+  ADD_OSQUERY_LINK_ADDITIONAL("libgcrypt.so")
   ADD_OSQUERY_LINK_ADDITIONAL("libresolv.so")
   ADD_OSQUERY_LINK_ADDITIONAL("blkid")
-  ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup libdevmapper.so libgcrypt.so")
   ADD_OSQUERY_LINK_ADDITIONAL("libuuid.so")
   ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")
   ADD_OSQUERY_LINK_ADDITIONAL("libmagic.so")

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -9,7 +9,7 @@
 
 set -e
 
-CFLAGS="-fPIE -fPIC -O2 -DNDEBUG -march=x86-64 -mno-avx"
+CFLAGS="-fPIE -fPIC -Os -DNDEBUG -march=x86-64 -mno-avx"
 CXXFLAGS="$CFLAGS"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/../build"

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -104,7 +104,11 @@ function main_centos() {
   install_cppnetlib
   install_google_benchmark
 
-  package device-mapper-devel
+  # Device mapper uses the exact version as the ABI.
+  # We will build and install a static version.
+  remove_package device-mapper-devel
+  install_device_mapper
+
   package libgcrypt-devel
   package gettext-devel
   install_libcryptsetup

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -72,7 +72,11 @@ function main_fedora() {
   install_cppnetlib
   install_google_benchmark
 
-  package device-mapper-devel
+  # Device mapper uses the exact version as the ABI.
+  # We will build and install a static version.
+  remove_package device-mapper-devel
+  install_device_mapper
+
   package libgcrypt-devel
   package gettext-devel
 

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -126,6 +126,11 @@ function main_oracle() {
     package rubygems
   fi
 
+  # Device mapper uses the exact version as the ABI.
+  # We will build and install a static version.
+  remove_package device-mapper-devel
+  install_device_mapper
+
   package file-libs
   install_sleuthkit
 

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -139,7 +139,11 @@ function main_rhel() {
   install_cppnetlib
   install_google_benchmark
 
-  package device-mapper-devel
+  # Device mapper uses the exact version as the ABI.
+  # We will build and install a static version.
+  remove_package device-mapper-devel
+  install_device_mapper
+
   package libgcrypt-devel
   package gettext-devel
   install_libcryptsetup


### PR DESCRIPTION
libdevmapper's ABI changes too rapidly, and the updates repo is not maintaining older packages. CentOS / RHEL / and other RH-based systems will now build and link devmapper statically.