### PR TITLE
Introduce table aliases

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -970,8 +970,8 @@ static int booleanValue(char *zArg) {
   if (sqlite3_stricmp(zArg, "off") == 0 || sqlite3_stricmp(zArg, "no") == 0) {
     return 0;
   }
-  fprintf(
-      stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n", zArg);
+  fprintf(stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n",
+          zArg);
   return 0;
 }
 
@@ -1022,18 +1022,11 @@ inline void meta_schema(int nArg, char **azArg) {
       continue;
     }
 
-    osquery::PluginRequest request = {{"action", "columns"}};
+    osquery::PluginRequest request = {{"action", "definition"}};
     osquery::PluginResponse response;
-
     osquery::Registry::call("table", table_name, request, response);
-    std::vector<std::string> columns;
-    for (const auto &column : response) {
-      columns.push_back(column.at("name") + " " + column.at("type"));
-    }
-
-    printf("CREATE TABLE %s(%s);\n",
-           table_name.c_str(),
-           osquery::join(columns, ", ").c_str());
+    fprintf(stdout, "CREATE TABLE %s%s;\n", table_name.c_str(),
+            response[0].at("definition").c_str());
   }
 }
 
@@ -1377,8 +1370,8 @@ static int process_input(struct callback_data *p, FILE *in) {
       if (rc || zErrMsg) {
         char zPrefix[100];
         if (in != 0 || !stdin_is_interactive) {
-          sqlite3_snprintf(
-              sizeof(zPrefix), zPrefix, "Error: near line %d:", startline);
+          sqlite3_snprintf(sizeof(zPrefix), zPrefix, "Error: near line %d:",
+                           startline);
         } else {
           sqlite3_snprintf(sizeof(zPrefix), zPrefix, "Error:");
         }
@@ -1462,10 +1455,10 @@ int launchIntoShell(int argc, char **argv) {
     data.mode = MODE_Pretty;
   }
 
-  sqlite3_snprintf(
-      sizeof(data.separator), data.separator, "%s", FLAGS_separator.c_str());
-  sqlite3_snprintf(
-      sizeof(data.nullvalue), data.nullvalue, "%s", FLAGS_nullvalue.c_str());
+  sqlite3_snprintf(sizeof(data.separator), data.separator, "%s",
+                   FLAGS_separator.c_str());
+  sqlite3_snprintf(sizeof(data.nullvalue), data.nullvalue, "%s",
+                   FLAGS_nullvalue.c_str());
 
   auto runQuery = [&data](const char *query) {
     char *error = 0;

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -29,8 +29,8 @@ class ExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-      std::make_tuple("example_text", TEXT_TYPE, DEFAULT),
-      std::make_tuple("example_integer", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("example_text", TEXT_TYPE, DEFAULT),
+        std::make_tuple("example_integer", INTEGER_TYPE, DEFAULT),
     };
   }
 
@@ -63,8 +63,8 @@ class ComplexExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-      std::make_tuple("flag_test", TEXT_TYPE, DEFAULT),
-      std::make_tuple("database_test", TEXT_TYPE, DEFAULT),
+        std::make_tuple("flag_test", TEXT_TYPE, DEFAULT),
+        std::make_tuple("database_test", TEXT_TYPE, DEFAULT),
     };
   }
 

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -64,6 +64,42 @@ TEST_F(VirtualTableTests, test_tableplugin_options) {
   EXPECT_EQ(response[0]["op"], INTEGER(INDEX | REQUIRED));
 }
 
+class aliasesTablePlugin : public TablePlugin {
+ private:
+  TableColumns columns() const override {
+    return {
+        std::make_tuple("id", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("username", TEXT_TYPE, DEFAULT),
+        std::make_tuple("name", TEXT_TYPE, DEFAULT),
+    };
+  }
+
+  std::vector<std::string> aliases() const override {
+    return {"aliases1", "aliases2"};
+  }
+
+  ColumnAliasSet columnAliases() const override {
+    return {
+        {"username", {"user_name"}},
+        {"name", {"name1", "name2", "name3", "name4"}},
+    };
+  }
+
+ private:
+  FRIEND_TEST(VirtualTableTests, test_tableplugin_aliases);
+};
+
+TEST_F(VirtualTableTests, test_tableplugin_aliases) {
+  auto table = std::make_shared<aliasesTablePlugin>();
+  std::vector<std::string> expected_aliases = {"aliases1", "aliases2"};
+  EXPECT_EQ(table->aliases(), expected_aliases);
+
+  PluginResponse response;
+  PluginRequest request = {{"action", "columns"}};
+  EXPECT_TRUE(table->call(request, response).ok());
+  // EXPECT_EQ(response[0]["op"], INTEGER(INDEX | REQUIRED));
+}
+
 TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
   auto table = std::make_shared<sampleTablePlugin>();
   table->setName("sample");

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -158,9 +158,10 @@ int xCreate(sqlite3 *db,
   // Create a TablePlugin Registry call, expect column details as the response.
   PluginResponse response;
   pVtab->content->name = std::string(argv[0]);
+  const auto &name = pVtab->content->name;
   // Get the table column information.
-  auto status = Registry::call("table", pVtab->content->name,
-                               {{"action", "columns"}}, response);
+  auto status =
+      Registry::call("table", name, {{"action", "columns"}}, response);
   if (!status.ok() || response.size() == 0) {
     delete pVtab->content;
     delete pVtab;
@@ -168,8 +169,8 @@ int xCreate(sqlite3 *db,
   }
 
   // Generate an SQL create table statement from the retrieved column details.
-  auto statement =
-      "CREATE TABLE " + pVtab->content->name + columnDefinition(response);
+  // This call to columnDefinition requests column aliases (as HIDDEN columns).
+  auto statement = "CREATE TABLE " + name + columnDefinition(response, true);
   int rc = sqlite3_declare_vtab(db, statement.c_str());
   if (rc != SQLITE_OK || !status.ok() || response.size() == 0) {
     delete pVtab->content;
@@ -177,12 +178,51 @@ int xCreate(sqlite3 *db,
     return (rc != SQLITE_OK) ? rc : SQLITE_ERROR;
   }
 
+  // Tables may request aliases as views.
+  std::set<std::string> views;
+
   // Keep a local copy of the column details in the VirtualTableContent struct.
   // This allows introspection into the column type without additional calls.
   for (const auto &column : response) {
-    pVtab->content->columns.push_back(std::make_tuple(
-        column.at("name"), columnTypeName(column.at("type")),
-        (ColumnOptions)AS_LITERAL(INTEGER_LITERAL, column.at("op"))));
+    if (column.count("id") == 0) {
+      // This does not define a column type.
+      continue;
+    }
+
+    if (column.at("id") == "column" && column.count("name") &&
+        column.count("type")) {
+      // This is a malformed column definition.
+      // Populate the virtual table specific persistent column information.
+      pVtab->content->columns.push_back(std::make_tuple(
+          column.at("name"), columnTypeName(column.at("type")),
+          (ColumnOptions)AS_LITERAL(INTEGER_LITERAL, column.at("op"))));
+    } else if (column.at("id") == "alias" && column.count("alias")) {
+      // Create associated views for table aliases.
+      views.insert(column.at("alias"));
+    } else if (column.at("id") == "columnAlias" && column.count("name") &&
+               column.count("target")) {
+      // Record the column in the set of columns.
+      // This is required because SQLITE uses indexes to identify columns.
+      // Use an UNKNOWN_TYPE as a pseudo-mask, since the type does not matter.
+      pVtab->content->columns.push_back(
+          std::make_tuple(column.at("name"), UNKNOWN_TYPE, HIDDEN));
+      // Record a mapping of the requested column alias name.
+      size_t target_index = 0;
+      for (size_t i = 0; i < pVtab->content->columns.size(); i++) {
+        const auto &target_column = pVtab->content->columns[i];
+        if (std::get<0>(target_column) == column.at("target")) {
+          target_index = i;
+          break;
+        }
+      }
+      pVtab->content->aliases[column.at("name")] = target_index;
+    }
+  }
+
+  // Create the requested 'aliases'.
+  for (const auto &view : views) {
+    auto statement = "CREATE VIEW " + view + " AS SELECT * FROM " + name;
+    sqlite3_exec(db, statement.c_str(), nullptr, nullptr, nullptr);
   }
   *ppVtab = (sqlite3_vtab *)pVtab;
   return rc;
@@ -195,12 +235,20 @@ int xColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col) {
     // Requested column index greater than column set size.
     return SQLITE_ERROR;
   }
-
-  const auto &column_name = std::get<0>(pVtab->content->columns[col]);
-  const auto &type = std::get<1>(pVtab->content->columns[col]);
   if (pCur->row >= pCur->data.size()) {
     // Request row index greater than row set size.
     return SQLITE_ERROR;
+  }
+
+  auto &column_name = std::get<0>(pVtab->content->columns[col]);
+  auto &type = std::get<1>(pVtab->content->columns[col]);
+  if (pVtab->content->aliases.count(column_name)) {
+    // Overwrite the aliased column with the type and name of the new column.
+    type = std::get<1>(
+        pVtab->content->columns[pVtab->content->aliases.at(column_name)]);
+    column_name = std::get<0>(
+        pVtab->content->columns[pVtab->content->aliases.at(column_name)]);
+    printf("setting column_name = %s type=%d\n", column_name.c_str(), type);
   }
 
   // Attempt to cast each xFilter-populated row/column to the SQLite type.
@@ -473,7 +521,7 @@ void attachVirtualTables(const SQLiteDBInstanceRef &instance) {
     auto status =
         Registry::call("table", name, {{"action", "columns"}}, response);
     if (status.ok()) {
-      auto statement = columnDefinition(response);
+      auto statement = columnDefinition(response, true);
       attachTableInternal(name, statement, instance);
     }
   }

--- a/specs/etc_hosts.table
+++ b/specs/etc_hosts.table
@@ -1,4 +1,4 @@
-table_name("etc_hosts")
+table_name("etc_hosts", aliases=["hosts"])
 description("Line-parsed /etc/hosts.")
 schema([
     Column("address", TEXT, "IP address mapping"),

--- a/specs/utility/time.table
+++ b/specs/utility/time.table
@@ -9,12 +9,14 @@ schema([
     Column("minutes", INTEGER, "Current minutes in the system"),
     Column("seconds", INTEGER, "Current seconds in the system"),
     Column("timezone", TEXT, "Current timezone in the system"),
-    Column("local_time", INTEGER, "Current local UNIX time in the system"),
+    Column("local_time", INTEGER, "Current local UNIX time in the system",
+        aliases=["localtime"]),
     Column("local_timezone", TEXT, "Current local timezone in the system"),
     Column("unix_time", INTEGER,
         "Current UNIX time in the system, converted to UTC if --utc enabled"),
     Column("timestamp", TEXT, "Current timestamp (log format) in the system"),
-    Column("datetime", TEXT, "Current date and time (ISO format) in the system"),
+    Column("datetime", TEXT, "Current date and time (ISO format) in the system",
+        aliases=["date_time"]),
     Column("iso_8601", TEXT, "Current time (ISO format) in the system"),
 ])
 attributes(utility=True)

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -178,7 +178,9 @@ class TableState(Singleton):
         self.description = ""
         self.attributes = {}
         self.examples = []
+        self.aliases = []
         self.has_options = False
+        self.has_column_aliases = False
 
     def columns(self):
         return [i for i in self.schema if isinstance(i, Column)]
@@ -200,6 +202,8 @@ class TableState(Singleton):
                     column_options.append(COLUMN_OPTIONS[option])
                     all_options.append(COLUMN_OPTIONS[option])
             column.options_set = " | ".join(column_options)
+            if len(column.aliases) > 0:
+                self.has_column_aliases = True
         if len(all_options) > 0:
             self.has_options = True
         if "cacheable" in self.attributes:
@@ -240,7 +244,9 @@ class TableState(Singleton):
             class_name=self.class_name,
             attributes=self.attributes,
             examples=self.examples,
+            aliases=self.aliases,
             has_options=self.has_options,
+            has_column_aliases=self.has_column_aliases,
         )
 
         with open(path, "w+") as file_h:
@@ -262,10 +268,11 @@ class Column(object):
     documentation generation and reference.
     """
 
-    def __init__(self, name, col_type, description="", **kwargs):
+    def __init__(self, name, col_type, description="", aliases=[], **kwargs):
         self.name = name
         self.type = col_type
         self.description = description
+        self.aliases = aliases
         self.options = kwargs
 
 
@@ -281,7 +288,7 @@ class ForeignKey(object):
         self.table = kwargs.get("table", "")
 
 
-def table_name(name):
+def table_name(name, aliases=[]):
     """define the virtual table name"""
     logging.debug("- table_name")
     logging.debug("  - called with: %s" % name)
@@ -289,6 +296,7 @@ def table_name(name):
     table.description = ""
     table.attributes = {}
     table.examples = []
+    table.aliases = aliases
 
 
 def schema(schema_list):

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -43,6 +43,32 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 {% endfor %}\
     };
   }
+{% if aliases|length > 0 %}\
+
+  std::vector<std::string> aliases() const override {
+    return {
+{% for alias in aliases %}\
+      "{{alias}}",
+{% endfor %}\
+    };
+  }
+{% endif %}\
+
+{% if has_column_aliases %}\
+
+  ColumnAliasSet columnAliases() const override {
+    return {
+{% for column in schema %}\
+{% if column.aliases|length > 0 %}\
+      {"{{column.name}}", {% raw %}{{% endraw %}\
+{% for alias in column.aliases %}"{{alias}}"\
+{% if not loop.last %}, {% endif %}\
+{% endfor %}}},
+{% endif %}\
+{% endfor %}\
+    };
+  }
+{% endif %}\
 
   QueryData generate(QueryContext& request) override {
 {% if class_name != "" %}\

--- a/tools/codegen/templates/foreign.cpp.in
+++ b/tools/codegen/templates/foreign.cpp.in
@@ -34,6 +34,32 @@ auto {{table_name_cc}}Register = []() {
 {% endfor %}\
       };
     }
+{% if aliases|length > 0 %}\
+
+    std::vector<std::string> aliases() const override {
+      return {
+{% for alias in aliases %}\
+        "{{alias}}",
+{% endfor %}\
+      };
+    }
+{% endif %}\
+
+{% if has_column_aliases %}\
+
+  ColumnAliasSet columnAliases() const override {
+    return {
+{% for column in schema %}\
+{% if column.aliases|length > 0 %}\
+      {"{{column.name}}", {% raw %}{{% endraw %}\
+{% for alias in column.aliases %}"{{alias}}"\
+{% if not loop.last %}, {% endif %}\
+{% endfor %}}},
+{% endif %}\
+{% endfor %}\
+    };
+  }
+{% endif %}\
 
     QueryData generate(QueryContext& request) override { return QueryData(); }
   };


### PR DESCRIPTION
Aliases (both column and table) allows us to change table and column names, then explicitly choose to support the old (deprecated) names.