### PR TITLE
Fixed typing warnings in FileOps tests

### DIFF
--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -23,13 +23,9 @@ namespace osquery {
 
 class FileOpsTests : public testing::Test {
  protected:
-  void SetUp() override {
-    createMockFileStructure();
-  }
+  void SetUp() override { createMockFileStructure(); }
 
-  void TearDown() override {
-    tearDownMockFileStructure();
-  }
+  void TearDown() override { tearDownMockFileStructure(); }
 
   bool globResultsMatch(const std::vector<std::string>& results,
                         std::vector<fs::path>& expected) {
@@ -55,15 +51,15 @@ class TempFile {
       : path_((fs::temp_directory_path() / fs::unique_path())
                   .make_preferred()
                   .string()) {}
- 
+
   ~TempFile() {
     if (fs::exists(path_)) {
       fs::remove(path_);
     }
   }
- 
+
   const std::string& path() const { return path_; }
- 
+
  private:
   std::string path_;
 };
@@ -76,7 +72,7 @@ TEST_F(FileOpsTests, test_openFile) {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
     EXPECT_FALSE(fd.isValid());
   }
-  
+
   {
     PlatformFile fd(path, PF_CREATE_NEW | PF_WRITE);
     EXPECT_TRUE(fd.isValid());
@@ -108,14 +104,16 @@ TEST_F(FileOpsTests, test_openFile) {
 TEST_F(FileOpsTests, test_fileIo) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
-   
-  const char *expected_read = "AAAABBBBCCCCDDDD";
-  const size_t expected_read_len = ::strlen(expected_read);
+
+  const char* expected_read = "AAAABBBBCCCCDDDD";
+  const ssize_t expected_read_len = ::strlen(expected_read);
+  const ssize_t expected_write_len = ::strlen(expected_read);
+  const size_t expected_buf_size = ::strlen(expected_read);
 
   {
     PlatformFile fd(path, PF_CREATE_NEW | PF_WRITE);
     EXPECT_TRUE(fd.isValid());
-    EXPECT_EQ(expected_read_len, fd.write(expected_read, expected_read_len));
+    EXPECT_EQ(expected_write_len, fd.write(expected_read, expected_read_len));
   }
 
   {
@@ -124,8 +122,8 @@ TEST_F(FileOpsTests, test_fileIo) {
     EXPECT_TRUE(fd.isValid());
     EXPECT_TRUE(fd.isFile());
     EXPECT_EQ(expected_read_len, fd.read(&buf[0], expected_read_len));
-    EXPECT_EQ(expected_read_len, buf.size());
-    for (size_t i = 0; i < expected_read_len; i++) {
+    EXPECT_EQ(expected_buf_size, buf.size());
+    for (ssize_t i = 0; i < expected_read_len; i++) {
       EXPECT_EQ(expected_read[i], buf[i]);
     }
   }
@@ -135,8 +133,8 @@ TEST_F(FileOpsTests, test_asyncIo) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
 
-  const char *expected = "AAAABBBBCCCCDDDDEEEEFFFFGGGG";
-  const size_t expected_len = ::strlen(expected);
+  const char* expected = "AAAABBBBCCCCDDDDEEEEFFFFGGGG";
+  const ssize_t expected_len = ::strlen(expected);
 
   {
     PlatformFile fd(path, PF_CREATE_NEW | PF_WRITE | PF_NONBLOCK);
@@ -160,9 +158,9 @@ TEST_F(FileOpsTests, test_asyncIo) {
     EXPECT_TRUE(fd.isFile());
 
     std::vector<char> buf(expected_len);
-    char *ptr = &buf[0];
+    char* ptr = &buf[0];
     ssize_t part_bytes = 0;
-    size_t iterations = 0;
+    int iterations = 0;
     do {
       part_bytes = fd.read(ptr, 4);
       if (part_bytes > 0) {
@@ -180,20 +178,25 @@ TEST_F(FileOpsTests, test_seekFile) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
 
-  const char *expected = "AABBBBAACCCAAAAADDDDAAAAAAAA";
-  const size_t expected_len = ::strlen(expected);
+  const char* expected = "AABBBBAACCCAAAAADDDDAAAAAAAA";
+  const ssize_t expected_len = ::strlen(expected);
+  off_t expected_offs;
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
     EXPECT_TRUE(fd.isValid());
-    EXPECT_EQ(expected_len, fd.write("AAAAAAAAAAAAAAAAAAAAAAAAAAAA", expected_len));
+    EXPECT_EQ(expected_len,
+              fd.write("AAAAAAAAAAAAAAAAAAAAAAAAAAAA", expected_len));
   }
+
+  // Cast to the proper type, off_t
+  expected_offs = expected_len - 12;
 
   {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_WRITE);
     EXPECT_TRUE(fd.isValid());
-    
-    EXPECT_EQ(expected_len - 12, fd.seek(-12, PF_SEEK_END));
+
+    EXPECT_EQ(expected_offs, fd.seek(-12, PF_SEEK_END));
     EXPECT_EQ(4, fd.write("DDDD", 4));
 
     EXPECT_EQ(2, fd.seek(2, PF_SEEK_BEGIN));
@@ -217,94 +220,75 @@ TEST_F(FileOpsTests, test_seekFile) {
 TEST_F(FileOpsTests, test_glob) {
   {
     std::vector<fs::path> expected{
-      kFakeDirectory + "/door.txt",
-      kFakeDirectory + "/root.txt",
-      kFakeDirectory + "/root2.txt",
-      kFakeDirectory + "/roto.txt"
-    };
+        kFakeDirectory + "/door.txt", kFakeDirectory + "/root.txt",
+        kFakeDirectory + "/root2.txt", kFakeDirectory + "/roto.txt"};
     auto result = platformGlob(kFakeDirectory + "/*.txt");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
     std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/",
-      kFakeDirectory + "/deep11/",
-      kFakeDirectory + "/door.txt",
-      kFakeDirectory + "/root.txt",
-      kFakeDirectory + "/root2.txt",
-      kFakeDirectory + "/roto.txt"
-    };
+        kFakeDirectory + "/deep1/",    kFakeDirectory + "/deep11/",
+        kFakeDirectory + "/door.txt",  kFakeDirectory + "/root.txt",
+        kFakeDirectory + "/root2.txt", kFakeDirectory + "/roto.txt"};
     auto result = platformGlob(kFakeDirectory + "/*");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/deep2/",
-      kFakeDirectory + "/deep1/level1.txt",
-      kFakeDirectory + "/deep11/deep2/",
-      kFakeDirectory + "/deep11/level1.txt",
-      kFakeDirectory + "/deep11/not_bash"
-    };
+    std::vector<fs::path> expected{kFakeDirectory + "/deep1/deep2/",
+                                   kFakeDirectory + "/deep1/level1.txt",
+                                   kFakeDirectory + "/deep11/deep2/",
+                                   kFakeDirectory + "/deep11/level1.txt",
+                                   kFakeDirectory + "/deep11/not_bash"};
     auto result = platformGlob(kFakeDirectory + "/*/*");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/deep2/level2.txt",
-      kFakeDirectory + "/deep11/deep2/deep3/",
-      kFakeDirectory + "/deep11/deep2/level2.txt"
-    };
+    std::vector<fs::path> expected{kFakeDirectory + "/deep1/deep2/level2.txt",
+                                   kFakeDirectory + "/deep11/deep2/deep3/",
+                                   kFakeDirectory + "/deep11/deep2/level2.txt"};
     auto result = platformGlob(kFakeDirectory + "/*/*/*");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep11/deep2/deep3/",
-      kFakeDirectory + "/deep11/deep2/level2.txt"
-    };
+    std::vector<fs::path> expected{kFakeDirectory + "/deep11/deep2/deep3/",
+                                   kFakeDirectory + "/deep11/deep2/level2.txt"};
     auto result = platformGlob(kFakeDirectory + "/*11/*/*");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/",
-      kFakeDirectory + "/root.txt"
-    };
+    std::vector<fs::path> expected{kFakeDirectory + "/deep1/",
+                                   kFakeDirectory + "/root.txt"};
     auto result = platformGlob(kFakeDirectory + "/{deep,root}{1,.txt}");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/deep2/level2.txt",
-      kFakeDirectory + "/deep11/deep2/deep3/",
-      kFakeDirectory + "/deep11/deep2/level2.txt"
-    };
+    std::vector<fs::path> expected{kFakeDirectory + "/deep1/deep2/level2.txt",
+                                   kFakeDirectory + "/deep11/deep2/deep3/",
+                                   kFakeDirectory + "/deep11/deep2/level2.txt"};
     auto result = platformGlob(kFakeDirectory + "/*/deep2/*");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 
   {
-    std::vector<fs::path> expected{
-      kFakeDirectory + "/deep1/deep2/",
+    std::vector<fs::path> expected{kFakeDirectory + "/deep1/deep2/",
 #ifdef WIN32
-      kFakeDirectory + "/deep1/level1.txt",
-      kFakeDirectory + "/deep11/deep2/",
+                                   kFakeDirectory + "/deep1/level1.txt",
+                                   kFakeDirectory + "/deep11/deep2/",
 #else
-      kFakeDirectory + "/deep11/deep2/",
-      kFakeDirectory + "/deep1/level1.txt",
+                                   kFakeDirectory + "/deep11/deep2/",
+                                   kFakeDirectory + "/deep1/level1.txt",
 #endif
-      kFakeDirectory + "/deep11/level1.txt",
-      kFakeDirectory + "/deep11/not_bash"
-    };
-    auto result = platformGlob(kFakeDirectory + "/*/{deep2,level1,not_bash}{,.txt}");
+                                   kFakeDirectory + "/deep11/level1.txt",
+                                   kFakeDirectory + "/deep11/not_bash"};
+    auto result =
+        platformGlob(kFakeDirectory + "/*/{deep2,level1,not_bash}{,.txt}");
     EXPECT_TRUE(globResultsMatch(result, expected));
   }
 }
 }
-


### PR DESCRIPTION
Some of the types in fileops tests were causing warnings to be thrown
during build, due to type mismatch. I've added a few local variables to
quiet these warnings.

Also note, a lot of clang formatting got applied as this was run through 
our formmater.