### PR TITLE
Reset configuration state in relative tests

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -314,7 +314,9 @@ class Config : private boost::noncopyable {
   friend class FilePathsConfigParserPluginTests;
   friend class FileEventsTableTests;
   friend class DecoratorsConfigParserPluginTests;
+  friend class SchedulerTests;
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
+  FRIEND_TEST(EventsConfigParserPluginTests, test_get_event);
   FRIEND_TEST(PacksTests, test_discovery_cache);
   FRIEND_TEST(SchedulerTests, test_monitor);
   FRIEND_TEST(SchedulerTests, test_config_results_purge);
@@ -468,13 +470,30 @@ class ConfigParserPlugin : public Plugin {
   virtual Status update(const std::string& source,
                         const ParserConfig& config) = 0;
 
+  /// Allow parsers to perform some setup before the configuration is loaded.
   Status setUp() override;
 
+  /**
+   * @brief Accessor for parser-manipulated data.
+   *
+   * Parsers should be used generically, for places within the code base that
+   * request a parser (check for its existence), should only use this ::getData
+   * accessor.
+   *
+   * More complex parsers that require dynamic casting are not recommended.
+   */
   const boost::property_tree::ptree& getData() const { return data_; }
+
+ protected:
+  /// Allow the config to request parser state resets.
+  virtual void reset();
 
  protected:
   /// Allow the config parser to keep some global state.
   boost::property_tree::ptree data_;
+
+ private:
+  friend class Config;
 };
 
 /**

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -583,6 +583,27 @@ void Config::reset() {
   valid_ = false;
   loaded_ = false;
   start_time_ = 0;
+
+  // Also request each parse to reset state.
+  for (const auto& plugin : Registry::all("config_parser")) {
+    std::shared_ptr<ConfigParserPlugin> parser = nullptr;
+    try {
+      parser = std::dynamic_pointer_cast<ConfigParserPlugin>(plugin.second);
+    } catch (const std::bad_cast& e) {
+      continue;
+    }
+    if (parser == nullptr || parser.get() == nullptr) {
+      continue;
+    }
+    parser->reset();
+  }
+}
+
+void ConfigParserPlugin::reset() {
+  // Resets will clear all top-level keys from the parser's data store.
+  for (auto& category : data_) {
+    boost::property_tree::ptree().swap(category.second);
+  }
 }
 
 void Config::recordQueryPerformance(const std::string& name,

--- a/osquery/config/parsers/decorators.cpp
+++ b/osquery/config/parsers/decorators.cpp
@@ -65,6 +65,9 @@ class DecoratorsConfigParserPlugin : public ConfigParserPlugin {
   /// Clear the decorations created from decorators for the given source.
   void clearSources(const std::string& source);
 
+  /// Clear all decorations.
+  virtual void reset() override;
+
  public:
   /// Set of configuration sources to the set of decorator queries.
   std::map<std::string, std::vector<std::string>> always_;
@@ -110,9 +113,25 @@ Status DecoratorsConfigParserPlugin::update(const std::string& source,
 void DecoratorsConfigParserPlugin::clearSources(const std::string& source) {
   // Reset the internal data store.
   WriteLock lock(DecoratorsConfigParserPlugin::kDecorationsMutex);
-  intervals_[source].clear();
-  always_[source].clear();
-  load_[source].clear();
+  if (intervals_.count(source) > 0) {
+    intervals_[source].clear();
+  }
+
+  if (always_.count(source) > 0) {
+    always_[source].clear();
+  }
+
+  if (load_.count(source) > 0) {
+    load_[source].clear();
+  }
+}
+
+void DecoratorsConfigParserPlugin::reset() {
+  // Reset the internal data store (for all sources).
+  for (const auto& source : DecoratorsConfigParserPlugin::kDecorations) {
+    clearSources(source.first);
+    clearDecorations(source.first);
+  }
 }
 
 void DecoratorsConfigParserPlugin::updateDecorations(

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -37,7 +37,10 @@ class DecoratorsConfigParserPluginTests : public testing::Test {
     FLAGS_disable_decorators = true;
   }
 
-  void TearDown() override { FLAGS_disable_decorators = decorator_status_; }
+  void TearDown() override {
+    Config::getInstance().reset();
+    FLAGS_disable_decorators = decorator_status_;
+  }
 
  protected:
   std::string content_;

--- a/osquery/config/parsers/tests/events_tests.cpp
+++ b/osquery/config/parsers/tests/events_tests.cpp
@@ -23,7 +23,7 @@ class EventsConfigParserPluginTests : public testing::Test {};
 TEST_F(EventsConfigParserPluginTests, test_get_event) {
   // Reset the schedule in case other tests were modifying.
   auto& c = Config::getInstance();
-  // TODO: might need a reset.
+  c.reset();
 
   // Generate content to update/add to the config.
   std::string content;
@@ -47,5 +47,8 @@ TEST_F(EventsConfigParserPluginTests, test_get_event) {
   for (const auto& var : data.get_child("events.environment_variables")) {
     EXPECT_TRUE(var.second.data() == "foo" || var.second.data() == "bar");
   }
+
+  // Reset the configuration.
+  c.reset();
 }
 }

--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -25,6 +25,11 @@ class FilePathsConfigParserPluginTests : public testing::Test {
 
     // Construct a config map, the typical output from `Config::genConfig`.
     config_data_["awesome"] = content_;
+    Config::getInstance().reset();
+  }
+
+  void TearDown() override {
+    Config::getInstance().reset();
   }
 
   size_t numFiles() {
@@ -61,14 +66,14 @@ TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
 }
 
 TEST_F(FilePathsConfigParserPluginTests, test_get_file_accesses) {
-  // Assume config data has been added.
+  Config::getInstance().update(config_data_);
   auto parser = Config::getParser("file_paths");
   auto& accesses = parser->getData().get_child("file_accesses");
   EXPECT_EQ(accesses.size(), 2U);
 }
 
 TEST_F(FilePathsConfigParserPluginTests, test_remove_source) {
-  EXPECT_GT(numFiles(), 0U);
+  Config::getInstance().update(config_data_);
   Config::getInstance().removeFiles("awesome");
   // Expect the pack's set to persist.
   // Do not call removeFiles, instead only update the pack/config content.

--- a/osquery/config/parsers/tests/options_tests.cpp
+++ b/osquery/config/parsers/tests/options_tests.cpp
@@ -28,5 +28,6 @@ TEST_F(OptionsConfigParserPluginTests, test_get_option) {
   EXPECT_EQ(c.getParser("options")->getData().get_child("options").get<bool>(
                 "enable_monitor"),
             true);
+  c.reset();
 }
 }

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -148,6 +148,7 @@ TEST_F(PacksTests, test_discovery_cache) {
   }));
 
   EXPECT_EQ(pack_count, 1U);
+  c.reset();
 }
 
 TEST_F(PacksTests, test_discovery_zero_state) {

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -26,9 +26,13 @@ class SchedulerTests : public testing::Test {
   void SetUp() override {
     logging_ = FLAGS_disable_logging;
     FLAGS_disable_logging = true;
+    Config::getInstance().reset();
   }
 
-  void TearDown() override { FLAGS_disable_logging = logging_; }
+  void TearDown() override {
+    FLAGS_disable_logging = logging_;
+    Config::getInstance().reset();
+  }
 
  private:
   bool logging_{false};


### PR DESCRIPTION
There are several tests that introduce confounds because they do not clear configuration state.

These changes mostly affect tests since the `Config::reset` method is not used during normal flow. This method was intended to restore a blank configuration state before/after a series of tests. It had two problems:
- It wasn't used in several test sets that explicitly changed configuration data.
- The reset did not extend into configuration parser state.