### PR TITLE
Filtering out LowBattery crash logs

### DIFF
--- a/osquery/tables/system/darwin/crashes.cpp
+++ b/osquery/tables/system/darwin/crashes.cpp
@@ -140,7 +140,8 @@ QueryData genCrashLogs(QueryContext& context) {
     std::vector<std::string> files;
     if (listFilesInDirectory(path, files)) {
       for (const auto& lf : files) {
-        if (alg::ends_with(lf, ".crash")) {
+        if (alg::ends_with(lf, ".crash") &&
+            lf.find("LowBattery") == std::string::npos) {
           Row r;
           r["type"] = type;
           readCrashDump(lf, r);


### PR DESCRIPTION
The mobile 'LowBattery' crash logs provide little if any data of value,
and seem to be nothing more than notification events.  We're filtering
these out of the crashes table.