### PR TITLE
Allow extensions to use the backing store

### DIFF
--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -32,6 +32,10 @@ void ExtensionHandler::call(ExtensionResponse& _return,
   // internal registry call. It is the ONLY actor that resolves registry
   // item aliases.
   auto local_item = Registry::getAlias(registry, item);
+  if (local_item.empty()) {
+    // Extensions may not know about active (non-option based registries).
+    local_item = Registry::getActive(registry);
+  }
 
   PluginResponse response;
   PluginRequest plugin_request;


### PR DESCRIPTION
This added test ensures extension processes can set/get database values.