### PR TITLE
Process Operations - osquery/core Integration

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -101,11 +101,7 @@ enum {
 namespace {
 extern "C" {
 static inline bool hasWorkerVariable() {
-  auto value = ::osquery::getEnvVar("OSQUERY_WORKER");
-  if (value) {
-    return true;
-  }
-  return false;
+  return ::osquery::getEnvVar("OSQUERY_WORKER").is_initialized();
 }
 
 volatile std::sig_atomic_t kHandledSignal{0};

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -14,9 +14,12 @@
 #include <thread>
 
 #include <stdio.h>
-#include <syslog.h>
 #include <time.h>
+
+#ifndef WIN32
+#include <syslog.h>
 #include <unistd.h>
+#endif
 
 #include <boost/filesystem.hpp>
 
@@ -31,6 +34,7 @@
 #include <osquery/registry.h>
 
 #include "osquery/core/watcher.h"
+#include "osquery/core/process.h"
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -97,13 +101,20 @@ enum {
 namespace {
 extern "C" {
 static inline bool hasWorkerVariable() {
-  return (getenv("OSQUERY_WORKER") != nullptr);
+  auto value = ::osquery::getEnvVar("OSQUERY_WORKER");
+  if (value) {
+    return true;
+  }
+  return false;
 }
 
 volatile std::sig_atomic_t kHandledSignal{0};
 
-static inline bool isWatcher() { return (osquery::Watcher::getWorker() > 0); }
+static inline bool isWatcher() {
+  return (osquery::Watcher::getWorker().isValid());
+}
 
+#ifndef WIN32
 void signalHandler(int num) {
   // Inform exit status of main threads blocked by service joins.
   if (kHandledSignal == 0) {
@@ -157,6 +168,7 @@ void signalHandler(int num) {
     // managed extension processes.
   }
 }
+#endif
 }
 }
 
@@ -164,7 +176,7 @@ namespace osquery {
 
 using chrono_clock = std::chrono::high_resolution_clock;
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(WIN32)
 CLI_FLAG(bool, daemonize, false, "Run as daemon (osqueryd only)");
 #endif
 
@@ -226,7 +238,11 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
   try {
     boost::filesystem::path::codecvt();
   } catch (const std::runtime_error& e) {
+#ifdef WIN32
+    setlocale(LC_ALL, "C");
+#else
     setenv("LC_ALL", "C", 1);
+#endif
   }
 
   // osquery implements a custom help/usage output.
@@ -285,6 +301,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
     }
   }
 
+#ifndef WIN32
   // All tools handle the same set of signals.
   // If a daemon process is a watchdog the signal is passed to the worker,
   // unless the worker has not yet started.
@@ -294,6 +311,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
   std::signal(SIGHUP, signalHandler);
   std::signal(SIGALRM, signalHandler);
   std::signal(SIGUSR1, signalHandler);
+#endif
 
   // If the caller is checking configuration, disable the watchdog/worker.
   if (FLAGS_config_check) {
@@ -304,7 +322,8 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
   initStatusLogger(binary_);
   if (tool != OSQUERY_EXTENSION) {
     if (isWorker()) {
-      VLOG(1) << "osquery worker initialized [watcher=" << getppid() << "]";
+      VLOG(1) << "osquery worker initialized [watcher="
+              << PlatformProcess::getLauncherProcess()->pid() << "]";
     } else {
       VLOG(1) << "osquery initialized [version=" << kVersion << "]";
     }
@@ -319,7 +338,7 @@ void Initializer::initDaemon() const {
     return;
   }
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(WIN32)
   // OS X uses launchd to daemonize.
   if (osquery::FLAGS_daemonize) {
     if (daemon(0, 0) == -1) {
@@ -328,9 +347,11 @@ void Initializer::initDaemon() const {
   }
 #endif
 
+#ifndef WIN32
   // Print the version to SYSLOG.
   syslog(
       LOG_NOTICE, "%s started [version=%s]", binary_.c_str(), kVersion.c_str());
+#endif
 
   // Check if /var/osquery exists
   if ((Flag::isDefault("pidfile") || Flag::isDefault("database_path")) &&
@@ -350,7 +371,8 @@ void Initializer::initDaemon() const {
       FLAGS_watchdog_level >= WATCHDOG_LEVEL_DEFAULT &&
       FLAGS_watchdog_level != WATCHDOG_LEVEL_DEBUG) {
     // Set CPU scheduling I/O limits.
-    setpriority(PRIO_PGRP, 0, 10);
+    setToBackgroundPriority();
+
 #ifdef __linux__
     // Using: ioprio_set(IOPRIO_WHO_PGRP, 0, IOPRIO_CLASS_IDLE);
     syscall(SYS_ioprio_set, IOPRIO_WHO_PGRP, 0, IOPRIO_CLASS_IDLE);
@@ -413,7 +435,8 @@ void Initializer::initWorker(const std::string& name) const {
 
   // Start a 'watcher watcher' thread to exit the process if the watcher exits.
   // In this case the parent process is called the 'watcher' process.
-  Dispatcher::addService(std::make_shared<WatcherWatcherRunner>(getppid()));
+  Dispatcher::addService(std::make_shared<WatcherWatcherRunner>(
+      PlatformProcess::getLauncherProcess()));
 }
 
 void Initializer::initWorkerWatcher(const std::string& name) const {
@@ -452,7 +475,7 @@ void Initializer::initActivePlugin(const std::string& type,
     }
     // The plugin is not local and is not active, wait and retry.
     delay += kExtensionInitializeLatencyUS;
-    ::usleep(kExtensionInitializeLatencyUS);
+    sleepFor(kExtensionInitializeLatencyUS);
   } while (delay < timeout);
 
   LOG(ERROR) << "Cannot activate " << name << " " << type
@@ -531,12 +554,14 @@ void Initializer::start() const {
   }
   initLogger(binary_);
 
+#ifndef WIN32
   // Initialize the distributed plugin, if necessary
   if (!FLAGS_disable_distributed) {
     if (Registry::exists("distributed", FLAGS_distributed_plugin)) {
       initActivePlugin("distributed", FLAGS_distributed_plugin);
     }
   }
+#endif
 
   // Start event threads.
   osquery::attachEvents();
@@ -559,7 +584,9 @@ void Initializer::requestShutdown(int retcode) {
   // Stop thrift services/clients/and their thread pools.
   kExitCode = retcode;
   if (std::this_thread::get_id() != kMainThreadId) {
+#ifndef WIN32
     raise(SIGUSR1);
+#endif
   } else {
     // The main thread is requesting a shutdown, meaning in almost every case
     // it is NOT waiting for a shutdown.
@@ -572,3 +599,4 @@ void Initializer::requestShutdown(int retcode) {
 
 void Initializer::shutdown(int retcode) { ::exit(retcode); }
 }
+

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -56,13 +56,13 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getLauncherProcess() {
 }
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
-    const std::string& exec_path, const std::string& name) {
+    const std::string& exec_path, int argc, char** argv) {
   auto worker_pid = ::fork();
   if (worker_pid < 0) {
     return std::shared_ptr<PlatformProcess>();
   } else if (worker_pid == 0) {
     setEnvVar("OSQUERY_WORKER", std::to_string(::getpid()).c_str());
-    ::execle(exec_path.c_str(), name.c_str(), nullptr, ::environ);
+    ::execve(exec_path.c_str(), argv, ::environ);
 
     // Code should never reach this point
     LOG(ERROR) << "osqueryd could not start worker process";

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -44,7 +44,7 @@ const PlatformPidType kInvalidPid = (PlatformPidType) - 1;
  * @brief Categories of process states adapted to be platform agnostic
  *
  * A process can have the following states. Unfortunately, because of operating
- * system differences. A genericstate change is not directly translatable on
+ * system differences. A generic state change is not directly translatable on
  * Windows. Therefore, PROCESS_STATE_CHANGE will only occur on POSIX systems.
  */
 enum ProcessState {

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -27,6 +27,7 @@
 namespace osquery {
 
 #ifdef WIN32
+
 /// Unfortunately, pid_t is not defined in Windows, however, DWORD is the
 /// most appropriate alternative since process ID on Windows are stored in
 /// a DWORD.
@@ -43,7 +44,7 @@ const PlatformPidType kInvalidPid = (PlatformPidType) - 1;
  * @brief Categories of process states adapted to be platform agnostic
  *
  * A process can have the following states. Unfortunately, because of operating
- * system differences. A generic state change is not directly translatable on
+ * system differences. A genericstate change is not directly translatable on
  * Windows. Therefore, PROCESS_STATE_CHANGE will only occur on POSIX systems.
  */
 enum ProcessState {
@@ -57,8 +58,7 @@ enum ProcessState {
  * @brief Platform-agnostic process object.
  *
  * PlatformProcess is a specialized, platform-agnostic class that handles the
- * process operation needs
- * of osquery.
+ * process operation needs of osquery.
  */
 class PlatformProcess : private boost::noncopyable {
  public:
@@ -101,11 +101,12 @@ class PlatformProcess : private boost::noncopyable {
   /**
    * @brief Creates a new worker process.
    *
-   * Launches a worker process given a worker executable path and a worker name.
-   * Any double quotes in the worker name will be stripped out.
+   * Launches a worker process given a worker executable path, number of
+   * arguments, and an array of arguments. All double quotes within each entry 
+   * in the array of arguments will be supplanted with a preceding blackslash.
    */
   static std::shared_ptr<PlatformProcess> launchWorker(
-      const std::string& exec_path, const std::string& name);
+      const std::string& exec_path, int argc, char** argv);
 
   /**
   * @brief Creates a new extension process.

--- a/osquery/core/testing.h
+++ b/osquery/core/testing.h
@@ -40,3 +40,4 @@ extern const size_t kExpectedWorkerArgsCount;
 extern const char *kExpectedExtensionArgs[];
 extern const size_t kExpectedExtensionArgsCount;
 }
+

--- a/osquery/core/testing.h
+++ b/osquery/core/testing.h
@@ -34,8 +34,9 @@ extern const char *kOsqueryTestModuleName;
 
 /// These are the expected arguments for our test worker process.
 extern const char *kExpectedWorkerArgs[];
+extern const size_t kExpectedWorkerArgsCount;
 
 /// These are the expected arguments for our test extensions process.
 extern const char *kExpectedExtensionArgs[];
+extern const size_t kExpectedExtensionArgsCount;
 }
-

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -360,7 +360,7 @@ void WatcherRunner::createWorker() {
   }
 
   auto worker = PlatformProcess::launchWorker(exec_path.string(), argv_[0]);
-  if (worker.get() == nullptr) {
+  if (worker == nullptr) {
     // Unrecoverable error, cannot create a worker process.
     LOG(ERROR) << "osqueryd could not create a worker process";
     Initializer::shutdown(EXIT_FAILURE);
@@ -401,7 +401,7 @@ bool WatcherRunner::createExtension(const std::string& extension) {
                                        Flag::getValue("extensions_timeout"),
                                        Flag::getValue("extensions_interval"),
                                        Flag::getValue("verbose"));
-  if (ext_process.get() == nullptr) {
+  if (ext_process == nullptr) {
     // Unrecoverable error, cannot create an extension process.
     LOG(ERROR) << "Cannot create extension process: " << extension;
     Initializer::shutdown(EXIT_FAILURE);

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -117,16 +117,14 @@ void Watcher::reset(const PlatformProcess& child) {
   // If it was not the worker pid then find the extension name to reset.
   for (const auto& extension : extensions()) {
     if (*extension.second == child) {
-      // TODO(#1991): Why is pid_t set to 0?
-      setExtension(extension.first, std::shared_ptr<PlatformProcess>());
+      setExtension(extension.first, std::make_shared<PlatformProcess>());
       resetExtensionCounters(extension.first, 0);
     }
   }
 }
 
 void Watcher::addExtensionPath(const std::string& path) {
-  // TODO(#1991): Why is pid_t set to 0?
-  setExtension(path, std::shared_ptr<PlatformProcess>());
+  setExtension(path, std::make_shared<PlatformProcess>());
   resetExtensionCounters(path, 0);
 }
 
@@ -280,11 +278,6 @@ bool WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
   // Only make a decision about the child sanity if it is still the watcher's
   // child. It's possible for the child to die, and its pid reused.
-  //
-  // TODO(#1991): I'm not sure this is doing what it should be doing on
-  // Windows...
-  //              Additionally, getCurrentProcess() *may* fail under exceptional
-  // cases
   if (parent != PlatformProcess::getCurrentProcess()->pid()) {
     // The child's parent is not the watcher.
     Watcher::reset(child);
@@ -359,7 +352,7 @@ void WatcherRunner::createWorker() {
     return;
   }
 
-  auto worker = PlatformProcess::launchWorker(exec_path.string(), argv_[0]);
+  auto worker = PlatformProcess::launchWorker(exec_path.string(), argc_, argv_);
   if (worker == nullptr) {
     // Unrecoverable error, cannot create a worker process.
     LOG(ERROR) << "osqueryd could not create a worker process";

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -139,11 +139,7 @@ bool Watcher::hasManagedExtensions() {
   // Setting this counter to 0 will prevent the worker from waiting for missing
   // dependent config plugins. Otherwise, its existence, will cause a worker to
   // wait for missing plugins to broadcast from managed extensions.
-  auto value = getEnvVar("OSQUERY_EXTENSIONS");
-  if (value) {
-    return true;
-  }
-  return false;
+  return getEnvVar("OSQUERY_EXTENSIONS").is_initialized();
 }
 
 bool WatcherRunner::ok() {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -13,12 +13,16 @@
 #include <atomic>
 #include <string>
 
+#ifndef WIN32
 #include <unistd.h>
+#endif
 
 #include <boost/noncopyable.hpp>
 
 #include <osquery/dispatcher.h>
 #include <osquery/flags.h>
+
+#include "osquery/core/process.h"
 
 /// Define a special debug/testing watchdog level.
 #define WATCHDOG_LEVEL_DEBUG 3
@@ -35,8 +39,8 @@ class WatcherRunner;
 /**
  * @brief Categories of process performance limitations.
  *
- * Performance limits are applied by a watcher thread on autoloaded extensions
  * and a optional daemon worker process. The performance types are identified
+ * Performance limits are applied by a watcher thread on autoloaded extensions
  * here, and organized into levels. Such that a caller may enforce rigor or
  * relax the performance expectations of a osquery daemon.
  */
@@ -113,12 +117,13 @@ class Watcher : private boost::noncopyable {
   static void unlock() { instance().lock_.unlock(); }
 
   /// Accessor for autoloadable extension paths.
-  static const std::map<std::string, pid_t>& extensions() {
+  static const std::map<std::string, std::shared_ptr<PlatformProcess>>&
+  extensions() {
     return instance().extensions_;
   }
 
   /// Lookup extension path from pid.
-  static std::string getExtensionPath(pid_t child);
+  static std::string getExtensionPath(const PlatformProcess& child);
 
   /// Remove an autoloadable extension path.
   static void removeExtensionPath(const std::string& extension);
@@ -127,20 +132,23 @@ class Watcher : private boost::noncopyable {
   static void addExtensionPath(const std::string& path);
 
   /// Get state information for a worker or extension child.
-  static PerformanceState& getState(pid_t child);
+  static PerformanceState& getState(const PlatformProcess& child);
   static PerformanceState& getState(const std::string& extension);
 
   /// Accessor for the worker process.
-  static pid_t getWorker() { return instance().worker_; }
+  static PlatformProcess& getWorker() { return *instance().worker_; }
 
   /// Setter for worker process.
-  static void setWorker(pid_t child) { instance().worker_ = child; }
+  static void setWorker(std::shared_ptr<PlatformProcess> child) {
+    instance().worker_ = child;
+  }
 
   /// Setter for an extension process.
-  static void setExtension(const std::string& extension, pid_t child);
+  static void setExtension(const std::string& extension,
+                           std::shared_ptr<PlatformProcess> child);
 
   /// Reset pid and performance counters for a worker or extension process.
-  static void reset(pid_t child);
+  static void reset(const PlatformProcess& child);
 
   /// Count the number of worker restarts.
   static size_t workerRestartCount() { return instance().worker_restarts_; }
@@ -166,7 +174,7 @@ class Watcher : private boost::noncopyable {
  private:
   /// Do not request the lock until extensions are used.
   Watcher()
-      : worker_(-1), worker_restarts_(0), lock_(mutex_, std::defer_lock) {}
+      : worker_(nullptr), worker_restarts_(0), lock_(mutex_, std::defer_lock) {}
   Watcher(Watcher const&);
 
   void operator=(Watcher const&);
@@ -185,13 +193,13 @@ class Watcher : private boost::noncopyable {
 
  private:
   /// Keep the single worker process/thread ID for inspection.
-  std::atomic<int> worker_{-1};
+  std::shared_ptr<PlatformProcess> worker_;
 
   /// Number of worker restarts NOT induced by a watchdog process.
   size_t worker_restarts_{0};
 
   /// Keep a list of resolved extension paths and their managed pids.
-  std::map<std::string, pid_t> extensions_;
+  std::map<std::string, std::shared_ptr<PlatformProcess>> extensions_;
 
   /// Paths to autoload extensions.
   std::vector<std::string> extensions_paths_;
@@ -255,9 +263,9 @@ class WatcherRunner : public InternalRunnable {
   /// Boilerplate function to sleep for some configured latency
   bool ok();
   /// Begin the worker-watcher process.
-  bool watch(pid_t child);
+  bool watch(const PlatformProcess& child) const;
   /// Inspect into the memory, CPU, and other worker/extension process states.
-  bool isChildSane(pid_t child);
+  bool isChildSane(const PlatformProcess& child) const;
 
  private:
   /// Fork and execute a worker process.
@@ -265,7 +273,7 @@ class WatcherRunner : public InternalRunnable {
   /// Fork an extension process.
   bool createExtension(const std::string& extension);
   /// If a worker/extension has otherwise gone insane, stop it.
-  void stopChild(pid_t child);
+  void stopChild(const PlatformProcess& child) const;
 
  private:
   /// Keep the invocation daemon's argc to iterate through argv.
@@ -279,16 +287,18 @@ class WatcherRunner : public InternalRunnable {
 /// The WatcherWatcher is spawned within the worker and watches the watcher.
 class WatcherWatcherRunner : public InternalRunnable {
  public:
-  explicit WatcherWatcherRunner(pid_t watcher) : watcher_(watcher) {}
+  explicit WatcherWatcherRunner(std::shared_ptr<PlatformProcess> watcher)
+      : watcher_(watcher) {}
 
   /// Runnable thread's entry point.
   void start();
 
  private:
   /// Parent, or watchdog, process ID.
-  pid_t watcher_{-1};
+  std::shared_ptr<PlatformProcess> watcher_;
 };
 
 /// Get a performance limit by name and optional level.
 size_t getWorkerLimit(WatchdogLimitType limit, int level = -1);
 }
+

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -173,7 +173,9 @@ class Watcher : private boost::noncopyable {
  private:
   /// Do not request the lock until extensions are used.
   Watcher()
-      : worker_(nullptr), worker_restarts_(0), lock_(mutex_, std::defer_lock) {}
+      : worker_(std::make_shared<PlatformProcess>()),
+        worker_restarts_(0),
+        lock_(mutex_, std::defer_lock) {}
   Watcher(Watcher const&);
 
   void operator=(Watcher const&);

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getCurrentProcess() {
   HANDLE handle =
       ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());
   if (handle == NULL) {
-    return std::shared_ptr<PlatformProcess>();
+    return std::make_shared<PlatformProcess>();
   }
 
   return std::make_shared<PlatformProcess>(handle);
@@ -88,7 +88,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getCurrentProcess() {
 std::shared_ptr<PlatformProcess> PlatformProcess::getLauncherProcess() {
   auto launcher_handle = getEnvVar("OSQUERY_LAUNCHER");
   if (!launcher_handle) {
-    return std::shared_ptr<PlatformProcess>();
+    return std::make_shared<PlatformProcess>();
   }
 
   // Convert the environment variable into a HANDLE (the value from environment
@@ -101,26 +101,27 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getLauncherProcess() {
         std::stoull(*launcher_handle, nullptr, 16)));
   }
   catch (std::invalid_argument e) {
-    return std::shared_ptr<PlatformProcess>();
+    return std::make_shared<PlatformProcess>();
   }
   catch (std::out_of_range e) {
-    return std::shared_ptr<PlatformProcess>();
+    return std::make_shared<PlatformProcess>();
   }
 
   if (handle == NULL || handle == INVALID_HANDLE_VALUE) {
-    return std::shared_ptr<PlatformProcess>();
+    return std::make_shared<PlatformProcess>();
   }
 
   return std::make_shared<PlatformProcess>(handle);
 }
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
-    const std::string &exec_path, const std::string &name) {
+    const std::string &exec_path, int argc, char **argv) {
   ::STARTUPINFOA si = {0};
   ::PROCESS_INFORMATION pi = {0};
 
   si.cb = sizeof(si);
 
+  std::stringstream argv_stream;
   std::stringstream handle_stream;
 
   // The HANDLE exposed to the child process is currently limited to only having
@@ -158,15 +159,29 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   // Since Windows does not accept a char * array for arguments, we have to
   // build one as a string. Therefore, we need to make sure that special
   // characters are not present that would obstruct the parsing of arguments.
-  // For now, we strip out all double quotes.
+  // For now, we strip out all double quotes. If the an entry in argv has
+  // spaces, we will put double-quotes around the entry.
+  //
+  // NOTE: This is extremely naive and will break the moment complexities are
+  //       involved... Windows command line argument parsing is extremely
+  //       nitpicky and is different in behavior than POSIX argv parsing.
   //
   // We don't directly use argv.c_str() as the value for lpCommandLine in
   // CreateProcess since that argument requires a modifiable buffer. So,
   // instead, we off-load the contents of argv into a vector which will have its
   // backing memory as modifiable.
-  auto argv =
-      std::string("\"") + boost::replace_all_copy(name, "\" ", " ") + "\"";
-  std::vector<char> mutable_argv(argv.begin(), argv.end());
+  for (size_t i = 0; i < argc; i++) {
+    std::string component(argv[i]);
+    if (component.find(" ") != std::string::npos) {
+      boost::replace_all(component, "\"", "\\\"");
+      argv_stream << "\"" << component << "\" ";
+    } else {
+      argv_stream << component << " ";
+    }
+  }
+
+  std::string cmdline = argv_stream.str();
+  std::vector<char> mutable_argv(cmdline.begin(), cmdline.end());
   mutable_argv.push_back('\0');
 
   BOOL status = ::CreateProcessA(exec_path.c_str(),

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -35,13 +35,18 @@ std::string kProcessTestExecPath;
 const char *kOsqueryTestModuleName = "osquery_tests.exe";
 
 /// These are the expected arguments for our test worker process.
-const char *kExpectedWorkerArgs[] = {"worker-test"};
+const char *kExpectedWorkerArgs[] = {"worker-test", "--socket",
+                                     "fake-socket", nullptr};
+const size_t kExpectedWorkerArgsCount =
+    (sizeof(osquery::kExpectedWorkerArgs) / sizeof(char *)) - 1;
 
 /// These are the expected arguments for our test extensions process.
 const char *kExpectedExtensionArgs[] = {
-    "osquery extension: extension-test", "--socket", "socket-name",
-    "--timeout",                         "100",      "--interval",
-    "5",                                 "--verbose"};
+    "osquery extension: extension-test", "--socket",  "socket-name",
+    "--timeout",                         "100",       "--interval",
+    "5",                                 "--verbose", nullptr};
+const size_t kExpectedExtensionArgsCount =
+    (sizeof(osquery::kExpectedExtensionArgs) / sizeof(char *)) - 1;
 
 static bool compareArguments(char *result[],
                              unsigned int result_nelms,
@@ -69,8 +74,7 @@ int workerMain(int argc, char *argv[]) {
   if (!osquery::compareArguments(argv,
                                  argc,
                                  osquery::kExpectedWorkerArgs,
-                                 sizeof(osquery::kExpectedWorkerArgs) /
-                                     sizeof(const char *))) {
+                                 osquery::kExpectedWorkerArgsCount)) {
     return ERROR_COMPARE_ARGUMENT;
   }
 
@@ -106,8 +110,7 @@ int extensionMain(int argc, char *argv[]) {
   if (!osquery::compareArguments(argv,
                                  argc,
                                  osquery::kExpectedExtensionArgs,
-                                 sizeof(osquery::kExpectedExtensionArgs) /
-                                     sizeof(const char *))) {
+                                 osquery::kExpectedExtensionArgsCount)) {
     return ERROR_COMPARE_ARGUMENT;
   }
   return EXTENSION_SUCCESS_CODE;


### PR DESCRIPTION
Replaced most instances of `pid_t` with `PlatformProcess` as necessary. 
Replaced platform-specific functions such as `getpid`, `getppid`, etc. with our equivalent process abstraction operations.
