### PR TITLE
Process Abstraction

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -165,7 +165,7 @@ macro(ADD_OSQUERY_LIBRARY IS_CORE TARGET)
     add_dependencies(${TARGET} osquery_extensions)
     # TODO(#1985): For Windows, ignore the -static compiler flag
     if(WIN32)
-      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS}")
+      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} /EHsc /MD")
     else()
       SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} -static")
     endif()
@@ -196,7 +196,7 @@ macro(ADD_OSQUERY_OBJCXX_LIBRARY IS_CORE TARGET)
     add_dependencies(${TARGET} osquery_extensions)
     # TODO(#1985): For Windows, ignore the -static compiler flag
     if(WIN32)
-      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} ${OBJCXX_COMPILE_FLAGS}")
+      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} ${OBJCXX_COMPILE_FLAGS} /EHsc /MD")
     else()
       SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} ${OBJCXX_COMPILE_FLAGS} -static")
     endif()
@@ -219,7 +219,7 @@ endmacro(ADD_OSQUERY_EXTENSION)
 
 macro(ADD_OSQUERY_MODULE TARGET)
   add_library(${TARGET} SHARED ${ARGN})
-  if(NOT FREEBSD)
+  if(NOT FREEBSD AND NOT WIN32)
     target_link_libraries(${TARGET} dl)
   endif()
   add_dependencies(${TARGET} libosquery)
@@ -242,8 +242,9 @@ macro(GET_GENERATION_DEPS BASE_PATH)
   # Depend on the generation code.
   set(GENERATION_DEPENDENCIES "")
   file(GLOB TABLE_FILES_TEMPLATES "${BASE_PATH}/osquery/tables/templates/*.in")
+  file(GLOB CODEGEN_PYTHON_FILES "${BASE_PATH}/tools/codegen/*.py")
   set(GENERATION_DEPENDENCIES
-    "${BASE_PATH}/tools/codegen/*.py"
+    "${CODEGEN_PYTHON_FILES}"
     "${BASE_PATH}/specs/blacklist"
   )
   list(APPEND GENERATION_DEPENDENCIES ${TABLE_FILES_TEMPLATES})

--- a/CMake/FindGtest.cmake
+++ b/CMake/FindGtest.cmake
@@ -1,2 +1,5 @@
 INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/third-party/gmock-1.7.0/gtest/include" "${CMAKE_SOURCE_DIR}/third-party/gmock-1.7.0/include")
+if(WIN32)
+    SET(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared gtest library" FORCE)
+endif()
 ADD_SUBDIRECTORY("${CMAKE_SOURCE_DIR}/third-party/gmock-1.7.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,7 @@ if(WIN32)
   # Win64 specific boost
   set(boost_filesystem_library "${BOOST_DEP_DIR}/lib64-msvc-14.0/libboost_filesystem-vc140-mt-1_59.lib")
   set(boost_system_library "${BOOST_DEP_DIR}/lib64-msvc-14.0/libboost_system-vc140-mt-1_59.lib")
+  set(boost_thread_library "${BOOST_DEP_DIR}/lib64-msvc-14.0/libboost_thread-vc140-mt-1_59.lib")
   set(boost_regex_library "${BOOST_DEP_DIR}/lib64-msvc-14.0/libboost_regex-vc140-mt-1_59.lib")
 
   # Win64 specific gflags
@@ -480,9 +481,11 @@ if(NOT DEFINED ENV{SKIP_ROCKSDB})
 endif()
 
 # Python is used for table spec generation and formating.
-if(PYTHON_VERSION_MAJOR STREQUAL "2" AND PYTHON_VERSION_MINOR STREQUAL "4")
-  WARNING_LOG("Found python 2.4, overriding to /usr/bin/python2.6")
-  set(PYTHON_EXECUTABLE "/usr/bin/python2.6")
+if(NOT WIN32)
+  if(PYTHON_VERSION_MAJOR STREQUAL "2" AND PYTHON_VERSION_MINOR STREQUAL "4")
+    WARNING_LOG("Found python 2.4, overriding to /usr/bin/python2.6")
+    set(PYTHON_EXECUTABLE "/usr/bin/python2.6")
+  endif()
 endif()
 
 enable_testing()
@@ -503,6 +506,7 @@ if(WIN32)
   include_directories("${WINDOWS_DEP_DIR}/gflags-dev/local/include")
   
   # TODO(#1990): We probably need to add our third-party link directories here
+  link_directories("${BOOST_DEP_DIR}/lib64-msvc-14.0")
 else()
   include_directories("/usr/local/include")
   link_directories("/usr/local/lib")

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -20,6 +20,15 @@
 
 #include <osquery/status.h>
 
+#ifdef WIN32
+#define WINVER               0x0601
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+using pid_t = DWORD; 
+#endif
+
 // clang-format off
 #ifndef STR
 #define STR_OF(x) #x
@@ -34,12 +43,24 @@
 #endif
 // clang-format on
 
+#ifndef WIN32
+
 #ifndef __constructor__
 #define __registry_constructor__ __attribute__((constructor(101)))
 #define __plugin_constructor__ __attribute__((constructor(102)))
+#define __default_constructor__ __attribute__((constructor))
 #else
 #define __registry_constructor__ __attribute__((__constructor__(101)))
 #define __plugin_constructor__ __attribute__((__constructor__(102)))
+#define __default_constructor__ __attribute__((__constructor__))
+#endif
+
+#else 
+
+#define __registry_constructor__
+#define __plugin_constructor__
+#define __default_constructor__
+
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.
@@ -246,6 +267,8 @@ size_t getUnixTime();
  */
 Status createPidFile();
 
+#ifndef WIN32
+
 class DropPrivileges;
 typedef std::shared_ptr<DropPrivileges> DropPrivilegesRef;
 
@@ -321,4 +344,6 @@ class DropPrivileges : private boost::noncopyable {
   FRIEND_TEST(PermissionsTests, test_path_drop);
   FRIEND_TEST(PermissionsTests, test_nobody_drop);
 };
+#endif
+
 }

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -21,11 +21,10 @@
 #include <osquery/status.h>
 
 #ifdef WIN32
-#define WINVER               0x0601
+#define WINVER  0x0a00
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-
 using pid_t = DWORD; 
 #endif
 

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -24,6 +24,12 @@
 #include <osquery/status.h>
 #include <osquery/tables.h>
 
+#ifdef WIN32
+#define USED_SYMBOL
+#else
+#define USED_SYMBOL  __attribute__((used))
+#endif
+
 namespace osquery {
 
 struct Subscription;
@@ -492,7 +498,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return The query-time table data, retrieved from a backing store.
    */
-  virtual QueryData genTable(QueryContext& context) __attribute__((used));
+  virtual QueryData genTable(QueryContext& context) USED_SYMBOL;
 
   /// Number of Subscription%s this EventSubscriber has used.
   size_t numSubscriptions() const { return subscription_count_; }

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -190,11 +190,20 @@ class FlagAlias {
  * @param value The default value, use a C++ literal.
  * @param desc A string literal used for help display.
  */
+#ifdef WIN32
+#define OSQUERY_FLAG(t, n, v, d, s, e, c, h)              \
+  using ::fLS::StringFlagDestructor;                      \
+  DEFINE_##t(n, v, d);                                    \
+  namespace flags {                                       \
+  const int flag_##n = Flag::create(#n, {d, s, e, c, h}); \
+  }
+#else
 #define OSQUERY_FLAG(t, n, v, d, s, e, c, h)              \
   DEFINE_##t(n, v, d);                                    \
   namespace flags {                                       \
   const int flag_##n = Flag::create(#n, {d, s, e, c, h}); \
   }
+#endif
 
 #define FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 0, 0)
 #define SHELL_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 1, 0, 0, 0)

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -13,6 +13,11 @@
 #include <string>
 #include <vector>
 
+#ifdef WIN32
+#define GLOG_NO_ABBREVIATED_SEVERITIES
+#define OS_WINDOWS
+#endif
+
 #include <glog/logging.h>
 
 #include <osquery/database.h>

--- a/include/osquery/sdk.h
+++ b/include/osquery/sdk.h
@@ -55,14 +55,14 @@ REGISTER_INTERNAL(ExternalSQLPlugin, "sql", "sql");
  * use the REGISTER_MODULE call within `initModule`.
  */
 #define REGISTER_EXTERNAL(type, registry, name)                            \
-  __attribute__((constructor)) static void type##ExtensionRegistryItem() { \
+  __default_constructor__ static void type##ExtensionRegistryItem() { \
     Registry::add<type>(registry, name);                                   \
   }
 
 /// Helper macro to write the `initModule` symbol without rewrites.
 #define DECLARE_MODULE(name)        \
   extern "C" void initModule(void); \
-  __attribute__((constructor)) static void declareModule()
+  __default_constructor__ static void declareModule()
 
 /**
  * @brief Create an osquery extension 'module'.

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -249,7 +249,7 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   set_target_properties(libosquery_testing PROPERTIES OUTPUT_NAME osquery_testing)
 
   # osquery core set of unit tests build with SDK.
-  add_executable(osquery_tests main/tests.cpp ${OSQUERY_TESTS})
+  add_executable(osquery_tests main/tests_core.cpp ${OSQUERY_TESTS})
   TARGET_OSQUERY_LINK_WHOLE(osquery_tests libosquery)
   target_link_libraries(osquery_tests gtest libosquery_testing)
   SET_OSQUERY_COMPILE(osquery_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -36,10 +36,22 @@ set(OSQUERY_LIBS
   ${OPENSSL_SSL_LIBRARY}
   ${READLINE_LIBRARIES}
 
-  pthread
-  bz2
-  z
 )
+
+if(WIN32)
+  set(OSQUERY_LIBS 
+    ${OSQUERY_LIBS} 
+    ${BZIP2_LIBRARIES}
+    ${boost_thread_library}   
+  )
+else()
+  set(OSQUERY_LIBS 
+    ${OSQUERY_LIBS} 
+    z 
+    bz2 
+    pthread
+  )
+endif()
 
 # If building with RocksDB (default) append associated libraries.
 if(ROCKSDB)
@@ -53,12 +65,14 @@ elseif(FREEBSD)
 endif()
 
 # Add default linking details (the first argument means SDK + core).
-ADD_OSQUERY_LINK_CORE("-rdynamic")
-foreach(DISTRO ${OSQUERY_REQUIRE_RUNTIMES})
-  if(${OSQUERY_BUILD_DISTRO} STREQUAL ${DISTRO})
-    ADD_OSQUERY_LINK_ADDITIONAL("-static-libstdc++")
-  endif()
-endforeach()
+if(NOT WIN32)
+  ADD_OSQUERY_LINK_CORE("-rdynamic")
+  foreach(DISTRO ${OSQUERY_REQUIRE_RUNTIMES})
+    if(${OSQUERY_BUILD_DISTRO} STREQUAL ${DISTRO})
+      ADD_OSQUERY_LINK_ADDITIONAL("-static-libstdc++")
+    endif()
+  endforeach()
+endif()
 
 # The platform-specific SDK + core libraries.
 if(APPLE)

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(APPLE)
-  set (OS_CORE_SOURCE
-    darwin/conversions.cpp
-  )
-elseif(WIN32)
+if(WIN32)
   set (OS_CORE_SOURCE
     windows/process.cpp
     windows/process_ops.cpp  
@@ -11,6 +7,13 @@ else()
   set (OS_CORE_SOURCE
     posix/process.cpp
     posix/process_ops.cpp
+  )
+endif()
+
+if(APPLE)
+  set (OS_CORE_SOURCE
+    ${OS_CORE_SOURCE}
+    darwin/conversions.cpp
   )
 endif()
 

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -2,8 +2,16 @@ if(APPLE)
   set (OS_CORE_SOURCE
     darwin/conversions.cpp
   )
+elseif(WIN32)
+  set (OS_CORE_SOURCE
+    windows/process.cpp
+    windows/process_ops.cpp  
+  )
 else()
-  set (OS_CORE_SOURCE "")
+  set (OS_CORE_SOURCE
+    posix/process.cpp
+    posix/process_ops.cpp
+  )
 endif()
 
 ADD_OSQUERY_LIBRARY(TRUE osquery_core
@@ -15,6 +23,7 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_core
   flags.cpp
   hash.cpp
   watcher.cpp
+  process_shared.cpp
 )
 
 file(GLOB OSQUERY_CORE_TESTS "tests/*.cpp")

--- a/osquery/core/hash.cpp
+++ b/osquery/core/hash.cpp
@@ -66,7 +66,11 @@ void Hash::update(const void* buffer, size_t size) {
 }
 
 std::string Hash::digest() {
+#ifdef WIN32
+  unsigned char *hash = (unsigned char *)_alloca(length_);
+#else
   unsigned char hash[length_];
+#endif
 
   memset(hash, 0, length_);
   if (algorithm_ == HASH_TYPE_MD5) {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -448,7 +448,7 @@ void Initializer::initWorker(const std::string& name) const {
 #ifdef WIN32
   // TODO: How will we deal with this?
 #else
-  Dispatcher::addService(std::make_shared<WatcherWatcherRunner>(getppid()));
+  Dispatcher::addService(std::make_shared<WatcherWatcherRunner>(getLauncherProcess()));
 #endif
 }
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -299,6 +299,9 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
   }
 
 #ifndef WIN32
+  // TODO(#1991): Think about making this into registerHandlers() within
+  //              our process abstraction
+  //
   // All tools handle the same set of signals.
   // If a daemon process is a watchdog the signal is passed to the worker,
   // unless the worker has not yet started.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -34,6 +34,7 @@
 #include <osquery/registry.h>
 
 #include "osquery/core/watcher.h"
+#include "osquery/core/process.h"
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -100,7 +101,10 @@ enum {
 namespace {
 extern "C" {
 static inline bool hasWorkerVariable() {
-  return (getenv("OSQUERY_WORKER") != nullptr);
+  if (auto value = ::osquery::getEnvVar("OSQUERY_WORKER")) {
+    return true;
+  }
+  return false;
 }
 
 volatile std::sig_atomic_t kHandledSignal{0};

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <vector>
+
+#include <signal.h>
+#include <sys/types.h>
+
+#include "osquery/core/process.h"
+
+extern char **environ;
+
+namespace osquery 
+{
+
+PlatformProcess::PlatformProcess(PlatformPidType id) : id_(id) { }
+
+PlatformProcess::~PlatformProcess(){ }
+
+bool PlatformProcess::kill()
+{
+  int status = ::kill(id_, SIGKILL);
+  return (status == 0);
+}
+
+PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name)
+{
+  auto worker_pid = ::fork();
+  if (worker_pid < 0) {
+    // Cannot create worker process
+    
+    // TODO: we need to differentiate this error and the error that occurs when exec fails.
+    //       This should return something akin to EXIT_FAILURE
+    return PlatformProcess(kInvalidPid);
+  } else if (worker_pid == 0) {
+    setEnvVar("OSQUERY_WORKER", std::to_string(::getpid()).c_str());
+    ::execle(exec_path.c_str(), name.c_str(), nullptr, ::environ);
+    
+    // Code should never reach this point
+
+    // TODO: if code does happen to reach here, we need to return a message like EXIT_CATASTROPHIC
+    return PlatformProcess(kInvalidPid);
+  }
+  return PlatformProcess(worker_pid);
+}
+
+PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path, 
+                                                 const std::string& extension, 
+                                                 const std::string& extensions_socket,
+                                                 const std::string& extensions_timeout,
+                                                 const std::string& extensions_interval,
+                                                 const std::string& verbose)
+{
+  auto ext_pid = ::fork();
+  if (ext_pid < 0) {
+    // Cannot create extension process
+    
+    // TODO: What we need here is to differentiate what we return for errors. 
+    //       This should return something akin to EXIT_FAILURE
+    return PlatformProcess(kInvalidPid);
+  } else if (ext_pid == 0) {
+    setEnvVar("OSQUERY_EXTENSIONS", std::to_string(::getpid()).c_str());
+    ::execle(exec_path.c_str(),
+             ("osquery extension: " + extension).c_str(),
+             "--socket",
+             extensions_socket.c_str(),
+             "--timeout",
+             extensions_timeout.c_str(),
+             "--interval",
+             extensions_interval.c_str(),
+             (verbose == "true") ? "--verbose" : (char*)nullptr,
+             (char*)nullptr,
+             ::environ);
+    
+    // Code should never reach this point
+
+    // TODO: if it does reach here, we need to return a message like EXIT_FAILURE
+    return PlatformProcess(kInvalidPid);
+  }
+
+  return PlatformProcess(ext_pid);
+}
+
+PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id)
+{
+  return PlatformProcess(id);
+}
+
+}
+

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -31,6 +31,10 @@ PlatformProcess::~PlatformProcess() { }
 
 PlatformProcess& PlatformProcess::operator=(const PlatformProcess& process) = default;
 
+int PlatformProcess::pid() const {
+  return id_;
+}
+
 bool PlatformProcess::kill() {
   if (id_ == kInvalidPid) {
     return false;

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -24,7 +24,12 @@ namespace osquery {
 PlatformProcess::PlatformProcess(PlatformPidType id)
   : id_(id) { }
 
+PlatformProcess::PlatformProcess(const PlatformProcess& src) = default;
+PlatformProcess::PlatformProcess(PlatformProcess&& src) = default;
+
 PlatformProcess::~PlatformProcess() { }
+
+PlatformProcess& PlatformProcess::operator=(const PlatformProcess& process) = default;
 
 bool PlatformProcess::kill() {
   if (id_ == kInvalidPid) {

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -17,15 +17,14 @@
 
 extern char **environ;
 
-namespace osquery 
-{
+namespace osquery {
 
-PlatformProcess::PlatformProcess(PlatformPidType id) : id_(id) { }
+PlatformProcess::PlatformProcess(PlatformPidType id)
+  : id_(id) { }
 
-PlatformProcess::~PlatformProcess(){ }
+PlatformProcess::~PlatformProcess() { }
 
-bool PlatformProcess::kill()
-{
+bool PlatformProcess::kill() {
   if (id_ == kInvalidPid) {
     return false;
   }
@@ -34,8 +33,7 @@ bool PlatformProcess::kill()
   return (status == 0);
 }
 
-PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name)
-{
+PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name) {
   auto worker_pid = ::fork();
   if (worker_pid < 0) {
     return PlatformProcess(kInvalidPid);
@@ -56,8 +54,7 @@ PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path,
                                                  const std::string& extensions_socket,
                                                  const std::string& extensions_timeout,
                                                  const std::string& extensions_interval,
-                                                 const std::string& verbose)
-{
+                                                 const std::string& verbose) {
   auto ext_pid = ::fork();
   if (ext_pid < 0) {
     return PlatformProcess(kInvalidPid);
@@ -84,10 +81,8 @@ PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path,
   return PlatformProcess(ext_pid);
 }
 
-PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id)
-{
+PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id) {
   return PlatformProcess(id);
 }
-
 }
 

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -13,6 +13,8 @@
 #include <signal.h>
 #include <sys/types.h>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/process.h"
 
 extern char **environ;
@@ -42,8 +44,8 @@ PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, cons
     ::execle(exec_path.c_str(), name.c_str(), nullptr, ::environ);
     
     // Code should never reach this point
-    //
-    // TODO(#1991): Consider calling Initializer::shutdown(EXIT_CATASTROPHIC)
+    LOG(ERROR) << "osqueryd could not start worker process";
+    Initializer::shutdown(EXIT_CATASTROPHIC);
     return PlatformProcess(kInvalidPid);
   }
   return PlatformProcess(worker_pid);
@@ -73,8 +75,8 @@ PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path,
              ::environ);
     
     // Code should never reach this point
-    //
-    // TODO(#1991): Consider calling Initializer::shutdown(EXIT_FAILURE)
+    VLOG(1) << "Could not start extension process: " << extension;
+    Initializer::shutdown(EXIT_FAILURE);
     return PlatformProcess(kInvalidPid);
   }
 

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -27,6 +27,14 @@ PlatformProcess::PlatformProcess(PlatformPidType id)
 PlatformProcess::PlatformProcess(const PlatformProcess& src) = default;
 PlatformProcess::PlatformProcess(PlatformProcess&& src) = default;
 
+bool PlatformProcess::operator==(const PlatformProcess& process) {
+  return (nativeHandle() == process.nativeHandle());
+}
+
+bool PlatformProcess::operator!=(const PlatformProcess& process) {
+  return (nativeHandle() != process.nativeHandle());
+}
+
 PlatformProcess::~PlatformProcess() { }
 
 PlatformProcess& PlatformProcess::operator=(const PlatformProcess& process) = default;

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -31,6 +31,10 @@ PlatformProcess getLauncherProcess()
 
 bool isLauncherProcessDead(PlatformProcess& launcher)
 {
+  if (!launcher.isValid()) {
+    return false;
+  }
+  
   return (::getppid() != launcher.nativeHandle());
 }
 

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -14,23 +14,19 @@
 
 #include "osquery/core/process.h"
 
-namespace osquery 
-{
+namespace osquery {
 
-PlatformProcess getCurrentProcess()
-{
+PlatformProcess getCurrentProcess() {
   pid_t pid = ::getpid();
   return PlatformProcess::fromPlatformPid(pid);
 }
 
-PlatformProcess getLauncherProcess()
-{
+PlatformProcess getLauncherProcess() {
   pid_t ppid = ::getppid();
   return PlatformProcess::fromPlatformPid(ppid);
 }
 
-bool isLauncherProcessDead(PlatformProcess& launcher)
-{
+bool isLauncherProcessDead(PlatformProcess& launcher) {
   if (!launcher.isValid()) {
     return false;
   }
@@ -38,19 +34,21 @@ bool isLauncherProcessDead(PlatformProcess& launcher)
   return (::getppid() != launcher.nativeHandle());
 }
 
-bool setEnvVar(const std::string& name, const std::string& value)
-{
+bool setEnvVar(const std::string& name, const std::string& value) {
   auto ret = ::setenv(name.c_str(), value.c_str(), 1);
   return (ret == 0);
 }
 
-boost::optional<std::string> getEnvVar(const std::string& name)
-{
+bool unsetEnvVar(const std::string& name) {
+  auto ret = ::unsetenv(name.c_str());
+  return (ret == 0);
+}
+
+boost::optional<std::string> getEnvVar(const std::string& name) {
   char *value = ::getenv(name.c_str());
   if (value) {
     return std::string(value);
   }
   return boost::none;
 }
-
 }

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+#include <stdlib.h>
+#include <boost/optional.hpp>
+
+#include "osquery/core/process.h"
+
+namespace osquery 
+{
+
+PlatformProcess getCurrentProcess()
+{
+  pid_t pid = ::getpid();
+  return PlatformProcess::fromPlatformPid(pid);
+}
+
+PlatformProcess getLauncherProcess()
+{
+  pid_t ppid = ::getppid();
+  return PlatformProcess::fromPlatformPid(ppid);
+}
+
+bool isLauncherProcessDead(PlatformProcess& launcher)
+{
+  return (::getppid() != launcher.nativeHandle());
+}
+
+bool setEnvVar(const std::string& name, const std::string& value)
+{
+  auto ret = ::setenv(name.c_str(), value.c_str(), 1);
+  return (ret == 0);
+}
+
+boost::optional<std::string> getEnvVar(const std::string& name)
+{
+  char *value = ::getenv(name.c_str());
+  if (value) {
+    return std::string(value);
+  }
+  return boost::none;
+}
+
+}

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -32,6 +32,8 @@ class PlatformProcess {
     PlatformProcess(PlatformProcess&& src);
     ~PlatformProcess();
 
+    int pid() const;
+
     PlatformPidType nativeHandle() const { return id_; }
     
     // TODO(#1991): Consider making kill() return an enumeration for more granularity if an
@@ -87,4 +89,9 @@ boost::optional<std::string> getEnvVar(const std::string& name);
 // TODO(#1991): Missing waitpid functionality
 // bool checkChildProcessStatus(osquery::PlatformProcess& process, int& status); -- watcher.cpp:193
 // void cleanupDefunctProcesses(); -- watcher.cpp:227
+
+// TODO(#1991): Missing setpriority functionality
+// void setToBackgroundPriority();
+
+// TODO(#1991): System logging?
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <boost/optional.hpp>
+
+#include <osquery/core.h>
+
+namespace osquery
+{
+
+#ifdef WIN32
+using PlatformPidType = HANDLE;
+#else
+using PlatformPidType = pid_t;
+#endif
+
+const PlatformPidType kInvalidPid = (PlatformPidType) -1;
+
+class PlatformProcess
+{
+  public:
+    PlatformProcess(PlatformPidType id);
+    ~PlatformProcess();
+
+    PlatformPidType nativeHandle() { return id_; }
+    
+    bool kill();                 // TODO: consider making kill() return an enumeration that
+                                 //       describes the various states
+    
+    bool isValid() { return (id_ != kInvalidPid); }
+
+    PlatformProcess& operator=(PlatformProcess& process);
+    bool operator==(const PlatformProcess& process);
+    bool operator!=(const PlatformProcess& process);
+    
+    static PlatformProcess launchWorker(const std::string& exec_path, const std::string& name);
+    static PlatformProcess launchExtension(const std::string& exec_path, 
+                                           const std::string& extension,
+                                           const std::string& extensions_socket,
+                                           const std::string& extensions_timeout,
+                                           const std::string& extensions_interval,
+                                           const std::string& verbose);
+    static PlatformProcess fromPlatformPid(PlatformPidType id);
+    
+  private:
+    PlatformPidType id_ = kInvalidPid;
+};
+
+PlatformProcess getCurrentProcess();
+PlatformProcess getLauncherProcess();
+
+void sleep(unsigned int msec);
+
+bool isLauncherProcessDead(PlatformProcess& launcher);
+bool setEnvVar(const std::string& name, const std::string& value);
+boost::optional<std::string> getEnvVar(const std::string& name);
+
+}

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -30,16 +30,19 @@ class PlatformProcess
 {
   public:
     PlatformProcess(PlatformPidType id);
+    PlatformProcess(PlatformProcess&& src);
     ~PlatformProcess();
 
     PlatformPidType nativeHandle() { return id_; }
     
-    bool kill();                 // TODO: consider making kill() return an enumeration that
-                                 //       describes the various states
+    // TODO(#1991): Consider making kill() return an enumeration for more granularity if an
+    //              error happens to occur.
+    // TODO(#1991): Also, consider adding an argument for exit code so that clients can specificy
+    //               the process exit code for the terminating process.
+    bool kill();
     
     bool isValid() { return (id_ != kInvalidPid); }
 
-    PlatformProcess& operator=(PlatformProcess& process);
     bool operator==(const PlatformProcess& process);
     bool operator!=(const PlatformProcess& process);
     
@@ -59,10 +62,12 @@ class PlatformProcess
 PlatformProcess getCurrentProcess();
 PlatformProcess getLauncherProcess();
 
-void sleep(unsigned int msec);
+void processSleep(unsigned int msec);
 
 bool isLauncherProcessDead(PlatformProcess& launcher);
 bool setEnvVar(const std::string& name, const std::string& value);
 boost::optional<std::string> getEnvVar(const std::string& name);
 
+// TODO(#1991): Missing register signal handlers function
+// TODO(#1991): Missing waitpid functionality
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -15,8 +15,7 @@
 
 #include <osquery/core.h>
 
-namespace osquery
-{
+namespace osquery {
 
 #ifdef WIN32
 using PlatformPidType = HANDLE;
@@ -26,8 +25,7 @@ using PlatformPidType = pid_t;
 
 const PlatformPidType kInvalidPid = (PlatformPidType) -1;
 
-class PlatformProcess
-{
+class PlatformProcess {
   public:
     PlatformProcess(PlatformPidType id);
     PlatformProcess(PlatformProcess&& src);
@@ -66,6 +64,7 @@ void processSleep(unsigned int msec);
 
 bool isLauncherProcessDead(PlatformProcess& launcher);
 bool setEnvVar(const std::string& name, const std::string& value);
+bool unsetEnvVar(const std::string& name);
 boost::optional<std::string> getEnvVar(const std::string& name);
 
 // TODO(#1991): Missing register signal handlers function

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -41,8 +41,19 @@ class PlatformProcess {
     
     bool isValid() { return (id_ != kInvalidPid); }
 
-    bool operator==(const PlatformProcess& process);
-    bool operator!=(const PlatformProcess& process);
+    // TODO(#1991): Before we can start substituting code blocks with our abstractions, we need to
+    //              decide on what to do for assignment operators. Integration requires some fields
+    //              in classes to be retyped as PlatformProcess. On the Windows side, we need to 
+    //              actually deal with resources such as HANDLEs. To prevent the leaking or premature
+    //              closing of HANDLEs, we need to decide upon the semantics.
+    //        
+    //              Ideally, I think the way to go about it is on assignment, copy to the new object
+    //              via duplication. This makes things decidably easier since after the operation,
+    //              both HANDLEs are usable.
+
+    // bool operator=(const PlatformProcess&& process);
+    // bool operator==(const PlatformProcess& process);
+    // bool operator!=(const PlatformProcess& process);
     
     static PlatformProcess launchWorker(const std::string& exec_path, const std::string& name);
     static PlatformProcess launchExtension(const std::string& exec_path, 
@@ -67,6 +78,12 @@ bool setEnvVar(const std::string& name, const std::string& value);
 bool unsetEnvVar(const std::string& name);
 boost::optional<std::string> getEnvVar(const std::string& name);
 
-// TODO(#1991): Missing register signal handlers function
+// TODO(#1991): Missing register signal handlers function. Consider using an abstraction layer for 
+//              conforming POSIX and Windows callback functions. We should consider using a lambda
+//              function for a more cleaner design.
+// void registerExitHandlers(<func-ptr-type>);
+
 // TODO(#1991): Missing waitpid functionality
+// bool checkChildProcessStatus(osquery::PlatformProcess& process, int& status); -- watcher.cpp:193
+// void cleanupDefunctProcesses(); -- watcher.cpp:227
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -55,8 +55,8 @@ class PlatformProcess {
     //              both HANDLEs are usable.
 
     PlatformProcess& operator=(const PlatformProcess& process);
-    // bool operator==(const PlatformProcess& process);
-    // bool operator!=(const PlatformProcess& process);
+    bool operator==(const PlatformProcess& process);
+    bool operator!=(const PlatformProcess& process);
     
     static PlatformProcess launchWorker(const std::string& exec_path, const std::string& name);
     static PlatformProcess launchExtension(const std::string& exec_path, 

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -28,10 +28,11 @@ const PlatformPidType kInvalidPid = (PlatformPidType) -1;
 class PlatformProcess {
   public:
     PlatformProcess(PlatformPidType id);
+    PlatformProcess(const PlatformProcess& src);
     PlatformProcess(PlatformProcess&& src);
     ~PlatformProcess();
 
-    PlatformPidType nativeHandle() { return id_; }
+    PlatformPidType nativeHandle() const { return id_; }
     
     // TODO(#1991): Consider making kill() return an enumeration for more granularity if an
     //              error happens to occur.
@@ -39,7 +40,7 @@ class PlatformProcess {
     //               the process exit code for the terminating process.
     bool kill();
     
-    bool isValid() { return (id_ != kInvalidPid); }
+    bool isValid() const { return (id_ != kInvalidPid); }
 
     // TODO(#1991): Before we can start substituting code blocks with our abstractions, we need to
     //              decide on what to do for assignment operators. Integration requires some fields
@@ -51,7 +52,7 @@ class PlatformProcess {
     //              via duplication. This makes things decidably easier since after the operation,
     //              both HANDLEs are usable.
 
-    // bool operator=(const PlatformProcess&& process);
+    PlatformProcess& operator=(const PlatformProcess& process);
     // bool operator==(const PlatformProcess& process);
     // bool operator!=(const PlatformProcess& process);
     

--- a/osquery/core/process_shared.cpp
+++ b/osquery/core/process_shared.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <chrono>
+#include <thread>
+#include <string>
+
+#include <boost/optional.hpp>
+
+#include "osquery/core/process.h"
+
+namespace osquery 
+{
+
+namespace ProcessOperations
+{
+
+void sleep(unsigned int msec)
+{
+  std::chrono::milliseconds mduration(msec);
+  std::this_thread::sleep_for(mduration);
+}
+
+}
+
+}

--- a/osquery/core/process_shared.cpp
+++ b/osquery/core/process_shared.cpp
@@ -19,15 +19,10 @@
 namespace osquery 
 {
 
-namespace ProcessOperations
-{
-
-void sleep(unsigned int msec)
+void processSleep(unsigned int msec)
 {
   std::chrono::milliseconds mduration(msec);
   std::this_thread::sleep_for(mduration);
-}
-
 }
 
 }

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -57,6 +57,7 @@ DECLARE_bool(disable_logging);
 typedef std::chrono::high_resolution_clock chrono_clock;
 
 void initTesting() {
+#ifndef WIN32
   // Allow unit test execution from anywhere in the osquery source/build tree.
   while (osquery::kTestDataPath != "/") {
     if (!fs::exists(osquery::kTestDataPath)) {
@@ -88,6 +89,7 @@ void initTesting() {
   // Set up the database instance for the unittests.
   DatabasePlugin::setAllowOpen(true);
   Registry::setActive("database", "ephemeral");
+#endif
 }
 
 void shutdownTesting() { DatabasePlugin::shutdown(); }
@@ -396,6 +398,7 @@ void tearDownMockFileStructure() {
 }
 
 void TLSServerRunner::start() {
+#ifndef WIN32
   auto& self = instance();
   if (self.server_ != 0) {
     return;
@@ -409,7 +412,9 @@ void TLSServerRunner::start() {
   if (self.server_ == 0) {
     // Start a python TLS/HTTPS or HTTP server.
     auto script = kTestDataPath + "/test_http_server.py --tls " + self.port_;
+
     execlp("sh", "sh", "-c", script.c_str(), nullptr);
+
     ::exit(0);
   }
 
@@ -424,6 +429,8 @@ void TLSServerRunner::start() {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     delay += 100;
   }
+
+#endif
 }
 
 void TLSServerRunner::setClientConfig() {
@@ -452,8 +459,10 @@ void TLSServerRunner::unsetClientConfig() {
 }
 
 void TLSServerRunner::stop() {
+#ifndef WIN32
   auto& self = instance();
   kill(self.server_, SIGKILL);
   self.server_ = 0;
+#endif
 }
 }

--- a/osquery/core/test_util.h
+++ b/osquery/core/test_util.h
@@ -22,6 +22,10 @@
 #include <osquery/database.h>
 #include <osquery/filesystem.h>
 
+// These codes are specifically for process abstraction testing
+#define EXTENSION_SUCCESS_CODE  0x45
+#define WORKER_SUCCESS_CODE     0x57
+
 namespace pt = boost::property_tree;
 
 namespace osquery {

--- a/osquery/core/tests/permissions_tests.cpp
+++ b/osquery/core/tests/permissions_tests.cpp
@@ -8,7 +8,9 @@
  *
  */
 
+#ifndef WIN32
 #include <pwd.h>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -25,6 +27,7 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
+#ifndef WIN32
 class PermissionsTests : public testing::Test {
  public:
   PermissionsTests() : perm_path_(kTestWorkingDirectory + "lowperms/") {}
@@ -113,4 +116,6 @@ TEST_F(PermissionsTests, test_nobody_drop) {
   EXPECT_EQ(geteuid(), getuid());
   EXPECT_EQ(getegid(), getgid());
 }
+#endif
+
 }

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -66,11 +66,11 @@ TEST_F(ProcessTests, test_constructor) {
 TEST_F(ProcessTests, test_constructorWin) {
   HANDLE handle = ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());
   EXPECT_NE(handle, reinterpret_cast<HANDLE>(NULL));
-  
+
   auto p = PlatformProcess(handle);
   EXPECT_TRUE(p.isValid());
   EXPECT_NE(p.nativeHandle(), handle);
-  
+
   ::CloseHandle(handle);
 }
 #else
@@ -80,6 +80,21 @@ TEST_F(ProcessTests, test_constructorPosix) {
   EXPECT_EQ(p.nativeHandle(), getpid());
 }
 #endif
+
+TEST_F(ProcessTests, test_getpid) {
+  int pid = -1;
+
+  PlatformProcess process = getCurrentProcess();
+  EXPECT_TRUE(process.isValid());
+
+#ifdef WIN32
+    pid = (int) ::GetCurrentProcessId();
+#else
+    pid = getpid();
+#endif
+
+  EXPECT_EQ(process.pid(), pid);
+}
 
 TEST_F(ProcessTests, test_assignment) {
   PlatformProcess process(kInvalidPid);

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -71,7 +71,10 @@ TEST_F(ProcessTests, test_constructorWin) {
   EXPECT_TRUE(p.isValid());
   EXPECT_NE(p.nativeHandle(), handle);
 
-  ::CloseHandle(handle);
+
+  if (handle) {
+    ::CloseHandle(handle);
+  }
 }
 #else
 TEST_F(ProcessTests, test_constructorPosix) {
@@ -112,6 +115,9 @@ TEST_F(ProcessTests, test_assignment) {
   // We make sure that the HANDLE values are not the same
   EXPECT_NE(current.nativeHandle(), process.nativeHandle());
 #endif
+
+  EXPECT_TRUE(current == process);
+  EXPECT_FALSE(current != process);
 }
 
 TEST_F(ProcessTests, test_envVar) {

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -81,6 +81,20 @@ TEST_F(ProcessTests, test_constructorPosix) {
 }
 #endif
 
+TEST_F(ProcessTests, test_assignment) {
+  PlatformProcess process(kInvalidPid);
+  EXPECT_FALSE(process.isValid());
+
+  PlatformProcess current = getCurrentProcess();
+  EXPECT_TRUE(current.isValid());
+
+  PlatformPidType old_type = current.nativeHandle();
+
+  process = current;
+  EXPECT_EQ(current.nativeHandle(), old_type);
+  EXPECT_NE(current.nativeHandle(), process.nativeHandle());
+}
+
 TEST_F(ProcessTests, test_envVar) {
   auto val = getEnvVar("GTEST_OSQUERY");
   EXPECT_FALSE(val);

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -1,0 +1,244 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+ 
+#include <osquery/core.h>
+#include <gtest/gtest.h>
+
+#ifdef WIN32
+#include <Shlwapi.h>
+#endif
+
+#include "osquery/core/process.h"
+
+extern char *self_exec_path;
+
+bool getProcessExitCode(osquery::PlatformProcess& process, int& exitCode)
+{
+  if (!process.isValid()) {
+    return false;
+  }
+
+#ifdef WIN32
+  DWORD code = 0;
+  DWORD ret = 0;
+
+  while ((ret = ::WaitForSingleObject(process.nativeHandle(), INFINITE)) != WAIT_FAILED &&
+    ret != WAIT_OBJECT_0);
+  if (ret == WAIT_FAILED) {
+    return false;
+  }
+
+  if (!::GetExitCodeProcess(process.nativeHandle(), &code)) {
+    return false;
+  }
+
+  if (code != STILL_ACTIVE) {
+    exitCode = code;
+    return true;
+  }
+#else
+  int status = 0;
+  if (::waitpid(process.nativeHandle(), &status, 0) == -1) {
+    return false;
+  }
+  if (WIFEXITED(status)) {
+    exitCode = WEXITSTATUS(status);
+    return true;
+  }
+#endif
+  return false;
+}
+
+#define EXTENSION_SUCCESS_CODE  0x45
+#define WORKER_SUCCESS_CODE     0x57
+
+#define OSQUERY_TESTS_MODULENAME  "osquery_tests.exe"
+
+const char *expected_worker_args[] = {
+  "worker-test"
+};
+const char *expected_extension_args[] = {
+  "osquery extension: extension-test",
+  "--socket",
+  "socket-name",
+  "--timeout",
+  "100",
+  "--interval",
+  "5",
+  "--verbose"
+};
+
+bool compareArguments(char *result[], 
+                      unsigned int result_nelms,
+                      const char *expected[], 
+                      unsigned int expected_nelms) {
+  if (result_nelms != expected_nelms) {
+    return false;
+  }
+
+  for (int i = 0; i < expected_nelms; i++) {
+    if (strlen(result[i]) != strlen(expected[i])) {
+      return false;
+    }
+
+    if (strncmp(result[i], expected[i], strlen(expected[i])) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int workerMain(int argc, char *argv[]) {
+  if (!compareArguments(argv,
+                        argc,
+                        expected_worker_args,
+                        sizeof(expected_worker_args) / sizeof(const char *))) {
+    return -1;
+  }
+
+  osquery::PlatformProcess process = osquery::getLauncherProcess();
+  if (!process.isValid()) {
+    return -2;
+  }
+
+#ifdef WIN32
+  CHAR buffer[1024] = { 0 };
+  DWORD size = 1024;
+  if (!QueryFullProcessImageNameA(process.nativeHandle(),
+                                  0,
+                                  buffer,
+                                  &size)) {
+    return -3;
+  }
+  PathStripPathA(buffer);
+
+  if (strlen(buffer) != strlen(OSQUERY_TESTS_MODULENAME)) {
+    return -4;
+  }
+
+  if (strncmp(buffer, OSQUERY_TESTS_MODULENAME, strlen(buffer)) != 0) {
+    return -5;
+  }
+#else
+  if (process.nativeHandle() != getppid()) {
+    return -3;
+  }
+#endif
+  return WORKER_SUCCESS_CODE;
+}
+
+int extensionMain(int argc, char *argv[]) {
+  if (!compareArguments(argv, 
+                        argc, 
+                        expected_extension_args, 
+                        sizeof(expected_extension_args) / sizeof(const char *))) {
+    return -1;
+  }
+  return EXTENSION_SUCCESS_CODE;
+}
+
+namespace osquery {
+
+class ProcessTests : public testing::Test {};
+
+TEST_F(ProcessTests, test_constructor) {
+  auto p = PlatformProcess(kInvalidPid);
+  EXPECT_FALSE(p.isValid());
+}
+
+#ifdef WIN32
+TEST_F(ProcessTests, test_constructorWin) {
+  HANDLE handle = ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());
+  EXPECT_NE(handle, reinterpret_cast<HANDLE>(NULL));
+  
+  auto p = PlatformProcess(handle);
+  EXPECT_TRUE(p.isValid());
+  EXPECT_NE(p.nativeHandle(), handle);
+  
+  ::CloseHandle(handle);
+}
+#else
+TEST_F(ProcessTests, test_constructorPosix) {
+  auto p = PlatformProcess(getpid());
+  EXPECT_TRUE(p.isValid());
+  EXPECT_EQ(p.nativeHandle(), getpid());
+}
+#endif
+
+TEST_F(ProcessTests, test_envVar) {
+  auto val = getEnvVar("GTEST_OSQUERY");
+  EXPECT_FALSE(val);
+  
+  EXPECT_TRUE(setEnvVar("GTEST_OSQUERY", "true"));
+  
+  val = getEnvVar("GTEST_OSQUERY");
+  EXPECT_EQ(*val, "true");
+  
+  EXPECT_TRUE(unsetEnvVar("GTEST_OSQUERY"));
+  
+  val = getEnvVar("GTEST_OSQUERY");
+  EXPECT_FALSE(val);
+}
+
+TEST_F(ProcessTests, test_launchExtension) {
+  // We are assuming fasdgasdglhasjldgbaousgd9uasbdf is not a valid process name...
+  {
+    osquery::PlatformProcess process = osquery::PlatformProcess::launchExtension(
+      "fasdgasdglhasjldgbaousgd9uasbdf",
+      "extension-test",
+      "socket-name",
+      "100",
+      "5",
+      "true"
+    );
+    EXPECT_FALSE(process.isValid());
+  }
+
+  {
+    osquery::PlatformProcess process = osquery::PlatformProcess::launchExtension(
+      self_exec_path,
+      "extension-test",
+      "socket-name",
+      "100",
+      "5",
+      "true"
+    );
+    EXPECT_TRUE(process.isValid());
+
+    int code = 0;
+    EXPECT_TRUE(getProcessExitCode(process, code));
+    EXPECT_EQ(code, EXTENSION_SUCCESS_CODE);
+  }
+}
+
+TEST_F(ProcessTests, test_launchWorker) {
+  {
+    // Assuming fasdgasdglhasjldgbaousgd9uasbdf is not a valid process
+    osquery::PlatformProcess process = osquery::PlatformProcess::launchWorker(
+      "fasdgasdglhasjldgbaousgd9uasbdf",
+      "worker-test"
+    );
+    EXPECT_FALSE(process.isValid());
+  }
+
+  {
+    osquery::PlatformProcess process = osquery::PlatformProcess::launchWorker(
+      self_exec_path,
+      "worker-test"
+    );
+    EXPECT_TRUE(process.isValid());
+
+    int code = 0;
+    EXPECT_TRUE(getProcessExitCode(process, code));
+    EXPECT_EQ(code, WORKER_SUCCESS_CODE);
+  }
+}
+}

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -107,7 +107,11 @@ TEST_F(ProcessTests, test_assignment) {
 
   process = current;
   EXPECT_EQ(current.nativeHandle(), old_type);
+
+#ifdef WIN32
+  // We make sure that the HANDLE values are not the same
   EXPECT_NE(current.nativeHandle(), process.nativeHandle());
+#endif
 }
 
 TEST_F(ProcessTests, test_envVar) {

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -11,11 +11,8 @@
 #include <osquery/core.h>
 #include <gtest/gtest.h>
 
-#ifdef WIN32
-#include <Shlwapi.h>
-#endif
-
 #include "osquery/core/process.h"
+#include "osquery/core/test_util.h"
 
 extern char *self_exec_path;
 
@@ -56,98 +53,9 @@ bool getProcessExitCode(osquery::PlatformProcess& process, int& exitCode)
   return false;
 }
 
-#define EXTENSION_SUCCESS_CODE  0x45
-#define WORKER_SUCCESS_CODE     0x57
-
-#define OSQUERY_TESTS_MODULENAME  "osquery_tests.exe"
-
-const char *expected_worker_args[] = {
-  "worker-test"
-};
-const char *expected_extension_args[] = {
-  "osquery extension: extension-test",
-  "--socket",
-  "socket-name",
-  "--timeout",
-  "100",
-  "--interval",
-  "5",
-  "--verbose"
-};
-
-bool compareArguments(char *result[], 
-                      unsigned int result_nelms,
-                      const char *expected[], 
-                      unsigned int expected_nelms) {
-  if (result_nelms != expected_nelms) {
-    return false;
-  }
-
-  for (int i = 0; i < expected_nelms; i++) {
-    if (strlen(result[i]) != strlen(expected[i])) {
-      return false;
-    }
-
-    if (strncmp(result[i], expected[i], strlen(expected[i])) != 0) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-int workerMain(int argc, char *argv[]) {
-  if (!compareArguments(argv,
-                        argc,
-                        expected_worker_args,
-                        sizeof(expected_worker_args) / sizeof(const char *))) {
-    return -1;
-  }
-
-  osquery::PlatformProcess process = osquery::getLauncherProcess();
-  if (!process.isValid()) {
-    return -2;
-  }
-
-#ifdef WIN32
-  CHAR buffer[1024] = { 0 };
-  DWORD size = 1024;
-  if (!QueryFullProcessImageNameA(process.nativeHandle(),
-                                  0,
-                                  buffer,
-                                  &size)) {
-    return -3;
-  }
-  PathStripPathA(buffer);
-
-  if (strlen(buffer) != strlen(OSQUERY_TESTS_MODULENAME)) {
-    return -4;
-  }
-
-  if (strncmp(buffer, OSQUERY_TESTS_MODULENAME, strlen(buffer)) != 0) {
-    return -5;
-  }
-#else
-  if (process.nativeHandle() != getppid()) {
-    return -3;
-  }
-#endif
-  return WORKER_SUCCESS_CODE;
-}
-
-int extensionMain(int argc, char *argv[]) {
-  if (!compareArguments(argv, 
-                        argc, 
-                        expected_extension_args, 
-                        sizeof(expected_extension_args) / sizeof(const char *))) {
-    return -1;
-  }
-  return EXTENSION_SUCCESS_CODE;
-}
-
 namespace osquery {
 
-class ProcessTests : public testing::Test {};
+class ProcessTests : public testing::Test { };
 
 TEST_F(ProcessTests, test_constructor) {
   auto p = PlatformProcess(kInvalidPid);

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -97,19 +97,6 @@ TEST_F(ProcessTests, test_envVar) {
 }
 
 TEST_F(ProcessTests, test_launchExtension) {
-  // We are assuming fasdgasdglhasjldgbaousgd9uasbdf is not a valid process name...
-  {
-    osquery::PlatformProcess process = osquery::PlatformProcess::launchExtension(
-      "fasdgasdglhasjldgbaousgd9uasbdf",
-      "extension-test",
-      "socket-name",
-      "100",
-      "5",
-      "true"
-    );
-    EXPECT_FALSE(process.isValid());
-  }
-
   {
     osquery::PlatformProcess process = osquery::PlatformProcess::launchExtension(
       self_exec_path,
@@ -128,15 +115,6 @@ TEST_F(ProcessTests, test_launchExtension) {
 }
 
 TEST_F(ProcessTests, test_launchWorker) {
-  {
-    // Assuming fasdgasdglhasjldgbaousgd9uasbdf is not a valid process
-    osquery::PlatformProcess process = osquery::PlatformProcess::launchWorker(
-      "fasdgasdglhasjldgbaousgd9uasbdf",
-      "worker-test"
-    );
-    EXPECT_FALSE(process.isValid());
-  }
-
   {
     osquery::PlatformProcess process = osquery::PlatformProcess::launchWorker(
       self_exec_path,

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -446,10 +446,10 @@ void WatcherWatcherRunner::start() {
   // XXX TODO: Stubbed out
 #ifndef WIN32
   while (!interrupted()) {
-    if (getppid() != watcher_) {
+    if (isLauncherProcessDead(watcher_)) {
       // Watcher died, the worker must follow.
-      VLOG(1) << "osqueryd worker (" << getpid()
-              << ") detected killed watcher (" << watcher_ << ")";
+      VLOG(1) << "osqueryd worker (" << getCurrentProcess().pid()
+              << ") detected killed watcher (" << watcher_.pid() << ")";
       // The watcher watcher is a thread. Do not join services after removing.
       Initializer::requestShutdown();
       break;

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -136,7 +136,10 @@ bool Watcher::hasManagedExtensions() {
   // Setting this counter to 0 will prevent the worker from waiting for missing
   // dependent config plugins. Otherwise, its existence, will cause a worker to
   // wait for missing plugins to broadcast from managed extensions.
-  return (getenv("OSQUERY_EXTENSIONS") != nullptr);
+  if (auto value = getEnvVar("OSQUERY_EXTENSIONS")) {
+    return true;
+  }
+  return false;
 }
 
 bool WatcherRunner::ok() {

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -24,6 +24,7 @@
 #include <osquery/sql.h>
 
 #include "osquery/core/watcher.h"
+#include "osquery/core/process.h"
 
 extern char** environ;
 
@@ -185,6 +186,7 @@ bool WatcherRunner::watch(pid_t child) {
 
   // XXX TODO: Stubbed out for now
 #ifndef WIN32
+  // TODO(#1991): We need to abstract the following
   pid_t result = waitpid(child, &status, WNOHANG);
   if (Watcher::fatesBound()) {
     // A signal was handled while the watcher was watching.
@@ -215,6 +217,7 @@ bool WatcherRunner::watch(pid_t child) {
 void WatcherRunner::stopChild(pid_t child) {
   // XXX TODO: Ignored for now
 #ifndef WIN32
+  // TODO(#1991): We need to abstract the following
   kill(child, SIGKILL);
 
   // Clean up the defunct (zombie) process.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -12,7 +12,10 @@
 
 #include <math.h>
 #include <signal.h>
+
+#ifndef WIN32
 #include <sys/wait.h>
+#endif
 
 #include <boost/filesystem.hpp>
 
@@ -179,6 +182,9 @@ void WatcherRunner::start() {
 
 bool WatcherRunner::watch(pid_t child) {
   int status = 0;
+
+  // XXX TODO: Stubbed out for now
+#ifndef WIN32
   pid_t result = waitpid(child, &status, WNOHANG);
   if (Watcher::fatesBound()) {
     // A signal was handled while the watcher was watching.
@@ -201,17 +207,24 @@ bool WatcherRunner::watch(pid_t child) {
     // If the worker process existed, store the exit code.
     Watcher::instance().worker_status_ = WEXITSTATUS(status);
   }
+#endif
+
   return true;
 }
 
 void WatcherRunner::stopChild(pid_t child) {
+  // XXX TODO: Ignored for now
+#ifndef WIN32
   kill(child, SIGKILL);
 
   // Clean up the defunct (zombie) process.
   waitpid(-1, 0, WNOHANG);
+#endif
 }
 
 bool WatcherRunner::isChildSane(pid_t child) {
+  // XXX TODO: Stubbed out...
+#ifndef WIN32
   auto rows = SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child));
   if (rows.size() == 0) {
     // Could not find worker process?
@@ -295,10 +308,14 @@ bool WatcherRunner::isChildSane(pid_t child) {
   if (use_worker_) {
     relayStatusLogs();
   }
+#endif
+
   return true;
 }
 
 void WatcherRunner::createWorker() {
+  // XXX TODO: Stubbed out
+#ifndef WIN32
   {
     WatcherLocker locker;
     if (Watcher::getState(Watcher::getWorker()).last_respawn_time >
@@ -359,6 +376,7 @@ void WatcherRunner::createWorker() {
   Watcher::resetWorkerCounters(getUnixTime());
   VLOG(1) << "osqueryd watcher (" << getpid() << ") executing worker ("
           << worker_pid << ")";
+#endif
 }
 
 bool WatcherRunner::createExtension(const std::string& extension) {
@@ -382,6 +400,8 @@ bool WatcherRunner::createExtension(const std::string& extension) {
     return false;
   }
 
+  // XXX TODO: Stubbed out
+#ifndef WIN32
   auto ext_pid = fork();
   if (ext_pid < 0) {
     // Unrecoverable error, cannot create an extension process.
@@ -411,10 +431,14 @@ bool WatcherRunner::createExtension(const std::string& extension) {
   Watcher::resetExtensionCounters(extension, getUnixTime());
   VLOG(1) << "Created and monitoring extension child (" << ext_pid
           << "): " << extension;
+#endif
+
   return true;
 }
 
 void WatcherWatcherRunner::start() {
+  // XXX TODO: Stubbed out
+#ifndef WIN32
   while (!interrupted()) {
     if (getppid() != watcher_) {
       // Watcher died, the worker must follow.
@@ -426,6 +450,7 @@ void WatcherWatcherRunner::start() {
     }
     pauseMilli(getWorkerLimit(INTERVAL) * 1000);
   }
+#endif
 }
 
 size_t getWorkerLimit(WatchdogLimitType name, int level) {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -290,7 +290,7 @@ class WatcherWatcherRunner : public InternalRunnable {
 
  private:
   /// Parent, or watchdog, process ID.
-  PlatformProcess watcher_{kInvalidProcessId};
+  PlatformProcess watcher_{kInvalidPid};
 };
 
 /// Get a performance limit by name and optional level.

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -13,7 +13,9 @@
 #include <atomic>
 #include <string>
 
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include <boost/noncopyable.hpp>
 
@@ -35,8 +37,8 @@ class WatcherRunner;
 /**
  * @brief Categories of process performance limitations.
  *
- * Performance limits are applied by a watcher thread on autoloaded extensions
  * and a optional daemon worker process. The performance types are identified
+ * Performance limits are applied by a watcher thread on autoloaded extensions
  * here, and organized into levels. Such that a caller may enforce rigor or
  * relax the performance expectations of a osquery daemon.
  */
@@ -286,7 +288,7 @@ class WatcherWatcherRunner : public InternalRunnable {
 
  private:
   /// Parent, or watchdog, process ID.
-  pid_t watcher_{-1};
+  pid_t watcher_{(pid_t) -1};
 };
 
 /// Get a performance limit by name and optional level.

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -22,6 +22,8 @@
 #include <osquery/dispatcher.h>
 #include <osquery/flags.h>
 
+#include "osquery/core/process.h"
+
 /// Define a special debug/testing watchdog level.
 #define WATCHDOG_LEVEL_DEBUG 3
 /// Define the default watchdog level, level below are considered permissive.
@@ -281,14 +283,14 @@ class WatcherRunner : public InternalRunnable {
 /// The WatcherWatcher is spawned within the worker and watches the watcher.
 class WatcherWatcherRunner : public InternalRunnable {
  public:
-  explicit WatcherWatcherRunner(pid_t watcher) : watcher_(watcher) {}
+  explicit WatcherWatcherRunner(const PlatformProcess& watcher) : watcher_(watcher) {}
 
   /// Runnable thread's entry point.
   void start();
 
  private:
   /// Parent, or watchdog, process ID.
-  pid_t watcher_{(pid_t) -1};
+  PlatformProcess watcher_{kInvalidProcessId};
 };
 
 /// Get a performance limit by name and optional level.

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -61,6 +61,10 @@ PlatformProcess& PlatformProcess::operator=(const PlatformProcess& process) {
   return *this;
 }
 
+int PlatformProcess::pid() const {
+  return ::GetProcessId(id_);
+}
+
 bool PlatformProcess::kill() {
   if (id_ == kInvalidPid) {
     return false;

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -17,11 +17,9 @@
 
 extern char **environ;
 
-namespace osquery 
-{
+namespace osquery {
 
-PlatformProcess::PlatformProcess(PlatformPidType id)
-{ 
+PlatformProcess::PlatformProcess(PlatformPidType id) { 
   PlatformPidType handle = kInvalidPid;
     
   if (id != kInvalidPid) {
@@ -39,22 +37,19 @@ PlatformProcess::PlatformProcess(PlatformPidType id)
   id_ = handle;
 }
 
-PlatformProcess::PlatformProcess(PlatformProcess&& src)
-{
+PlatformProcess::PlatformProcess(PlatformProcess&& src) {
   id_ = src.id_;
   src.id_ = kInvalidPid;
 }  
 
-PlatformProcess::~PlatformProcess()
-{ 
+PlatformProcess::~PlatformProcess() { 
   if (id_ != kInvalidPid) {
     ::CloseHandle(id_);
     id_ = kInvalidPid;
   }
 }
 
-bool PlatformProcess::kill()
-{
+bool PlatformProcess::kill() {
   if (id_ == kInvalidPid) {
     return false;
   }
@@ -62,8 +57,7 @@ bool PlatformProcess::kill()
   return ::TerminateProcess(id_, 0);
 }
 
-PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name)
-{
+PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name) {
   ::STARTUPINFOA si = { 0 };
   ::PROCESS_INFORMATION pi = { 0 };
   
@@ -100,6 +94,7 @@ PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, cons
   
   std::string args = args_stream.str();
   std::vector<char> argv(args.begin(), args.end());
+  argv.push_back('\0');
   
   BOOL status = ::CreateProcessA(exec_path.c_str(),
                                  &argv[0],
@@ -131,8 +126,7 @@ PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path,
                                                  const std::string& extensions_socket,
                                                  const std::string& extensions_timeout,
                                                  const std::string& extensions_interval,
-                                                 const std::string& verbose)
-{
+                                                 const std::string& verbose) {
   ::STARTUPINFOA si = { 0 };
   ::PROCESS_INFORMATION pi = { 0 };
   
@@ -183,10 +177,8 @@ PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path,
   return process;
 }
 
-PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id)
-{
+PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id) {
   return PlatformProcess(id);
 }
-
 }
 

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -60,6 +60,14 @@ PlatformProcess& PlatformProcess::operator=(const PlatformProcess& process) {
   return *this;
 }
 
+bool PlatformProcess::operator==(const PlatformProcess& process) {
+  return (::GetProcessId(nativeHandle()) == ::GetProcessId(process.nativeHandle()));
+}
+
+bool PlatformProcess::operator!=(const PlatformProcess& process) {
+  return (::GetProcessId(nativeHandle()) != ::GetProcessId(process.nativeHandle()));
+}
+
 int PlatformProcess::pid() const {
   return ::GetProcessId(id_);
 }

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -45,8 +45,7 @@ PlatformProcess::PlatformProcess(const PlatformProcess& src) {
 }
 
 PlatformProcess::PlatformProcess(PlatformProcess&& src) {
-  id_ = src.id_;
-  src.id_ = kInvalidPid;
+  id_ = duplicateHandle(src.nativeHandle());
 }  
 
 PlatformProcess::~PlatformProcess() { 

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -45,7 +45,8 @@ PlatformProcess::PlatformProcess(const PlatformProcess& src) {
 }
 
 PlatformProcess::PlatformProcess(PlatformProcess&& src) {
-  id_ = duplicateHandle(src.nativeHandle());
+  id_ = kInvalidPid;
+  std::swap(id_, src.id_);
 }  
 
 PlatformProcess::~PlatformProcess() { 

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <vector>
+#include <sstream>
+
+#include <signal.h>
+#include <sys/types.h>
+
+#include "osquery/core/process.h"
+
+extern char **environ;
+
+namespace osquery 
+{
+
+PlatformProcess::PlatformProcess(PlatformPidType id) : id_(id) 
+{ 
+  PlatformPidType handle = kInvalidPid;
+  if (!::DuplicateHandle(GetCurrentProcess(), 
+                         id, 
+                         GetCurrentProcess(),
+                         &handle,
+                         0,
+                         FALSE,
+                         DUPLICATE_SAME_ACCESS)) {
+    id_ = kInvalidPid;
+  } else {
+    id_ = handle;
+  }
+}
+
+PlatformProcess::~PlatformProcess()
+{ 
+  if (id_ != kInvalidPid) {
+    ::CloseHandle(id_);
+  }
+  id_ = kInvalidPid;
+}
+
+bool PlatformProcess::kill()
+{
+  return ::TerminateProcess(id_, 0);
+}
+
+PlatformProcess PlatformProcess::launchWorker(const std::string& exec_path, const std::string& name)
+{
+  ::STARTUPINFOA si = { 0 };
+  ::PROCESS_INFORMATION pi = { 0 };
+  
+  si.cb = sizeof(si);
+  
+  // XXX TODO XXX: We need to make that name does not contain any shell restricted characters.
+  std::stringstream args_stream;
+  args_stream << "\"" << name << "\"";
+  
+  std::stringstream handle_stream;
+  
+  HANDLE hLauncherProcess = ::OpenProcess(SYNCHRONIZE, TRUE, GetCurrentProcessId());
+  if (hLauncherProcess == NULL) {
+    // Failed to obtain HANDLE for current process
+    
+    // TODO: return a special error message?
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  handle_stream << hLauncherProcess;
+  std::string handle = handle_stream.str();
+  
+  if (!::SetEnvironmentVariableA("OSQUERY_WORKER", "1") ||
+      !::SetEnvironmentVariableA("OSQUERY_LAUNCHER", handle.c_str())) {
+    // Failed to set a crucial environment variable
+    ::CloseHandle(hLauncherProcess);
+    
+    // TODO: how do we differentiate error levels?
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  std::string args = args_stream.str();
+  std::vector<char> argv(args.begin(), args.end());
+  
+  BOOL status = ::CreateProcessA(exec_path.c_str(),
+                                 &argv[0],
+                                 NULL,
+                                 NULL,
+                                 TRUE,
+                                 0,
+                                 NULL,
+                                 NULL,
+                                 &si,
+                                 &pi);
+  ::SetEnvironmentVariableA("OSQUERY_WORKER", NULL);
+  ::SetEnvironmentVariableA("OSQUERY_LAUNCHER", NULL);
+  ::CloseHandle(hLauncherProcess);
+  
+  if (!status) {
+    // Failed to create a new process
+    
+    // TODO: how do we differentiate error messages and provide debugging feedback?
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  PlatformProcess process(pi.hProcess);
+  ::CloseHandle(pi.hThread);
+  ::CloseHandle(pi.hProcess);
+  
+  return process;
+}
+
+PlatformProcess PlatformProcess::launchExtension(const std::string& exec_path, 
+                                                 const std::string& extension, 
+                                                 const std::string& extensions_socket,
+                                                 const std::string& extensions_timeout,
+                                                 const std::string& extensions_interval,
+                                                 const std::string& verbose)
+{
+  ::STARTUPINFOA si = { 0 };
+  ::PROCESS_INFORMATION pi = { 0 };
+  
+  si.cb = sizeof(si);
+  
+  std::stringstream args_stream;
+  args_stream << "\"osquery extension: " << extension << "\" ";
+  args_stream << "--socket " << extensions_socket << " ";
+  args_stream << "--timeout " << extensions_timeout << " ";
+  args_stream << "--interval " << extensions_interval << " ";
+  
+  if (verbose == "true") {
+    args_stream << "--verbose";
+  }
+  
+  std::string args = args_stream.str();
+  std::vector<char> argv(args.begin(), args.end());
+  argv.push_back('\0');
+
+  if (!::SetEnvironmentVariableA("OSQUERY_EXTENSIONS", "1")) {
+    // Failed to set important environment variable
+    
+    // TODO: differentiate error message
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  BOOL status = ::CreateProcessA(exec_path.c_str(),
+                                 &argv[0],
+                                 NULL,
+                                 NULL,
+                                 TRUE,
+                                 0,
+                                 NULL,
+                                 NULL,
+                                 &si,
+                                 &pi);
+  ::SetEnvironmentVariableA("OSQUERY_EXTENSIONS", NULL);
+  
+  if (!status) {
+    // Failed to create process
+    
+    // TODO: differentiate error message
+    return PlatformProcess(kInvalidPid);
+  }
+
+  PlatformProcess process(pi.hProcess);
+  ::CloseHandle(pi.hThread);
+  ::CloseHandle(pi.hProcess);
+  
+  return process;
+}
+
+PlatformProcess PlatformProcess::fromPlatformPid(PlatformPidType id)
+{
+  return PlatformProcess(id);
+}
+
+}
+

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -15,11 +15,9 @@
 
 #include "osquery/core/process.h"
 
-namespace osquery 
-{
+namespace osquery {
 
-PlatformProcess getCurrentProcess()
-{
+PlatformProcess getCurrentProcess() {
   HANDLE handle = ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());
   if (handle == NULL) {
     return PlatformProcess(kInvalidPid);
@@ -29,8 +27,7 @@ PlatformProcess getCurrentProcess()
   return process;
 }
 
-PlatformProcess getLauncherProcess()
-{
+PlatformProcess getLauncherProcess() {
   auto launcher_handle = getEnvVar("OSQUERY_LAUNCHER");
   if (!launcher_handle) {
     return PlatformProcess(kInvalidPid);
@@ -51,8 +48,7 @@ PlatformProcess getLauncherProcess()
   return launcher;
 }
 
-bool isLauncherProcessDead(PlatformProcess& launcher)
-{
+bool isLauncherProcessDead(PlatformProcess& launcher) {
   DWORD code = 0 ;
   if (!::GetExitCodeProcess(launcher.nativeHandle(), &code)) {
     // TODO(#1991): If an error occurs with GetExitCodeProcess, do we want to return a Status 
@@ -63,13 +59,15 @@ bool isLauncherProcessDead(PlatformProcess& launcher)
   return (code != STILL_ACTIVE);
 }
 
-bool setEnvVar(const std::string& name, const std::string& value)
-{
+bool setEnvVar(const std::string& name, const std::string& value) {
   return (::SetEnvironmentVariableA(name.c_str(), value.c_str()) == TRUE);
 }
 
-boost::optional<std::string> getEnvVar(const std::string& name)
-{
+bool unsetEnvVar(const std::string& name) {
+  return (::SetEnvironmentVariableA(name.c_str(), NULL) == TRUE);
+}
+
+boost::optional<std::string> getEnvVar(const std::string& name) {
   const int kInitialBufferSize = 1024;
   std::vector<char> buf;
   buf.assign(kInitialBufferSize, '\0');
@@ -96,5 +94,4 @@ boost::optional<std::string> getEnvVar(const std::string& name)
   
   return std::string(&buf[0], value_len);
 }
-
 }

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -20,21 +20,43 @@ namespace osquery
 
 PlatformProcess getCurrentProcess()
 {
-  // OpenProcess with GetCurrentProcessId with full privileges
-  return PlatformProcess(kInvalidPid);
+  HANDLE handle = ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());
+  if (handle == NULL) {
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  PlatformProcess process(handle);
+  return process;
 }
 
 PlatformProcess getLauncherProcess()
 {
-  // Check for existence of OSQUERY_LAUNCHER
-  return PlatformProcess(kInvalidPid);  
+  auto launcher_handle = getEnvVar("OSQUERY_LAUNCHER");
+  if (!launcher_handle) {
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  // Convert the environment variable into a HANDLE (the value from environment variable 
+  // should be a hex value). As a precaution, ensure that the HANDLE is valid.
+  //
+  // TODO(#1991): HANDLE in Windows is defined as "void *". As a result, its size depends
+  //              on the underlying processor architecture. Since we don't claim to support
+  //              32 bit, we will be using std::stoull for now.
+  HANDLE handle = reinterpret_cast<HANDLE>(std::stoull(*launcher_handle, nullptr, 16));
+  if (handle == NULL || handle == INVALID_HANDLE_VALUE) {
+    return PlatformProcess(kInvalidPid);
+  }
+  
+  PlatformProcess launcher(handle);
+  return launcher;
 }
 
 bool isLauncherProcessDead(PlatformProcess& launcher)
 {
   DWORD code = 0 ;
   if (!::GetExitCodeProcess(launcher.nativeHandle(), &code)) {
-    // TODO: how do we propogate an error?
+    // TODO(#1991): If an error occurs with GetExitCodeProcess, do we want to return a Status 
+    //              object to describe the error with more granularity?
     return false;
   }
   
@@ -54,17 +76,20 @@ boost::optional<std::string> getEnvVar(const std::string& name)
   
   DWORD value_len = ::GetEnvironmentVariableA(name.c_str(), &buf[0], kInitialBufferSize);
   if (value_len == 0) {
-    // Either environment variable name is invalid or something has gone horribly wrong
+    // TODO(#1991): Do we want figure out a way to be more granular in terms of the error to 
+    //              return?
     return boost::none;
   }
   
-  // We understand that there is always the possibility of a race-condition
+  // It is always possible that between the first GetEnvironmentVariableA call and this one, 
+  // a change was made to our target environment variable that altered the size. Currently,
+  // we ignore this scenario and fail if the returned size is greater than what we expect.
   if (value_len > kInitialBufferSize) {
     buf.assign(value_len, '\0');
     value_len = ::GetEnvironmentVariableA(name.c_str(), &buf[0], value_len);
     if (value_len == 0 || value_len > buf.size()) {
-      // Could not retrieve environment variable
-      
+      // The size returned is greater than the size we expected. Currently, we will not deal
+      // with this scenario and just return as if an error has occurred.
       return boost::none;
     }
   }

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+#include <vector>
+#include <stdlib.h>
+#include <boost/optional.hpp>
+
+#include "osquery/core/process.h"
+
+namespace osquery 
+{
+
+PlatformProcess getCurrentProcess()
+{
+  // OpenProcess with GetCurrentProcessId with full privileges
+  return PlatformProcess(kInvalidPid);
+}
+
+PlatformProcess getLauncherProcess()
+{
+  // Check for existence of OSQUERY_LAUNCHER
+  return PlatformProcess(kInvalidPid);  
+}
+
+bool isLauncherProcessDead(PlatformProcess& launcher)
+{
+  DWORD code = 0 ;
+  if (!::GetExitCodeProcess(launcher.nativeHandle(), &code)) {
+    // TODO: how do we propogate an error?
+    return false;
+  }
+  
+  return (code != STILL_ACTIVE);
+}
+
+bool setEnvVar(const std::string& name, const std::string& value)
+{
+  return (::SetEnvironmentVariableA(name.c_str(), value.c_str()) == TRUE);
+}
+
+boost::optional<std::string> getEnvVar(const std::string& name)
+{
+  const int kInitialBufferSize = 1024;
+  std::vector<char> buf;
+  buf.assign(kInitialBufferSize, '\0');
+  
+  DWORD value_len = ::GetEnvironmentVariableA(name.c_str(), &buf[0], kInitialBufferSize);
+  if (value_len == 0) {
+    // Either environment variable name is invalid or something has gone horribly wrong
+    return boost::none;
+  }
+  
+  // We understand that there is always the possibility of a race-condition
+  if (value_len > kInitialBufferSize) {
+    buf.assign(value_len, '\0');
+    value_len = ::GetEnvironmentVariableA(name.c_str(), &buf[0], value_len);
+    if (value_len == 0 || value_len > buf.size()) {
+      // Could not retrieve environment variable
+      
+      return boost::none;
+    }
+  }
+  
+  return std::string(&buf[0], value_len);
+}
+
+}

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -125,7 +125,11 @@ void Dispatcher::stopServices() {
       }
       // We only need to check if std::terminate is called very quickly after
       // the std::thread is created.
+#ifdef WIN32
+      Sleep(20);
+#else
       ::usleep(20);
+#endif
     }
     service->interrupt();
     DLOG(INFO) << "Service: " << &*service << " has been interrupted";

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -31,8 +31,10 @@ namespace osquery {
 // Millisecond latency between initalizing manager pings.
 const size_t kExtensionInitializeLatencyUS = 20000;
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 const std::string kModuleExtension = ".dylib";
+#elif defined(WIN32)
+const std::string kModuleExtension = ".dll";
 #else
 const std::string kModuleExtension = ".so";
 #endif
@@ -299,7 +301,11 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
     }
     // Increase the total wait detail.
     delay += kExtensionInitializeLatencyUS;
+#ifdef WIN32
+    Sleep(kExtensionInitializeLatencyUS);
+#else
     ::usleep(kExtensionInitializeLatencyUS);
+#endif
   } while (delay < timeout);
   return Status(1, "Extension socket not available: " + path);
 }

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -203,6 +203,7 @@ inline void removeStalePaths(const std::string& manager) {
 }
 
 void ExtensionRunnerCore::startServer(TProcessorRef processor) {
+#ifndef WIN32
   {
     std::unique_lock<std::mutex> lock(service_start_);
     // A request to stop the service may occur before the thread starts.
@@ -224,6 +225,7 @@ void ExtensionRunnerCore::startServer(TProcessorRef processor) {
   }
 
   server_->serve();
+#endif
 }
 
 void ExtensionRunner::start() {

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -48,7 +48,11 @@ typedef SHARED_PTR_IMPL<TServerTransport> TServerTransportRef;
 typedef SHARED_PTR_IMPL<TTransportFactory> TTransportFactoryRef;
 typedef SHARED_PTR_IMPL<TProtocolFactory> TProtocolFactoryRef;
 typedef SHARED_PTR_IMPL<ThreadManager> TThreadManagerRef;
+
+#ifndef WIN32
 typedef SHARED_PTR_IMPL<PosixThreadFactory> PosixThreadFactoryRef;
+#endif
+
 using TThreadedServerRef = std::shared_ptr<TThreadedServer>;
 
 namespace extensions {

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -50,7 +50,11 @@ class ExtensionsTest : public testing::Test {
         client.get()->ping(status);
         return (status.code == ExtensionCode::EXT_SUCCESS);
       } catch (const std::exception& e) {
+#ifdef WIN32
+        Sleep(kDelayUS);
+#else
         ::usleep(kDelayUS);
+#endif
       }
     }
 
@@ -65,7 +69,11 @@ class ExtensionsTest : public testing::Test {
         EXManagerClient client(socket_path);
         client.get()->query(response, sql);
       } catch (const std::exception& e) {
+#ifdef WIN32
+        Sleep(kDelayUS);
+#else
         ::usleep(kDelayUS);
+#endif
       }
     }
 
@@ -95,7 +103,11 @@ class ExtensionsTest : public testing::Test {
       if (pathExists(socket_path).ok() && isReadable(socket_path).ok()) {
         return true;
       }
+#ifdef WIN32
+      Sleep(kDelayUS);
+#else
       ::usleep(kDelayUS);
+#endif
       delay += kDelayUS;
     }
     return false;

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -88,6 +88,7 @@ TEST_F(FilesystemTests, test_read_limit) {
   EXPECT_FALSE(status.ok());
   FLAGS_read_max = max;
 
+#ifndef WIN32
   if (getuid() != 0) {
     content.erase();
     FLAGS_read_user_max = 2;
@@ -104,6 +105,7 @@ TEST_F(FilesystemTests, test_read_limit) {
     status = readFile(kFakeDirectory + "/root2.txt", content);
     EXPECT_TRUE(status.ok());
   }
+#endif
 }
 
 TEST_F(FilesystemTests, test_list_files_missing_directory) {

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -12,9 +12,25 @@
 
 #include <osquery/logger.h>
 
+#include "osquery/core/process.h"
 #include "osquery/core/test_util.h"
 
+// TODO(#1991): We import and export the following symbols to support launchWorker
+//              and launchExtension unit tests. The question for the future is how
+//              to integrate it better so that the main tests.cpp doesn't have 
+//              dependencies on unit tests elsewhere.
+char *self_exec_path = nullptr;
+extern int workerMain(int argc, char *argv[]);
+extern int extensionMain(int argc, char *argv[]);
+
 int main(int argc, char* argv[]) {
+  if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
+    return workerMain(argc, argv);
+  } else if (val = osquery::getEnvVar("OSQUERY_EXTENSIONS")) {
+    return extensionMain(argc, argv);
+  }
+  self_exec_path = argv[0];
+
   osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -12,25 +12,9 @@
 
 #include <osquery/logger.h>
 
-#include "osquery/core/process.h"
 #include "osquery/core/test_util.h"
 
-// TODO(#1991): We import and export the following symbols to support launchWorker
-//              and launchExtension unit tests. The question for the future is how
-//              to integrate it better so that the main tests.cpp doesn't have 
-//              dependencies on unit tests elsewhere.
-char *self_exec_path = nullptr;
-extern int workerMain(int argc, char *argv[]);
-extern int extensionMain(int argc, char *argv[]);
-
 int main(int argc, char* argv[]) {
-  if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
-    return workerMain(argc, argv);
-  } else if (val = osquery::getEnvVar("OSQUERY_EXTENSIONS")) {
-    return extensionMain(argc, argv);
-  }
-  self_exec_path = argv[0];
-
   osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging

--- a/osquery/main/tests_core.cpp
+++ b/osquery/main/tests_core.cpp
@@ -47,7 +47,7 @@ bool compareArguments(char *result[],
     return false;
   }
 
-  for (int i = 0; i < expected_nelms; i++) {
+  for (unsigned int i = 0; i < expected_nelms; i++) {
     if (strlen(result[i]) != strlen(expected[i])) {
       return false;
     }
@@ -112,8 +112,7 @@ int extensionMain(int argc, char *argv[]) {
 int main(int argc, char* argv[]) {
   if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
     return workerMain(argc, argv);
-  }
-  else if (val = osquery::getEnvVar("OSQUERY_EXTENSIONS")) {
+  } else if ((val = osquery::getEnvVar("OSQUERY_EXTENSIONS"))) {
     return extensionMain(argc, argv);
   }
   self_exec_path = argv[0];

--- a/osquery/main/tests_core.cpp
+++ b/osquery/main/tests_core.cpp
@@ -1,0 +1,129 @@
+/*
+*  Copyright (c) 2014-present, Facebook, Inc.
+*  All rights reserved.
+*
+*  This source code is licensed under the BSD-style license found in the
+*  LICENSE file in the root directory of this source tree. An additional grant
+*  of patent rights can be found in the PATENTS file in the same directory.
+*
+*/
+
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <Shlwapi.h>
+#endif
+
+#include <gtest/gtest.h>
+
+#include <osquery/logger.h>
+
+#include "osquery/core/process.h"
+#include "osquery/core/test_util.h"
+
+#define OSQUERY_TESTS_MODULENAME  "osquery_tests.exe"
+
+char *self_exec_path = nullptr;
+
+const char *expected_worker_args[] = {
+  "worker-test"
+};
+const char *expected_extension_args[] = {
+  "osquery extension: extension-test",
+  "--socket",
+  "socket-name",
+  "--timeout",
+  "100",
+  "--interval",
+  "5",
+  "--verbose"
+};
+
+bool compareArguments(char *result[],
+  unsigned int result_nelms,
+  const char *expected[],
+  unsigned int expected_nelms) {
+  if (result_nelms != expected_nelms) {
+    return false;
+  }
+
+  for (int i = 0; i < expected_nelms; i++) {
+    if (strlen(result[i]) != strlen(expected[i])) {
+      return false;
+    }
+
+    if (strncmp(result[i], expected[i], strlen(expected[i])) != 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+int workerMain(int argc, char *argv[]) {
+  if (!compareArguments(argv,
+    argc,
+    expected_worker_args,
+    sizeof(expected_worker_args) / sizeof(const char *))) {
+    return -1;
+  }
+
+  osquery::PlatformProcess process = osquery::getLauncherProcess();
+  if (!process.isValid()) {
+    return -2;
+  }
+
+#ifdef WIN32
+  CHAR buffer[1024] = { 0 };
+  DWORD size = 1024;
+  if (!QueryFullProcessImageNameA(process.nativeHandle(),
+    0,
+    buffer,
+    &size)) {
+    return -3;
+  }
+  PathStripPathA(buffer);
+
+  if (strlen(buffer) != strlen(OSQUERY_TESTS_MODULENAME)) {
+    return -4;
+  }
+
+  if (strncmp(buffer, OSQUERY_TESTS_MODULENAME, strlen(buffer)) != 0) {
+    return -5;
+  }
+#else
+  if (process.nativeHandle() != getppid()) {
+    return -3;
+  }
+#endif
+  return WORKER_SUCCESS_CODE;
+}
+
+int extensionMain(int argc, char *argv[]) {
+  if (!compareArguments(argv,
+    argc,
+    expected_extension_args,
+    sizeof(expected_extension_args) / sizeof(const char *))) {
+    return -1;
+  }
+  return EXTENSION_SUCCESS_CODE;
+}
+
+int main(int argc, char* argv[]) {
+  if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
+    return workerMain(argc, argv);
+  }
+  else if (val = osquery::getEnvVar("OSQUERY_EXTENSIONS")) {
+    return extensionMain(argc, argv);
+  }
+  self_exec_path = argv[0];
+
+  osquery::initTesting();
+  testing::InitGoogleTest(&argc, argv);
+  // Optionally enable Goggle Logging
+  // google::InitGoogleLogging(argv[0]);
+  auto result = RUN_ALL_TESTS();
+
+  osquery::shutdownTesting();
+  return result;
+}

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -11,7 +11,9 @@
 #include <cstdlib>
 #include <sstream>
 
+#ifndef WIN32
 #include <dlfcn.h>
+#endif
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -523,6 +525,7 @@ void RegistryFactory::declareModule(const std::string& name,
 
 RegistryModuleLoader::RegistryModuleLoader(const std::string& path)
     : handle_(nullptr), path_(path) {
+#ifndef WIN32
   // Tell the registry that we are attempting to construct a module.
   // Locking the registry prevents the module's global initialization from
   // adding or creating registry items.
@@ -542,9 +545,11 @@ RegistryModuleLoader::RegistryModuleLoader(const std::string& path)
     dlclose(handle_);
     handle_ = nullptr;
   }
+#endif
 }
 
 void RegistryModuleLoader::init() {
+#ifndef WIN32
   if (handle_ == nullptr || RegistryFactory::locked()) {
     handle_ = nullptr;
     return;
@@ -563,6 +568,7 @@ void RegistryModuleLoader::init() {
     dlclose(handle_);
     handle_ = nullptr;
   }
+#endif
 }
 
 RegistryModuleLoader::~RegistryModuleLoader() {

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -37,6 +37,7 @@ void genFileInfo(const fs::path& path,
                  const fs::path& parent,
                  const std::string& pattern,
                  QueryData& results) {
+#ifndef WIN32
   // Must provide the path, filename, directory separate from boost path->string
   // helpers to match any explicit (query-parsed) predicate constraints.
   struct stat file_stat, link_stat;
@@ -86,6 +87,7 @@ void genFileInfo(const fs::path& path,
   r["is_char"] = (S_ISCHR(file_stat.st_mode)) ? "1" : "0";
   r["is_block"] = (S_ISBLK(file_stat.st_mode)) ? "1" : "0";
   results.push_back(r);
+#endif
 }
 
 QueryData genFile(QueryContext& context) {

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -154,6 +154,7 @@ QueryData genOsqueryRegistry(QueryContext& context) {
 QueryData genOsqueryExtensions(QueryContext& context) {
   QueryData results;
 
+#ifndef WIN32
   ExtensionList extensions;
   if (getExtensions(extensions).ok()) {
     for (const auto& extension : extensions) {
@@ -179,12 +180,15 @@ QueryData genOsqueryExtensions(QueryContext& context) {
     r["type"] = "module";
     results.push_back(r);
   }
+#endif
 
   return results;
 }
 
 QueryData genOsqueryInfo(QueryContext& context) {
   QueryData results;
+
+#ifndef WIN32
   Row r;
   r["pid"] = INTEGER(getpid());
   r["version"] = kVersion;
@@ -200,6 +204,8 @@ QueryData genOsqueryInfo(QueryContext& context) {
   r["start_time"] = INTEGER(Config::getInstance().getStartTime());
 
   results.push_back(r);
+#endif
+
   return results;
 }
 

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -128,7 +128,7 @@ def platformAction():
 def distroAction():
     family, osType = _platform()
     print _distro(osType)
- 
+
 def familyAction():
     family, osType = _platform()
     if family:


### PR DESCRIPTION
At the moment, this is **not** complete and it is **not** recommended to test.

This is not integrated with `osquery/core` at the moment. Currently, we have an interface defined with some limited implementation of some of the interface functions. Additionally, we have a lot of `ifdef` preprocessor commands in the code base so that `osquery_tests.exe` can be successfully built.

**Thing that need to be done:**
- [ ]  Testing of the abstracted functions on both Linux and Windows
- [x]  Work out how to differentiate error conditions for functions like `launchWorker` and `launchExtension` (for example, let the caller know that the failure is because of `fork` or `execve`)
- [ ]  Integration with `osquery/core` - replace the current chunks of code for doing platform specific stuff and replace it with the new, abstracted functions

Closes #1991, closes #1992, closes #1993, closes #1994 