### PR TITLE
Remove the logHealth method from logger plugins

### DIFF
--- a/osquery/config/parsers/decorators.h
+++ b/osquery/config/parsers/decorators.h
@@ -50,7 +50,7 @@ void runDecorators(DecorationPoint point,
  * set of decoration point results.
  *
  * Decorations are applied to log items before they are sent to the downstream
- * logging APIs: logString, logSnapshot, logHealthStatus, etc.
+ * logging APIs: logString, logSnapshot, etc.
  *
  * @param results the output parameter to write decorations.
  */

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -326,8 +326,6 @@ Status LoggerPlugin::call(const PluginRequest& request,
     return this->logString(request.at("string"));
   } else if (request.count("snapshot") > 0) {
     return this->logSnapshot(request.at("snapshot"));
-  } else if (request.count("health") > 0) {
-    return this->logHealth(request.at("health"));
   } else if (request.count("init") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
     return this->init(request.at("init"), intermediate_logs);
@@ -399,21 +397,6 @@ Status logSnapshotQuery(const QueryLogItem& item) {
     json.pop_back();
   }
   return Registry::call("logger", {{"snapshot", json}});
-}
-
-Status logHealthStatus(const QueryLogItem& item) {
-  if (FLAGS_disable_logging) {
-    return Status(0, "Logging disabled");
-  }
-
-  std::string json;
-  if (!serializeQueryLogItemJSON(item, json)) {
-    return Status(1, "Could not serialize health");
-  }
-  if (!json.empty() && json.back() == '\n') {
-    json.pop_back();
-  }
-  return Registry::call("logger", {{"health", json}});
 }
 
 void relayStatusLogs() {

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -43,8 +43,6 @@ class LoggerTests : public testing::Test {
   // Count added and removed snapshot rows
   static int snapshot_rows_added;
   static int snapshot_rows_removed;
-  // Count the added health status rows
-  static int health_status_rows;
 
  private:
   /// Save the status of logging before running tests, restore afterward.
@@ -57,7 +55,6 @@ std::vector<std::string> LoggerTests::status_messages;
 int LoggerTests::statuses_logged = 0;
 int LoggerTests::snapshot_rows_added = 0;
 int LoggerTests::snapshot_rows_removed = 0;
-int LoggerTests::health_status_rows = 0;
 
 class TestLoggerPlugin : public LoggerPlugin {
  public:
@@ -90,11 +87,6 @@ class TestLoggerPlugin : public LoggerPlugin {
   Status logSnapshot(const std::string& s) {
     LoggerTests::snapshot_rows_added += 1;
     LoggerTests::snapshot_rows_removed += 0;
-    return Status(0, "OK");
-  }
-
-  Status logHealth(const std::string& s) {
-    LoggerTests::health_status_rows += 1;
     return Status(0, "OK");
   }
 };
@@ -185,10 +177,6 @@ TEST_F(LoggerTests, test_logger_snapshots) {
 
   // Expect the plugin to optionally handle snapshot logging.
   EXPECT_EQ(LoggerTests::snapshot_rows_added, 1);
-
-  // Add the same item as a health status log item.
-  logHealthStatus(item);
-  EXPECT_EQ(LoggerTests::health_status_rows, 1);
 }
 
 class SecondTestLoggerPlugin : public LoggerPlugin {


### PR DESCRIPTION
These APIs are not used within the logger plugins or the osquery codebase. 