### PR TITLE
Fix benchmark target and bump version of google-benchmark to 1.0.0

### DIFF
--- a/osquery/main/benchmarks.cpp
+++ b/osquery/main/benchmarks.cpp
@@ -12,7 +12,7 @@
 
 #include "osquery/core/test_util.h"
 
-int main(int argc, const char* argv[]) {
+int main(int argc, char *argv[]) {
   osquery::initTesting();
   ::benchmark::Initialize(&argc, argv);
   ::benchmark::RunSpecifiedBenchmarks();

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -314,7 +314,7 @@ function install_gflags() {
 }
 
 function install_google_benchmark() {
-  SOURCE=benchmark-0.1.0
+  SOURCE=benchmark-1.0.0
   TARBALL=$SOURCE.tar.gz
   URL=$DEPS_URL/$TARBALL
 


### PR DESCRIPTION
google-benchmark jumped from 0.1.0 to 1.0.0 on homebrew and had minor API change which caused compilation failures. The release is here: https://github.com/google/benchmark/releases/tag/v1.0.0

Manually pulled in 1.0.0 and tested on vagrant boxes and via brew on OS X.
But prior to testing on build hosts, the updated sources will need to be pushed to s3/deps.