### PR TITLE
Allow building on Debian Jessie

### DIFF
--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -27,7 +27,6 @@ function main_debian() {
   package python-pip
   package python-dev
   package ruby-dev
-  package ruby1.8-dev
   package libffi-dev
   package rubygems
   package gcc
@@ -52,12 +51,11 @@ function main_debian() {
   package clang
 
   if [[ $DISTRO == "wheezy" ]]; then
-    install_cmake
+    package ruby1.8-dev
     # thrift requires automate 1.13 or later
     remove_package automake
     install_automake
   elif [[ $DISTRO == "jessie" ]]; then
-    package cmake
     package automake
   fi
 
@@ -69,6 +67,7 @@ function main_debian() {
     gem_install fpm
   fi
 
+  install_cmake
   install_boost
   install_gflags
   install_glog


### PR DESCRIPTION
Fixes #2055. Compared to from #2091, also moves the not in jessie ruby1.8-dev package to wheezy