### PR TITLE
Add local_timezone and datetime (ISO) to time table

### DIFF
--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -32,12 +32,16 @@ QueryData genTime(QueryContext& context) {
   // The concept of 'now' is configurable.
   struct tm* gmt = std::gmtime(&local_time);
   struct tm* now = (FLAGS_utc) ? gmt : std::localtime(&local_time);
+  struct tm* local = std::localtime(&local_time);
 
   char weekday[10] = {0};
   strftime(weekday, sizeof(weekday), "%A", now);
 
   char timezone[5] = {0};
   strftime(timezone, sizeof(timezone), "%Z", now);
+
+  char local_timezone[5] = {0};
+  strftime(local_timezone, sizeof(local_timezone), "%Z", local);
 
   char iso_8601[21] = {0};
   strftime(iso_8601, sizeof(iso_8601), "%FT%TZ", gmt);
@@ -50,9 +54,12 @@ QueryData genTime(QueryContext& context) {
   r["minutes"] = INTEGER(now->tm_min);
   r["seconds"] = INTEGER(now->tm_sec);
   r["timezone"] = TEXT(timezone);
-  r["unix_time"] = INTEGER(osquery_time);
   r["local_time"] = INTEGER(local_time);
+  r["local_timezone"] = TEXT(local_timezone);
+  r["unix_time"] = INTEGER(osquery_time);
   r["timestamp"] = TEXT(osquery_timestamp);
+  // Date time is provided in ISO 8601 format, then duplicated in iso_8601.
+  r["datetime"] = TEXT(iso_8601);
   r["iso_8601"] = TEXT(iso_8601);
 
   QueryData results;

--- a/specs/utility/time.table
+++ b/specs/utility/time.table
@@ -10,10 +10,12 @@ schema([
     Column("seconds", INTEGER, "Current seconds in the system"),
     Column("timezone", TEXT, "Current timezone in the system"),
     Column("local_time", INTEGER, "Current local UNIX time in the system"),
+    Column("local_timezone", TEXT, "Current local timezone in the system"),
     Column("unix_time", INTEGER,
         "Current UNIX time in the system, converted to UTC if --utc enabled"),
-    Column("timestamp", TEXT, "Current timestamp in the system"),
-    Column("iso_8601", TEXT, "Current time (iso format) in the system"),
+    Column("timestamp", TEXT, "Current timestamp (log format) in the system"),
+    Column("datetime", TEXT, "Current date and time (ISO format) in the system"),
+    Column("iso_8601", TEXT, "Current time (ISO format) in the system"),
 ])
 attributes(utility=True)
 implementation("time@genTime")


### PR DESCRIPTION
It is often helpful to know the local timezone of the machine. For this use
local_timezone, as the base timezone will use local or UTC depending on the
--utc flag. This will be default=UTC in osquery 1.8.0.

The datetime field is added to mimic ISO 8601, along with iso_8601.
The timestamp field remains as the time stamp used for logging (within osquery)
and commonly outside of osquery. The goal for adding multiple representations
is to allow joining/augmenting of other tables.

Cc: @PoppySeedPlehzr 