### PR TITLE
Add systemd service to Xenial

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -41,7 +41,6 @@ elseif(LINUX)
       set(PACKAGE_DEPENDENCIES
         "${PACKAGE_DEPENDENCIES}"
         "libc6 (>=2.13)"
-        "libapt-pkg4.12"
       )
     endif()
 

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -112,7 +112,7 @@ function main() {
   cp $OSQUERY_EXAMPLE_CONFIG_SRC $INSTALL_PREFIX$OSQUERY_EXAMPLE_CONFIG_DST
   cp $PACKS_SRC/* $INSTALL_PREFIX/$PACKS_DST
 
-  if [[ $DISTRO = "centos7" || $DISTRO = "rhel7" ]]; then
+  if [[ $DISTRO = "centos7" || $DISTRO = "rhel7" || $DISTRO = "xenial" ]]; then
     # Install the systemd service and sysconfig
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SERVICE_DST`
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST`

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -118,7 +118,7 @@ function main_centos() {
   package audit-libs-devel
   package audit-libs-static
 
-  gem_install fpm
+  gem_install fpm -v 1.3.3
 
   install_aws_sdk
 }


### PR DESCRIPTION
Opt in the Ubuntu 16.04 `make_linux_package`, wrapped by `make packages` into including a systemd service unit. This is the same unit as CentOS 7.