### PR TITLE
Add detection for KeRange Ransomware

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -194,6 +194,19 @@
       "removed": false,
       "description": "Report on Apple/OS X XProtect 'report' generation. Reports are generated when OS X matches an item in xprotect_entries.",
       "value": "Although XProtect reports are rare, they may be worth collecting and aggregating internally."
+    },
+    "KeRange_Ransomware_Transmission_1": { 
+      "query" : "select * from file where path = '/Applications/Transmission.app/Contents/Resources/General.rtf' or path = '/Volumes/Transmission/Transmission.app/Contents/Resources/General.rtf' or path like '/Users/%/Library/kernel_service' or path like '/Users/%/Library/%.kernel_%'",
+      "interval" : "3600",
+      "description" : "Transmission app is infected with KeRange ransomware",
+      "value": "File artifact used by Ransomware KeRange"
     }
+    "KeRange_Ransomware_Transmission_2": { 
+      "query" : "select * from processes where name = 'kernel_service'",
+      "interval" : "1200",
+      "description" : "Transmission app is infected with KeRange ransomware",
+      "value": "Process artifact used by Ransomware KeRange"
+    }
+
   }
 }


### PR DESCRIPTION
From the blog:  http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer

1. Using either Terminal or Finder, check whether /Applications/Transmission.app/Contents/Resources/ General.rtf or /Volumes/Transmission/Transmission.app/Contents/Resources/ General.rtf exist. If any of these exist, the Transmission application is infected and we suggest deleting this version of Transmission.
2. Using “Activity Monitor” preinstalled in OS X, check whether any process named “kernel_service” is running. If so, double check the process, choose the “Open Files and Ports” and check whether there is a file name like “/Users/<username>/Library/kernel_service” (Figure 12). If so, the process is KeRanger’s main process. We suggest terminating it with “Quit -> Force Quit”.
3. After these steps, we also recommend users check whether the files “.kernel_pid”, “.kernel_time”, “.kernel_complete” or “kernel_service” existing in ~/Library directory. If so, you should delete them.