### PR TITLE
Allow table specs to use multiple row indexes

### DIFF
--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -195,7 +195,7 @@ void TablePlugin::setCache(size_t step,
 }
 
 std::string columnDefinition(const TableColumns& columns) {
-  std::vector<std::string> epilog;
+  std::map<std::string, bool> epilog;
   std::string statement = "(";
   for (size_t i = 0; i < columns.size(); ++i) {
     const auto& column = columns.at(i);
@@ -204,7 +204,7 @@ std::string columnDefinition(const TableColumns& columns) {
     auto& options = std::get<2>(column);
     if (options & INDEX) {
       statement += " PRIMARY KEY";
-      epilog.push_back("WITHOUT ROWID");
+      epilog["WITHOUT ROWID"] = true;
     }
     if (options & HIDDEN) {
       statement += " HIDDEN";
@@ -215,8 +215,8 @@ std::string columnDefinition(const TableColumns& columns) {
   }
 
   statement += ")";
-  for (auto& epilog_statement : epilog) {
-    statement += " " + std::move(epilog_statement);
+  for (auto& ei : epilog) {
+    statement += " " + std::move(ei.first);
   }
   return statement;
 }

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -173,6 +173,7 @@ int xCreate(sqlite3 *db,
   auto statement = "CREATE TABLE " + name + columnDefinition(response, true);
   int rc = sqlite3_declare_vtab(db, statement.c_str());
   if (rc != SQLITE_OK || !status.ok() || response.size() == 0) {
+    LOG(ERROR) << "Error creating virtual table: " << name << " (" << rc << ")";
     delete pVtab->content;
     delete pVtab;
     return (rc != SQLITE_OK) ? rc : SQLITE_ERROR;

--- a/specs/system_controls.table
+++ b/specs/system_controls.table
@@ -2,7 +2,7 @@ table_name("system_controls")
 description("sysctl names, values, and settings information.")
 schema([
     Column("name", TEXT, "Full sysctl MIB name", index=True),
-    Column("oid", TEXT, "Control MIB", index=True),
+    Column("oid", TEXT, "Control MIB"),
     Column("subsystem", TEXT, "Subsystem ID, control type"),
     Column("current_value", TEXT, "Value of setting"),
     Column("config_value", TEXT, "The MIB value set in /etc/sysctl.conf"),


### PR DESCRIPTION
This does not yet make multi-column primary keys. That will take some reading and re-parsing and is generally not helpful right now.