### PR TITLE
Use ruby/gem ABI version 1.9.1 on 12.04

### DIFF
--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -58,6 +58,12 @@ function main_ubuntu() {
   package libreadline-dev
   package libcurl4-openssl-dev
 
+  if [[ $DISTRO = "precise" ]]; then
+    package ruby1.9.3
+    sudo update-alternatives --set ruby /usr/bin/ruby1.9.1
+    sudo update-alternatives --set gem /usr/bin/gem1.9.1
+  fi
+
   if [[ $DISTRO = "lucid" ]]; then
     package libopenssl-ruby
 


### PR DESCRIPTION
`fpm`'s dependency `ruby-xz` wants ruby version 1.9.3, this is an alias to the ABI equivalent 1.9.1 and seems to work fine on Precise. 