### PR TITLE
Add define to enable SQLite WHERETRACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,13 @@ add_definitions(
   -DBOOST_NO_CXX11_VARIADIC_TEMPLATES
 )
 
+if(DEFINED ENV{SQLITE_DEBUG})
+  add_definitions(
+    -DSQLITE_DEBUG=1
+    -DSQLITE_ENABLE_WHERETRACE=1
+  )
+endif()
+
 if(APPLE)
   LOG_PLATFORM("OS X")
 elseif(OSQUERY_BUILD_PLATFORM STREQUAL "debian")

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ clean: .setup
 	cd build/$(BUILD_DIR) && cmake ../../ && \
 		$(DEFINES) $(MAKE) clean --no-print-directory $(MAKEFLAGS)
 
+strip: .setup
+	cd build/$(BUILD_DIR) && find ./osquery -executable -type f | xargs strip
+
 distclean:
 	rm -rf .sources build/$(BUILD_DIR) build/debug_$(BUILD_DIR) build/docs
 ifeq ($(PLATFORM),Linux)

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -159,12 +159,14 @@ OSQUERY_PLATFORM=custom_linux;1.0 # Set a wacky platform/distro name
 OSQUERY_BUILD_VERSION=9.9.9 # Set a wacky version string
 BUILD_LINK_SHARED=True # Set CMake library discovery to prefer shared libraries
 SDK_VERSION=9.9.9 # Set a wacky SDK-version string
+OSX_VERSION_MIN=10.11 # Override the native minimum OS X version ABI
+
 SANITIZE_THREAD=True # Add -fsanitize=thread when using "make sanitize"
-OPTIMIZED=True # Disable generic CPU optimizations
+OPTIMIZED=True # Enable specific CPU optimizations (not recommended)
 SKIP_TESTS=True # Skip unit test building (very very not recommended!)
 SKIP_BENCHMARKS=True # Build unit tests but skip building benchmark targets
 SKIP_TABLES=True # Build platform without any table implementations or specs
-OSX_VERSION_MIN=10.11 # Override the native minimum OS X version ABI
+SQLITE_DEBUG=True # Enable SQLite query debugging (very verbose!)
 ```
 
 ## Custom Packages
@@ -194,9 +196,7 @@ Pay attention to the environment variable `RUN_RELEASE_TESTS=1`, which enables t
 
 ## Notes and FAQ
 
-
 When trying to make, if you encounter:
-
 ```
 Requested dependencies may have changed, run: make deps
 ```

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -32,6 +32,10 @@
 #include "osquery/devtools/devtools.h"
 #include "osquery/sql/virtual_table.h"
 
+#if defined(SQLITE_ENABLE_WHERETRACE)
+extern int sqlite3WhereTrace;
+#endif
+
 namespace osquery {
 
 /// Define flags used by the shell. They are parsed by the drop-in shell.
@@ -1674,6 +1678,10 @@ namespace osquery {
 int launchIntoShell(int argc, char **argv) {
   struct callback_data data;
   main_init(&data);
+
+#if defined(SQLITE_ENABLE_WHERETRACE)
+  sqlite3WhereTrace = 0xffffffff;
+#endif
 
   {
     // Hold the manager connection instance again in callbacks.


### PR DESCRIPTION
This is handy when debugging complex SQL queries when results are unexpected.

To build with the two SQLite-specific defines the entire project will be recompiled/relinked. There is a better way to stack these defines, but since we build SQLite as a third-party isolated CMake project, the defines should be at the top-level. Since this type of debugging is very rare it's not worth the reorganization effort.