### PR TITLE
Adding sip_config table to it-compliance pack

### DIFF
--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -201,6 +201,14 @@
       "version" : "1.4.5",
       "description" : "Retrieves the current filters and chains per filter in the target system.",
       "value" : "General security posture."
+    },
+    "sip_config": {
+      "query" : "select * from sip_config;",
+      "interval" : "86400",
+      "platform" : "darwin",
+      "version" : "1.7.0",
+      "description" : "Retrieves the current System Integrity Protection configuration in the target system.",
+      "value" : "General security posture."
     }
   }
 }


### PR DESCRIPTION
Getting the current status of System Integrity Protection in the it-compliance pack. The table was added in version 1.7.0