### PR TITLE
Upgrade signature table

### DIFF
--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -4,6 +4,9 @@ schema([
     Column("path", TEXT, "Must provide a path or directory", required=True),
     Column("signed", INTEGER, "1 If the file is signed else 0"),
     Column("identifier", TEXT, "The signing identifier sealed into the signature"),
+    Column("cdhash", TEXT, "SHA1 hash of the application Code Directory"),
+    Column("team_identifier", TEXT, "The team signing identifier sealed into the signature"),
+    Column("authority", TEXT, "Certificate Common Name"),
 ])
 implementation("signature@genSignature")
 examples([


### PR DESCRIPTION
I am adding three new fields to the signature table so we can have more info. Here is the breakdown:

- `cdhash` - code directory hash
(Ref: [Code Signing Requirement Language](https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html))
- `team_identifier` - an unique id of the app developer (osx 10.10 or later) 
- `authority` - the common name of the signed certificate

