### PR TITLE
Apple System Log Virtual Table Implementation

### DIFF
--- a/osquery/tables/system/darwin/asl.cpp
+++ b/osquery/tables/system/darwin/asl.cpp
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/tables/system/darwin/asl_utils.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genAsl(QueryContext &context) {
+  QueryData results;
+
+  aslmsg query = createAslQuery(context);
+  aslresponse result = asl_search(nullptr, query);
+
+  aslmsg row = nullptr;
+  while ((row = asl_next(result)) != nullptr) {
+    Row r;
+    readAslRow(row, r);
+    results.push_back(r);
+  }
+  asl_release(result);
+  asl_release(query);
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/darwin/asl_utils.cpp
+++ b/osquery/tables/system/darwin/asl_utils.cpp
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "asl_utils.h"
+
+namespace ba = boost::algorithm;
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Map osquery ConstraintOperator to the corresponding ASL op code
+ */
+const std::map<ConstraintOperator, uint32_t> kSupportedAslOps = {
+  {EQUALS, ASL_QUERY_OP_EQUAL},
+  {GREATER_THAN, ASL_QUERY_OP_GREATER},
+  {GREATER_THAN_OR_EQUALS, ASL_QUERY_OP_GREATER_EQUAL},
+  {LESS_THAN, ASL_QUERY_OP_LESS},
+  {LESS_THAN_OR_EQUALS, ASL_QUERY_OP_LESS_EQUAL},
+  {LIKE, ASL_QUERY_OP_EQUAL | ASL_QUERY_OP_REGEX | ASL_QUERY_OP_CASEFOLD}};
+
+/**
+ * @brief Map ASL keys to the corresponding osquery column name
+ */
+const std::map<std::string, std::string> kAslKeyToColumnMap = {
+    {"Time", "time"},         {"TimeNanoSec", "time_nano_sec"},
+    {"Host", "host"},         {"Sender", "sender"},
+    {"Facility", "facility"}, {"PID", "pid"},
+    {"UID", "uid"},           {"GID", "gid"},
+    {"Level", "level"},       {"Message", "message"},
+    {"RefPID", "ref_pid"},    {"RefProc", "ref_proc"}};
+
+/**
+ * @brief Map osquery column names to the corresponding ASL keys
+ */
+const std::map<std::string, std::string> kColumnToAslKeyMap = {
+    {"time", "Time"},         {"time_nano_sec", "TimeNanoSec"},
+    {"host", "Host"},         {"sender", "Sender"},
+    {"facility", "Facility"}, {"pid", "PID"},
+    {"uid", "UID"},           {"gid", "GID"},
+    {"level", "Level"},       {"message", "Message"},
+    {"ref_pid", "RefPID"},    {"ref_proc", "RefProc"}};
+
+/**
+ * @brief Column name for the extra column.
+ *
+ * ASL allows fields not defined in asl.h to be sent with logs. These fields
+ * will be aggregated into a JSON string and dumped into a column with this
+ * name.
+ */
+const std::string kExtraColumnKey = "extra";
+
+/**
+ * @brief Determine whether to use numeric ASL operations given a column type
+ */
+static inline bool isNumeric(ColumnType coltype) {
+  switch (coltype) {
+  case INTEGER_TYPE:
+  case BIGINT_TYPE:
+  case UNSIGNED_BIGINT_TYPE:
+  case DOUBLE_TYPE:
+    return true;
+  default:
+    return false;
+  }
+}
+
+void addQueryOp(aslmsg& query,
+                const std::string& key,
+                const std::string& value,
+                ConstraintOperator op,
+                ColumnType col_type) {
+  if (key == kExtraColumnKey) {
+    // ASL doesn't know about the 'Extra' column, so we can't do the matching
+    // through the ASL query. Do nothing here, and later SQLite's engine will
+    // do the match.
+    return;
+  }
+
+  // Only some queries can be supported through ASL, those that are not will
+  // just be performed later by the SQLite engine.
+  if (kSupportedAslOps.count(op) > 0) {
+    uint32_t asl_op = kSupportedAslOps.at(op);
+    std::string modified_val = value;
+    std::string modified_key = kColumnToAslKeyMap.at(key);
+    switch (op) {
+    case LIKE:
+      // In the LIKE case, we need to convert the like string to a regex for
+      // use in the ASL query
+      modified_val = convertLikeRegex(value);
+      break;
+    default:
+      if (isNumeric(col_type)) {
+        asl_op |= ASL_QUERY_OP_NUMERIC;
+      }
+    }
+    asl_set_query(query, modified_key.c_str(), modified_val.c_str(), asl_op);
+  }
+}
+
+aslmsg createAslQuery(const QueryContext& context) {
+  aslmsg query = asl_new(ASL_TYPE_QUERY);
+
+  // Set constraints in query
+  for (const auto& it : context.constraints) {
+    const std::string& key = it.first;
+    ColumnType col_type = it.second.affinity;
+    for (const auto& constraint : it.second.getAll()) {
+      addQueryOp(query, key, constraint.expr, static_cast<ConstraintOperator>(constraint.op), col_type);
+    }
+  }
+  return query;
+}
+
+void readAslRow(aslmsg row, Row& r) {
+  pt::ptree extras;
+
+  // Fetch each column individually, adding it to the result map
+  size_t i = 0;
+  for (const char* key = asl_key(row, i); key != nullptr;
+       key = asl_key(row, ++i)) {
+    const char* val = asl_get(row, key);
+
+    // Rarely, asl_fetch_key_val_op will return a NULL pointer for
+    // key/value, so we defend against that case by using the empty string
+    std::string key_s = key != nullptr ? std::string(key) : "";
+    std::string val_s = val != nullptr ? std::string(val) : "";
+
+    if (kAslKeyToColumnMap.count(key_s) > 0) {
+      // This key is a default column
+      r[kAslKeyToColumnMap.at(key_s)] = val_s;
+    } else {
+      // This key is not a default column, add it to extras
+      extras.push_back(pt::ptree::value_type(key_s, pt::ptree(val_s)));
+    }
+  }
+
+  // Join up the extras and add them to the Extra column
+  std::stringstream ss;
+  pt::write_json(ss, extras, false);
+  r[kExtraColumnKey] = ss.str();
+}
+
+std::string convertLikeRegex(const std::string& like_str) {
+  // % is equivalent to .*
+  // _ is equivalent to .
+  std::string res = ba::replace_all_copy(like_str, "%", ".*");
+  ba::replace_all(res, "_", ".");
+  return res;
+}
+}
+}

--- a/osquery/tables/system/darwin/asl_utils.h
+++ b/osquery/tables/system/darwin/asl_utils.h
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <string>
+
+#include <asl.h>
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#ifndef ASL_API_VERSION
+#define OLD_ASL_API
+#endif
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+#ifdef OLD_ASL_API
+inline void asl_release(aslmsg msg) { asl_free(msg); }
+
+inline void asl_release(aslresponse resp) { aslresponse_free(resp); }
+
+inline aslmsg asl_next(aslresponse resp) { return aslresponse_next(resp); }
+#endif
+
+/**
+ * @brief Add a new operation to the query.
+ *
+ * All of the operations are logically ANDed when performing the query.
+ *
+ * @param query The query on which to add the operation
+ * @param key Key to match on
+ * @param value Value that should match for the key and operation.
+ * @param op The (osquery) operator to use. Will be converted to the equivalent
+ * ASL operator.
+ * @param col_type Type of the column that this operation is performed on.
+ */
+void addQueryOp(aslmsg& query,
+                const std::string& key,
+                const std::string& value,
+                ConstraintOperator op,
+                ColumnType col_type);
+
+/**
+ * @brief Create an ASL query object from the QueryContext.
+ *
+ * @param context QueryContext used to form the query.
+ *
+ * @return An ASL query object corresponding to the context.
+ */
+aslmsg createAslQuery(const QueryContext& context);
+
+/**
+ * @brief Read a row of ASL data into an osquery Row.
+ *
+ * @param row The ASL row to read data from.
+ * @param r The osquery Row to write data into.
+ */
+void readAslRow(aslmsg row, Row& r);
+
+/**
+ * @brief Convert a LIKE format string into a regex
+ *
+ * @param like_str The LIKE style string to convert
+ *
+ * @return A regex corresponding to the input LIKE string
+ */
+std::string convertLikeRegex(const std::string& like_str);
+}
+}

--- a/osquery/tables/system/darwin/tests/asl_tests.cpp
+++ b/osquery/tables/system/darwin/tests/asl_tests.cpp
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/filesystem.h>
+#include <osquery/sql.h>
+
+#include "osquery/tables/system/darwin/asl_utils.h"
+#include "osquery/core/test_util.h"
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+class AslTests : public testing::Test {};
+
+#ifndef OLD_ASL_API
+TEST_F(AslTests, test_add_query_op) {
+  aslmsg query = asl_new(ASL_TYPE_QUERY);
+  ASSERT_EQ((uint32_t)ASL_TYPE_QUERY, asl_get_type(query));
+  ASSERT_EQ((size_t)0, asl_count(query));
+
+  const char *key, *val;
+  uint32_t op;
+
+  addQueryOp(query, "sender", "bar", EQUALS, TEXT_TYPE);
+  ASSERT_EQ((size_t)1, asl_count(query));
+
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 0, &key, &val, &op));
+  ASSERT_STREQ("Sender", key);
+  ASSERT_STREQ("bar", val);
+  ASSERT_EQ((uint32_t)ASL_QUERY_OP_EQUAL, op);
+
+  addQueryOp(query, "level", "1", GREATER_THAN, INTEGER_TYPE);
+  ASSERT_EQ((size_t)2, asl_count(query));
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 1, &key, &val, &op));
+  ASSERT_STREQ("Level", key);
+  ASSERT_STREQ("1", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_GREATER | ASL_QUERY_OP_NUMERIC), op);
+
+  addQueryOp(query, "gid", "999", LESS_THAN, BIGINT_TYPE);
+  ASSERT_EQ((size_t)3, asl_count(query));
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 2, &key, &val, &op));
+  ASSERT_STREQ("GID", key);
+  ASSERT_STREQ("999", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_LESS | ASL_QUERY_OP_NUMERIC), op);
+
+  addQueryOp(query, "facility", "hoo", GREATER_THAN_OR_EQUALS, TEXT_TYPE);
+  ASSERT_EQ((size_t)4, asl_count(query));
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 3, &key, &val, &op));
+  ASSERT_STREQ("Facility", key);
+  ASSERT_STREQ("hoo", val);
+  ASSERT_EQ((uint32_t)ASL_QUERY_OP_GREATER_EQUAL, op);
+
+  addQueryOp(query, "pid", "30", LESS_THAN_OR_EQUALS, INTEGER_TYPE);
+  ASSERT_EQ((size_t)5, asl_count(query));
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 4, &key, &val, &op));
+  ASSERT_STREQ("PID", key);
+  ASSERT_STREQ("30", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_LESS_EQUAL | ASL_QUERY_OP_NUMERIC), op);
+
+  addQueryOp(query, "ref_proc", "%tom%", LIKE, TEXT_TYPE);
+  ASSERT_EQ((size_t)6, asl_count(query));
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 5, &key, &val, &op));
+  ASSERT_STREQ("RefProc", key);
+  ASSERT_STREQ(".*tom.*", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_EQUAL | ASL_QUERY_OP_REGEX |
+                       ASL_QUERY_OP_CASEFOLD),
+            op);
+
+  // Queries against the extra column should not be sent to ASL
+  addQueryOp(query, "extra", "tom", EQUALS, TEXT_TYPE);
+  ASSERT_EQ((size_t)6, asl_count(query));
+
+  // Queries with unsupported operators should not be sent to ASL
+  addQueryOp(query, "host", "tom", GLOB, TEXT_TYPE);
+  ASSERT_EQ((size_t)6, asl_count(query));
+
+  asl_release(query);
+}
+
+TEST_F(AslTests, test_create_asl_query) {
+  QueryContext ctx;
+  ctx.constraints["sender"].add(Constraint(EQUALS, "bar"));
+  ctx.constraints["sender"].add(Constraint(LIKE, "%a%"));
+  ctx.constraints["message"].affinity = INTEGER_TYPE;
+  ctx.constraints["message"].add(Constraint(LESS_THAN, "10"));
+
+  aslmsg query = createAslQuery(ctx);
+
+  ASSERT_EQ((uint32_t)ASL_TYPE_QUERY, asl_get_type(query));
+  ASSERT_EQ((size_t)3, asl_count(query));
+
+  const char *key, *val;
+  uint32_t op;
+
+  // Ordering doesn't really matter here, only that we only ended up with
+  // (message, baz, LESS) and (sender, bar, EQUAL)
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 0, &key, &val, &op));
+  ASSERT_STREQ("Message", key);
+  ASSERT_STREQ("10", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_LESS | ASL_QUERY_OP_NUMERIC), op);
+
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 1, &key, &val, &op));
+  ASSERT_STREQ("Sender", key);
+  ASSERT_STREQ("bar", val);
+  ASSERT_EQ((uint32_t)ASL_QUERY_OP_EQUAL, op);
+
+  ASSERT_EQ(0, asl_fetch_key_val_op(query, 2, &key, &val, &op));
+  ASSERT_STREQ("Sender", key);
+  ASSERT_STREQ(".*a.*", val);
+  ASSERT_EQ((uint32_t)(ASL_QUERY_OP_EQUAL | ASL_QUERY_OP_REGEX |
+                       ASL_QUERY_OP_CASEFOLD),
+            op);
+
+  asl_release(query);
+}
+#endif
+
+TEST_F(AslTests, test_read_asl_row) {
+  aslmsg row = asl_new(ASL_TYPE_MSG);
+  ASSERT_EQ(0, asl_set(row, "Sender", "foo"));
+  ASSERT_EQ(0, asl_set(row, "Level", "1"));
+  ASSERT_EQ(0, asl_set(row, "Message", "bar"));
+  ASSERT_EQ(0, asl_set(row, "Bang", "bang_val"));
+
+  Row r;
+  readAslRow(row, r);
+
+  ASSERT_EQ((size_t)4, r.size());
+
+  ASSERT_EQ("foo", r["sender"]);
+  ASSERT_EQ("1", r["level"]);
+  ASSERT_EQ("bar", r["message"]);
+  ASSERT_EQ((size_t)0, r.count("bang"));
+  ASSERT_EQ("{\"Bang\":\"bang_val\"}\n", r["extra"]);
+
+  asl_release(row);
+}
+
+TEST_F(AslTests, test_convert_like_regex) {
+  EXPECT_EQ(".*", convertLikeRegex("%"));
+  EXPECT_EQ("foo.*", convertLikeRegex("foo%"));
+  EXPECT_EQ(".*foo.*", convertLikeRegex("%foo%"));
+  EXPECT_EQ(".*.*", convertLikeRegex("%%"));
+  EXPECT_EQ(".*.*", convertLikeRegex("%%"));
+  EXPECT_EQ(".", convertLikeRegex("_"));
+  EXPECT_EQ("foo.", convertLikeRegex("foo_"));
+  EXPECT_EQ(".foo", convertLikeRegex("_foo"));
+  EXPECT_EQ(".foo.", convertLikeRegex("_foo_"));
+  EXPECT_EQ("..*", convertLikeRegex("_%"));
+  EXPECT_EQ(".*foo..*", convertLikeRegex("%foo_%"));
+}
+
+TEST_F(AslTests, test_actual_query) {
+  // Not actually a unit test, but it's a decent assumption that any machine
+  // running this test has some entries in ASL, and we'd like to ensure that
+  // actual queries are successful
+  auto results = SQL("select * from asl limit 10");
+  ASSERT_GT(results.rows().size(), (size_t)0);
+
+  // Assumes there is something written to the console
+  results =
+      SQL("select * from asl where facility = 'com.apple.console' limit 10");
+  ASSERT_GT(results.rows().size(), (size_t)0);
+  ASSERT_EQ("com.apple.console", results.rows()[0].at("facility"));
+  results = SQL(
+      "select * from asl where facility = 'com.apple.console' "
+      "and pid <= 99999 limit 10");
+  ASSERT_GT(results.rows().size(), (size_t)0);
+  ASSERT_EQ("com.apple.console", results.rows()[0].at("facility"));
+  ASSERT_LT(AS_LITERAL(BIGINT_LITERAL, results.rows()[0].at("pid")), 99999);
+}
+}
+}

--- a/specs/darwin/asl.table
+++ b/specs/darwin/asl.table
@@ -1,0 +1,24 @@
+table_name("asl")
+description("Queries the Apple System Log data structure for system events")
+
+# Columns pulled from asl.h
+# Descriptions mostly as retrieved from asl.h, some with clarifications
+schema([
+    Column("time", INTEGER, "Unix timestamp.  Set automatically"),
+    Column("time_nano_sec", INTEGER, "Nanosecond time."),
+    Column("host", TEXT, "Sender's address (set by the server)."),
+    Column("sender", TEXT, "Sender's identification string.  Default is process name."),
+    Column("facility", TEXT, "Sender's facility.  Default is 'user'."),
+    Column("pid", INTEGER, "Sending process ID encoded as a string.  Set automatically."),
+    # UID and GID of 4294967294 have been encountered
+    Column("gid", BIGINT, "GID that sent the log message (set by the server)."),
+    Column("uid", BIGINT, "UID that sent the log message (set by the server)."),
+    Column("level", INTEGER, "Log level number.  See levels in asl.h."),
+    Column("message", TEXT, "Message text."),
+    Column("ref_pid", INTEGER, "Reference PID for messages proxied by launchd"),
+    Column("ref_proc", TEXT, "Reference process for messages proxied by launchd"),
+    # Gather anything extra into the "extra" column
+    Column("extra", TEXT, "Extra columns, in JSON format. Queries against this column are performed entirely in SQLite, so do not benefit from efficient querying via asl.h."),
+])
+
+implementation("asl@genAsl")


### PR DESCRIPTION
This table allows querying agains the Apple System Log (ASL) data store.

It can efficiently query on exact matches, but using `like` can be pretty slow. I am including results of perf testing below. For reference, my 2 month old machine had only about 18,000 logs in the store. A different test machine had about 500,000 lines of log spam. The following results are with ~350,000 logs inserted into the store on my machine.

```
$ python ./tools/profile.py --leaks --config osquery.conf
Analyzing leaks in query: select count(*) from asl;
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: select * from asl where Facility = 'com.apple.console';
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: select * from asl where Facility = 'com.apple.console' and Sender = 'zwass';
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: select * from asl where Facility = 'com.apple.console' and Extra like '%CFLog%';
  definitely: 0 leaks for 0 total leaked bytes.
Analyzing leaks in query: select * from asl where Message like 'foo%0000%bar';
  definitely: 0 leaks for 0 total leaked bytes.
$ python ./tools/profile.py --count 1 --rounds 1 --config osquery.conf
Profiling query: select count(*) from asl;
 D:3  C:2  M:3  F:0  U:3  asl_test_1 (1/1): duration: 5.53927206993 cpu_time: 5.38284032 memory: 49901568 fds: 5 utilization: 89.2833333333
Profiling query: select * from asl where Facility = 'com.apple.console';
 D:2  C:2  M:1  F:0  U:3  asl_test_2 (1/1): duration: 2.01075696945 cpu_time: 1.93590024 memory: 10362880 fds: 5 utilization: 77.3
Profiling query: select * from asl where Facility = 'com.apple.console' and Sender = 'zwass';
 D:2  C:2  M:0  F:0  U:3  asl_test_3 (1/1): duration: 2.01712489128 cpu_time: 1.854731184 memory: 7528448 fds: 5 utilization: 73.84
Profiling query: select * from asl where Facility = 'com.apple.console' and Extra like '%CFLog%';
 D:2  C:2  M:1  F:0  U:3  asl_test_4 (1/1): duration: 2.01865315437 cpu_time: 1.909220512 memory: 10027008 fds: 5 utilization: 76.12
Profiling query: select * from asl where Message like 'foo%0000%bar';
 D:3  C:2  M:0  F:0  U:3  asl_test_5 (1/1): duration: 6.03976988792 cpu_time: 5.537139504 memory: 7860224 fds: 5 utilization: 84.7461538462
```
I will squash these many commits before merge.