### PR TITLE
Add removeService to Dispatcher API

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -23,6 +23,8 @@
 
 namespace osquery {
 
+class Dispatcher;
+
 /// A throw/catch relay between a pause request and cancel event.
 struct RunnerInterruptError {};
 
@@ -106,10 +108,7 @@ class InternalRunnable : private boost::noncopyable,
    *
    * This is used by the Dispatcher only.
    */
-  virtual void run() final {
-    run_ = true;
-    start();
-  }
+  virtual void run() final;
 
   /**
    * @brief Check if the thread's entrypoint (run) executed.
@@ -166,7 +165,7 @@ class Dispatcher : private boost::noncopyable {
   static void stopServices();
 
   /// Return number of services.
-  size_t serviceCount() { return service_threads_.size(); }
+  size_t serviceCount() { return services_.size(); }
 
  private:
   /**
@@ -176,9 +175,11 @@ class Dispatcher : private boost::noncopyable {
    * Dispatcher's constructor is private.
    */
   Dispatcher() {}
-  Dispatcher(Dispatcher const&);
-  void operator=(Dispatcher const&);
   virtual ~Dispatcher() {}
+
+ private:
+  /// When a service ends, it will remove itself from the dispatcher.
+  static void removeService(const InternalRunnable* service);
 
  private:
   /// The set of shared osquery service threads.
@@ -207,6 +208,7 @@ class Dispatcher : private boost::noncopyable {
   std::atomic<bool> stopping_{false};
 
  private:
+  friend class InternalRunnable;
   friend class ExtensionsTest;
 };
 }

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -259,6 +259,8 @@ function main() {
              --version ${BUILD_VERSION}-${APP_VERSION} \
              $KERNEL_OUTPUT_PKG_PATH 2>&1  1>/dev/null
     log "kernel package created at $KERNEL_OUTPUT_PKG_PATH"
+  else
+    log "skipping kernel package, no kext found"
   fi
 
 }

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -13,6 +13,9 @@ LSB_RELEASE=/etc/lsb-release
 DEBIAN_VERSION=/etc/debian_version
 LIB_SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
+# For OS X, define the distro that builds the kernel extension.
+DARWIN_KERNEL_VERSION="10.11"
+
 function platform() {
   local  __out=$1
   FAMILY="`python $LIB_SCRIPT_DIR/get_platform.py --family`"
@@ -111,7 +114,7 @@ function build() {
   # Build kernel extension/module and tests.
   BUILD_KERNEL=0
   if [[ "$PLATFORM" = "darwin" ]]; then
-    if [[ "$DISTRO" = "10.10" ]]; then
+    if [[ "$DISTRO" = "$DARWIN_KERNEL_VERSION" ]]; then
       BUILD_KERNEL=1
     fi
   fi


### PR DESCRIPTION
With a `::removeService` method, combined with the abstracted thread start in the Dispatcher API, services auto-remove when finished.

This will un-break the kernel communication tests. These tests only stop when all their producer threads/services have ended.