### PR TITLE
Migrate from Open Code of Conduct to Contributor Covenant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,4 +184,14 @@ It's worth noting that you should exercise caution when copying code of any kind
 
 ## Code of Conduct
 
-This project adheres to the [Open Code of Conduct](http://todogroup.org/opencodeofconduct/#osquery/osquery@fb.com). By participating, you are expected to honor this code.
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)


### PR DESCRIPTION
The Open Code of Conduct is no longer maintained or supported. Many
other projects have found success with Contributor Covenant and it's
quickly becoming a standard. This PR migrates osquery's code of conduct
to use Contributor Covenant.