### PR TITLE
[Fix #2058] Send Content-Encoding when using TLS compression

### DIFF
--- a/osquery/remote/remote.cpp
+++ b/osquery/remote/remote.cpp
@@ -18,7 +18,7 @@ namespace osquery {
 #define MOD_GZIP_ZLIB_WINDOWSIZE 15
 #define MOD_GZIP_ZLIB_CFACTOR 9
 
-void compress(std::string& data) {
+std::string compressString(const std::string& data) {
   z_stream zs;
   memset(&zs, 0, sizeof(zs));
 
@@ -28,7 +28,7 @@ void compress(std::string& data) {
                    MOD_GZIP_ZLIB_WINDOWSIZE + 16,
                    MOD_GZIP_ZLIB_CFACTOR,
                    Z_DEFAULT_STRATEGY) != Z_OK) {
-    return;
+    return std::string();
   }
 
   zs.next_in = (Bytef*)data.data();
@@ -52,9 +52,9 @@ void compress(std::string& data) {
 
   deflateEnd(&zs);
   if (ret != Z_STREAM_END) {
-    return;
+    return std::string();
   }
 
-  data = std::move(output);
+  return output;
 }
 }

--- a/osquery/remote/requests.h
+++ b/osquery/remote/requests.h
@@ -32,7 +32,7 @@ class Serializer;
  *
  * @param data The input/output mutable container.
  */
-void compress(std::string& data);
+std::string compressString(const std::string& data);
 
 /**
  * @brief Abstract base class for remote transport implementations
@@ -75,10 +75,12 @@ class Transport {
    * @brief Send a simple request to the destination with parameters
    *
    * @param params A string representing the serialized parameters
+   * @param compress True of the request was requested to be compressed
    *
    * @return success or failure of the operation
    */
-  virtual Status sendRequest(const std::string& params) = 0;
+  virtual Status sendRequest(const std::string& params,
+                             bool compress = false) = 0;
 
   /**
    * @brief Get the status of the response
@@ -231,10 +233,7 @@ class Request {
       return s;
     }
 
-    if (options_.get("compress", false)) {
-      compress(serialized);
-    }
-    return transport_->sendRequest(serialized);
+    return transport_->sendRequest(serialized, options_.get("compress", false));
   }
 
   /**

--- a/osquery/remote/tests/requests_tests.cpp
+++ b/osquery/remote/tests/requests_tests.cpp
@@ -23,12 +23,12 @@ class RequestsTests : public testing::Test {
 
 class MockTransport : public Transport {
  public:
-  Status sendRequest() {
+  Status sendRequest() override {
     response_status_ = Status(0, "OK");
     return response_status_;
   }
 
-  Status sendRequest(const std::string& params) {
+  Status sendRequest(const std::string& params, bool compress) override {
     response_params_.put<std::string>("foo", "baz");
     response_status_ = Status(0, "OK");
     return response_status_;
@@ -80,13 +80,14 @@ TEST_F(RequestsTests, test_call_with_params) {
 
 class CopyTransport : public Transport {
  public:
-  Status sendRequest() {
+  Status sendRequest() override {
     response_status_ = Status(0, "OK");
     return response_status_;
   }
 
-  Status sendRequest(const std::string& params) {
-    response_status_ = Status(0, params);
+  Status sendRequest(const std::string& params, bool compress) override {
+    // Optionally compress.
+    response_status_ = Status(0, (compress) ? compressString(params) : params);
     return response_status_;
   }
 };

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -37,6 +37,7 @@ void ERR_remove_state(unsigned long);
 // Our third-party version of cpp-netlib uses OpenSSL APIs.
 // On OS X these symbols are marked deprecated and clang will warn against
 // us including them. We are squashing the noise for OS X's OpenSSL only.
+// clang-format off
 #if defined(DARWIN)
 _Pragma("clang diagnostic push")
 _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
@@ -45,6 +46,7 @@ _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
 #if defined(DARWIN)
 _Pragma("clang diagnostic pop")
 #endif
+// clang-format on
 
 #include <osquery/flags.h>
 
@@ -81,7 +83,7 @@ class TLSTransport : public Transport {
    * Return code (1) for general connectivity problems, return code (2) for TLS
    * specific errors.
    */
-  Status sendRequest();
+  Status sendRequest() override;
 
   /**
    * @brief Send a simple request to the destination with parameters
@@ -92,7 +94,7 @@ class TLSTransport : public Transport {
    * Return code (1) for general connectivity problems, return code (2) for TLS
    * specific errors.
    */
-  Status sendRequest(const std::string& params);
+  Status sendRequest(const std::string& params, bool compress = false) override;
 
   /**
    * @brief Class destructor


### PR DESCRIPTION
When the configuration flag: --logger_tls_compress is used the client should
send a "Content-Encoding: gzip".