### PR TITLE
Inconsistant Pathing for Flags File

### DIFF
--- a/tools/deployment/com.facebook.osqueryd.plist
+++ b/tools/deployment/com.facebook.osqueryd.plist
@@ -11,7 +11,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/usr/local/bin/osqueryd</string>
-    <string> --flagfile="/var/osquery/osquery.flags"</string>
+    <string> --flagfile="/private/var/osquery/osquery.flags"</string>
   </array>
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
When I added the flag file switch it was aimed at `/var/osquery`, but the package is built such that everything exists in `/private/var/osquery`. This simply makes this more consistent.