### PR TITLE
fix the cpu id displayed in core column

### DIFF
--- a/osquery/tables/system/linux/cpu_time.cpp
+++ b/osquery/tables/system/linux/cpu_time.cpp
@@ -11,9 +11,9 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-#include <osquery/tables.h>
-#include <osquery/filesystem.h>
 #include "osquery/core/conversions.h"
+#include <osquery/filesystem.h>
+#include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
@@ -22,67 +22,73 @@ const std::string kProcStat = "/proc/stat";
 
 std::vector<std::string> procFromFile(const std::string &path) {
 
-    if (!isReadable(path).ok()) {
-        return {};
-    }
+  if (!isReadable(path).ok()) {
+    return {};
+  }
 
-    std::string content;
-    if (!readFile(path, content).ok()) {
-        return {};
-    }
+  std::string content;
+  if (!readFile(path, content).ok()) {
+    return {};
+  }
 
-    auto lines = split(content, "\n");
-    std::vector<std::string> proc_lines;
-    for (auto &line : lines) {
-        boost::trim(line);
-        if (boost::starts_with(line, "cpu")) {
-            proc_lines.push_back(line);
-        }
+  auto lines = split(content, "\n");
+  std::vector<std::string> proc_lines;
+  for (auto &line : lines) {
+    boost::trim(line);
+    if (boost::starts_with(line, "cpu")) {
+      proc_lines.push_back(line);
     }
+  }
 
-    // Remove first cpu line which doesn't give specific core information.
-    if (proc_lines.size() > 0 && proc_lines.front().size() >= 4 &&
-        proc_lines.front().substr(0, 4).compare("cpu ") == 0) {
-        proc_lines.erase(proc_lines.begin());
-    }
+  // Remove first cpu line which doesn't give specific core information.
+  if (proc_lines.size() > 0 && proc_lines.front().size() >= 4 &&
+      proc_lines.front().substr(0, 4).compare("cpu ") == 0) {
+    proc_lines.erase(proc_lines.begin());
+  }
 
-    return proc_lines;
+  return proc_lines;
 }
 
 static void genCpuTimeLine(const std::string &line, QueryData &results) {
 
-    auto words = osquery::split(line, " ");
+  auto words = osquery::split(line, " ");
 
-    if (words.size() < 11) {
-        // This probably means there's an error in the /proc/stat file.
-        return;
-    }
+  if (words.size() < 11) {
+    // This probably means there's an error in the /proc/stat file.
+    return;
+  }
 
-    Row r;
-    r["core"] = words[0].back();
-    r["user"] = words[1];
-    r["nice"] = words[2];
-    r["system"] = words[3];
-    r["idle"] = words[4];
-    r["iowait"] = words[5];
-    r["irq"] = words[6];
-    r["softirq"] = words[7];
-    r["steal"] = words[8];
-    r["guest"] = words[9];
-    r["guest_nice"] = words[10];
+  if (words[0].size() > 3 && words[0].substr(0, 3).compare("cpu") == 0) {
+    words[0].erase(0, 3);
+  } else {
+    // First column must start with "cpu" followed by a number
+    return;
+  }
+  Row r;
+  r["core"] = words[0];
+  r["user"] = words[1];
+  r["nice"] = words[2];
+  r["system"] = words[3];
+  r["idle"] = words[4];
+  r["iowait"] = words[5];
+  r["irq"] = words[6];
+  r["softirq"] = words[7];
+  r["steal"] = words[8];
+  r["guest"] = words[9];
+  r["guest_nice"] = words[10];
 
-    results.push_back(r);
+  results.push_back(r);
 }
 
 QueryData genCpuTime(QueryContext &context) {
-    QueryData results;
+  QueryData results;
 
-    auto proc_lines = procFromFile(kProcStat);
-    for (const auto &line : proc_lines) {
-        genCpuTimeLine(line, results);
-    }
+  auto proc_lines = procFromFile(kProcStat);
+  for (const auto &line : proc_lines) {
+    genCpuTimeLine(line, results);
+  }
 
-    return results;
+  return results;
 }
 }
 }


### PR DESCRIPTION
We assume the first word starts with 'cpu' and we split the string and get the cpu id. 

This should address #2025