### PR TITLE
Several package updates within provision code

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -66,7 +66,7 @@ else()
 	find_package(Libdpkg REQUIRED)
 	add_definitions(-DLIBDPKG_VERSION=${LIBDPKG_VERSION_NUMBER})
 
-    ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg")
+    ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg liblzma.so")
     ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup libdevmapper.so")
   endif()
 

--- a/tools/provision/amazon.sh
+++ b/tools/provision/amazon.sh
@@ -69,6 +69,7 @@ function main_amazon() {
   install_rocksdb
   install_thrift
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
   install_sleuthkit

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -102,6 +102,7 @@ function main_centos() {
   install_rocksdb
   install_thrift
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
 

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -31,7 +31,8 @@ function main_darwin() {
   package thrift
   package yara
   package libressl
-  package cpp-netlib
+  package asio
+  package cpp-netlib devel
   package google-benchmark
   package libmagic
   package sleuthkit

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -52,17 +52,15 @@ function main_debian() {
   
   if [[ $DISTRO == "wheezy" ]]; then
     install_cmake
-    install_boost
-
     # thrift requires automate 1.13 or later
     remove_package automake
     install_automake
   elif [[ $DISTRO == "jessie" ]]; then 
     package cmake
-    package libboost-all-dev
     package automake
   fi 
 
+  install_boost
   install_google_benchmark
 
   package rubygems
@@ -74,6 +72,7 @@ function main_debian() {
   install_rocksdb 
   install_thrift
   install_yara
+  install_asio
   install_cppnetlib
   install_sleuthkit
   

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -39,13 +39,8 @@ function main_fedora() {
 
   if [[ $DISTRO -lt "22" ]]; then
     install_cmake
-    install_boost
-    install_iptables_dev
   else
     package cmake
-    package boost-devel
-    package boost-static
-    package iptables-devel
   fi
 
   package doxygen
@@ -56,20 +51,15 @@ function main_fedora() {
   package automake
   package libtool
 
-  if [[ $DISTRO -lt "22" ]]; then
-    install_snappy
-    install_thrift
-  else
-    package snappy
-    package snappy-devel
-    package thrift
-    package thrift-devel
-  fi
-
+  install_boost
+  install_iptables_dev
+  install_snappy
+  install_thrift
   install_gflags
   install_glog
   install_rocksdb
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
 

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -110,6 +110,7 @@ function main_oracle() {
   install_rocksdb
   install_thrift
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
 

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -137,6 +137,7 @@ function main_rhel() {
   install_rocksdb
   install_thrift
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
 

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -94,7 +94,6 @@ function main_ubuntu() {
     install_autoconf
     install_automake
     install_libtool
-    install_boost
   else
     package clang-3.6
     package clang-format-3.6
@@ -109,29 +108,29 @@ function main_ubuntu() {
     package autoconf
     package automake
     package libtool
-    package libboost1.55-all-dev
   fi
 
   set_cc gcc #-4.8
   set_cxx g++ #-4.8
 
   install_cmake
+  install_boost
+
   install_gflags
   install_glog
   install_iptables_dev
 
   if [[ $DISTRO = "lucid" ]]; then
-    install_snappy
-    install_libaptpkg
     gem_install --no-user-install fpm -v 1.3.3
   else
     # No clang++ on lucid
     set_cc clang
     set_cxx clang++
-    package libsnappy-dev
-    package libapt-pkg-dev
     gem_install fpm
   fi
+
+  install_snappy
+  install_libaptpkg
 
   if [[ $DISTRO = "lucid" ]]; then
     install_openssl
@@ -143,6 +142,7 @@ function main_ubuntu() {
   install_thrift
   install_rocksdb
   install_yara
+  install_asio
   install_cppnetlib
   install_google_benchmark
 


### PR DESCRIPTION
1. Update boost to 1.60 from 1.55 on Linux platforms
2. Add asio (1.11.0) to the deps set
3. Update snappy to 1.1.3 on Linux platforms
4. Update cpp-netlib to 0.12.0-rc1 from 0.11 on Linux platforms
 - OS X and brew also include 0.12.0-rc1 as a devel option
5. Update libapt to 1.2.6 from 0.8.6 on Ubuntu/Debian
 - This adds lzma as a dependent link
6. Upgrade RocksDB to 4.4 from 4.1