### PR TITLE
Change .clang-format standard from Cpp03 to Cpp11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -27,7 +27,7 @@ PenaltyReturnTypeOnItsOwnLine: 200
 PointerBindsToType: true
 SpacesBeforeTrailingComments: 1
 Cpp11BracedListStyle: true
-Standard: Cpp03
+Standard: Cpp11
 IndentWidth: 2
 TabWidth: 8
 UseTab: Never


### PR DESCRIPTION
This fixes issue #1934, and potentially other C++11 compatibility.

On a couple of test files, this change did not seem to change the formatting (besides fixing the problem of #1934).

Files tested:
```
include/osquery/events.h
osquery/events/linux/inotify.cpp
osquery/events/linux/inotify.h
osquery/events/linux/tests/audit_tests.cpp
```