### PR TITLE
Adding detectiong for OSX Keranger

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -182,9 +182,9 @@
       "description" : "Detect RAT used by Hacking Team",
       "value" : "Artifact used by this malware"
     },
-    "HackingTeam_Mac_Persistence": { 
+    "HackingTeam_Mac_Persistence": {
       "query": "select * from file where directory like '/Users/%/Library/Preferences/8pHbqThW%';",
-      "interval": "86400", 
+      "interval": "86400",
       "description": "Detection persistency by Hacking Team",
       "value": "Artifact used by Hacking Team"
     },
@@ -194,6 +194,18 @@
       "removed": false,
       "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
       "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally."
+    },
+    "Keranger_1": {
+      "query": "select * from processes where name = 'kernel_service';",
+      "interval": "86400",
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "value": "Artifact used by this malware"
+    },
+    "Keranger_2": {
+      "query": "select * from file where path like '/Users/%/Library/.kernel_%' or path like '/Users/%/Library/kernel_service';",
+      "interval": "86400",
+      "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
+      "value": "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Adding detection for OSX malware/ransomware Keranger. Related: https://forum.transmissionbt.com/viewtopic.php?f=4&t=17834
http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/