### PR TITLE
Fix pessimizing move warnings

### DIFF
--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -279,7 +279,7 @@ QueryData genApps(QueryContext& context) {
     genApplication(tree, path, results);
   }
 
-  return std::move(results);
+  return results;
 }
 
 QueryData genAppSchemes(QueryContext& context) {

--- a/osquery/tables/system/darwin/launchd.cpp
+++ b/osquery/tables/system/darwin/launchd.cpp
@@ -130,7 +130,7 @@ QueryData genLaunchd(QueryContext& context) {
     genLaunchdItem(tree, path, results);
   }
 
-  return std::move(results);
+  return results;
 }
 
 void genLaunchdOverride(const fs::path& path, QueryData& results) {

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -254,7 +254,7 @@ QueryData genOSXPreferences(QueryContext& context) {
     genOSXDefaultPreferences(context, results);
   }
 
-  return std::move(results);
+  return results;
 }
 }
 }

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -165,7 +165,7 @@ QueryData genXProtectEntries(QueryContext& context) {
     }
   }
 
-  return std::move(results);
+  return results;
 }
 
 QueryData genXProtectMeta(QueryContext& context) {
@@ -214,7 +214,7 @@ QueryData genXProtectMeta(QueryContext& context) {
     }
   }
 
-  return std::move(results);
+  return results;
 }
 }
 }


### PR DESCRIPTION
Fixes warnings generated by Clang when `std::move` is used in a `return`
statement. Verified by `make clean`, saw no warnings, `make test` passes.