### PR TITLE
Enhance publisher resource locking on OS X

### DIFF
--- a/osquery/events/darwin/diskarbitration.h
+++ b/osquery/events/darwin/diskarbitration.h
@@ -87,7 +87,12 @@ class DiskArbitrationEventPublisher
                    const CFDictionaryRef &dict);
 
  private:
+  /// Disk arbitration session.
   DASessionRef session_{nullptr};
+
+  /// Publisher's run loop.
   CFRunLoopRef run_loop_{nullptr};
+
+  mutable Mutex mutex_;
 };
 }

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -98,9 +98,6 @@ class FSEventsEventPublisher
   /// Entrypoint to the run loop
   Status run() override;
 
-  /// Delete all paths from prior configuration.
-  void removeSubscriptions(const std::string& subscriber) override;
-
  public:
   /// FSEvents registers a client callback instead of using a select/poll loop.
   static void Callback(ConstFSEventStreamRef fsevent_stream,

--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #include <osquery/events.h>
 #include <osquery/status.h>
 
@@ -76,20 +78,20 @@ class IOKitEventPublisher
   void stop() override;
 
  private:
-  // The publisher state machine will start, restart, and stop the run loop.
+  /// The publisher state machine will start, restart, and stop the run loop.
   CFRunLoopRef run_loop_{nullptr};
 
-  // Notification port, should close.
+  /// Notification port, should close.
   IONotificationPortRef port_{nullptr};
 
-  // Device attach iterator.
+  /// Device attach iterator.
   io_iterator_t iterator_;
 
-  // Device detach notification.
-  std::vector<std::shared_ptr<struct DeviceTracker> > devices_;
+  /// Device detach notification.
+  std::vector<std::shared_ptr<struct DeviceTracker>> devices_;
 
-  // Device notification tracking lock.
-  std::mutex notification_mutex_;
+  /// Device notification and container access protection mutex.
+  mutable Mutex mutex_;
 
   /**
    * @brief Should events be emitted by the callback.
@@ -98,6 +100,6 @@ class IOKitEventPublisher
    * consumed by an iterator walk. Do not emit events for this initial seed.
    * The publisher started boolean is set after a successful restart.
    */
-  bool publisher_started_{false};
+  std::atomic<bool> publisher_started_{false};
 };
 }

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -92,44 +92,56 @@ void SCNetworkEventPublisher::addAddress(
 }
 
 void SCNetworkEventPublisher::configure() {
-  for (const auto& sub : subscriptions_) {
-    auto sc = getSubscriptionContext(sub->context);
-    if (sc->type == ADDRESS_TARGET) {
-      auto existing_address = std::find(
-          target_addresses_.begin(), target_addresses_.end(), sc->target);
-      if (existing_address != target_addresses_.end()) {
-        // Add the address target.
-        addAddress(sc);
-      }
-    } else {
-      auto existing_hostname =
-          std::find(target_names_.begin(), target_names_.end(), sc->target);
-      if (existing_hostname != target_names_.end()) {
-        // Add the hostname target.
-        addHostname(sc);
+  // Must stop before clearing contexts.
+  stop();
+
+  {
+    WriteLock lock(mutex_);
+    // Clear all targets.
+    targets_.clear();
+    contexts_.clear();
+    target_names_.clear();
+    target_addresses_.clear();
+
+    for (const auto& sub : subscriptions_) {
+      auto sc = getSubscriptionContext(sub->context);
+      if (sc->type == ADDRESS_TARGET) {
+        auto existing_address = std::find(
+            target_addresses_.begin(), target_addresses_.end(), sc->target);
+        if (existing_address != target_addresses_.end()) {
+          // Add the address target.
+          addAddress(sc);
+        }
+      } else {
+        auto existing_hostname =
+            std::find(target_names_.begin(), target_names_.end(), sc->target);
+        if (existing_hostname != target_names_.end()) {
+          // Add the hostname target.
+          addHostname(sc);
+        }
       }
     }
-  }
 
-  // Make sure at least one target exists.
-  if (targets_.empty()) {
-    auto sc = createSubscriptionContext();
-    sc->type = NAME_TARGET;
-    sc->target = "localhost";
-    addHostname(sc);
+    // Make sure at least one target exists.
+    if (targets_.empty()) {
+      auto sc = createSubscriptionContext();
+      sc->type = NAME_TARGET;
+      sc->target = "localhost";
+      addHostname(sc);
+    }
   }
 
   restart();
 }
 
 void SCNetworkEventPublisher::restart() {
-  stop();
-
   if (run_loop_ == nullptr) {
-    // Cannot schedule.
     return;
   }
 
+  stop();
+
+  WriteLock lock(mutex_);
   for (const auto& target : targets_) {
     SCNetworkReachabilityScheduleWithRunLoop(
         target, run_loop_, kCFRunLoopDefaultMode);
@@ -142,11 +154,13 @@ void SCNetworkEventPublisher::stop() {
     return;
   }
 
+  WriteLock lock(mutex_);
   for (const auto& target : targets_) {
     SCNetworkReachabilityUnscheduleFromRunLoop(
         target, run_loop_, kCFRunLoopDefaultMode);
   }
 
+  // Stop the run loop.
   CFRunLoopStop(run_loop_);
 }
 

--- a/osquery/events/darwin/scnetwork.h
+++ b/osquery/events/darwin/scnetwork.h
@@ -90,10 +90,22 @@ class SCNetworkEventPublisher
                  const SCNetworkReachabilityRef& target);
 
  private:
+  /// Configured hostname targets.
   std::vector<std::string> target_names_;
+
+  /// Configured host address targets.
   std::vector<std::string> target_addresses_;
+
+  /// A container for all reachability targets.
   std::vector<SCNetworkReachabilityRef> targets_;
+
+  /// A target-association context sortage.
   std::vector<SCNetworkReachabilityContext*> contexts_;
+
+  /// This publisher thread's runloop.
   CFRunLoopRef run_loop_{nullptr};
+
+  /// Storage/container operations protection mutex.
+  mutable Mutex mutex_;
 };
 }


### PR DESCRIPTION
Add some consistency to the resource locking and start/configure/restart workflow in OS X's event publishers. We should create a RunLoop-based publisher wrapper the abstracts some of the actions to protect against critical sections with respect to starting the publisher and arbitrarily requesting stoppage or reconfigurations (caused by configuration updates). 