### PR TITLE
Treating the disabled plugins as a folder

### DIFF
--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -11,6 +11,7 @@ schema([
     Column("development_region", TEXT, "Plugin language-localization"),
     Column("native", INTEGER, "Plugin requires native execution"),
     Column("path", TEXT, "Path to plugin bundle"),
+    Column("disabled", INTEGER, "Is the plugin disabled. 1 = Disabled"),
     ForeignKey(column="uid", table="users")
 ])
 attributes(user_data=True)


### PR DESCRIPTION
Changed the browser_plugins table to iterate through the Disabled folder, so that the disabled folder is no longer treated like a plugin.  Additionally added a 'disabled' flag to the table which correlates with plugins living in the disabled folder.