### PR TITLE
[Fix #1920] Detach thread before joining/clearing (terminate)

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -221,7 +221,7 @@ class EventPublisherPlugin : public Plugin {
    * run loop manager will exit the stepping loop and fall through to a call
    * to tearDown followed by a removal of the publisher.
    */
-  virtual void end() {}
+  virtual void stop() {}
 
   /**
    * @brief A new EventSubscriber is subscribing events of this publisher type.
@@ -298,7 +298,7 @@ class EventPublisherPlugin : public Plugin {
 
   /// An Event ID is assigned by the EventPublisher within the EventContext.
   /// This is not used to store event date in the backing store.
-  EventContextID next_ec_id_{0};
+  std::atomic<EventContextID> next_ec_id_{0};
 
  private:
   /// Set ending to True to cause event type run loops to finish.

--- a/osquery/config/plugins/tls.cpp
+++ b/osquery/config/plugins/tls.cpp
@@ -8,22 +8,22 @@
  *
  */
 
-#include <vector>
 #include <sstream>
+#include <vector>
 
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 #include <osquery/config.h>
 #include <osquery/enroll.h>
 #include <osquery/flags.h>
 #include <osquery/registry.h>
 
+#include "osquery/core/conversions.h"
 #include "osquery/dispatcher/dispatcher.h"
 #include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"
 #include "osquery/remote/utility.h"
-#include "osquery/core/conversions.h"
 
 namespace pt = boost::property_tree;
 
@@ -112,10 +112,10 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
 }
 
 void TLSConfigRefreshRunner::start() {
-  while (true) {
+  while (!interrupted()) {
     // Cool off and time wait the configured period.
     // Apply this interruption initially as at t=0 the config was read.
-    osquery::interruptableSleep(FLAGS_config_tls_refresh * 1000);
+    pauseMilli(FLAGS_config_tls_refresh * 1000);
 
     // Access the configuration.
     auto plugin = Registry::get("config", "tls");

--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -11,9 +11,8 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
-#include <set>
-#include <string>
 #include <thread>
 #include <vector>
 
@@ -21,78 +20,112 @@
 
 #include <osquery/core.h>
 
-// osquery is built with various versions of thrift that use different search
-// paths for their includes. Unfortunately, changing include paths is not
-// possible in every build system.
-// clang-format off
-#ifndef OSQUERY_THRIFT_LIB
-#define OSQUERY_THRIFT_LIB thrift
-#endif
-
-#ifndef OSQUERY_THRIFT_SERVER_LIB
-#define OSQUERY_THRIFT_SERVER_LIB thrift/server
-#endif
-
-#ifndef OSQUERY_THRIFT_POINTER
-#define OSQUERY_THRIFT_POINTER boost
-#endif
-
-#include CONCAT(OSQUERY_THRIFT_LIB,/concurrency/Thread.h)
-#include CONCAT(OSQUERY_THRIFT_LIB,/concurrency/ThreadManager.h)
-#include CONCAT(OSQUERY_THRIFT_LIB,/concurrency/PosixThreadFactory.h)
-// clang-format on
-
 namespace osquery {
 
-/// Create easier to reference typedefs for Thrift layer implementations.
-#define SHARED_PTR_IMPL OSQUERY_THRIFT_POINTER::shared_ptr
-using InternalThreadManager = apache::thrift::concurrency::ThreadManager;
-using InternalThreadManagerRef = SHARED_PTR_IMPL<InternalThreadManager>;
+/// A throw/catch relay between a pause request and cancel event.
+struct RunnerInterruptError {};
 
-/**
- * @brief Default number of threads in the thread pool.
- *
- * The amount of threads that the thread pool will be created with if another
- * value is not specified on the command-line.
- */
-extern const int kDefaultThreadPoolSize;
+class RunnerInterruptPoint : private boost::noncopyable {
+ public:
+  RunnerInterruptPoint() : stop_(false) {}
 
-class InternalRunnable : public apache::thrift::concurrency::Runnable {
+  /// Cancel the pause request.
+  void cancel();
+
+  /// Pause until the requested millisecond delay has elapsed or a cancel.
+  void pause(size_t milli);
+
+ private:
+  /// Communicate between the pause and cancel event.
+  bool stop_;
+
+  /// Protection around pause and cancel calls.
+  std::mutex mutex_;
+
+  /// Wait for notification or a pause expiration.
+  std::condition_variable condition_;
+};
+
+class InternalRunnable : private boost::noncopyable {
  public:
   InternalRunnable() : run_(false) {}
   virtual ~InternalRunnable() {}
 
  public:
-  /// The std::thread entrypoint.
-  void run() {
+  /**
+   * @brief The std::thread entrypoint.
+   *
+   * This is used by the Dispatcher only.
+   */
+  virtual void run() final {
     run_ = true;
     start();
   }
 
-  /// Check if the thread's entrypoint (run) executed, meaning thread context
-  /// was allocated.
+  /**
+   * @brief Check if the thread's entrypoint (run) executed.
+   *
+   * It is possible for the Runnable to be allocated without the thread context.
+   * ::hasRun makes a much better guess at the state of the thread.
+   * If it has run then stop must be called.
+   */
   bool hasRun() { return run_; }
 
-  /// The runnable may also tear down services before the thread context
-  /// is removed.
-  virtual void stop() {}
+  /**
+   * @brief The std::thread's interruption point.
+   */
+  virtual void interrupt() final {
+    WriteLock lock(stopping_);
+    // Set the service as interrupted.
+    interrupted_ = true;
+    // Tear down the service's resources such that exiting the expected run
+    // loop within ::start does not need to.
+    stop();
+    // Cancel the run loop's pause request.
+    point_.cancel();
+  }
 
  protected:
+  /// Allow the runnable to check interruption.
+  bool interrupted() {
+    WriteLock lock(stopping_);
+    return interrupted_;
+  }
+
   /// Require the runnable thread define an entrypoint.
   virtual void start() = 0;
 
+  /// Require the runnable thread to define a stop/interrupt point.
+  virtual void stop() {}
+
+  /// Put the runnable into an interruptible sleep.
+  virtual void pause() { pauseMilli(100); }
+
+  /// Put the runnable into an interruptible sleep.
+  virtual void pauseMilli(size_t milli);
+
  private:
   std::atomic<bool> run_{false};
+
+  /// If a service includes a run loop it should check for interrupted.
   std::atomic<bool> interrupted_{false};
+
+  /**
+   * @brief Protect interruption checking and resource tear down.
+   *
+   * A tearDown mutex protects the runnable service's resources.
+   * Interruption means resources have been stopped.
+   * Non-interruption means no attempt to affect resources has been started.
+   */
+  std::mutex stopping_;
+
+  /// Use an interruption point to exit a pause if the thread was interrupted.
+  RunnerInterruptPoint point_;
 };
 
 /// An internal runnable used throughout osquery as dispatcher services.
 using InternalRunnableRef = std::shared_ptr<InternalRunnable>;
 using InternalThreadRef = std::shared_ptr<std::thread>;
-/// A thrift internal runnable with variable pointer wrapping.
-using ThriftInternalRunnableRef = SHARED_PTR_IMPL<InternalRunnable>;
-using ThriftThreadFactory =
-    SHARED_PTR_IMPL<apache::thrift::concurrency::PosixThreadFactory>;
 
 /**
  * @brief Singleton for queuing asynchronous tasks to be executed in parallel
@@ -115,66 +148,8 @@ class Dispatcher : private boost::noncopyable {
     return instance;
   }
 
-  /**
-   * @brief Add a task to the dispatcher.
-   *
-   * Adding tasks to the Dispatcher's thread pool requires you to create a
-   * "runnable" class which publicly implements Apache Thrift's Runnable
-   * class. Create a shared pointer to the class and you're all set to
-   * schedule work.
-   *
-   * @code{.cpp}
-   *   class TestRunnable : public apache::thrift::concurrency::Runnable {
-   *    public:
-   *     int* i;
-   *     TestRunnable(int* i) : i(i) {}
-   *     virtual void run() { ++*i; }
-   *   };
-   *
-   *   int i = 5;
-   *   Dispatcher::add(std::make_shared<TestRunnable>(&i);
-   *   while (dispatch->totalTaskCount() > 0) {}
-   *   assert(i == 6);
-   * @endcode
-   *
-   * @param task a C++11 std shared pointer to an instance of a class which
-   * publicly inherits from `apache::thrift::concurrency::Runnable`.
-   *
-   * @return osquery success status
-   */
-  static Status add(ThriftInternalRunnableRef task);
-
   /// See `add`, but services are not limited to a thread poll size.
   static Status addService(InternalRunnableRef service);
-
-  /**
-   * @brief Getter for the underlying thread manager instance.
-   *
-   * Use this getter if you'd like to perform some operations which the
-   * Dispatcher API doesn't support, but you are certain are supported by the
-   * backing Apache Thrift thread manager.
-   *
-   * Use this method with caution, as it only exists to allow developers to
-   * iterate quickly in the event that the pragmatic decision to access the
-   * underlying thread manager has been determined to be necessary.
-   *
-   * @code{.cpp}
-   *   auto t = osquery::Dispatcher::getThreadManager();
-   * @endcode
-   *
-   * @return a shared pointer to the Apache Thrift `ThreadManager` instance
-   * which is currently being used to orchestrate multi-threaded operations.
-   */
-  InternalThreadManagerRef getThreadManager() const;
-
-  /**
-   * @brief Joins the thread manager.
-   *
-   * This is the same as stop, except that it will block until all the workers
-   * have finished their work. At that point the ThreadManager will transition
-   * into the STOPPED state.
-   */
-  static void join();
 
   /// See `join`, but applied to osquery services.
   static void joinServices();
@@ -182,81 +157,8 @@ class Dispatcher : private boost::noncopyable {
   /// Destroy and stop all osquery service threads and service objects.
   static void stopServices();
 
-  /**
-   * @brief Get the current state of the thread manager.
-   *
-   * @return an Apache Thrift STATE enum.
-   */
-  InternalThreadManager::STATE state() const;
-
-  /**
-   * @brief Add a worker thread.
-   *
-   * Use this method to add an additional thread to the thread pool.
-   *
-   * @param value is a size_t indicating how many additional worker threads
-   * should be added to the thread group. If not parameter is supplied, one
-   * worker thread is added.
-   *
-   * @see osquery::Dispatcher::removeWorker
-   */
-  static void addWorker(size_t value = 1);
-
-  /**
-   * @brief Remove a worker thread.
-   *
-   * Use this method to remove a thread from the thread pool.
-   *
-   * @param value is a size_t indicating how many additional worker threads
-   * should be removed from the thread group. If not parameter is supplied,
-   * one worker thread is removed.
-   *
-   * @see osquery::Dispatcher::addWorker
-   */
-  static void removeWorker(size_t value = 1);
-
-  /**
-   * @brief Gets the current number of idle worker threads.
-   *
-   * @return the number of idle worker threads.
-   */
-  size_t idleWorkerCount() const;
-
-  /**
-   * @brief Gets the current number of total worker threads.
-   *
-   * @return the current number of total worker threads.
-   */
-  size_t workerCount() const;
-
-  /**
-   * @brief Gets the current number of pending tasks.
-   *
-   * @return the current number of pending tasks.
-   */
-  size_t pendingTaskCount() const;
-
-  /**
-   * @brief Gets the current number of pending and executing tasks.
-   *
-   * @return the current number of pending and executing tasks.
-   */
-  size_t totalTaskCount() const;
-
-  /**
-   * @brief Gets the maximum pending task count. 0 indicates no maximum.
-   *
-   * @return the maximum pending task count. 0 indicates no maximum.
-   */
-  size_t pendingTaskCountMax() const;
-
-  /**
-   * @brief Gets the number of tasks which have been expired without being
-   * run.
-   *
-   * @return he number of tasks which have been expired without being run.
-   */
-  size_t expiredTaskCount() const;
+  /// Return number of services.
+  size_t serviceCount() { return service_threads_.size(); }
 
  private:
   /**
@@ -268,24 +170,9 @@ class Dispatcher : private boost::noncopyable {
   Dispatcher() {}
   Dispatcher(Dispatcher const&);
   void operator=(Dispatcher const&);
-  virtual ~Dispatcher();
-
-  /// Initialize the thread poll when the first dispatcher thread is needed.
-  void init();
+  virtual ~Dispatcher() {}
 
  private:
-  /**
-   * @brief Internal shared pointer which references Thrift's thread manager
-   *
-   * All thread operations occur via Apache Thrift's ThreadManager class. This
-   * private member represents a shared pointer to an instantiation of that
-   * thread manager, which can be used to accomplish various threading
-   * objectives.
-   *
-   * @see getThreadManager
-   */
-  InternalThreadManagerRef thread_manager_{nullptr};
-
   /// The set of shared osquery service threads.
   std::vector<InternalThreadRef> service_threads_;
 
@@ -295,7 +182,4 @@ class Dispatcher : private boost::noncopyable {
  private:
   friend class ExtensionsTest;
 };
-
-/// Allow a dispatched thread to wait while processing or to prevent thrashing.
-void interruptableSleep(size_t milli);
 }

--- a/osquery/dispatcher/distributed.cpp
+++ b/osquery/dispatcher/distributed.cpp
@@ -8,8 +8,8 @@
  *
  */
 
-#include <osquery/flags.h>
 #include <osquery/distributed.h>
+#include <osquery/flags.h>
 
 #include "osquery/dispatcher/distributed.h"
 
@@ -25,12 +25,12 @@ DECLARE_string(distributed_plugin);
 
 void DistributedRunner::start() {
   auto dist = Distributed();
-  while (true) {
+  while (!interrupted()) {
     dist.pullUpdates();
     if (dist.getPendingQueryCount() > 0) {
       dist.runQueries();
     }
-    ::sleep(FLAGS_distributed_interval);
+    pauseMilli(FLAGS_distributed_interval * 1000);
   }
 }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -129,7 +129,10 @@ void SchedulerRunner::start() {
           }
         }));
     // Put the thread into an interruptible sleep without a config instance.
-    osquery::interruptableSleep(interval_ * 1000);
+    pauseMilli(interval_ * 1000);
+    if (interrupted()) {
+      break;
+    }
   }
 }
 

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "osquery/dispatcher/dispatcher.h"
 
 namespace osquery {
@@ -17,19 +19,23 @@ namespace osquery {
 /// A Dispatcher service thread that watches an ExtensionManagerHandler.
 class SchedulerRunner : public InternalRunnable {
  public:
-  virtual ~SchedulerRunner() {}
   SchedulerRunner(unsigned long int timeout, size_t interval)
       : interval_(interval), timeout_(timeout) {}
 
  public:
   /// The Dispatcher thread entry point.
-  void start();
+  void start() override;
+
+  /// The Dispatcher interrupt point.
+  void stop() override {}
 
  protected:
   /// The UNIX domain socket path for the ExtensionManager.
   std::map<std::string, size_t> splay_;
+
   /// Interval in seconds between schedule steps.
   size_t interval_;
+
   /// Maximum number of steps.
   unsigned long int timeout_;
 };

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -16,12 +16,14 @@
 
 namespace osquery {
 
-class DispatcherTests : public testing::Test {};
+class DispatcherTests : public testing::Test {
+  void TearDown() override {}
+};
 
 TEST_F(DispatcherTests, test_singleton) {
   auto& one = Dispatcher::instance();
   auto& two = Dispatcher::instance();
-  EXPECT_EQ(one.getThreadManager().get(), two.getThreadManager().get());
+  EXPECT_EQ(&one, &two);
 }
 
 class TestRunnable : public InternalRunnable {
@@ -30,19 +32,4 @@ class TestRunnable : public InternalRunnable {
   explicit TestRunnable(int* i) : i(i) {}
   virtual void start() { ++*i; }
 };
-
-TEST_F(DispatcherTests, test_add_work) {
-  auto& dispatcher = Dispatcher::instance();
-  int base = 5;
-  int repetitions = 1;
-
-  int i = base;
-  for (int c = 0; c < repetitions; ++c) {
-    dispatcher.add(OSQUERY_THRIFT_POINTER::make_shared<TestRunnable>(&i));
-  }
-  while (dispatcher.totalTaskCount() > 0) {
-  }
-
-  EXPECT_EQ(i, base + repetitions);
-}
 }

--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -239,8 +239,6 @@ Status DiskArbitrationEventPublisher::run() {
   }
 
   CFRunLoopRun();
-
-  osquery::publisherSleep(1000);
   return Status(0, "OK");
 }
 

--- a/osquery/events/darwin/diskarbitration.h
+++ b/osquery/events/darwin/diskarbitration.h
@@ -68,9 +68,6 @@ class DiskArbitrationEventPublisher
 
   Status run() override;
 
-  // Callin for stopping the streams/run loop.
-  void end() override { stop(); }
-
   static void DiskAppearedCallback(DADiskRef disk, void *context);
 
   static void DiskDisappearedCallback(DADiskRef disk, void *context);
@@ -78,7 +75,7 @@ class DiskArbitrationEventPublisher
  private:
   void restart();
 
-  void stop();
+  void stop() override;
 
   static std::string getProperty(const CFStringRef &property,
                                  const CFDictionaryRef &dict);

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -124,6 +124,7 @@ void FSEventsEventPublisher::restart() {
 
 void FSEventsEventPublisher::stop() {
   // Stop the stream.
+  WriteLock lock(mutex_);
   if (stream_ != nullptr) {
     FSEventStreamStop(stream_);
     stream_started_ = false;

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -98,9 +98,6 @@ class FSEventsEventPublisher
   /// Entrypoint to the run loop
   Status run() override;
 
-  /// Callin for stopping the streams/run loop.
-  void end() override { stop(); }
-
   /// Delete all paths from prior configuration.
   void removeSubscriptions(const std::string& subscriber) override;
 
@@ -122,7 +119,7 @@ class FSEventsEventPublisher
   void restart();
 
   /// Stop the stream and the run loop.
-  void stop();
+  void stop() override;
 
   /// Cause the FSEvents to flush kernel-buffered events.
   void flush(bool async = false);

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -198,9 +198,6 @@ Status IOKitEventPublisher::run() {
 
   // Start the run loop, it may be removed with a tearDown.
   CFRunLoopRun();
-
-  // Add artificial latency to run loop.
-  osquery::publisherSleep(1000);
   return Status(0, "OK");
 }
 

--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -58,8 +58,6 @@ class IOKitEventPublisher
 
   Status run() override;
 
-  void end() override { stop(); }
-
   bool shouldFire(const IOKitSubscriptionContextRef& sc,
                   const IOKitEventContextRef& ec) const override;
 
@@ -75,7 +73,7 @@ class IOKitEventPublisher
 
  private:
   void restart();
-  void stop();
+  void stop() override;
 
  private:
   // The publisher state machine will start, restart, and stop the run loop.

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -20,6 +20,7 @@ namespace osquery {
 REGISTER(SCNetworkEventPublisher, "event_publisher", "scnetwork");
 
 void SCNetworkEventPublisher::tearDown() {
+  stop();
   for (auto target : targets_) {
     CFRelease(target);
   }
@@ -110,6 +111,14 @@ void SCNetworkEventPublisher::configure() {
     }
   }
 
+  // Make sure at least one target exists.
+  if (targets_.empty()) {
+    auto sc = createSubscriptionContext();
+    sc->type = NAME_TARGET;
+    sc->target = "localhost";
+    addHostname(sc);
+  }
+
   restart();
 }
 
@@ -149,9 +158,6 @@ Status SCNetworkEventPublisher::run() {
 
   // Start the run loop, it may be removed with a tearDown.
   CFRunLoopRun();
-
-  // Do not expect the run loop to exit often, if so, add artificial latency.
-  osquery::publisherSleep(1000);
   return Status(0, "OK");
 }
 };

--- a/osquery/events/darwin/scnetwork.h
+++ b/osquery/events/darwin/scnetwork.h
@@ -14,8 +14,8 @@
 
 #include <SystemConfiguration/SCNetworkReachability.h>
 
-#include <osquery/status.h>
 #include <osquery/events.h>
+#include <osquery/status.h>
 
 namespace osquery {
 
@@ -66,9 +66,6 @@ class SCNetworkEventPublisher
   // Entrypoint to the run loop
   Status run() override;
 
-  // The event factory may end, stopping the SCNetwork runloop.
-  void end() override { stop(); }
-
  public:
   /// SCNetwork registers a client callback instead of using a select/poll loop.
   static void Callback(const SCNetworkReachabilityRef target,
@@ -84,7 +81,7 @@ class SCNetworkEventPublisher
   void restart();
 
   // Stop the run loop.
-  void stop();
+  void stop() override;
 
  private:
   void addHostname(const SCNetworkSubscriptionContextRef& sc);

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -569,9 +569,12 @@ Status EventFactory::run(EventPublisherID& type_id) {
   publisher->hasStarted(true);
 
   auto status = Status(0, "OK");
-  while (!publisher->isEnding() && status.ok()) {
+  while (!publisher->isEnding()) {
     // Can optionally implement a global cooloff latency here.
     status = publisher->run();
+    if (!status.ok()) {
+      break;
+    }
     publisher->restart_count_++;
     osquery::publisherSleep(EVENTS_COOLOFF);
   }
@@ -775,7 +778,7 @@ Status EventFactory::deregisterEventPublisher(EventPublisherID& type_id) {
       // event thread wrapper when isEnding is next checked.
       ef.event_pubs_.erase(type_id);
     } else {
-      publisher->end();
+      publisher->stop();
     }
   }
   return Status(0, "OK");

--- a/osquery/events/kernel/tests/kernel_communication_tests.cpp
+++ b/osquery/events/kernel/tests/kernel_communication_tests.cpp
@@ -8,8 +8,8 @@
  *
  */
 
-#include <sys/ioctl.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 #include <unistd.h>
 
 #include <boost/make_shared.hpp>
@@ -21,7 +21,12 @@
 
 namespace osquery {
 
-class KernelCommunicationTests : public testing::Test {};
+class KernelCommunicationTests : public testing::Test {
+  void TearDown() override {
+    Dispatcher::stopServices();
+    Dispatcher::joinServices();
+  }
+};
 
 #ifdef KERNEL_TEST
 class KernelProducerRunnable : public InternalRunnable {
@@ -57,15 +62,15 @@ TEST_F(KernelCommunicationTests, test_communication) {
   auto& dispatcher = Dispatcher::instance();
 
   for (unsigned int c = 0; c < num_threads; ++c) {
-    dispatcher.add(OSQUERY_THRIFT_POINTER::make_shared<KernelProducerRunnable>(
-        events_per_thread, c % 2));
+    dispatcher.addService(
+        std::make_shared<KernelProducerRunnable>(events_per_thread, c % 2));
   }
 
   osquery_event_t event;
   osquery::CQueue::event* event_buf = nullptr;
   unsigned int tasks = 0;
   do {
-    tasks = dispatcher.totalTaskCount();
+    tasks = dispatcher.serviceCount();
     drops += queue.kernelSync(OSQUERY_NO_BLOCK);
     unsigned int max_before_sync = 2000;
     while (max_before_sync > 0 && (event = queue.dequeue(&event_buf))) {

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -18,8 +18,8 @@
 #include <osquery/sql.h>
 
 #include "osquery/core/conversions.h"
-#include "osquery/extensions/interface.h"
 #include "osquery/core/watcher.h"
+#include "osquery/extensions/interface.h"
 
 using namespace osquery::extensions;
 
@@ -80,9 +80,9 @@ void ExtensionWatcher::start() {
   // Watch the manager, if the socket is removed then the extension will die.
   // A check for sane paths and activity is applied before the watcher
   // service is added and started.
-  while (true) {
+  while (!interrupted()) {
     watch();
-    interruptableSleep(interval_);
+    pauseMilli(interval_);
   }
 }
 
@@ -478,8 +478,7 @@ Status getExtensions(const std::string& manager_path,
 
   // Convert from Thrift-internal list type to RouteUUID/ExtenionInfo type.
   for (const auto& ext : ext_list) {
-    extensions[ext.first] = {ext.second.name,
-                             ext.second.version,
+    extensions[ext.first] = {ext.second.name, ext.second.version,
                              ext.second.min_sdk_version,
                              ext.second.sdk_version};
   }

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -23,6 +23,7 @@
 #include CONCAT(OSQUERY_THRIFT_LIB,/transport/TServerSocket.h)
 #include CONCAT(OSQUERY_THRIFT_LIB,/transport/TBufferTransports.h)
 #include CONCAT(OSQUERY_THRIFT_LIB,/transport/TSocket.h)
+#include CONCAT(OSQUERY_THRIFT_LIB,/concurrency/ThreadManager.h)
 
 // Include intermediate Thrift-generated interface definitions.
 #include CONCAT(OSQUERY_THRIFT,Extension.h)

--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -8,7 +8,9 @@
  *
  */
 
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <boost/property_tree/json_parser.hpp>
@@ -66,7 +68,7 @@ static inline void iterate(std::vector<std::string>& input,
     // It may choose to clear/move the data.
     predicate(item);
     if (++count % 100 == 0) {
-      osquery::interruptableSleep(20);
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
   }
 }
@@ -221,11 +223,11 @@ void TLSLogForwarderRunner::check() {
 }
 
 void TLSLogForwarderRunner::start() {
-  while (true) {
+  while (!interrupted()) {
     check();
 
     // Cool off and time wait the configured period.
-    osquery::interruptableSleep(FLAGS_logger_tls_period * 1000);
+    pauseMilli(FLAGS_logger_tls_period * 1000);
   }
 }
 }

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -27,6 +27,9 @@ namespace osquery {
 
 HIDDEN_FLAG(bool, registry_exceptions, false, "Allow plugin exceptions");
 
+/// Mutex to control access to registry extensions and their UUIDs.
+Mutex gRegistryExtensionsMutex;
+
 void RegistryHelperCore::remove(const std::string& item_name) {
   if (items_.count(item_name) > 0) {
     items_[item_name]->tearDown();
@@ -334,6 +337,7 @@ Status RegistryFactory::addBroadcast(const RouteUUID& uuid,
 }
 
 Status RegistryFactory::removeBroadcast(const RouteUUID& uuid) {
+  WriteLock lock(gRegistryExtensionsMutex);
   if (instance().extensions_.count(uuid) == 0) {
     return Status(1, "Unknown extension UUID: " + std::to_string(uuid));
   }
@@ -463,6 +467,7 @@ std::vector<std::string> RegistryFactory::names(
 }
 
 std::vector<RouteUUID> RegistryFactory::routeUUIDs() {
+  WriteLock lock(gRegistryExtensionsMutex);
   std::vector<RouteUUID> uuids;
   for (const auto& extension : instance().extensions_) {
     uuids.push_back(extension);

--- a/tools/tests/sanitize_blacklist.txt
+++ b/tools/tests/sanitize_blacklist.txt
@@ -15,6 +15,8 @@ fun:google::RawLog__SetLastTime
 # Thrift
 fun:apache::thrift::transport::TServerSocket::listen
 fun:apache::thrift::transport::TServerSocket::notify
+fun:apache::thrift::transport::TServerSocket::interrupt
+fun:apache::thrift::transport::TServerSocket::interruptChildren
 src:*thrift/transport/TServerSocket.cpp
 
 # RocksDB


### PR DESCRIPTION
Prevent `std::~thread` from calling `::terminate` on the thread context after we cancel and join using the native handle.