### PR TITLE
Move dispatcher to public API

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <osquery/core.h>
+#include <osquery/dispatcher.h>
 #include <osquery/registry.h>
 #include <osquery/status.h>
 #include <osquery/tables.h>
@@ -172,7 +173,7 @@ struct Subscription : private boost::noncopyable {
   Subscription() = delete;
 };
 
-class EventPublisherPlugin : public Plugin {
+class EventPublisherPlugin : public Plugin, public InterruptableRunnable {
  public:
   /**
    * @brief A new Subscription was added, potentially change state based on all
@@ -220,7 +221,7 @@ class EventPublisherPlugin : public Plugin {
    * run loop manager will exit the stepping loop and fall through to a call
    * to tearDown followed by a removal of the publisher.
    */
-  virtual void stop() {}
+  virtual void stop() override {}
 
   /**
    * @brief A new EventSubscriber is subscribing events of this publisher type.
@@ -952,9 +953,6 @@ class EventSubscriber : public EventSubscriberPlugin {
 /// Iterate the event publisher registry and create run loops for each using
 /// the event factory.
 void attachEvents();
-
-/// Sleep in a std::thread interruptible state.
-void publisherSleep(size_t milli);
 
 CREATE_REGISTRY(EventPublisherPlugin, "event_publisher");
 CREATE_REGISTRY(EventSubscriberPlugin, "event_subscriber");

--- a/osquery/config/plugins/tls.cpp
+++ b/osquery/config/plugins/tls.cpp
@@ -15,12 +15,12 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <osquery/config.h>
+#include <osquery/dispatcher.h>
 #include <osquery/enroll.h>
 #include <osquery/flags.h>
 #include <osquery/registry.h>
 
 #include "osquery/core/conversions.h"
-#include "osquery/dispatcher/dispatcher.h"
 #include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"
 #include "osquery/remote/utility.h"

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -22,6 +22,7 @@
 
 #include <osquery/config.h>
 #include <osquery/core.h>
+#include <osquery/dispatcher.h>
 #include <osquery/events.h>
 #include <osquery/extensions.h>
 #include <osquery/filesystem.h>
@@ -30,7 +31,6 @@
 #include <osquery/registry.h>
 
 #include "osquery/core/watcher.h"
-#include "osquery/dispatcher/dispatcher.h"
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -21,7 +21,6 @@
 #include <osquery/sql.h>
 
 #include "osquery/core/watcher.h"
-#include "osquery/dispatcher/dispatcher.h"
 
 extern char** environ;
 

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -17,9 +17,8 @@
 
 #include <boost/noncopyable.hpp>
 
+#include <osquery/dispatcher.h>
 #include <osquery/flags.h>
-
-#include "osquery/dispatcher/dispatcher.h"
 
 /// Define a special debug/testing watchdog level.
 #define WATCHDOG_LEVEL_DEBUG 3

--- a/osquery/dispatcher/distributed.h
+++ b/osquery/dispatcher/distributed.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "osquery/dispatcher/dispatcher.h"
+#include <osquery/dispatcher.h>
 
 namespace osquery {
 

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -12,7 +12,7 @@
 
 #include <map>
 
-#include "osquery/dispatcher/dispatcher.h"
+#include <osquery/dispatcher.h>
 
 namespace osquery {
 

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -8,11 +8,9 @@
  *
  */
 
-#include <boost/make_shared.hpp>
-
 #include <gtest/gtest.h>
 
-#include "osquery/dispatcher/dispatcher.h"
+#include <osquery/dispatcher.h>
 
 namespace osquery {
 

--- a/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
+++ b/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
@@ -14,7 +14,8 @@
 
 #include <benchmark/benchmark.h>
 
-#include "osquery/dispatcher/dispatcher.h"
+#include <osquery/dispatcher.h>
+
 #include "osquery/events/kernel.h"
 
 namespace osquery {

--- a/osquery/events/kernel/tests/kernel_communication_tests.cpp
+++ b/osquery/events/kernel/tests/kernel_communication_tests.cpp
@@ -16,7 +16,8 @@
 
 #include <gtest/gtest.h>
 
-#include "osquery/dispatcher/dispatcher.h"
+#include <osquery/dispatcher.h>
+
 #include "osquery/events/kernel.h"
 
 namespace osquery {

--- a/osquery/events/linux/audit.cpp
+++ b/osquery/events/linux/audit.cpp
@@ -328,7 +328,7 @@ Status AuditEventPublisher::run() {
   }
 
   // Only apply a cool down if the reply request failed.
-  osquery::publisherSleep(kAuditMLatency);
+  pauseMilli(kAuditMLatency);
   return Status(0, "OK");
 }
 

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -187,7 +187,7 @@ Status INotifyEventPublisher::run() {
     p += (sizeof(struct inotify_event)) + event->len;
   }
 
-  osquery::publisherSleep(kINotifyMLatency);
+  pauseMilli(kINotifyMLatency);
   return Status(0, "OK");
 }
 
@@ -237,8 +237,8 @@ bool INotifyEventPublisher::shouldFire(const INotifySubscriptionContextRef& sc,
 
   // inotify will not monitor recursively, new directories need watches.
   if (sc->recursive && ec->action == "CREATED" && isDirectory(ec->path)) {
-    const_cast<INotifyEventPublisher*>(this)->addMonitor(
-        ec->path + '/', sc->mask, true);
+    const_cast<INotifyEventPublisher*>(this)
+        ->addMonitor(ec->path + '/', sc->mask, true);
   }
 
   return true;

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -96,7 +96,7 @@ Status UdevEventPublisher::run() {
 
   udev_device_unref(device);
 
-  osquery::publisherSleep(kUdevMLatency);
+  pauseMilli(kUdevMLatency);
   return Status(0, "OK");
 }
 

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -10,9 +10,8 @@
 
 #pragma once
 
+#include <osquery/dispatcher.h>
 #include <osquery/extensions.h>
-
-#include "osquery/dispatcher/dispatcher.h"
 
 // osquery is built with various versions of thrift that use different search
 // paths for their includes. Unfortunately, changing include paths is not

--- a/osquery/logger/plugins/tls.h
+++ b/osquery/logger/plugins/tls.h
@@ -10,9 +10,8 @@
 
 #pragma once
 
+#include <osquery/dispatcher.h>
 #include <osquery/logger.h>
-
-#include "osquery/dispatcher/dispatcher.h"
 
 namespace osquery {
 


### PR DESCRIPTION
By breaking the "interruptable" portion of internal runnables into its own set of traits, we can reuse the fast-interruption within event publishers. This results in faster tear down for the publishers on Linux. There is repeated code within the event publisher implementation and internal runnables w.r.t. start and stop state which can be removed (or unified) later.