### PR TITLE
OSX Keranger detection fix

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -202,7 +202,7 @@
       "value": "Artifact used by this malware"
     },
     "Keranger_2": {
-      "query": "select * from file where path like '/Users/%/Library/.kernel_%' or path like '/Users/%/Library/kernel_service';",
+      "query": "select * from file where path like '/Users/%/Library/.kernel_%' union select * from file where path like '/Users/%/Library/kernel_service';",
       "interval": "86400",
       "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
       "value": "Artifact used by this malware"


### PR DESCRIPTION
Query uses `OR` and this will be supported in the next release (with SQLite 3.12.0). For reference:

#1898 and https://github.com/facebook/osquery/commit/6afd1a29cf849e4e2d91831dcb3af5beea5dce29