### PR TITLE
Revive the OS X kernel-based publishers

### DIFF
--- a/kernel/include/feeds.h
+++ b/kernel/include/feeds.h
@@ -171,8 +171,10 @@ typedef struct {
 } osquery_subscription_args_t;
 
 // Flags for buffer sync options.
-#define OSQUERY_DEFAULT 0
-#define OSQUERY_NO_BLOCK 1
+enum osquery_options {
+  OSQUERY_OPTIONS_DEFAULT = 0,
+  OSQUERY_OPTIONS_NO_BLOCK = 1,
+};
 
 typedef struct {
   // Option such as OSQUERY_NO_BLOCK.

--- a/kernel/src/osquery.cpp
+++ b/kernel/src/osquery.cpp
@@ -141,7 +141,7 @@ static int update_user_kernel_buffer(int options,
           &osquery.cqueue, read_offset, max_read_offset)) {
     return -EINVAL;
   }
-  if (!(options & OSQUERY_NO_BLOCK)) {
+  if (!(options & OSQUERY_OPTIONS_NO_BLOCK)) {
     ssize_t offset = 0;
     if ((offset = osquery_cqueue_wait_for_data(&osquery.cqueue)) < 0) {
       return -EINVAL;

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -150,7 +150,7 @@ Status RocksDBDatabasePlugin::setUp() {
     options_.compaction_style = rocksdb::kCompactionStyleLevel;
     options_.arena_block_size = (4 * 1024);
     options_.write_buffer_size = (4 * 1024) * 100; // 100 blocks.
-    options_.max_write_buffer_number = 2;
+    options_.max_write_buffer_number = 3;
     options_.min_write_buffer_number_to_merge = 1;
     options_.max_background_compactions = 2;
     options_.max_background_flushes = 2;

--- a/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
+++ b/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
@@ -41,7 +41,7 @@ static inline void producerThread(benchmark::State &state) {
     if (queue == nullptr) {
       continue;
     }
-    drops += queue->kernelSync(OSQUERY_NO_BLOCK);
+    drops += queue->kernelSync(OSQUERY_OPTIONS_NO_BLOCK);
     syncs++;
     max_before_sync = 2000;
     while (max_before_sync > 0 && (event = queue->dequeue(&event_buf))) {

--- a/osquery/events/kernel/circular_queue_user.cpp
+++ b/osquery/events/kernel/circular_queue_user.cpp
@@ -78,7 +78,7 @@ osquery_event_t CQueue::dequeue(CQueue::event **event) {
 
 int CQueue::kernelSync(int options) {
   // A positive return indicates drops, 0 is all good in the hood.
-  // Options are listed in kernel feeds; primarily OSQUERY_NO_BLOCK.
+  // Options are listed in kernel feeds; primarily OSQUERY_OPTIONS_NO_BLOCK.
   osquery_buf_sync_args_t sync;
   sync.read_offset = read_ - buffer_;
   sync.options = options;

--- a/osquery/events/kernel/circular_queue_user.h
+++ b/osquery/events/kernel/circular_queue_user.h
@@ -80,8 +80,9 @@ class CQueue : private boost::noncopyable {
    *
    * This allow the two view of the buffer to maintain consistency.
    *
-   * @param options Options to be passed to the kernel.  Primarily used for
-   *   OSQUERY_NO_BLOCK, which allows the sync to not block if there is no data.
+   * @param options Options to be passed to the kernel. Primarily used for
+   *   OSQUERY_OPTIONS_NO_BLOCK, which allows the sync to not block if there is
+   *   no data.
    * @return Returns the number of dropped events, or negative if too many.
    */
   int kernelSync(int options);

--- a/osquery/events/kernel/tests/kernel_communication_tests.cpp
+++ b/osquery/events/kernel/tests/kernel_communication_tests.cpp
@@ -72,7 +72,7 @@ TEST_F(KernelCommunicationTests, test_communication) {
   unsigned int tasks = 0;
   do {
     tasks = dispatcher.serviceCount();
-    drops += queue.kernelSync(OSQUERY_NO_BLOCK);
+    drops += queue.kernelSync(OSQUERY_OPTIONS_NO_BLOCK);
     unsigned int max_before_sync = 2000;
     while (max_before_sync > 0 && (event = queue.dequeue(&event_buf))) {
       switch (event) {

--- a/osquery/tables/events/darwin/process_events.cpp
+++ b/osquery/tables/events/darwin/process_events.cpp
@@ -30,6 +30,11 @@ class ProcessEventSubscriber : public EventSubscriber<KernelEventPublisher> {
 REGISTER(ProcessEventSubscriber, "event_subscriber", "process_events");
 
 Status ProcessEventSubscriber::init() {
+  auto pubref = EventFactory::getEventPublisher("kernel");
+  if (pubref == nullptr || pubref->isEnding()) {
+    return Status(1, "No kernel event publisher");
+  }
+
   auto sc = createSubscriptionContext();
   sc->event_type = OSQUERY_PROCESS_EVENT;
   subscribe(&ProcessEventSubscriber::Callback, sc);

--- a/osquery/tables/events/process_file_events.cpp
+++ b/osquery/tables/events/process_file_events.cpp
@@ -20,16 +20,7 @@ namespace osquery {
 class ProcessFileEventSubscriber
     : public EventSubscriber<KernelEventPublisher> {
  public:
-  Status init() override {
-    auto pubref = EventFactory::getEventPublisher("kernel");
-    if (pubref == nullptr || !pubref->hasStarted() || pubref->isEnding()) {
-      return Status(1, "No kernel event publisher");
-    }
-
-    configure();
-    return Status(0);
-  }
-
+  Status init() override;
   /// Walk the configuration's file paths, create subscriptions.
   void configure() override;
 
@@ -38,6 +29,16 @@ class ProcessFileEventSubscriber
 };
 
 REGISTER(ProcessFileEventSubscriber, "event_subscriber", "process_file_events");
+
+Status ProcessFileEventSubscriber::init() {
+  auto pubref = EventFactory::getEventPublisher("kernel");
+  if (pubref == nullptr || pubref->isEnding()) {
+    return Status(1, "No kernel event publisher");
+  }
+
+  configure();
+  return Status(0);
+}
 
 void ProcessFileEventSubscriber::configure() {
   // There may be a better way to find the set intersection/difference.


### PR DESCRIPTION
The OS X kernel subscribers have not been starting because they expect the publisher thread to run before they begin configuration. Due to some recent refactors the publisher thread creation now occurs after configuration.

The subscriber logic to check for a valid kernel connection is still valid.