### PR TITLE
Introduce --utc flag to convert all calendar UNIX times to UTC

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -71,6 +71,10 @@ Disable userland watchdog process. **osqueryd** uses a watchdog process to monit
 Performance limit level (0=loose, 1=normal, 2=restrictive, 3=debug). The default watchdog process uses a "level" to configure performance limits.
 The higher the level the more strict the limits become. The "debug" level disables the performance limits completely.
 
+`--utc=false`
+
+Attempt to convert all UNIX calendar times to UTC. In version 1.8.0 this will be `true` by default.
+
 ### Backing storage control flags
 
 `--database_in_memory=false`

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -226,18 +226,18 @@ std::string generateHostUUID();
 std::string getHostIdentifier();
 
 /**
- * @brief Getter for the current time, in a human-readable format.
- *
- * @return the current date/time in the format: "Wed Sep 21 10:27:52 2011"
- */
-std::string getAsciiTime();
-
-/**
  * @brief Getter for the current UNIX time.
  *
  * @return an int representing the amount of seconds since the UNIX epoch
  */
 size_t getUnixTime();
+
+/**
+ * @brief Getter for the current time, in a human-readable format.
+ *
+ * @return the current date/time in the format: "Wed Sep 21 10:27:52 2011"
+ */
+std::string getAsciiTime();
 
 /**
  * @brief Create a pid file

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -55,6 +55,8 @@ FLAG(string,
      "hostname",
      "Field used to identify the host running osquery (hostname, uuid)");
 
+FLAG(bool, utc, false, "Convert all UNIX times to UTC");
+
 std::string getHostname() {
   static long max_hostname = sysconf(_SC_HOST_NAME_MAX);
   long size = (max_hostname > 255) ? max_hostname + 1 : 256;
@@ -141,6 +143,9 @@ std::string getAsciiTime() {
 
 size_t getUnixTime() {
   auto result = std::time(nullptr);
+  if (FLAGS_utc) {
+    result = std::mktime(std::gmtime(&result));
+  }
   return result;
 }
 

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -13,11 +13,22 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/core.h>
+#include <osquery/flags.h>
+
 #include "osquery/core/conversions.h"
 
 #include "osquery/core/test_util.h"
 
+#define EXPECT_WITHIN_INCLUSIVE(lower, upper, val)                     \
+  do {                                                                 \
+    EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperGE, val, lower); \
+    EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperLE, val, upper); \
+  } while (0)
+
 namespace osquery {
+
+DECLARE_bool(utc);
 
 class ConversionsTests : public testing::Test {};
 
@@ -31,6 +42,21 @@ TEST_F(ConversionsTests, test_conversion) {
   std::shared_ptr<Foobar> s2 = std::make_shared<Foobar>();
   boost::shared_ptr<Foobar> b2 = std_to_boost_shared_ptr(s2);
   EXPECT_EQ(s2.get(), b2.get());
+}
+
+TEST_F(ConversionsTests, test_utc) {
+  auto utc = FLAGS_utc;
+  FLAGS_utc = false;
+  auto t1 = getUnixTime();
+  auto at1 = std::time(nullptr);
+  EXPECT_WITHIN_INCLUSIVE(t1 - 10U, t1 + 10, static_cast<size_t>(at1));
+
+  FLAGS_utc = true;
+  auto t2 = getUnixTime();
+  auto rt2 = std::time(nullptr);
+  auto at2 = std::mktime(std::gmtime(&rt2));
+  EXPECT_WITHIN_INCLUSIVE(t2 - 10, t2 + 10, static_cast<size_t>(at2));
+  FLAGS_utc = utc;
 }
 
 TEST_F(ConversionsTests, test_base64) {
@@ -55,7 +81,7 @@ TEST_F(ConversionsTests, test_ascii_false) {
 }
 
 TEST_F(ConversionsTests, test_unicode_unescape) {
-  std::vector<std::pair<std::string, std::string> > conversions = {
+  std::vector<std::pair<std::string, std::string>> conversions = {
       std::make_pair("\\u0025hi", "%hi"),
       std::make_pair("hi\\u0025", "hi%"),
       std::make_pair("\\uFFFFhi", "\\uFFFFhi"),

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -9,29 +9,35 @@
  */
 
 #include <ctime>
+
 #include <boost/algorithm/string/trim.hpp>
 
+#include <osquery/core.h>
+#include <osquery/flags.h>
 #include <osquery/tables.h>
 
 namespace osquery {
+
+DECLARE_bool(utc);
+
 namespace tables {
 
 QueryData genTime(QueryContext& context) {
   Row r;
-  time_t _time = time(nullptr);
-  struct tm* now = localtime(&_time);
-  struct tm* gmt = gmtime(&_time);
+  // Request UNIX time (a wrapper around std::time).
+  auto local_time = std::time(nullptr);
+  auto osquery_time = getUnixTime();
+  auto osquery_timestamp = getAsciiTime();
+
+  // The concept of 'now' is configurable.
+  struct tm* gmt = std::gmtime(&local_time);
+  struct tm* now = (FLAGS_utc) ? gmt : std::localtime(&local_time);
 
   char weekday[10] = {0};
   strftime(weekday, sizeof(weekday), "%A", now);
 
   char timezone[5] = {0};
   strftime(timezone, sizeof(timezone), "%Z", now);
-
-  std::string timestamp;
-  timestamp = asctime(gmt);
-  boost::algorithm::trim(timestamp);
-  timestamp += " UTC";
 
   char iso_8601[21] = {0};
   strftime(iso_8601, sizeof(iso_8601), "%FT%TZ", gmt);
@@ -44,8 +50,9 @@ QueryData genTime(QueryContext& context) {
   r["minutes"] = INTEGER(now->tm_min);
   r["seconds"] = INTEGER(now->tm_sec);
   r["timezone"] = TEXT(timezone);
-  r["unix_time"] = INTEGER(_time);
-  r["timestamp"] = TEXT(timestamp);
+  r["unix_time"] = INTEGER(osquery_time);
+  r["local_time"] = INTEGER(local_time);
+  r["timestamp"] = TEXT(osquery_timestamp);
   r["iso_8601"] = TEXT(iso_8601);
 
   QueryData results;

--- a/specs/utility/time.table
+++ b/specs/utility/time.table
@@ -9,7 +9,9 @@ schema([
     Column("minutes", INTEGER, "Current minutes in the system"),
     Column("seconds", INTEGER, "Current seconds in the system"),
     Column("timezone", TEXT, "Current timezone in the system"),
-    Column("unix_time", INTEGER, "Current UNIX time in the system"),
+    Column("local_time", INTEGER, "Current local UNIX time in the system"),
+    Column("unix_time", INTEGER,
+        "Current UNIX time in the system, converted to UTC if --utc enabled"),
     Column("timestamp", TEXT, "Current timestamp in the system"),
     Column("iso_8601", TEXT, "Current time (iso format) in the system"),
 ])


### PR DESCRIPTION
Beginning in version 1.8.0 all time uses will converge on an osquery-provided
getUnixTime() API call that returns, by default, UNIX time integers converted
to UTC/GMT. The 'time' table will respond with the parsed time for the
configuration. If the timezone is not UTC then osquery is using localtime.

This configuration option will affect the 'unix_time' response in the 'time'
table. Because of this configurable-effect the table is extended to include
'local_time' which is always the system local UNIX time.