### PR TITLE
Cpu time table implementation (solves #1889)

### DIFF
--- a/osquery/tables/system/linux/cpu_time.cpp
+++ b/osquery/tables/system/linux/cpu_time.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/tables.h>
+#include <osquery/filesystem.h>
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+const std::string kProcStat = "/proc/stat";
+
+std::vector<std::string> procFromFile(const std::string &path) {
+
+    if (!isReadable(path).ok()) {
+        return {};
+    }
+
+    std::string content;
+    if (!readFile(path, content).ok()) {
+        return {};
+    }
+
+    auto lines = split(content, "\n");
+    std::vector<std::string> proc_lines;
+    for (auto &line : lines) {
+        boost::trim(line);
+        if (boost::starts_with(line, "cpu")) {
+            proc_lines.push_back(line);
+        }
+    }
+
+    // Remove first cpu line which doesn't give specific core information.
+    if (proc_lines.size() > 0 && proc_lines.front().size() >= 4 &&
+        proc_lines.front().substr(0, 4).compare("cpu ") == 0) {
+        proc_lines.erase(proc_lines.begin());
+    }
+
+    return proc_lines;
+}
+
+static void genCpuTimeLine(const std::string &line, QueryData &results) {
+
+    auto words = osquery::split(line, " ");
+
+    if (words.size() < 11) {
+        // This probably means there's an error in the /proc/stat file.
+        return;
+    }
+
+    Row r;
+    r["core"] = words[0].back();
+    r["user"] = words[1];
+    r["nice"] = words[2];
+    r["system"] = words[3];
+    r["idle"] = words[4];
+    r["iowait"] = words[5];
+    r["irq"] = words[6];
+    r["softirq"] = words[7];
+    r["steal"] = words[8];
+    r["guest"] = words[9];
+    r["guest_nice"] = words[10];
+
+    results.push_back(r);
+}
+
+QueryData genCpuTime(QueryContext &context) {
+    QueryData results;
+
+    auto proc_lines = procFromFile(kProcStat);
+    for (const auto &line : proc_lines) {
+        genCpuTimeLine(line, results);
+    }
+
+    return results;
+}
+}
+}

--- a/specs/linux/cpu_time.table
+++ b/specs/linux/cpu_time.table
@@ -1,0 +1,16 @@
+table_name("cpu_time")
+description("Displays information from /proc/stat file about the time the cpu cores spent in different parts of the system.")
+schema([
+    Column("core", INTEGER, "Name of the cpu (core)"),
+    Column("user", BIGINT, "Time spent in user mode"),
+    Column("nice", BIGINT, "Time spent in user mode with low priority (nice)"),
+    Column("system", BIGINT, "Time spent in system mode"),
+    Column("idle", BIGINT, "Time spent in the idle task"),
+    Column("iowait", BIGINT, "Time spent waiting for I/O to complete"),
+    Column("irq", BIGINT, "Time spent servicing interrupts"),
+    Column("softirq", BIGINT, "Time spent servicing softirqs"),
+    Column("steal", BIGINT, "Time spent in other operating systems when running in a virtualized environment"),
+    Column("guest", BIGINT, "Time spent running a virtual CPU for a guest OS under the control of the Linux kernel"),
+    Column("guest_nice", BIGINT, "Time spent running a niced guest "),
+])
+implementation("linux/cpu_time@genCpuTime")


### PR DESCRIPTION
Implemented table for seeing where every cpu core spent time since the system was started. Information is taken from /proc/stat . Adapted the original spec file from @xavinux a little to arrive at the the current spec file. 