### PR TITLE
Add build support for Scientific Linux

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -101,6 +101,12 @@ elseif(LINUX)
         "${PACKAGE_DEPENDENCIES}"
         "libudev"
       )
+    elseif(OSQUERY_BUILD_DISTRO STREQUAL "scientific6")
+      set(PACKAGE_ITERATION "1.el6")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+        "libudev"
+      )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "oracle6")
       set(PACKAGE_ITERATION "1.oel6")
       set(PACKAGE_DEPENDENCIES
@@ -114,6 +120,11 @@ elseif(LINUX)
       )
     elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel7")
       set(PACKAGE_ITERATION "1.rhel7")
+      set(PACKAGE_DEPENDENCIES
+        "${PACKAGE_DEPENDENCIES}"
+      )
+    elseif(OSQUERY_BUILD_DISTRO STREQUAL "scientific7")
+      set(PACKAGE_ITERATION "1.el7")
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
       )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(OSQUERY_REQUIRE_RUNTIMES
   "lucid"
   "precise"
   "centos6"
+  "scientific6"
   "rhel6"
   "oracle6"
   "wheezy"
@@ -287,6 +288,10 @@ elseif(OSQUERY_BUILD_PLATFORM STREQUAL "centos")
   set(REDHAT_BASED TRUE)
   set(CENTOS TRUE)
   LOG_PLATFORM("CentOS")
+elseif(OSQUERY_BUILD_PLATFORM STREQUAL "scientific")
+  set(REDHAT_BASED TRUE)
+  set(SCIENTIFIC TRUE)
+  LOG_PLATFORM("Scientific Linux")
 elseif(OSQUERY_BUILD_PLATFORM STREQUAL "rhel")
   set(REDHAT_BASED TRUE)
   set(RHEL TRUE)
@@ -307,7 +312,7 @@ elseif(OSQUERY_BUILD_PLATFORM STREQUAL "windows")
   LOG_PLATFORM("Windows")
 endif()
 
-if("${OSQUERY_BUILD_DISTRO}" MATCHES "^(centos|rhel|oracle)7$")
+if("${OSQUERY_BUILD_DISTRO}" MATCHES "^(centos|rhel|scientific|oracle)7$")
   # Useful for libudev version detection.
   set(SYSTEMD TRUE)
 endif()

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -61,7 +61,8 @@ if(APPLE)
 elseif(LINUX OR FREEBSD)
   ADD_OSQUERY_LINK_CORE("-Wl,-zrelro -Wl,-znow")
   if(NOT ${OSQUERY_BUILD_DISTRO} STREQUAL "rhel6" AND
-     NOT ${OSQUERY_BUILD_DISTRO} STREQUAL "centos6")
+     NOT ${OSQUERY_BUILD_DISTRO} STREQUAL "centos6" AND
+     NOT ${OSQUERY_BUILD_DISTRO} STREQUAL "scientific6")
     ADD_OSQUERY_LINK_CORE("-Wl,--gc-sections")
   endif()
   ADD_OSQUERY_LINK_CORE("librt.so")

--- a/osquery/tables/system/centos/rpm_packages.cpp
+++ b/osquery/tables/system/centos/rpm_packages.cpp
@@ -147,7 +147,7 @@ QueryData genRpmPackageFiles(QueryContext& context) {
       r["mode"] = lsperms(rpmfiFMode(fi));
       r["size"] = BIGINT(rpmfiFSize(fi));
 
-#if defined(CENTOS_CENTOS6) || defined(RHEL_RHEL6)
+#if defined(CENTOS_CENTOS6) || defined(RHEL_RHEL6) || defined(SCIENTIFIC_SCIENTIFIC6)
       // Older versions of rpmlib/rpmip use a hash algorithm enum.
       pgpHashAlgo digest_algo;
 #else

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -43,7 +43,7 @@ void genFDEStatusForBlockDevice(const std::string &name,
     r["encrypted"] = "1";
 
     int crypt_init;
-#if defined(CENTOS_CENTOS6) || defined(RHEL_RHEL6)
+#if defined(CENTOS_CENTOS6) || defined(RHEL_RHEL6) || defined(SCIENTIFIC_SCIENTIFIC6)
     crypt_init = crypt_init_by_name(&cd, name.c_str());
 #else
     crypt_init =

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -20,6 +20,9 @@ function platform() {
   elif [[ -n `grep -o "CentOS" $SYSTEM_RELEASE 2>/dev/null` ]]; then
     FAMILY="redhat"
     eval $__out="centos"
+  elif [[ -n `grep -o "Scientific Linux" $SYSTEM_RELEASE 2>/dev/null` ]]; then
+    FAMILY="redhat"
+    eval $__out="scientific"
   elif [[ -n `grep -o "Red Hat Enterprise" $SYSTEM_RELEASE 2>/dev/null` ]]; then
     FAMILY="redhat"
     eval $__out="rhel"
@@ -54,6 +57,8 @@ function distro() {
     eval $__out=`grep -o "release [5-7]" $SYSTEM_RELEASE | sed 's/release /oracle/g'`
   elif [[ $1 = "centos" ]]; then
     eval $__out=`grep -o "release [6-7]" $SYSTEM_RELEASE | sed 's/release /centos/g'`
+  elif [[ $1 = "scientific" ]]; then
+    eval $__out=`grep -o "release [6-7]" $SYSTEM_RELEASE | sed 's/release /scientific/g'`
   elif [[ $1 = "rhel" ]]; then
     eval $__out=`grep -o "release [6-7]" $SYSTEM_RELEASE | sed 's/release /rhel/g'`
   elif [[ $1 = "amazon" ]]; then

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -55,6 +55,10 @@ function main() {
     log "detected centos ($DISTRO)"
     source "$SCRIPT_DIR/provision/centos.sh"
     main_centos
+  elif [[ $OS = "scientific" ]]; then
+    log "detected scientific linux ($DISTRO)"
+    source "$SCRIPT_DIR/provision/scientific.sh"
+    main_scientific
   elif [[ $OS = "rhel" ]]; then
     log "detected rhel ($DISTRO)"
     source "$SCRIPT_DIR/provision/rhel.sh"

--- a/tools/provision/files/scientific6.devtoolset.repo
+++ b/tools/provision/files/scientific6.devtoolset.repo
@@ -1,0 +1,10 @@
+[devtoolset]
+Name=Scientific Linux devtoolset - $basearch
+baseurl=http://ftp.scientificlinux.org/linux/scientific/6x/external_products/devtoolset/$basearch/
+        http://ftp1.scientificlinux.org/linux/scientific/6x/external_products/devtoolset/$basearch/
+        http://ftp2.scientificlinux.org/linux/scientific/6x/external_products/devtoolset/$basearch/
+
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl6
+

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+function main_scientific() {
+  sudo yum update -y
+  package epel-release -y
+
+  package texinfo
+  package wget
+  package git-all
+  package unzip
+  package xz
+  package xz-devel
+  package python-pip
+  package python-devel
+  package rpm-build
+  package ruby
+  package ruby-devel
+  package rubygems
+  package bzip2
+  package bzip2-devel
+  package openssl-devel
+  package readline-devel
+  package rpm-devel
+  package libblkid-devel
+
+  if [[ $DISTRO = "scientific6" ]]; then
+    # Install the SL6 Devtools-2 yum repository.
+    sudo cp $FILES_DIR/scientific6.devtoolset.repo /etc/yum.repos.d/
+
+    package devtoolset-2-gcc
+    package devtoolset-2-binutils
+    package devtoolset-2-gcc-c++
+
+    if [[ ! -e /usr/bin/gcc ]]; then
+      sudo ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /usr/bin/gcc
+    fi
+    if [[ ! -e /usr/bin/g++ ]]; then
+      sudo ln -s /opt/rh/devtoolset-2/root/usr/bin/gcc /usr/bin/g++
+    fi
+
+    source /opt/rh/devtoolset-2/enable
+    if [[ ! -d /usr/lib/gcc ]]; then
+      sudo ln -s /opt/rh/devtoolset-2/root/usr/lib/gcc /usr/lib/
+    fi
+  elif [[ $DISTRO = "scientific7" ]]; then
+    package gcc
+    package binutils
+    package gcc-c++
+  fi
+
+  package clang
+  package clang-devel
+
+  install_cmake
+
+  set_cc clang
+  set_cxx clang++
+
+  if [[ $DISTRO = "scientific6" ]]; then
+    package libudev-devel
+  fi
+
+  package doxygen
+  package byacc
+  package flex
+
+  if [[ $DISTRO = "scientific6" ]]; then
+    remove_package autoconf
+    remove_package automake
+    remove_package libtool
+
+    export M4="/usr/bin/m4"
+    install_autoconf
+    install_automake
+    install_libtool
+
+    install_bison
+
+    package file-libs
+  elif [[ $DISTRO = "scientific7" ]]; then
+    package autoconf
+    package automake
+    package libtool
+    package file-devel
+    package systemd-devel
+    package bison
+  fi
+
+  install_boost
+  install_gflags
+  install_glog
+  install_google_benchmark
+
+  install_snappy
+  install_rocksdb
+  install_thrift
+  install_yara
+  install_asio
+  install_cppnetlib
+  install_sleuthkit
+
+  # Device mapper uses the exact version as the ABI.
+  # We will build and install a static version.
+  remove_package device-mapper-devel
+  install_device_mapper
+
+  package libgcrypt-devel
+  package gettext-devel
+  install_libcryptsetup
+  install_iptables_dev
+
+  package audit-libs-devel
+  package audit-libs-static
+
+  gem_install fpm
+}


### PR DESCRIPTION
Scientific Linux is a derivative of RHEL, and is very similar to CentOS. I added the appropriate provision script, based on the CentOS provision script, to allow for building on Scientific Linux. The main difference between the two is that it uses SL's devtools repository instead of the CentOS one, primarily so that the package signature verification works properly.