### PR TITLE
[Fix #1973] Improve logging/extensions relays

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -292,7 +292,9 @@ bool WatcherRunner::isChildSane(pid_t child) {
 
   // The worker is sane, no action needed.
   // Attempt to flush status logs to the well-behaved worker.
-  relayStatusLogs();
+  if (use_worker_) {
+    relayStatusLogs();
+  }
   return true;
 }
 

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -138,11 +138,15 @@ TEST_F(LoggerTests, test_log_string) {
   // plugin that has not been added to the registry.
   EXPECT_FALSE(logString("{\"json\": true}", "event", "does_not_exist"));
 
-  // Expect the plugin to receive logs if status logging is disabled.
+  // Expect the plugin not to receive logs if status logging is disabled.
   FLAGS_disable_logging = true;
   EXPECT_TRUE(logString("test", "event"));
-  EXPECT_EQ(LoggerTests::log_lines.size(), 2U);
+  EXPECT_EQ(LoggerTests::log_lines.size(), 1U);
   FLAGS_disable_logging = false;
+
+  // If logging is re-enabled, logs should send as usual.
+  EXPECT_TRUE(logString("test", "event"));
+  EXPECT_EQ(LoggerTests::log_lines.size(), 2U);
 }
 
 TEST_F(LoggerTests, test_logger_log_status) {


### PR DESCRIPTION
1. Only attempt to relay status logs if the process is a watcher. The responsible thread is overloaded to also monitor autoloaded extensions.
2. Only re-enable buffering of status logs if the sink was enabled before the disabler (odd-style of log lock) was requested.
3. Fail fast for the logging methods if logging is disabled. This will prevent weird error messages when a plugin cannot be found, as in most cases the logging disabling is *very* much related.