### PR TITLE
Refactor logStatus and logger initialization

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -328,7 +328,8 @@ Status LoggerPlugin::call(const PluginRequest& request,
     return this->logSnapshot(request.at("snapshot"));
   } else if (request.count("init") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
-    return this->init(request.at("init"), intermediate_logs);
+    this->init(request.at("init"), intermediate_logs);
+    return Status(this->usesLogStatus() ? 0 : 1);
   } else if (request.count("status") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
     return this->logStatus(intermediate_logs);

--- a/osquery/logger/plugins/aws_firehose.h
+++ b/osquery/logger/plugins/aws_firehose.h
@@ -20,7 +20,6 @@
 #include <osquery/dispatcher.h>
 #include <osquery/logger.h>
 
-#include "osquery/core/test_util.h"
 #include "osquery/logger/plugins/buffered.h"
 
 namespace osquery {
@@ -55,10 +54,9 @@ class FirehoseLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
-  Status init(const std::string& name,
-              const std::vector<StatusLogLine>& log) override {
-    return Status(1, "Does not support status logs");
-  }
+ protected:
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override {}
 
   Status logString(const std::string& s) override;
 

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -20,7 +20,6 @@
 #include <osquery/dispatcher.h>
 #include <osquery/logger.h>
 
-#include "osquery/core/test_util.h"
 #include "osquery/logger/plugins/buffered.h"
 
 namespace osquery {
@@ -56,10 +55,9 @@ class KinesisLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
-  Status init(const std::string& name,
-              const std::vector<StatusLogLine>& log) override {
-    return Status(1, "Does not support status logs");
-  }
+ private:
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override {}
 
   Status logString(const std::string& s) override;
 

--- a/osquery/logger/plugins/aws_util.h
+++ b/osquery/logger/plugins/aws_util.h
@@ -20,6 +20,8 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+#include <osquery/status.h>
+
 namespace osquery {
 
 /**
@@ -90,7 +92,7 @@ class OsqueryAWSCredentialsProviderChain
  *
  * @return 0 if successful, 1 if the region was not recognized
  */
-Status getAWSRegion(Aws::Region& region);
+Status getAWSRegion(Aws::Region &region);
 
 /**
  * @brief Instantiate an AWS client with the appropriate osquery configs

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -53,8 +53,8 @@ class FilesystemLoggerPlugin : public LoggerPlugin {
    * that will return an error during initialization. This allows Glog to
    * write directly to files.
    */
-  Status init(const std::string& name,
-              const std::vector<StatusLogLine>& log) override;
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override;
 
   /// Write a status to Glog.
   Status logStatus(const std::vector<StatusLogLine>& log) override;
@@ -127,8 +127,8 @@ Status FilesystemLoggerPlugin::logSnapshot(const std::string& s) {
   return logStringToFile(s, kFilesystemLoggerSnapshots);
 }
 
-Status FilesystemLoggerPlugin::init(const std::string& name,
-                                    const std::vector<StatusLogLine>& log) {
+void FilesystemLoggerPlugin::init(const std::string& name,
+                                  const std::vector<StatusLogLine>& log) {
   // Stop the internal Glog facilities.
   google::ShutdownGoogleLogging();
 
@@ -163,13 +163,11 @@ Status FilesystemLoggerPlugin::init(const std::string& name,
   // Now funnel the intermediate status logs provided to `init`.
   logStatus(log);
 
+  // The filesystem logger cheats and uses Glog to log to the filesystem so
+  // we can return failure here and stop the custom log sink.
   // Restore settings for logging to stderr.
   FLAGS_logtostderr = log_to_stderr;
   FLAGS_alsologtostderr = also_log_to_stderr;
   FLAGS_stderrthreshold = stderr_threshold;
-
-  // The filesystem logger cheats and uses Glog to log to the filesystem so
-  // we can return failure here and stop the custom log sink.
-  return Status(1, "No status logger used for filesystem");
 }
 }

--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -22,9 +22,12 @@ FLAG(int32,
 
 class SyslogLoggerPlugin : public LoggerPlugin {
  public:
+  bool usesLogStatus() override { return true; }
+
+ protected:
   Status logString(const std::string& s) override;
-  Status init(const std::string& name,
-              const std::vector<StatusLogLine>& log) override;
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override;
   Status logStatus(const std::vector<StatusLogLine>& log) override;
 };
 
@@ -57,8 +60,8 @@ Status SyslogLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
   return Status(0, "OK");
 }
 
-Status SyslogLoggerPlugin::init(const std::string& name,
-                                const std::vector<StatusLogLine>& log) {
+void SyslogLoggerPlugin::init(const std::string& name,
+                              const std::vector<StatusLogLine>& log) {
   closelog();
 
   // Define the syslog/target's application name.
@@ -68,6 +71,6 @@ Status SyslogLoggerPlugin::init(const std::string& name,
   openlog(name.c_str(), LOG_PID | LOG_CONS, FLAGS_logger_syslog_facility << 3);
 
   // Now funnel the intermediate status logs provided to `init`.
-  return logStatus(log);
+  logStatus(log);
 }
 }

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -24,7 +24,7 @@ DECLARE_string(logger_path);
 
 class FilesystemLoggerTests : public testing::Test {
  public:
-  void SetUp() {
+  void SetUp() override {
     auto logger_path = fs::path(kTestWorkingDirectory) / "unittests.logs";
     FLAGS_logger_path = logger_path.string();
     fs::create_directories(FLAGS_logger_path);
@@ -37,7 +37,7 @@ class FilesystemLoggerTests : public testing::Test {
     FLAGS_disable_logging = false;
   }
 
-  void TearDown() { FLAGS_disable_logging = logging_status_; }
+  void TearDown() override { FLAGS_disable_logging = logging_status_; }
 
   std::string getContent() { return std::string(); }
 

--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -8,11 +8,6 @@
  *
  */
 
-#include <chrono>
-#include <string>
-#include <thread>
-#include <vector>
-
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -20,9 +15,7 @@
 #include <osquery/flags.h>
 #include <osquery/registry.h>
 
-#include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"
-#include "osquery/remote/transports/tls.h"
 #include "osquery/remote/utility.h"
 
 #include "osquery/config/parsers/decorators.h"
@@ -78,12 +71,12 @@ Status TLSLoggerPlugin::setUp() {
   return Status(0);
 }
 
-Status TLSLoggerPlugin::init(const std::string& name,
-                             const std::vector<StatusLogLine>& log) {
+void TLSLoggerPlugin::init(const std::string& name,
+                           const std::vector<StatusLogLine>& log) {
   // Restart the glog facilities using the name init was provided.
   google::ShutdownGoogleLogging();
   google::InitGoogleLogging(name.c_str());
-  return logStatus(log);
+  logStatus(log);
 }
 
 Status TLSLogForwarder::send(std::vector<std::string>& log_data,
@@ -126,5 +119,4 @@ Status TLSLogForwarder::send(std::vector<std::string>& log_data,
   }
   return request.call(params);
 }
-
 }

--- a/osquery/logger/plugins/tls.h
+++ b/osquery/logger/plugins/tls.h
@@ -53,13 +53,15 @@ class TLSLoggerPlugin : public LoggerPlugin {
    * backing store. They will flush to a TLS endpoint under normal conditions
    * in a supporting/asynchronous thread.
    */
-  Status init(const std::string& name,
-              const std::vector<StatusLogLine>& log) override;
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override;
 
   /// Setup node key and worker thread for sending logs.
   Status setUp() override;
 
- public:
+  bool usesLogStatus() override { return true; }
+
+ protected:
   /// Log a result string. This is the basic catch-all for snapshots and events.
   Status logString(const std::string& s) override;
 


### PR DESCRIPTION
The initialization of a logger plugin was confusing. The 'init' step was introduced to allow a daemon to buffer status events before a logger plugin is determined by external/remote configuration. The buffered statuses could then be transferred via a medium other than Glog (the default). To determine if Glog should continue to write statuses to the filesystem the 'init' method returned a Status.

Logger plugins should now use a feature method override to select how status logs should be handled.