### PR TITLE
Build debug packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,11 @@ elseif(OSQUERY_BUILD_PLATFORM STREQUAL "windows")
   LOG_PLATFORM("Windows")
 endif()
 
+if("${OSQUERY_BUILD_DISTRO}" MATCHES "^(centos|rhel|oracle)7$")
+  # Useful for libudev version detection.
+  set(SYSTEMD TRUE)
+endif()
+
 if(REDHAT_BASED)
   add_definitions(-DREDHAT_BASED=1)
 elseif(DEBIAN_BASED)

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -68,6 +68,11 @@ elseif(LINUX OR FREEBSD)
   ADD_OSQUERY_LINK_CORE("librt.so")
 endif()
 
+if(LINUX)
+  # For Ubuntu/CentOS packages add the build SHA1.
+  ADD_OSQUERY_LINK_CORE("-Wl,--build-id")
+endif()
+
 # The remaining boost libraries are discovered with find_library.
 ADD_OSQUERY_LINK_CORE("glog")
 ADD_OSQUERY_LINK_CORE("boost_system")

--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -1,8 +1,8 @@
 if(APPLE)
-  ADD_OSQUERY_LINK(FALSE "-framework CoreServices")
-  ADD_OSQUERY_LINK(FALSE "-framework SystemConfiguration")
-  ADD_OSQUERY_LINK(FALSE "-framework IOKit")
-  ADD_OSQUERY_LINK(FALSE "-framework DiskArbitration")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreServices")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework SystemConfiguration")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework IOKit")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework DiskArbitration")
 
 
   file(GLOB OSQUERY_EVENTS_DARWIN "darwin/*.cpp")
@@ -11,8 +11,10 @@ elseif(FREEBSD)
   file(GLOB OSQUERY_EVENTS_FREEBSD "freebsd/*.cpp")
   ADD_OSQUERY_LIBRARY(FALSE osquery_events_freebsd ${OSQUERY_EVENTS_FREEBSD})
 else()
-  ADD_OSQUERY_LINK(FALSE "udev")
-  ADD_OSQUERY_LINK(FALSE "audit")
+  # See the root CMakeLists for SYSTEMD detection.
+  # The udev library link is not available without systemd-devel.
+  ADD_OSQUERY_LINK_ADDITIONAL("udev")
+  ADD_OSQUERY_LINK_ADDITIONAL("audit")
 
   file(GLOB OSQUERY_EVENTS_LINUX "linux/*.cpp")
   ADD_OSQUERY_LIBRARY(FALSE osquery_events_linux ${OSQUERY_EVENTS_LINUX})

--- a/tools/deployment/getfiles.py
+++ b/tools/deployment/getfiles.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import os
+import sys
+
+try:
+    import argparse
+except ImportError:
+    print("Cannot import argparse.")
+    exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=(
+        "List files from compile_commands.json."
+    ))
+    parser.add_argument(
+        "--build", metavar="PATH",
+        help="Path to osquery build (./build/<sys>/) directory"
+    )
+    parser.add_argument(
+        "--base", metavar="PATH", default="",
+        help="Real path of source base."
+    )
+
+    args = parser.parse_args()
+
+    commands_path = os.path.join(args.build, "compile_commands.json")
+    if not os.path.exists(commands_path):
+        print("Cannot find '%s'" % (commands_path))
+        exit(1)
+
+    with open(commands_path, 'r') as fh: content = fh.read()
+    data = json.loads(content)
+    for file in data:
+        if file['file'].find("_tests.cpp") > 0 or file['file'].find("_benchmark") > 0:
+            continue
+        if file['file'].find("gtest") > 0:
+            continue
+        print(file['file'].replace(args.base, ""))
+        pass

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -94,7 +94,7 @@ function main_centos() {
     package automake
     package libtool
     package file-devel
-
+    package systemd-devel
     package bison
   fi
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -201,7 +201,8 @@ function install_cppnetlib() {
   URL=$DEPS_URL/$TARBALL
 
   SOURCE=cpp-netlib-$SOURCE
-  if provision cppnetlib /usr/local/lib/libcppnetlib-client-connections.a; then
+  # Note: use the header install since libdir was uncontrolled for a while.
+  if provision cppnetlib /usr/local/include/boost/network/version.hpp; then
     pushd $SOURCE
     mkdir -p build
     pushd build
@@ -358,6 +359,9 @@ function install_device_mapper() {
     make libdm.device-mapper -j $THREADS
     sudo cp libdm/ioctl/libdevmapper.a /usr/local/lib/
     sudo cp libdm/libdevmapper.h /usr/local/include/
+    pushd libdm
+    sudo make install_pkgconfig
+    popd
     popd
   fi
 }
@@ -402,10 +406,10 @@ function install_libcryptsetup() {
 
   if provision libcryptsetup /usr/local/lib/libcryptsetup.a; then
     pushd $SOURCE
-    ./autogen.sh
-    ./configure --prefix=/usr/local --enable-static --disable-shared \
-      --disable-selinux --disable-udev --disable-veritysetup  --disable-nls \
-      CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS"
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/ \
+      ./autogen.sh --prefix=/usr/local --enable-static --disable-shared \
+        --disable-selinux --disable-udev --disable-veritysetup  --disable-nls \
+        CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS"
     pushd lib
     make -j $THREADS
     sudo make install

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -131,6 +131,7 @@ function main_rhel() {
     package automake
     package libtool
     package file-devel
+    package systemd-devel
   fi
 
   install_snappy


### PR DESCRIPTION
This fixes a build issue for CentOS7 where devmapper's pkgconfig was not installed. This would fail the cryptsetup build during `make deps`. This also attempts a poor man's `-debuginfo` package build for CentOS7/Ubuntu.