### PR TITLE
Add detection for OSX Pirrit

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -230,6 +230,12 @@
       "interval": "86400",
       "description": "(https://www.virustotal.com/en/file/9530d481f7bb07aac98a46357bfcff96e2936a90571b4629ae865a2ce63e5c8e/analysis/1458973247/)",
       "value": "Artifact used by this malware"
+    },
+    "OSX_Pirrit": {
+      "query": "select * from preferences where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
+      "interval": "86400",
+      "description": "(https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/)",
+      "value": "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
See: https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/

Someone also wrote a removal script for it:
https://github.com/aserper/osx.pirrit_removal/blob/master/remove_pirrit.sh