### PR TITLE
Various cleanups

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -77,8 +77,7 @@ using EventPublisherRef = std::shared_ptr<BaseEventPublisher>;
 using SubscriptionContextRef = std::shared_ptr<SubscriptionContext>;
 using EventContextRef = std::shared_ptr<EventContext>;
 using BaseEventSubscriber = EventSubscriber<BaseEventPublisher>;
-using EventSubscriberRef =
-    std::shared_ptr<EventSubscriber<BaseEventPublisher> >;
+using EventSubscriberRef = std::shared_ptr<EventSubscriber<BaseEventPublisher>>;
 
 /**
  * @brief EventSubscriber%s may exist in various states.
@@ -428,8 +427,10 @@ class EventSubscriberPlugin : public Plugin {
    * The subscriber must count the number of buffered records and check if
    * that count exceeds the configured `events_max` limit. If an overflow
    * occurs the subscriber will expire N-events_max from the end of the queue.
+   *
+   * @param cleanup Perform an intense scan of zombie event IDs.
    */
-  void expireCheck();
+  void expireCheck(bool cleanup = false);
 
   /**
    * @brief Add an EventID, EventTime pair to all matching list types.
@@ -731,7 +732,7 @@ class EventFactory : private boost::noncopyable {
   std::map<EventSubscriberID, EventSubscriberRef> event_subs_;
 
   /// Set of running EventPublisher run loop threads.
-  std::vector<std::shared_ptr<std::thread> > threads_;
+  std::vector<std::shared_ptr<std::thread>> threads_;
 
   /// Factory publisher state manipulation.
   Mutex factory_lock_;

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -167,6 +167,7 @@ if(NOT ${OSQUERY_BUILD_SDK_ONLY})
   TARGET_OSQUERY_LINK_WHOLE(shell libosquery_additional)
   SET_OSQUERY_COMPILE(shell "${CXX_COMPILE_FLAGS}")
   set_target_properties(shell PROPERTIES OUTPUT_NAME osqueryi)
+  add_dependencies(shell osquery_tools)
 
   add_executable(daemon main/daemon.cpp)
   TARGET_OSQUERY_LINK_WHOLE(daemon libosquery)
@@ -180,6 +181,13 @@ if(NOT ${OSQUERY_BUILD_SDK_ONLY})
     DESTINATION include
     COMPONENT devel OPTIONAL
     PATTERN ".*" EXCLUDE
+  )
+
+  # A friendly echo printed after the library is built.
+  add_custom_target(osquery_tools ALL
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan --bold
+      "-- Building osqueryi: ${CMAKE_BINARY_DIR}/osqueryi"
+      "-- Building osqueryd: ${CMAKE_BINARY_DIR}/osqueryd"
   )
 
   # make install (executables)

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -29,7 +29,7 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-const std::map<WatchdogLimitType, std::vector<size_t> > kWatchdogLimits = {
+const std::map<WatchdogLimitType, std::vector<size_t>> kWatchdogLimits = {
     // Maximum MB worker can privately allocate.
     {MEMORY_LIMIT, {80, 50, 30, 1000}},
     // Percent of user or system CPU worker can utilize for LATENCY_LIMIT
@@ -44,8 +44,6 @@ const std::map<WatchdogLimitType, std::vector<size_t> > kWatchdogLimits = {
     // How often to poll for performance limit violations.
     {INTERVAL, {3, 3, 3, 1}},
 };
-
-const std::string kExtensionExtension = ".ext";
 
 CLI_FLAG(int32,
          watchdog_level,
@@ -122,23 +120,8 @@ void Watcher::reset(pid_t child) {
 }
 
 void Watcher::addExtensionPath(const std::string& path) {
-  // Resolve acceptable extension binaries from autoload paths.
-  if (isDirectory(path).ok()) {
-    VLOG(1) << "Cannot autoload extension from directory: " << path;
-    return;
-  }
-
-  // Only autoload extensions which were safe at the time of discovery.
-  // If the extension binary later becomes unsafe (permissions change) then
-  // it will fail to reload if a reload is ever needed.
-  fs::path extension(path);
-  if (safePermissions(extension.parent_path().string(), path, true)) {
-    if (extension.extension().string() == kExtensionExtension) {
-      setExtension(extension.string(), 0);
-      resetExtensionCounters(extension.string(), 0);
-      VLOG(1) << "Found autoloadable extension: " << extension.string();
-    }
-  }
+  setExtension(path, 0);
+  resetExtensionCounters(path, 0);
 }
 
 bool Watcher::hasManagedExtensions() {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -286,32 +286,47 @@ void EventSubscriberPlugin::expireIndexes(
   setDatabaseValue(kEvents, index_key + "." + list_type, new_indexes);
 }
 
-void EventSubscriberPlugin::expireCheck() {
+void EventSubscriberPlugin::expireCheck(bool cleanup) {
   auto data_key = "data." + dbNamespace();
   auto eid_key = "eid." + dbNamespace();
+  // Min key will be the last surviving key.
+  size_t min_key = 0;
 
-  std::vector<std::string> keys;
-  scanDatabaseKeys(kEvents, keys, data_key);
-  if (keys.size() <= FLAGS_events_max) {
-    return;
+  {
+    std::vector<std::string> keys;
+    scanDatabaseKeys(kEvents, keys, data_key);
+    if (keys.size() <= FLAGS_events_max) {
+      return;
+    }
+
+    // There is an overflow of events buffered for this subscriber.
+    LOG(WARNING) << "Expiring events for subscriber: " << getName()
+                 << " limit (" << FLAGS_events_max
+                 << ") exceeded: " << keys.size();
+    // Inspect the N-FLAGS_events_max -th event's value and expire before the
+    // time within the content.
+    std::string last_key;
+    getDatabaseValue(kEvents, eid_key, last_key);
+    // The EID is the next-index.
+    // EID - events_max is the most last-recent event to keep.
+    min_key = boost::lexical_cast<size_t>(last_key) - FLAGS_events_max;
+
+    if (cleanup) {
+      // Scan each of the keys in keys, if their ID portion is < min_key.
+      // Nix them, this requires lots of conversions, use with care.
+      for (const auto& key : keys) {
+        if (std::stoul(key.substr(key.rfind('.') + 1)) < min_key) {
+          deleteDatabaseValue(kEvents, key);
+        }
+      }
+    }
   }
-
-  // There is an overflow of events buffered for this subscriber.
-  LOG(WARNING) << "Expiring events for subscriber: " << getName() << " limit ("
-               << FLAGS_events_max << ") exceeded: " << keys.size();
-  // Inspect the N-FLAGS_events_max -th event's value and expire before the
-  // time within the content.
-  std::string last_key;
-  getDatabaseValue(kEvents, eid_key, last_key);
-  // The EID is the next-index.
-  // EID - events_max is the most last-recent event to keep.
-  size_t max_key = boost::lexical_cast<size_t>(last_key) - FLAGS_events_max - 1;
 
   // Convert the key index into a time using the content.
   // The last-recent event is fetched and the corresponding time is used as
   // the expiration time for the subscriber.
   std::string content;
-  getDatabaseValue(kEvents, data_key + "." + std::to_string(max_key), content);
+  getDatabaseValue(kEvents, data_key + "." + std::to_string(min_key), content);
 
   // Decode the value into a row structure to extract the time.
   Row r;
@@ -327,7 +342,7 @@ void EventSubscriberPlugin::expireCheck() {
 
   // Finally, attempt an index query to trigger expirations.
   // In this case the result set is not used.
-  getIndexes(expire_time_ - 1, 0);
+  getIndexes(expire_time_, 0);
 }
 
 std::vector<EventRecord> EventSubscriberPlugin::getRecords(
@@ -492,6 +507,10 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
   auto status = serializeRowJSON(r, data);
   if (!status.ok()) {
     return status;
+  }
+  // Then remove the newline.
+  if (data.size() > 0 && data.back() == '\n') {
+    data.pop_back();
   }
 
   // Use the last EventID and a checkpoint bucket size to periodically apply
@@ -679,7 +698,7 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
   // Let the module initialize any Subscriptions.
   auto status = Status(0, "OK");
   if (!FLAGS_disable_events && !specialized_sub->disabled) {
-    specialized_sub->expireCheck();
+    specialized_sub->expireCheck(true);
     status = specialized_sub->init();
     specialized_sub->state(SUBSCRIBER_RUNNING);
   } else {

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -183,8 +183,7 @@ void ExtensionRunnerCore::stop() {
     std::unique_lock<std::mutex> lock(service_start_);
     service_stopping_ = true;
     if (transport_ != nullptr) {
-      transport_->interrupt();
-      transport_->interruptChildren();
+      // This is an opportunity to interrupt the transport listens.
     }
   }
 

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -173,14 +173,16 @@ function main() {
     PACKAGE_DEBUG_DEPENDENCIES="osquery = $PACKAGE_VERSION"
 
     # Create Build-ID links for executables and Dwarfs.
-    BUILD_ID_SHELL=`readelf -n "$BUILD_DIR/osquery/osqueryi" | grep "Build ID" | awk '{print $3}'`
-    BUILD_ID_DAEMON=`readelf -n "$BUILD_DIR/osquery/osqueryd" | grep "Build ID" | awk '{print $3}'`
+    BUILD_ID_SHELL=`eu-readelf -n "$BUILD_DIR/osquery/osqueryi" | grep "Build ID" | awk '{print $3}'`
+    BUILD_ID_DAEMON=`eu-readelf -n "$BUILD_DIR/osquery/osqueryd" | grep "Build ID" | awk '{print $3}'`
     BUILDLINK_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/.build-id/64
-    mkdir -p $BUILDLINK_DEBUG_DIR
-    ln -s ../../../../bin/osqueryi $BUILDLINK_DEBUG_DIR/$BUILD_ID_SHELL
-    ln -s ../../bin/osqueryi.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID_SHELL.debug
-    ln -s ../../../../bin/osqueryd $BUILDLINK_DEBUG_DIR/$BUILD_ID_DAEMON
-    ln -s ../../bin/osqueryd.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID_DAEMON.debug
+    if [[ ! "$BUILD_ID_SHELL" = "" ]]; then
+      mkdir -p $BUILDLINK_DEBUG_DIR
+      ln -s ../../../../bin/osqueryi $BUILDLINK_DEBUG_DIR/$BUILD_ID_SHELL
+      ln -s ../../bin/osqueryi.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID_SHELL.debug
+      ln -s ../../../../bin/osqueryd $BUILDLINK_DEBUG_DIR/$BUILD_ID_DAEMON
+      ln -s ../../bin/osqueryd.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID_DAEMON.debug
+    fi
 
     # Install the non-stripped binaries.
     BINARY_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/usr/bin/
@@ -190,8 +192,8 @@ function main() {
 
     # Finally install the source.
     SOURCE_DEBUG_DIR=$DEBUG_PREFIX/usr/src/debug/osquery-$PACKAGE_VERSION
-    BUILD_DIR=`realpath "$BUILD_DIR"`
-    SOURCE_DIR=`realpath "$SOURCE_DIR"`
+    BUILD_DIR=`readlink --canonicalize "$BUILD_DIR"`
+    SOURCE_DIR=`readlink --canonicalize "$SOURCE_DIR"`
     for file in `"$SCRIPT_DIR/getfiles.py" --build "$BUILD_DIR/" --base "$SOURCE_DIR/"`
     do
       mkdir -p `dirname "$SOURCE_DEBUG_DIR/$file"`


### PR DESCRIPTION
1. Add a catch-all cleanup for events expiration when the daemon/shell starts. This should only affect processes that stop with too many buffered events.
2. Add a friendly note in the CMake output indicating the expected directory of the output shell/daemon binary.
3. Add appropriate warning logs when extensions/modules cannot load.
4. Fix CentOS 6.5 debuginfo package building.
5. Remove "unneeded" Thrift transport interruptions (for the extensions server/clients).