### PR TITLE
Introduce within-query caching

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -126,6 +126,9 @@ struct ModuleInfo {
 /// The call-in prototype for Registry modules.
 using ModuleInitalizer = void (*)(void);
 
+/// The registry includes a single optimization for table generation.
+struct QueryContext;
+
 template <class PluginItem>
 class PluginFactory {};
 
@@ -375,6 +378,9 @@ class RegistryHelperCore : private boost::noncopyable {
 
   /// If a module was initialized/declared then store lookup information.
   std::map<std::string, RouteUUID> modules_;
+
+ private:
+  friend class RegistryFactory;
 };
 
 /**
@@ -661,6 +667,11 @@ class RegistryFactory : private boost::noncopyable {
   /// A helper call that uses the active plugin (if the registry has one).
   static Status call(const std::string& registry_name,
                      const PluginRequest& request);
+
+  /// A helper call optimized for table data generation.
+  static Status callTable(const std::string& table_name,
+                          QueryContext& context,
+                          PluginResponse& response);
 
   /// Set a registry's active plugin.
   static Status setActive(const std::string& registry_name,

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -111,17 +111,19 @@ Status TablePlugin::call(const PluginRequest& request,
   }
 
   if (request.at("action") == "generate") {
-    // "generate" runs the table implementation using a PluginRequest with
-    // optional serialized QueryContext and returns the QueryData results as
-    // the PluginRequest data.
+    // The "generate" action runs the table implementation using a PluginRequest
+    // with optional serialized QueryContext and returns the QueryData results
+    // as the PluginRequest data.
+
+    // Create a fake table implementation for caching.
     QueryContext context;
     if (request.count("context") > 0) {
       setContextFromRequest(request, context);
     }
     response = generate(context);
   } else if (request.at("action") == "columns") {
-    // "columns" returns a PluginRequest filled with column information
-    // such as name and type.
+    // The "columns" action returns a PluginRequest filled with column
+    // information such as name and type.
     const auto& column_list = columns();
     for (const auto& column : column_list) {
       response.push_back(

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -95,6 +95,7 @@ QueryData SQL::selectAllFrom(const std::string& table,
                              const std::string& expr) {
   PluginRequest request = {{"action", "generate"}};
   {
+    // Create a fake content, there will be no caching.
     QueryContext ctx;
     ctx.constraints[column].add(Constraint(op, expr));
     TablePlugin::setRequestFromContext(ctx, request);

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -278,22 +278,18 @@ Status getQueryColumnsInternal(const std::string& q,
 /// The SQLiteSQLPlugin implements the "sql" registry for internal/core.
 class SQLiteSQLPlugin : SQLPlugin {
  public:
-  Status query(const std::string& q, QueryData& results) const {
-    auto dbc = SQLiteDBManager::get();
-    auto result = queryInternal(q, results, dbc->db());
-    dbc->clearAffectedTables();
-    return result;
-  }
+  /// Execute SQL and store results.
+  Status query(const std::string& q, QueryData& results) const override;
 
-  Status getQueryColumns(const std::string& q, TableColumns& columns) const {
-    auto dbc = SQLiteDBManager::get();
-    return getQueryColumnsInternal(q, columns, dbc->db());
-  }
+  /// Introspect, explain, the suspected types selected in an SQL statement.
+  Status getQueryColumns(const std::string& q,
+                         TableColumns& columns) const override;
 
   /// Create a SQLite module and attach (CREATE).
-  Status attach(const std::string& name);
+  Status attach(const std::string& name) override;
+
   /// Detach a virtual table (DROP).
-  void detach(const std::string& name);
+  void detach(const std::string& name) override;
 };
 
 /**
@@ -306,11 +302,7 @@ class SQLInternal : public SQL {
    *
    * @param q An osquery SQL query
    */
-  explicit SQLInternal(const std::string& q) {
-    auto dbc = SQLiteDBManager::get();
-    status_ = queryInternal(q, results_, dbc->db());
-    dbc->clearAffectedTables();
-  }
+  explicit SQLInternal(const std::string& q);
 };
 
 /**

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -32,7 +32,7 @@ class {{class_name}} {
 
 class {{table_name_cc}}TablePlugin : public TablePlugin {
  private:
-  TableColumns columns() const {
+  TableColumns columns() const override {
     return {
 {% for column in schema %}\
       {"{{column.name}}", {{column.type.affinity}}}\
@@ -41,7 +41,7 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
     };
   }
 
-  QueryData generate(QueryContext& request) {
+  QueryData generate(QueryContext& request) override {
 {% if class_name != "" %}\
     if (EventFactory::exists(getName())) {
       auto subscriber = EventFactory::getEventSubscriber(getName());


### PR DESCRIPTION
This adds a new optimization feature that allows expensive tables to cache their results between JOINs. Consider JOINing a list of open sockets, for each process, then requesting to hash each process path. This query may hash the same path multiple times.

Within-query caching allows the hash table to respond with the previous result of the hash request as long as the requested computation was the result of a single query. Subsequent queries will perform subsequent hashing.