### PR TITLE
Ability to add default configs and postinstall scripts to deb/rpm packages

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -37,8 +37,8 @@ SYSTEMD_SYSCONFIG_DST="/etc/sysconfig/osqueryd"
 CTL_SRC="$SCRIPT_DIR/osqueryctl"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/usr/share/osquery/packs/"
-OSQUERY_POSTINSTALL=$OSQUERY_POSTINSTALL
-OSQUERY_CONFIG_SRC=$OSQUERY_CONFIG_SRC
+OSQUERY_POSTINSTALL=${OSQUERY_POSTINSTALL:-""}
+OSQUERY_CONFIG_SRC=${OSQUERY_CONFIG_SRC:-""}
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"
 OSQUERY_LOG_DIR="/var/log/osquery/"
@@ -121,7 +121,7 @@ function main() {
   cp $PACKS_SRC/* $INSTALL_PREFIX/$PACKS_DST
 
   if [ $OSQUERY_CONFIG_SRC != "" ] && [ -f $OSQUERY_CONFIG_SRC ]; then
-    echo "[*] CONFIG SETUP"
+    log "config setup"
     cp $OSQUERY_CONFIG_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/osquery.conf
   fi
 


### PR DESCRIPTION
Added changes to package creation for linux for custom configs and post install scripts to optionally be included in base deb/rpm via env vars.  To build a package with a default osquery config and postinst script (to make osquery autostart after install), do the following:
````
cat << EOF >> postinst.sh
#!/bin/bash
update-rc.d osqueryd defaults
service osqueryd start
EOF

OSQUERY_CONFIG_SRC=/some/directory/osquery.example.conf OSQUERY_POSTINSTALL=./postinst.sh make package
````