### PR TITLE
[#1886] Use mnemonics for process states on Darwin

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -19,7 +19,6 @@
 #include <mach-o/dyld_images.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/trim.hpp>
 
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
@@ -36,6 +35,14 @@ namespace tables {
 
 #define CPU_TIME_RATIO 1000000
 #define START_TIME_RATIO 1000000000
+
+// Process states are as defined in sys/proc.h
+// SIDL   (1) Process being created by fork
+// SRUN   (2) Currently runnable
+// SSLEEP (3) Sleeping on an address
+// SSTOP  (4) Process debugging or suspension
+// SZOMB  (5) Awaiting collection by parent
+const char kProcessStateMapping[] = {' ', 'I', 'R', 'S', 'T', 'Z'};
 
 std::set<int> getProcList(const QueryContext &context) {
   std::set<int> pidlist;
@@ -68,8 +75,8 @@ std::set<int> getProcList(const QueryContext &context) {
     return pidlist;
   }
 
-  int num_pids = bufsize / sizeof(pid_t);
-  for (int i = 0; i < num_pids; ++i) {
+  size_t num_pids = bufsize / sizeof(pid_t);
+  for (size_t i = 0; i < num_pids; ++i) {
     // if the pid is negative or 0, it doesn't represent a real process so
     // continue the iterations so that we don't add it to the results set
     if (pids[i] <= 0) {
@@ -95,7 +102,7 @@ struct proc_cred {
   uint32_t parent{0};
   uint32_t group{0};
   uint32_t status{0};
-  uint32_t nice{0};
+  int32_t nice{0};
   struct {
     uid_t uid{0};
     gid_t gid{0};
@@ -257,8 +264,10 @@ QueryData genProcesses(QueryContext &context) {
     if (getProcCred(pid, cred)) {
       r["parent"] = BIGINT(cred.parent);
       r["group"] = BIGINT(cred.group);
-      // Use Linux diction for process status/state.
-      r["state"] = INTEGER(cred.status);
+      // check if process state is one of the expected ones
+      r["state"] = (1 <= cred.status && cred.status <= 5)
+                       ? TEXT(kProcessStateMapping[cred.status])
+                       : TEXT('?');
       r["nice"] = INTEGER(cred.nice);
       r["uid"] = BIGINT(cred.real.uid);
       r["gid"] = BIGINT(cred.real.gid);
@@ -545,7 +554,7 @@ void genProcessMemoryMap(int pid, QueryData &results) {
   }
 }
 
-QueryData genProcessMemoryMap(QueryContext& context) {
+QueryData genProcessMemoryMap(QueryContext &context) {
   QueryData results;
 
   auto pidlist = getProcList(context);


### PR DESCRIPTION
Process states in `processes` table now use mnemonics instead of the integer code. They follow closely to the states defined `sys/proc.h`, which means processes with state as:

```
  state    value   meaning                           mnemonic
 -------- ------- --------------------------------- ----------
  SIDL     1       process being created by fork     'I'
  SRUN     2       currently runnable                'R'
  SSLEEP   3       sleeping on an address            'S'
  SSTOP    4       process debugging or suspension   'T'
  SZOMB    5       awaiting collection by parent     'Z'
```

Note: The mnemonics here will not match up with what `ps` or `top` reports.

`ps` and `top` queries run state of all Mach Threads (by grabbing a Mach Task)<sup>1</sup> of a process, and then coalesces it to represent the process state.

This is no longer possible to do by non-Apple signed binaries, as the only way to a Mach Task (and therefore list of Mach Threads) is by calling `task_for_pid()`, which no longer works under System Integrity Protection (SIP) introduced in OS X 10.11

---
1. BSD process <=> mach task, and within a mach task are list of all mach threads for that task.