### PR TITLE
systemd properly supervised

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -9,9 +9,6 @@ PIDFile=/var/run/osqueryd.pid
 EnvironmentFile=/etc/sysconfig/osqueryd
 ExecStartPre=/bin/sh -c "if [[ ! -f $FLAG_FILE ]]; then touch $FLAG_FILE; fi"
 ExecStart=/usr/bin/osqueryd \
-  --force \
-  --pidfile /var/run/osqueryd.pid \
-  --daemonize \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE
 Restart=on-abort


### PR DESCRIPTION
Basically you're not supposed to daemonize with systemd, ever. Type=forking is meant as a backwards compatibility thing for services that can't not daemonize, but it's unreliable and you end up not supervising the process correctly, which leads to issues like systemd thinking you're dead when you're not and restarting, or osquery dying and systemd not noticing and not restarting it.