### PR TITLE
Allow NULL values, stop using -1 as int/double invalid values

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -43,13 +43,14 @@ SHELL_FLAG(bool, csv, false, "Set output mode to 'csv'");
 SHELL_FLAG(bool, json, false, "Set output mode to 'json'");
 SHELL_FLAG(bool, line, false, "Set output mode to 'line'");
 SHELL_FLAG(bool, list, false, "Set output mode to 'list'");
-SHELL_FLAG(string, nullvalue, "", "Set string for NULL values, default ''");
 SHELL_FLAG(string, separator, "|", "Set output field separator, default '|'");
 SHELL_FLAG(bool, header, true, "Toggle column headers true/false");
 
 /// Define short-hand shell switches.
 SHELL_FLAG(bool, L, false, "List all table names");
 SHELL_FLAG(string, A, "", "Select all from a table");
+
+DECLARE_string(nullvalue);
 }
 
 static char zHelp[] =
@@ -694,8 +695,10 @@ static int shell_callback(
 
     osquery::Row r;
     for (i = 0; i < nArg; ++i) {
-      if (azCol[i] != nullptr && azArg[i] != nullptr) {
-        r[std::string(azCol[i])] = std::string(azArg[i]);
+      if (azCol[i] != nullptr) {
+        r[std::string(azCol[i])] = (azArg[i] == nullptr)
+                                       ? osquery::FLAGS_nullvalue
+                                       : std::string(azArg[i]);
       }
     }
     osquery::computeRowLengths(r, p->prettyPrint->lengths);

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -236,4 +236,40 @@ TEST_F(VirtualTableTests, test_json_extract) {
   ASSERT_EQ(results.size(), 1U);
   EXPECT_EQ(results[0]["test"], "1");
 }
+
+TEST_F(VirtualTableTests, test_null_values) {
+  auto dbc = SQLiteDBManager::get();
+
+  std::string statement = "SELECT NULL as null_value;";
+  {
+    QueryData results;
+    auto status = queryInternal(statement, results, dbc->db());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(results[0]["null_value"], "");
+  }
+
+  // Try INTEGER.
+  {
+    QueryData results;
+    statement = "SELECT CAST(NULL as INTEGER) as null_value;";
+    queryInternal(statement, results, dbc->db());
+    EXPECT_EQ(results[0]["null_value"], "");
+  }
+
+  // BIGINT.
+  {
+    QueryData results;
+    statement = "SELECT CAST(NULL as BIGINT) as null_value;";
+    queryInternal(statement, results, dbc->db());
+    EXPECT_EQ(results[0]["null_value"], "");
+  }
+
+  // Try DOUBLE.
+  {
+    QueryData results;
+    statement = "SELECT CAST(NULL as DOUBLE) as null_value;";
+    queryInternal(statement, results, dbc->db());
+    EXPECT_EQ(results[0]["null_value"], "");
+  }
+}
 }

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -545,7 +545,7 @@ void genProcessMemoryMap(int pid, QueryData &results) {
   }
 }
 
-QueryData genProcessMemoryMap(QueryContext& context) {
+QueryData genProcessMemoryMap(QueryContext &context) {
   QueryData results;
 
   auto pidlist = getProcList(context);


### PR DESCRIPTION
There is somewhat of a breaking change here:
 - Previously `INTEGER`, `BIGINT`, and `DOUBLE` typed columns would emit a `-1` if the content could not be safely parsed into the corresponding literal type. This was bad form as some column use `-1` as an expected result-- and all of the literal types are signed.
 - There are several conversions / helper methods like `--json` that assume a value for each column.
 - `NULL` values within the shell's default output mode: `pretty` will respect the `--nullvalue` SQLite shell CLI switch.
 - `--nullvalue` is NOT available for the `osqueryd` so expect null content to result in missing column fields. **This will result in errant/spurious differential results as we are implicitly changing expectations of output fields.**
