### PR TITLE
[Fix #2030] Add generate_foreign and --enable_foreign

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -156,7 +156,10 @@ if(NOT ${OSQUERY_BUILD_SDK_ONLY})
   # Generate the osquery additional tables (the non-util).
   GENERATE_TABLES("${CMAKE_SOURCE_DIR}")
   AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
+  AMALGAMATE("${CMAKE_SOURCE_DIR}" "foreign" AMALGAMATION_FOREIGN)
   ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_foreign_amalgamation ${AMALGAMATION_FOREIGN})
+
 
   # Create the static libosquery_additional.
   add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -344,6 +344,8 @@ def main(argc, argv):
         "--debug", default=False, action="store_true",
         help="Output debug messages (when developing)"
     )
+    parser.add_argument("--foreign", default=False, action="store_true",
+        help="Generate a foreign table")
     parser.add_argument("--templates", default=SCRIPT_DIR + "/templates",
                         help="Path to codegen output .cpp.in templates")
     parser.add_argument("spec_file", help="Path to input .table spec file")
@@ -355,12 +357,8 @@ def main(argc, argv):
     else:
         logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
 
-    if argc < 3:
-        usage()
-        sys.exit(1)
     filename = args.spec_file
     output = args.output
-
     if filename.endswith(".table"):
         # Adding a 3rd parameter will enable the blacklist
         disable_blacklist = argc > 3
@@ -373,7 +371,8 @@ def main(argc, argv):
             if not disable_blacklist and blacklisted:
                 table.blacklist(output)
             else:
-                table.generate(output)
+                template_type = "default" if not args.foreign else "foreign"
+                table.generate(output, template=template_type)
 
 if __name__ == "__main__":
     SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))

--- a/tools/codegen/templates/amalgamation.cpp.in
+++ b/tools/codegen/templates/amalgamation.cpp.in
@@ -18,7 +18,13 @@
 
 
 namespace osquery {
+{% if foreign %}
+void registerForeignTables() {
+{% endif %}
 {% for table in tables %}
 {{table}}
 {% endfor %}
+{% if foreign %}
+}
+{% endif %}
 }

--- a/tools/codegen/templates/foreign.cpp.in
+++ b/tools/codegen/templates/foreign.cpp.in
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*
+** This file is generated. Do not modify it manually!
+*/
+
+#include <osquery/events.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+auto {{table_name_cc}}Register = []() {
+/// BEGIN[GENTABLE]
+  class {{table_name_cc}}TablePlugin : public TablePlugin {
+   private:
+    TableColumns columns() const {
+      return {
+{% for column in schema %}\
+        {"{{column.name}}", {{column.type.affinity}}}\
+{% if not loop.last %}, {% endif %}
+{% endfor %}\
+      };
+    }
+
+    QueryData generate(QueryContext& request) { return QueryData(); }
+  };
+
+  Registry::add<{{table_name_cc}}TablePlugin>("table", "{{table_name}}");
+/// END[GENTABLE]
+};
+
+}
+}


### PR DESCRIPTION
This adds all table specs to all osquery binaries, regardless of platform. This allows for an opaque `--enable_foriegn` switch to start the binary with the foreign specs, which have no backing implementation. These tables will appear as virtual tables but will never return row data.