### PR TITLE
Add time column to shell_history table

### DIFF
--- a/osquery/tables/system/shell_history.cpp
+++ b/osquery/tables/system/shell_history.cpp
@@ -32,8 +32,11 @@ const std::vector<std::string> kShellHistoryFiles = {
 void genShellHistoryForUser(const std::string& uid,
                             const std::string& directory,
                             QueryData& results) {
-  auto timestamp_rx = xp::sregex::compile("^#(?P<timestamp>[0-9]+)$");
-  xp::smatch timestamp_matches;
+  auto bash_timestamp_rx = xp::sregex::compile("^#(?P<timestamp>[0-9]+)$");
+  xp::smatch bash_timestamp_matches;
+  auto zsh_timestamp_rx = xp::sregex::compile(
+      "^: {0,10}(?P<timestamp>[0-9]{1,11}):[0-9]+;(?P<command>.*)$");
+  xp::smatch zsh_timestamp_matches;
 
   for (const auto& hfile : kShellHistoryFiles) {
     boost::filesystem::path history_file = directory;
@@ -45,23 +48,29 @@ void genShellHistoryForUser(const std::string& uid,
       continue;
     }
 
-    std::string prev_timestamp;
+    std::string prev_bash_timestamp;
     for (const auto& line : split(history_content, "\n")) {
-      if (prev_timestamp.empty() &&
-          xp::regex_search(line, timestamp_matches, timestamp_rx)) {
-        prev_timestamp = timestamp_matches["timestamp"];
+      if (prev_bash_timestamp.empty() &&
+          xp::regex_search(line, bash_timestamp_matches, bash_timestamp_rx)) {
+        prev_bash_timestamp = bash_timestamp_matches["timestamp"];
         continue;
       }
 
       Row r;
 
-      if (!prev_timestamp.empty()) {
-        r["time"] = INTEGER(prev_timestamp);
-        prev_timestamp.clear();
+      if (!prev_bash_timestamp.empty()) {
+        r["time"] = INTEGER(prev_bash_timestamp);
+        r["command"] = line;
+        prev_bash_timestamp.clear();
+      } else if (xp::regex_search(
+                     line, zsh_timestamp_matches, zsh_timestamp_rx)) {
+        r["time"] = INTEGER(zsh_timestamp_matches["timestamp"]);
+        r["command"] = zsh_timestamp_matches["command"];
+      } else {
+        r["command"] = line;
       }
 
       r["uid"] = uid;
-      r["command"] = line;
       r["history_file"] = history_file.string();
       results.push_back(r);
     }

--- a/specs/shell_history.table
+++ b/specs/shell_history.table
@@ -2,6 +2,7 @@ table_name("shell_history")
 description("A line-delimited (command) table of per-user .*_history data.")
 schema([
     Column("uid", BIGINT, "Shell history owner", additional=True),
+    Column("time", INTEGER, "Entry timestamp"),
     Column("command", TEXT, "Unparsed date/line/command history line"),
     Column("history_file", TEXT, "Path to the .*_history for this user"),
     ForeignKey(column="uid", table="users"),


### PR DESCRIPTION
Bash can be configured to include timestamps in the bash_history file. If enabled, the resulting history file would look something like this:
```
#1459654091
ls
#1459654139
pwd
#1459654234
echo "hello world"
```
The timestamp, if present, would be in Unix time format preceded by a # character on the line above the command that it applies to. A simple way to enable this is to run `export HISTTIMEFORMAT="%F %T"`.

If available, this information is very useful to have. The shell_history table currently considers these timestamp lines to be commands, which gets annoying with this configured across a large fleet. This change checks for this timestamp and adds it to a new "time" column if present.
```
osquery> select time, command from shell_history;
+------------+--------------------+
| time       | command            |
+------------+--------------------+
| 1459654091 | ls                 |
| 1459654139 | pwd                |
| 1459654234 | echo "hello world" |
+------------+--------------------+
osquery> select datetime(time, 'unixepoch', 'localtime') as datetime, command from shell_history;
+---------------------+--------------------+
| datetime            | command            |
+---------------------+--------------------+
| 2016-04-02 20:28:11 | ls                 |
| 2016-04-02 20:28:59 | pwd                |
| 2016-04-02 20:30:34 | echo "hello world" |
+---------------------+--------------------+
```