### PR TITLE
Fix make_package build for OS X/Linux

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -12,9 +12,9 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
 BUILD_DIR="$SOURCE_DIR/build/linux"
-export PATH="$PATH:/usr/local/bin"
 
-source $SCRIPT_DIR/../lib.sh
+export PATH="$PATH:/usr/local/bin"
+source "$SOURCE_DIR/tools/lib.sh"
 
 PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`
 PACKAGE_ARCH=`uname -m`

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -11,9 +11,6 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
-source $SOURCE_DIR/tools/lib.sh
-distro "darwin" BUILD_VERSION
-
 BUILD_DIR="$SOURCE_DIR/build/"
 if [[ ! -z "$DEBUG" ]]; then
   BUILD_DIR="${BUILD_DIR}debug_"
@@ -24,9 +21,10 @@ if [[ "$BUILD_VERSION" == "10.11" ]]; then
 else
   BUILD_DIR="${BUILD_DIR}darwin$BUILD_VERSION"
 fi
-export PATH="$PATH:/usr/local/bin"
 
-source $SCRIPT_DIR/../lib.sh
+export PATH="$PATH:/usr/local/bin"
+source "$SOURCE_DIR/tools/lib.sh"
+distro "darwin" BUILD_VERSION
 
 # Binary identifiers
 APP_VERSION=`git describe --tags HEAD`
@@ -55,11 +53,11 @@ OSQUERY_LOG_DIR="/private/var/log/osquery/"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 
 WORKING_DIR=/tmp/osquery_packaging
-INSTALL_PREFIX=$WORKING_DIR/prefix
-SCRIPT_ROOT=$WORKING_DIR/scripts
-PREINSTALL=$SCRIPT_ROOT/preinstall
-POSTINSTALL=$SCRIPT_ROOT/postinstall
-OSQUERYCTL_PATH="$SOURCE_DIR/tools/deployment/osqueryctl"
+INSTALL_PREFIX="$WORKING_DIR/prefix"
+SCRIPT_ROOT="$WORKING_DIR/scripts"
+PREINSTALL="$SCRIPT_ROOT/preinstall"
+POSTINSTALL="$SCRIPT_ROOT/postinstall"
+OSQUERYCTL_PATH="$SCRIPT_DIR/osqueryctl"
 
 # Kernel extension identifiers and config files
 KERNEL_INLINE=false
@@ -69,10 +67,10 @@ KERNEL_EXTENSION_SRC="$BUILD_DIR/kernel/osquery.kext"
 KERNEL_EXTENSION_DST="/Library/Extensions/osquery.kext"
 
 KERNEL_WORKING_DIR=/tmp/osquery_kernel_packaging
-KERNEL_INSTALL_PREFIX=$KERNEL_WORKING_DIR/prefix
-KERNEL_SCRIPT_ROOT=$KERNEL_WORKING_DIR/scripts
-KERNEL_PREINSTALL=$KERNEL_SCRIPT_ROOT/preinstall
-KERNEL_POSTINSTALL=$KERNEL_SCRIPT_ROOT/postinstall
+KERNEL_INSTALL_PREFIX="$KERNEL_WORKING_DIR/prefix"
+KERNEL_SCRIPT_ROOT="$KERNEL_WORKING_DIR/scripts"
+KERNEL_PREINSTALL="$KERNEL_SCRIPT_ROOT/preinstall"
+KERNEL_POSTINSTALL="$KERNEL_SCRIPT_ROOT/postinstall"
 
 SCRIPT_PREFIX_TEXT="#!/usr/bin/env bash
 

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -11,12 +11,12 @@ ORACLE_RELEASE=/etc/oracle-release
 SYSTEM_RELEASE=/etc/system-release
 LSB_RELEASE=/etc/lsb-release
 DEBIAN_VERSION=/etc/debian_version
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+LIB_SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 function platform() {
   local  __out=$1
-  FAMILY="`python $SCRIPT_DIR/get_platform.py --family`"
-  eval $__out=`python $SCRIPT_DIR/get_platform.py --platform`
+  FAMILY="`python $LIB_SCRIPT_DIR/get_platform.py --family`"
+  eval $__out=`python $LIB_SCRIPT_DIR/get_platform.py --platform`
 }
 
 function _platform() {
@@ -26,7 +26,7 @@ function _platform() {
 
 function distro() {
   local __out=$2
-  eval $__out=`python $SCRIPT_DIR/get_platform.py --distro`
+  eval $__out=`python $LIB_SCRIPT_DIR/get_platform.py --distro`
 }
 
 function _distro() {
@@ -123,7 +123,7 @@ function build() {
 
   RUN_TESTS=$1
 
-  cd $SCRIPT_DIR/../
+  cd $LIB_SCRIPT_DIR/../
 
   # Run build host provisions and install library dependencies.
   if [[ ! -z $RUN_BUILD_DEPS ]]; then


### PR DESCRIPTION
There seems to have been a regression in package building. The `./tools/lib.sh` script now overloads the `SCRIPT_DIR` variable, which is also used in the package build scripts.

This changes the file-local variable in `./tools/lib.sh`.