### PR TITLE
Add logEvent API to logger plugins

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -699,6 +699,12 @@ class EventFactory : private boost::noncopyable {
   /// Return a list of subscriber registry names,
   static std::vector<std::string> subscriberNames();
 
+  /// Set log forwarding by adding a logger receiver.
+  static void addForwarder(const std::string& logger);
+
+  /// Optionally forward events to loggers.
+  static void forwardEvent(const std::string& event);
+
  public:
   /// The dispatched event thread's entry-point (if needed).
   static Status run(EventPublisherID& type_id);
@@ -756,6 +762,9 @@ class EventFactory : private boost::noncopyable {
 
   /// Set of running EventPublisher run loop threads.
   std::vector<std::shared_ptr<std::thread>> threads_;
+
+  /// Set of logger plugins to forward events.
+  std::vector<std::string> loggers_;
 
   /// Factory publisher state manipulation.
   Mutex factory_lock_;

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -40,6 +40,7 @@ class LoggerTests : public testing::Test {
 
   // Count calls to logStatus
   static int statuses_logged;
+  static int events_logged;
   // Count added and removed snapshot rows
   static int snapshot_rows_added;
   static int snapshot_rows_removed;
@@ -53,19 +54,27 @@ std::vector<std::string> LoggerTests::log_lines;
 StatusLogLine LoggerTests::last_status;
 std::vector<std::string> LoggerTests::status_messages;
 int LoggerTests::statuses_logged = 0;
+int LoggerTests::events_logged = 0;
 int LoggerTests::snapshot_rows_added = 0;
 int LoggerTests::snapshot_rows_removed = 0;
 
 class TestLoggerPlugin : public LoggerPlugin {
  protected:
-  bool usesLogStatus() { return shouldLogStatus; }
+  bool usesLogStatus() override { return shouldLogStatus; }
+  bool usesLogEvent() override { return shouldLogEvent; }
 
-  Status logString(const std::string& s) {
+  Status logEvent(const std::string& e) override {
+    LoggerTests::events_logged++;
+    return Status(0, "OK");
+  }
+
+  Status logString(const std::string& s) override {
     LoggerTests::log_lines.push_back(s);
     return Status(0, s);
   }
 
-  void init(const std::string& name, const std::vector<StatusLogLine>& log) {
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override {
     for (const auto& status : log) {
       LoggerTests::status_messages.push_back(status.message);
     }
@@ -75,12 +84,12 @@ class TestLoggerPlugin : public LoggerPlugin {
     }
   }
 
-  Status logStatus(const std::vector<StatusLogLine>& log) {
+  Status logStatus(const std::vector<StatusLogLine>& log) override {
     ++LoggerTests::statuses_logged;
     return Status(0, "OK");
   }
 
-  Status logSnapshot(const std::string& s) {
+  Status logSnapshot(const std::string& s) override {
     LoggerTests::snapshot_rows_added += 1;
     LoggerTests::snapshot_rows_removed += 0;
     return Status(0, "OK");
@@ -89,6 +98,9 @@ class TestLoggerPlugin : public LoggerPlugin {
  public:
   /// Allow test methods to change status logging state.
   bool shouldLogStatus{true};
+
+  /// Allow test methods to change event logging state.
+  bool shouldLogEvent{true};
 };
 
 TEST_F(LoggerTests, test_plugin) {
@@ -147,6 +159,21 @@ TEST_F(LoggerTests, test_logger_log_status) {
 
   // The second warning status will be sent to the logger plugin.
   EXPECT_EQ(LoggerTests::statuses_logged, 1);
+}
+
+TEST_F(LoggerTests, test_feature_request) {
+  // Retrieve the test logger plugin.
+  auto plugin = Registry::get("logger", "test");
+  auto logger = std::dynamic_pointer_cast<TestLoggerPlugin>(plugin);
+
+  logger->shouldLogEvent = false;
+  logger->shouldLogStatus = false;
+  auto status = Registry::call("logger", "test", {{"action", "features"}});
+  EXPECT_EQ(status.getCode(), 0);
+
+  logger->shouldLogStatus = true;
+  status = Registry::call("logger", "test", {{"action", "features"}});
+  EXPECT_EQ(status.getCode(), LOGGER_FEATURE_LOGSTATUS);
 }
 
 TEST_F(LoggerTests, test_logger_variations) {


### PR DESCRIPTION
This adds an additional API to logger plugins that requests `EventSubscriber`-based tables to send their events directly to logger plugins.

To have events forwarded to a `LoggerPluggin` that is registered as active via `--logger_plugin=YourPlugin` you must implement the following methods:
```cpp
 bool usesLogEvent() override { return true; }
 Status logEvent(const std::string& event) override { return Status(0); }
```

The event `std::string` will be the JSON-encoded event that is normally stored in RocksDB. If a `LoggerPlugin` requests forwarding of events, the event data is still stored in RocksDB to support the subscriber table abstraction.