### PR TITLE
Update AWS logger code for AWS SDK 0.12.4

### DIFF
--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -1,17 +1,11 @@
 file(GLOB OSQUERY_LOGGER "*.cpp")
 ADD_OSQUERY_LIBRARY(TRUE osquery_logger ${OSQUERY_LOGGER})
 
-if(FALSE)
-# BUILD BUG: See issue #2107
 file(GLOB OSQUERY_LOGGER_PLUGINS "plugins/*.cpp")
 file(GLOB OSQUERY_LOGGER_PLUGIN_TESTS "plugins/tests/*.cpp")
 ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-kinesis")
 ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-firehose")
 ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-core")
-else()
-file(GLOB OSQUERY_LOGGER_PLUGINS "plugins/[!a]*.cpp")
-file(GLOB OSQUERY_LOGGER_PLUGIN_TESTS "plugins/tests/[!a]*.cpp")
-endif()
 ADD_OSQUERY_LIBRARY(FALSE osquery_logger_plugins ${OSQUERY_LOGGER_PLUGINS})
 
 file(GLOB OSQUERY_LOGGER_TESTS "tests/*.cpp")

--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -42,6 +42,7 @@ const size_t FirehoseLogForwarder::kFirehoseMaxRecords = 500;
 const size_t FirehoseLogForwarder::kFirehoseMaxLogBytes = 1000000 - 256;
 
 Status FirehoseLoggerPlugin::setUp() {
+  initAwsSdk();
   forwarder_ = std::make_shared<FirehoseLogForwarder>();
   Status s = forwarder_->setUp();
   if (!s.ok()) {

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -41,6 +41,7 @@ const size_t KinesisLogForwarder::kKinesisMaxRecords = 500;
 const size_t KinesisLogForwarder::kKinesisMaxLogBytes = 1000000 - 256;
 
 Status KinesisLoggerPlugin::setUp() {
+  initAwsSdk();
   forwarder_ = std::make_shared<KinesisLogForwarder>();
   Status s = forwarder_->setUp();
   if (!s.ok()) {

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -8,15 +8,19 @@
  *
  */
 
+#include <mutex>
 #include <sstream>
 #include <string>
 
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <aws/core/Aws.h>
 #include <aws/core/Region.h>
 #include <aws/core/client/AWSClient.h>
 #include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/standard/StandardHttpResponse.h>
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -58,6 +62,26 @@ std::shared_ptr<Aws::Http::HttpClient>
 NetlibHttpClientFactory::CreateHttpClient(
     const Aws::Client::ClientConfiguration& clientConfiguration) const {
   return std::make_shared<NetlibHttpClient>();
+}
+
+std::shared_ptr<Aws::Http::HttpRequest>
+NetlibHttpClientFactory::CreateHttpRequest(
+    const Aws::String& uri,
+    Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  return CreateHttpRequest(Aws::Http::URI(uri), method, streamFactory);
+}
+
+std::shared_ptr<Aws::Http::HttpRequest>
+NetlibHttpClientFactory::CreateHttpRequest(
+    const Aws::Http::URI& uri,
+    Aws::Http::HttpMethod method,
+    const Aws::IOStreamFactory& streamFactory) const {
+  auto request =
+      std::make_shared<Aws::Http::Standard::StandardHttpRequest>(uri, method);
+  request->SetResponseStreamFactory(streamFactory);
+
+  return request;
 }
 
 std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
@@ -210,6 +234,21 @@ Status getAWSRegionFromProfile(Aws::Region& region) {
   }
 
   return Status(0);
+}
+
+void initAwsSdk() {
+  static std::once_flag once_flag;
+  try {
+    std::call_once(once_flag, []() {
+      Aws::SDKOptions options;
+      options.httpOptions.httpClientFactory_create_fn = []() {
+        return std::make_shared<NetlibHttpClientFactory>();
+      };
+      Aws::InitAPI(options);
+    });
+  } catch (const std::system_error& e) {
+    LOG(ERROR) << "call_once was not executed for initAwsSdk";
+  }
 }
 
 Status getAWSRegion(Aws::Region& region) {

--- a/osquery/logger/plugins/aws_util.h
+++ b/osquery/logger/plugins/aws_util.h
@@ -32,6 +32,14 @@ class NetlibHttpClientFactory : public Aws::Http::HttpClientFactory {
   std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(
       const Aws::Client::ClientConfiguration &clientConfiguration)
       const override;
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::String &uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory &streamFactory) const override;
+  std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+      const Aws::Http::URI &uri,
+      Aws::Http::HttpMethod method,
+      const Aws::IOStreamFactory &streamFactory) const override;
 };
 
 /**
@@ -86,6 +94,16 @@ class OsqueryAWSCredentialsProviderChain
 };
 
 /**
+ * @brief Initialize the AWS SDK
+ *
+ * This function is intended to be called from the ::setUp() method of logger
+ * plugins that use the AWS SDK. It initializes the SDK, instructing it to use
+ * our custom NetlibHttpClientFactory. This function may be called more than
+ * once, but initializing will only occur on the first call.
+ */
+void initAwsSdk();
+
+/**
  * @brief Retrieve the Aws::Region from the aws_region flag
  *
  * @param region The Aws::Region to place the result in
@@ -115,8 +133,7 @@ Status makeAWSClient(std::shared_ptr<Client> &client) {
     return s;
   }
   client = std::make_shared<Client>(
-      std::make_shared<OsqueryAWSCredentialsProviderChain>(), client_config,
-      std::make_shared<NetlibHttpClientFactory>());
+      std::make_shared<OsqueryAWSCredentialsProviderChain>(), client_config);
   return Status(0);
 }
 }

--- a/osquery/logger/plugins/tests/aws_firehose_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_firehose_tests.cpp
@@ -22,6 +22,7 @@
 
 #include "osquery/core/test_util.h"
 #include "osquery/logger/plugins/aws_firehose.h"
+#include "osquery/logger/plugins/aws_util.h"
 
 using namespace testing;
 
@@ -42,7 +43,10 @@ class MockFirehoseClient : public Aws::Firehose::FirehoseClient {
           const Aws::Firehose::Model::PutRecordBatchRequest& request));
 };
 
-class FirehoseTests : public testing::Test {};
+class FirehoseTests : public testing::Test {
+ public:
+  void SetUp() override { initAwsSdk(); }
+};
 
 TEST_F(FirehoseTests, test_send) {
   FirehoseLogForwarder forwarder;

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -20,6 +20,7 @@
 
 #include "osquery/core/test_util.h"
 #include "osquery/logger/plugins/aws_kinesis.h"
+#include "osquery/logger/plugins/aws_util.h"
 
 using namespace testing;
 
@@ -41,7 +42,10 @@ class MockKinesisClient : public Aws::Kinesis::KinesisClient {
           const Aws::Kinesis::Model::PutRecordsRequest& request));
 };
 
-class KinesisTests : public testing::Test {};
+class KinesisTests : public testing::Test {
+ public:
+  void SetUp() override { initAwsSdk(); }
+};
 
 TEST_F(KinesisTests, test_send) {
   KinesisLogForwarder forwarder;

--- a/osquery/logger/plugins/tests/aws_util_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_util_tests.cpp
@@ -28,7 +28,10 @@ static const char* kAwsProfileFileEnvVar = "AWS_SHARED_CREDENTIALS_FILE";
 static const char* kAwsAccessKeyEnvVar = "AWS_ACCESS_KEY_ID";
 static const char* kAwsSecretKeyEnvVar = "AWS_SECRET_ACCESS_KEY";
 
-class AwsUtilTests : public testing::Test {};
+class AwsUtilTests : public testing::Test {
+ public:
+  void SetUp() override { initAwsSdk(); }
+};
 
 TEST_F(AwsUtilTests, test_get_credentials) {
   // Set a good path for the credentials file


### PR DESCRIPTION
The AWS SDK changed how custom HTTP clients are used, and this commit brings
compatibility with the new initialization style.