### PR TITLE
Protect udev publisher from fast interrupts

### DIFF
--- a/osquery/dispatcher/dispatcher.h
+++ b/osquery/dispatcher/dispatcher.h
@@ -185,6 +185,19 @@ class Dispatcher : private boost::noncopyable {
   // Protection around double joins.
   mutable Mutex join_mutex_;
 
+  /**
+   * @brief Signal to the Dispatcher that no services should be created.
+   *
+   * The Dispatcher will not add services if it is shutting down until
+   * a join has completed of existing services.
+   *
+   * This prevents a very strange race where the dispatcher is signaled to
+   * abort or interrupt and serviced are sill waiting to be added.
+   * A future join will be requested AFTER all services were expected to have
+   * been interrupted.
+   */
+  std::atomic<bool> stopping_{false};
+
  private:
   friend class ExtensionsTest;
 };

--- a/osquery/events/linux/udev.h
+++ b/osquery/events/linux/udev.h
@@ -112,7 +112,12 @@ class UdevEventPublisher
  private:
   /// udev handle (socket descriptor contained within).
   struct udev* handle_{nullptr};
+
+  /// udev monitor.
   struct udev_monitor* monitor_{nullptr};
+
+  /// Protection around udev resources.
+  Mutex mutex_;
 
  private:
   /// Check subscription details.


### PR DESCRIPTION
This actually hardens both the platform and specifically the UDEV publisher from fast terminations. There are several tests that stress the speed at which osquery may be interrupted. If interrupted too quickly the `Dispatcher` facilities may cause an ABRT hang (for several additional seconds) as services can be added to the monitor AFTER a stop/interruption event is requested. This causes the main thread to join services that will never be interrupted.