### PR TITLE
[Fix #2032] Remove manual Thrift library discovery

### DIFF
--- a/CMake/FindThrift.cmake
+++ b/CMake/FindThrift.cmake
@@ -11,28 +11,8 @@ if(APPLE AND NOT DEFINED $ENV{THRIFT_HOME})
   set(ENV{THRIFT_HOME} ${BREW_PREFIX})
 endif()
 
-# prefer the thrift version supplied in THRIFT_HOME
-find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h HINTS
-  $ENV{THRIFT_HOME}/include/
-  /usr/local/include/
-  /opt/local/include/
-)
-
-find_path(THRIFT_CONTRIB_DIR share/fb303/if/fb303.thrift HINTS
-  $ENV{THRIFT_HOME}
-  /usr/local/
-)
-
-set(THRIFT_LIB_PATHS
-  $ENV{THRIFT_HOME}/lib
-  /usr/local/lib
-  /opt/local/lib)
-
-# prefer the thrift version supplied in THRIFT_HOME
+# Prefer the thrift version supplied in THRIFT_HOME
 if(NOT DEFINED THRIFT_FOUND)
-  find_library(THRIFT_LIBRARY NAMES thrift HINTS ${THRIFT_LIB_PATHS})
-  #find_library(THRIFT_STATIC_LIBRARY NAMES libthrift.a HINTS ${THRIFT_LIB_PATHS})
-
   find_program(THRIFT_COMPILER thrift
     $ENV{THRIFT_HOME}/bin
     /usr/local/bin
@@ -40,20 +20,15 @@ if(NOT DEFINED THRIFT_FOUND)
     NO_DEFAULT_PATH
   )
 
-  if (THRIFT_LIBRARY)
+  if (THRIFT_COMPILER)
     set(THRIFT_FOUND TRUE)
-    LOG_LIBRARY(thrift "${THRIFT_LIBRARY}")
     exec_program(${THRIFT_COMPILER}
       ARGS -version OUTPUT_VARIABLE THRIFT_VERSION RETURN_VALUE THRIFT_RETURN)
   else()
-    message(FATAL_ERROR "Thrift compiler/libraries NOT found.")
+    message(FATAL_ERROR "Thrift compiler NOT found.")
   endif()
 
-  mark_as_advanced(
-    THRIFT_LIBRARY
-    THRIFT_COMPILER
-    THRIFT_INCLUDE_DIR
-  )
+  mark_as_advanced(THRIFT_COMPILER)
 endif()
 
 if (NOT "${THRIFT_VERSION}" STREQUAL "Thrift version 0.9.3")

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -30,8 +30,6 @@ endif()
 
 # The core set of osquery libraries most discovered with find_package.
 set(OSQUERY_LIBS
-  # This includes librocksdb[_lite] and libsnappy.
-  ${THRIFT_LIBRARY}
   ${OPENSSL_CRYPTO_LIBRARY}
   ${OPENSSL_SSL_LIBRARY}
   ${READLINE_LIBRARIES}
@@ -81,6 +79,7 @@ if(LINUX)
 endif()
 
 # The remaining boost libraries are discovered with find_library.
+ADD_OSQUERY_LINK_CORE("thrift")
 ADD_OSQUERY_LINK_CORE("gflags")
 ADD_OSQUERY_LINK_CORE("glog")
 ADD_OSQUERY_LINK_CORE("boost_system")


### PR DESCRIPTION
The Thrift library should be discovered simiarly to all others. When using the build-macros for library discovery the caller can choose how to discover static or dynamic links.