### PR TITLE
[Fix #1962] Clear cache of distributed query results after flush

### DIFF
--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -152,9 +152,13 @@ Status Distributed::flushCompleted() {
   }
 
   PluginResponse response;
-  return Registry::call("distributed",
-                        {{"action", "writeResults"}, {"results", results}},
-                        response);
+  s = Registry::call("distributed",
+                     {{"action", "writeResults"}, {"results", results}},
+                     response);
+  if (s.ok()) {
+    results_.clear();
+  }
+  return s;
 }
 
 Status Distributed::acceptWork(const std::string& work) {

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -183,6 +183,6 @@ TEST_F(DistributedTests, test_workflow) {
   EXPECT_EQ(s.toString(), "OK");
 
   EXPECT_EQ(dist.getPendingQueryCount(), 0U);
-  EXPECT_EQ(dist.results_.size(), 2U);
+  EXPECT_EQ(dist.results_.size(), 0U);
 }
 }


### PR DESCRIPTION
If the distributed plugin's `writeResults` method can be successfully
called, we must clear the local vector of results so that we're not
constantly growing it over time.