### PR TITLE
Add decorators to example config

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -399,7 +399,8 @@ Decorator queries exist in osquery versions 1.7.3+ and are used to add additiona
 {
   "decorators": {
     "load": [
-      "SELECT version FROM osquery_info"
+      "SELECT version FROM osquery_info",
+      "SELECT uuid AS host_uuid FROM system_info"
     ],
     "always": [
       "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1;"
@@ -423,10 +424,10 @@ Each decorator query should return at most 1 row. A warning will be generated if
 The columns, and their values, will be appended to each log line as follows. Assuming the above set of decorators is used, and the schedule is execution for over an hour (3600 seconds):
 
 ```json
-{"decorators": {"user": "you", "uptime": "10000", "version": "1.7.3"}}
+{"decorations": {"user": "you", "uptime": "10000", "version": "1.7.3"}}
 ```
 
-Expect the normal set of log keys to be included and note that `decorators` is a top-level key in the log line whose value is an embedded map.
+Expect the normal set of log keys to be included and note that `decorations` is a top-level key in the log line whose value is an embedded map.
 
 The `interval` type uses a map of interval 'periods' as keys, and the set of decorator queries for each value. Each of these intervals MUST be minute-intervals. Anything not divisible by 60 will generate a warning, and will not run.
 

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -63,6 +63,14 @@
     }
   },
 
+  // Decorators are normal queries that append data to every query.
+  "decorators": {
+    "load": [
+      "SELECT uuid AS host_uuid FROM system_info;",
+      "SELECT user AS username FROM logged_in_users ORDER BY time DESC LIMIT 1;"
+    ]
+  },
+
   // Add default osquery packs or install your own.
   //
   // There are several 'default' packs installed with 'make install' or via


### PR DESCRIPTION
Having `host_uuid`, regardless of the `--host_identifier` flag, is useful for every query differential result. This adds an example set of decorator queries that log both the suspected username and actual host UUID.