### PR TITLE
[Fix #2055] Compile and build CMake on Debian

### DIFF
--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -52,12 +52,10 @@ function main_debian() {
   package clang
 
   if [[ $DISTRO == "wheezy" ]]; then
-    install_cmake
     # thrift requires automate 1.13 or later
     remove_package automake
     install_automake
   elif [[ $DISTRO == "jessie" ]]; then
-    package cmake
     package automake
   fi
 
@@ -69,6 +67,7 @@ function main_debian() {
     gem_install fpm
   fi
 
+  install_cmake
   install_boost
   install_gflags
   install_glog


### PR DESCRIPTION
Newer versions of CMake are needed to build the new AWS SDK dependencies. Debian Jesse does not include a new-enough version so we should compile/build our included CMake on all versions.

Cc: @zwass 