### PR TITLE
Fix shell's --profile switch

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -354,7 +354,7 @@ class RegistryHelperCore : private boost::noncopyable {
 
  protected:
   /// A map of registered plugin instances to their registered identifier.
-  std::map<std::string, std::shared_ptr<Plugin> > items_;
+  std::map<std::string, std::shared_ptr<Plugin>> items_;
 
   /// If aliases are used, a map of alias to item name.
   std::map<std::string, std::string> aliases_;
@@ -781,6 +781,9 @@ class RegistryFactory : private boost::noncopyable {
   /// Calling startExtension should declare the registry external.
   /// This will cause extension-internal events to forward to osquery core.
   bool external_{false};
+
+  /// Protector for broadcast lookups and external registry mutations.
+  mutable Mutex mutex_;
 
  private:
   friend class RegistryHelperCore;

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -105,7 +105,6 @@ volatile std::sig_atomic_t kHandledSignal{0};
 static inline bool isWatcher() { return (osquery::Watcher::getWorker() > 0); }
 
 void signalHandler(int num) {
-
   // Inform exit status of main threads blocked by service joins.
   if (kHandledSignal == 0) {
     kHandledSignal = num;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -131,12 +131,19 @@ void ExtensionManagerWatcher::watch() {
 
   ExtensionStatus status;
   for (const auto& uuid : uuids) {
-    try {
-      auto client = EXClient(getExtensionSocket(uuid));
-      // Ping the extension until it goes down.
-      client.get()->ping(status);
-    } catch (const std::exception& e) {
-      failures_[uuid] += 1;
+    auto path = getExtensionSocket(uuid);
+    if (isWritable(path)) {
+      try {
+        auto client = EXClient(path);
+        // Ping the extension until it goes down.
+        client.get()->ping(status);
+      } catch (const std::exception& e) {
+        failures_[uuid] += 1;
+        continue;
+      }
+    } else {
+      // Immediate fail non-writable paths.
+      failures_[uuid] = 3;
       continue;
     }
 

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <osquery/core.h>
+#include <osquery/database.h>
 #include <osquery/extensions.h>
 #include <osquery/flags.h>
 
@@ -30,6 +31,8 @@ HIDDEN_FLAG(int32,
             profile_delay,
             0,
             "Sleep a number of seconds before and after the profiling");
+
+DECLARE_bool(disable_caching);
 }
 
 int profile(int argc, char *argv[]) {
@@ -47,6 +50,10 @@ int profile(int argc, char *argv[]) {
   if (osquery::FLAGS_profile_delay > 0) {
     ::sleep(osquery::FLAGS_profile_delay);
   }
+
+  // Perform some duplication from Initializer with respect to database setup.
+  osquery::DatabasePlugin::setAllowOpen(true);
+  osquery::Registry::setActive("database", "ephemeral");
 
   auto dbc = osquery::SQLiteDBManager::get();
   for (size_t i = 0; i < static_cast<size_t>(osquery::FLAGS_profile); ++i) {
@@ -82,6 +89,7 @@ int main(int argc, char *argv[]) {
       osquery::FLAGS_L || osquery::FLAGS_profile > 0) {
     // A query was set as a positional argument, via stdin, or profiling is on.
     osquery::FLAGS_disable_events = true;
+    osquery::FLAGS_disable_caching = true;
     // The shell may have loaded table extensions, if not, disable the manager.
     if (!osquery::Watcher::hasManagedExtensions()) {
       osquery::FLAGS_disable_extensions = true;
@@ -94,11 +102,11 @@ int main(int argc, char *argv[]) {
 
     // Virtual tables will be attached to the shell's in-memory SQLite DB.
     retcode = osquery::launchIntoShell(argc, argv);
+    // Finally shutdown.
+    runner.requestShutdown();
   } else {
     retcode = profile(argc, argv);
   }
 
-  // Finally shutdown.
-  runner.requestShutdown();
   return retcode;
 }

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -124,6 +124,9 @@ Status SQLiteSQLPlugin::attach(const std::string& name) {
   }
 
   auto statement = columnDefinition(response);
+  // Attach requests occurring via the plugin/registry APIs must act on the
+  // primary database. To allow this, getConnection can explicitly request the
+  // primary instance and avoid the contention decisions.
   auto dbc = SQLiteDBManager::getConnection(true);
   return attachTableInternal(name, statement, dbc);
 }

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -62,6 +62,11 @@ Status attachTableInternal(const std::string &name,
 /// Detach (drop) a table.
 Status detachTableInternal(const std::string &name, sqlite3 *db);
 
+Status attachFunctionInternal(
+    const std::string &name,
+    std::function<
+        void(sqlite3_context *context, int argc, sqlite3_value **argv)> func);
+
 /// Attach all table plugins to an in-memory SQLite database.
 void attachVirtualTables(const SQLiteDBInstanceRef &instance);
 }


### PR DESCRIPTION
A few of the refactors around database access have left the shell's `--profile` features in a bad state. Current `--profile` on any table implementation requiring database access will SIGSEG the shell.

This PR also fixes some TSAN issues with the shell and the managed/concurrent DB access. When the shell is used with extensions, some of the more-or-less opaque implementation borrowed from the SQLite shell remained unprotected.