### PR TITLE
Add --ephemeral for daemons and disable shell events

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -34,25 +34,26 @@
 #endif
 // clang-format on
 
-#ifndef __constructor__
+#ifdef WIN32
+#define USED_SYMBOL
+#else
+#define USED_SYMBOL __attribute__((used))
+#endif
 
+#ifndef __constructor__
 #ifdef WIN32
 #define __registry_constructor__
 #define __plugin_constructor__
 #else
-#define __registry_constructor__ __attribute__((constructor(101)))
-#define __plugin_constructor__ __attribute__((constructor(102)))
+#define __registry_constructor__ __attribute__((constructor(101))) USED_SYMBOL
+#define __plugin_constructor__ __attribute__((constructor(102))) USED_SYMBOL
 #endif
 
 #else
-#define __registry_constructor__ __attribute__((__constructor__(101)))
-#define __plugin_constructor__ __attribute__((__constructor__(102)))
-#endif
-
-#ifdef WIN32
-#define USED_REFERENCE
-#else
-#define USED_REFERENCE __attribute__((used))
+#define __registry_constructor__ __attribute__((__constructor__(101))) \
+  USED_SYMBOL
+#define __plugin_constructor__ __attribute__((__constructor__(102))) \
+  USED_SYMBOL
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.
@@ -128,6 +129,13 @@ class Initializer : private boost::noncopyable {
    * for sane/non-default configurations, etc.
    */
   void initDaemon() const;
+
+  /**
+   * @brief Sets up the process as an osquery shell.
+   *
+   * The shell is lighter than a daemon and disables (by default) features.
+   */
+  void initShell() const;
 
   /**
    * @brief Daemon tools may want to continually spawn worker processes

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -492,7 +492,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return The query-time table data, retrieved from a backing store.
    */
-  virtual QueryData genTable(QueryContext& context) USED_REFERENCE;
+  virtual QueryData genTable(QueryContext& context) USED_SYMBOL;
 
   /// Number of Subscription%s this EventSubscriber has used.
   size_t numSubscriptions() const { return subscription_count_; }

--- a/osquery/core/test_util.cpp
+++ b/osquery/core/test_util.cpp
@@ -53,6 +53,7 @@ DECLARE_string(modules_autoload);
 DECLARE_string(extensions_autoload);
 DECLARE_string(enroll_tls_endpoint);
 DECLARE_bool(disable_logging);
+DECLARE_bool(disable_database);
 
 typedef std::chrono::high_resolution_clock chrono_clock;
 
@@ -83,11 +84,12 @@ void initTesting() {
   FLAGS_extensions_autoload = kTestWorkingDirectory + "unittests-ext.load";
   FLAGS_modules_autoload = kTestWorkingDirectory + "unittests-mod.load";
   FLAGS_disable_logging = true;
+  FLAGS_disable_database = true;
 
   // Tests need a database plugin.
   // Set up the database instance for the unittests.
   DatabasePlugin::setAllowOpen(true);
-  Registry::setActive("database", "ephemeral");
+  DatabasePlugin::initPlugin();
 }
 
 void shutdownTesting() { DatabasePlugin::shutdown(); }
@@ -159,8 +161,8 @@ QueryData getTestDBExpectedResults() {
   return d;
 }
 
-std::vector<std::pair<std::string, QueryData> > getTestDBResultStream() {
-  std::vector<std::pair<std::string, QueryData> > results;
+std::vector<std::pair<std::string, QueryData>> getTestDBResultStream() {
+  std::vector<std::pair<std::string, QueryData>> results;
 
   std::string q2 =
       "INSERT INTO test_table (username, age) VALUES (\"joe\", 25)";

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -34,6 +34,8 @@ CLI_FLAG(bool,
          "Keep osquery backing-store in memory");
 FLAG_ALIAS(bool, use_in_memory_database, database_in_memory);
 
+FLAG(bool, disable_database, false, "Disable the persistent RocksDB storage");
+
 #if defined(SKIP_ROCKSDB)
 #define DATABASE_PLUGIN "sqlite"
 #else
@@ -424,7 +426,8 @@ bool addUniqueRowToQueryData(QueryData& q, const Row& r) {
 
 bool DatabasePlugin::initPlugin() {
   // Initialize the database plugin using the flag.
-  return Registry::setActive("database", kInternalDatabase).ok();
+  auto plugin = (FLAGS_disable_database) ? "ephemeral" : kInternalDatabase;
+  return Registry::setActive("database", plugin).ok();
 }
 
 void DatabasePlugin::shutdown() {


### PR DESCRIPTION
This changes several initialization steps:
- The daemon (and shell, though not needed) have a new `--ephemeral` flag.
- Events are now disabled in the shell by default, use `--nodisable_events` to re-enable.
- RocksDB-based backing storage is now disabled in the shell by default.

The `--ephemeral` flag for the daemon is disabled by default and will allow skipping configuration and database path sanity, and skipping `--pidfile` checks. This is intended to be used when debugging or monitoring the daemon process.

To make the RocksDB backing storage feature usage very clear we introduce a new flag: `--disable_database`. The shell sets this to true unless overridden in a `--flagfile` or via command line arguments.

Closes: #2109, #2110