### PR TITLE
Add type safe dispatcher pause APIs

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <memory>
 #include <thread>
@@ -33,7 +34,10 @@ class RunnerInterruptPoint : private boost::noncopyable {
   void cancel();
 
   /// Pause until the requested millisecond delay has elapsed or a cancel.
-  void pause(size_t milli);
+  void pause(size_t milli) { pause(std::chrono::milliseconds(milli)); }
+
+  /// Pause until the requested millisecond delay has elapsed or a cancel.
+  void pause(std::chrono::milliseconds milli);
 
  private:
   /// Communicate between the pause and cancel event.
@@ -63,10 +67,15 @@ class InterruptableRunnable {
   virtual void stop() = 0;
 
   /// Put the runnable into an interruptible sleep.
-  virtual void pause() { pauseMilli(100); }
+  virtual void pause() { pauseMilli(std::chrono::milliseconds(100)); }
 
   /// Put the runnable into an interruptible sleep.
-  virtual void pauseMilli(size_t milli);
+  virtual void pauseMilli(size_t milli) {
+    pauseMilli(std::chrono::milliseconds(milli));
+  }
+
+  /// Put the runnable into an interruptible sleep.
+  virtual void pauseMilli(std::chrono::milliseconds milli);
 
  private:
   /**

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -36,11 +36,9 @@ void RunnerInterruptPoint::cancel() {
 }
 
 /// Pause until the requested millisecond delay has elapsed or a cancel.
-void RunnerInterruptPoint::pause(size_t milli) {
+void RunnerInterruptPoint::pause(std::chrono::milliseconds milli) {
   std::unique_lock<std::mutex> lock(mutex_);
-  if (stop_ ||
-      condition_.wait_for(lock, std::chrono::milliseconds(milli)) ==
-          std::cv_status::no_timeout) {
+  if (stop_ || condition_.wait_for(lock, milli) == std::cv_status::no_timeout) {
     stop_ = false;
     throw RunnerInterruptError();
   }
@@ -62,7 +60,7 @@ bool InterruptableRunnable::interrupted() {
   return interrupted_;
 }
 
-void InterruptableRunnable::pauseMilli(size_t milli) {
+void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
   try {
     point_.pause(milli);
   } catch (const RunnerInterruptError&) {


### PR DESCRIPTION
These APIs using std::chrono::duration allow us to take advantage of
automatic time conversion and type safety among different units of time.
No changes were made to existing call sites.