### PR TITLE
Use local AWS-SDK formula for OS X

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -15,6 +15,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="$SCRIPT_DIR/../build"
 WORKING_DIR="/tmp/osquery-provisioning"
 FILES_DIR="$SCRIPT_DIR/provision/files"
+FORMULA_DIR="$SCRIPT_DIR/provision/formula"
 DEPS_URL=https://osquery-packages.s3.amazonaws.com/deps
 export PATH="$PATH:/usr/local/bin"
 

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -36,5 +36,6 @@ function main_darwin() {
   package google-benchmark
   package libmagic
   package sleuthkit
-  package aws-sdk-cpp
+
+  local_brew aws-sdk-cpp
 }

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -1,0 +1,45 @@
+class AwsSdkCpp < Formula
+  desc "AWS SDK for C++"
+  homepage "https://github.com/aws/aws-sdk-cpp"
+  url "https://github.com/aws/aws-sdk-cpp.git"
+  version "0.12.4"
+
+  bottle :unneeded
+
+  option "with-static", "Build with static linking"
+  option "without-http-client", "Don't include the libcurl HTTP client"
+  option "with-logging-only", "Only build logging-related SDKs"
+  option "with-minimize-size", "Request size optimization"
+
+  depends_on "cmake" => :build
+
+  def install
+    args = std_cmake_args
+    args << "-DSTATIC_LINKING=1" if build.with? "static" or true
+    args << "-DNO_HTTP_CLIENT=1" if build.without? "http-client" or true
+    args << "-DBUILD_ONLY=firehose;kinesis" if build.with? "logging-only" or true
+    args << "-DMINIMIZE_SIZE=ON" if build.with? "minimize-size" or true
+
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make"
+      system "make", "install"
+    end
+
+    lib.install Dir[lib/"mac/Release/*"].select { |f| File.file? f }
+  end
+
+  test do
+    (testpath/"test.cpp").write <<-EOS.undent
+      #include <aws/core/Version.h>
+      #include <iostream>
+
+      int main() {
+          std::cout << Aws::Version::GetVersionString() << std::endl;
+          return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-o", "test", "-laws-cpp-sdk-core"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Thus begins our need to include local (modified) brew formulas. This commit adds a new provision library method: local_brew. Use this function within provision scripts to install packages that are not appropriate for homebrew-core.

/cc @zwass 