### PR TITLE
IOKitLib.h not IOKitlib.h

### DIFF
--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -14,7 +14,7 @@
 #include <osquery/status.h>
 
 #include <CoreServices/CoreServices.h>
-#include <IOKit/IOKitlib.h>
+#include <IOKit/IOKitLib.h>
 
 namespace osquery {
 


### PR DESCRIPTION
As with all other appearances of IOKitLib.h in the osquery sources, use
the capitalization "IOKitLib.h" not "IOKitlib.h" to avoid build failure
on case-sensitive file systems.