### PR TITLE
[Fix #1878] Rename processes 'group' to 'pgroup'

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -263,7 +263,7 @@ QueryData genProcesses(QueryContext &context) {
     proc_cred cred;
     if (getProcCred(pid, cred)) {
       r["parent"] = BIGINT(cred.parent);
-      r["group"] = BIGINT(cred.group);
+      r["pgroup"] = BIGINT(cred.group);
       // check if process state is one of the expected ones
       r["state"] = (1 <= cred.status && cred.status <= 5)
                        ? TEXT(kProcessStateMapping[cred.status])

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -249,7 +249,7 @@ void genProcess(const std::string& pid, QueryData& results) {
   r["parent"] = proc_stat.parent;
   r["path"] = readProcLink("exe", pid);
   r["name"] = proc_stat.name;
-  r["group"] = proc_stat.group;
+  r["pgroup"] = proc_stat.group;
   r["state"] = proc_stat.state;
   r["nice"] = proc_stat.nice;
   // Read/parse cmdline arguments.

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -24,7 +24,7 @@ schema([
     Column("start_time", BIGINT,
         "Process start in seconds since boot (non-sleeping)"),
     Column("parent", BIGINT, "Process parent's PID"),
-    Column("group", BIGINT, "Process group"),
+    Column("pgroup", BIGINT, "Process group"),
     Column("nice", INTEGER, "Process nice level (-20 to 20, default 0)"),
 ])
 implementation("system/processes@genProcesses")


### PR DESCRIPTION
`group` is a reserved term in SQLite, explicitly selecting or including this column in a predicate has confusing usage requirements. If we use `pgroup` then there's no need to name-escape the column.