### PR TITLE
Use SQLite 3.14.0 to support LIKE and EQUALS

### DIFF
--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -195,6 +195,7 @@ void TablePlugin::setCache(size_t step,
 }
 
 std::string columnDefinition(const TableColumns& columns) {
+  std::vector<std::string> epilog;
   std::string statement = "(";
   for (size_t i = 0; i < columns.size(); ++i) {
     const auto& column = columns.at(i);
@@ -203,6 +204,7 @@ std::string columnDefinition(const TableColumns& columns) {
     auto& options = std::get<2>(column);
     if (options & INDEX) {
       statement += " PRIMARY KEY";
+      epilog.push_back("WITHOUT ROWID");
     }
     if (options & HIDDEN) {
       statement += " HIDDEN";
@@ -211,7 +213,12 @@ std::string columnDefinition(const TableColumns& columns) {
       statement += ", ";
     }
   }
-  return statement += ")";
+
+  statement += ")";
+  for (auto& epilog_statement : epilog) {
+    statement += " " + std::move(epilog_statement);
+  }
+  return statement;
 }
 
 std::string columnDefinition(const PluginResponse& response, bool aliases) {

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -62,6 +62,10 @@ TEST_F(VirtualTableTests, test_tableplugin_options) {
 
   response = table->routeInfo();
   EXPECT_EQ(INTEGER(INDEX | REQUIRED), response[0]["op"]);
+
+  std::string expected_statement =
+      "(`id` INTEGER PRIMARY KEY, `username` TEXT, `name` TEXT) WITHOUT ROWID";
+  EXPECT_EQ(expected_statement, columnDefinition(response, true));
 }
 
 class aliasesTablePlugin : public TablePlugin {

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -89,7 +89,7 @@ TEST_F(SystemsTablesTests, test_abstract_joins) {
 
   // Check LIKE and = operands.
   results =
-      SQL("select path from file where path = '/etc/' and path LIKE '/dev/%'");
+      SQL("select path from file where path = '/etc/' or path LIKE '/dev/%'");
   ASSERT_GT(results.rows().size(), 1U);
 }
 }

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -87,15 +87,10 @@ TEST_F(SystemsTablesTests, test_abstract_joins) {
       "1) p left join file using (path) left join hash using (path);");
   ASSERT_EQ(results.rows().size(), 1U);
 
-  // Check that a nested subselect on the same virtual table can perform and
-  // inner join on a LIKE operand. It would be awesome if the base join against
-  // hash did not need an explicit left join.
-  results = SQL(
-      "select * from (select file.* from (select * from file where directory = "
-      "'/etc' and type = 'directory' and mode = '0755') f join file on "
-      "file.path LIKE f.path || '/%' where file.type = 'regular') left join "
-      "hash using (path);");
-  ASSERT_GT(results.rows().size(), 0U);
+  // Check LIKE and = operands.
+  results =
+      SQL("select path from file where path = '/etc/' and path LIKE '/dev/%'");
+  ASSERT_GT(results.rows().size(), 1U);
 }
 }
 }

--- a/specs/darwin/iokit_registry.table
+++ b/specs/darwin/iokit_registry.table
@@ -3,7 +3,7 @@ description("The full IOKit registry without selecting a plane.")
 schema([
     Column("name", TEXT, "Default name of the node"),
     Column("class", TEXT, "Best matching device class (most-specific category)"),
-    Column("id", BIGINT, "IOKit internal registry ID"),
+    Column("id", BIGINT, "IOKit internal registry ID", index=True),
     Column("parent", BIGINT, "Parent registry ID"),
     Column("busy_state", INTEGER, "1 if the node is in a busy state else 0"),
     Column("retain_count", INTEGER, "The node reference count"),

--- a/specs/darwin/iokit_registry.table
+++ b/specs/darwin/iokit_registry.table
@@ -3,7 +3,7 @@ description("The full IOKit registry without selecting a plane.")
 schema([
     Column("name", TEXT, "Default name of the node"),
     Column("class", TEXT, "Best matching device class (most-specific category)"),
-    Column("id", BIGINT, "IOKit internal registry ID", index=True),
+    Column("id", BIGINT, "IOKit internal registry ID"),
     Column("parent", BIGINT, "Parent registry ID"),
     Column("busy_state", INTEGER, "1 if the node is in a busy state else 0"),
     Column("retain_count", INTEGER, "The node reference count"),

--- a/specs/darwin/kernel_extensions.table
+++ b/specs/darwin/kernel_extensions.table
@@ -1,13 +1,13 @@
 table_name("kernel_extensions")
 description("OS X's kernel extensions, both loaded and within the load search path.")
 schema([
-    Column("idx", INTEGER, "Extension load tag or index"),
+    Column("idx", INTEGER, "Extension load tag or index", index=True),
     Column("refs", INTEGER, "Reference count"),
     Column("size", BIGINT, "Bytes of wired memory used by extension"),
     Column("name", TEXT, "Extension label"),
     Column("version", TEXT, "Extension version"),
     Column("linked_against", TEXT,
       "Indexes of extensions this extension is linked against"),
-    Column("path", TEXT, "Optional path to extension bundle")
+    Column("path", TEXT, "Optional path to extension bundle"),
 ])
 implementation("kextstat@genKernelExtensions")

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -7,7 +7,8 @@ schema([
     Column("created", TEXT, "Data item was created"),
     Column("modified", TEXT, "Date of last modification"),
     Column("type", TEXT, "Keychain item type (class)"),
-    Column("path", TEXT, "Path to keychain containing item"),
+    Column("path", TEXT, "Path to keychain containing item",
+      additional=True),
 ])
 attributes(cacheable=True)
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -10,5 +10,4 @@ schema([
     Column("path", TEXT, "Path to keychain containing item",
       additional=True),
 ])
-attributes(cacheable=True)
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/launchd.table
+++ b/specs/darwin/launchd.table
@@ -1,8 +1,7 @@
 table_name("launchd")
 description("LaunchAgents and LaunchDaemons from default search paths.")
 schema([
-    Column("path", TEXT, "Path to daemon or agent plist", index=True,
-        additional=True),
+    Column("path", TEXT, "Path to daemon or agent plist", index=True),
     Column("name", TEXT, "File name of plist (used by launchd)"),
     Column("label", TEXT, "Daemon or agent service name"),
     Column("program", TEXT, "Path to target program"),

--- a/specs/darwin/launchd.table
+++ b/specs/darwin/launchd.table
@@ -1,7 +1,8 @@
 table_name("launchd")
 description("LaunchAgents and LaunchDaemons from default search paths.")
 schema([
-    Column("path", TEXT, "Path to daemon or agent plist"),
+    Column("path", TEXT, "Path to daemon or agent plist", index=True,
+        additional=True),
     Column("name", TEXT, "File name of plist (used by launchd)"),
     Column("label", TEXT, "Daemon or agent service name"),
     Column("program", TEXT, "Path to target program"),

--- a/specs/darwin/smc_keys.table
+++ b/specs/darwin/smc_keys.table
@@ -1,7 +1,7 @@
 table_name("smc_keys")
 description("Apple's system management controller keys.")
 schema([
-    Column("key", TEXT, "4-character key", additional=True),
+    Column("key", TEXT, "4-character key", additional=True, index=True),
     Column("type", TEXT, "SMC-reported type literal type"),
     Column("size", INTEGER, "Reported size of data in bytes"),
     Column("value", TEXT, "A type-encoded representation of the key value"),

--- a/specs/groups.table
+++ b/specs/groups.table
@@ -1,7 +1,7 @@
 table_name("groups")
 description("Local system groups.")
 schema([
-    Column("gid", BIGINT, "Unsigned int64 group ID"),
+    Column("gid", BIGINT, "Unsigned int64 group ID", index=True),
     Column("gid_signed", BIGINT, "A signed int64 version of gid"),
     Column("groupname", TEXT, "Canonical local group name"),
 ])

--- a/specs/users.table
+++ b/specs/users.table
@@ -1,7 +1,7 @@
 table_name("users")
 description("Local system users.")
 schema([
-    Column("uid", BIGINT, "User ID"),
+    Column("uid", BIGINT, "User ID", index=True),
     Column("gid", BIGINT, "Group ID (unsigned)"),
     Column("uid_signed", BIGINT, "User ID as int64 signed (Apple)"),
     Column("gid_signed", BIGINT, "Default group ID as int64 signed (Apple)"),

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -1,7 +1,7 @@
 table_name("file")
 description("Interactive filesystem attributes and metadata.")
 schema([
-    Column("path", TEXT, "Absolute file path", required=True),
+    Column("path", TEXT, "Absolute file path", required=True, index=True),
     Column("directory", TEXT, "Directory of file(s)", required=True),
     Column("filename", TEXT, "Name portion of file path"),
     Column("inode", BIGINT, "Filesystem inode number"),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -76,7 +76,6 @@ COLUMN_OPTIONS = {
 
 # Column options that render tables uncacheable.
 NON_CACHEABLE = [
-    "INDEX",
     "REQUIRED",
     "ADDITIONAL",
     "OPTIMIZED",


### PR DESCRIPTION
This commit bumps the third-party SQLite to the 3.14.0 pre-release (18:59). With 3.14.0 the `LIKE` and `EQUALS` constraint operators may be mixed within a query. Previously these would fail to produce a valid set.

As part of the support, each virtual table should choose to bypass rowid-based deduplication using the new "`WITHOUT ROWID`" create table epilog. This will be appended to the schema if the table defines a `PRIMARY KEY` using `index=True`.