### PR TITLE
Fix OS X kernel extension autoload

### DIFF
--- a/osquery/events/darwin/kernel_util.cpp
+++ b/osquery/events/darwin/kernel_util.cpp
@@ -35,12 +35,13 @@ static const std::string kKernelBundleRegex =
     ".*Kernel Extensions in "
     "backtrace:.*com\\.facebook\\.security\\.osquery.*Kernel version:";
 static const std::string kBlockingFile = "/var/osquery/.gtfo";
-static const std::string kKernelPackageFile = "com.facebook.osquery.kernel.pkg";
+static const std::string kKernelPackageReceipt =
+    "/private/var/db/receipts/com.facebook.osquery.kernel.plist";
 
 void loadKernelExtension() {
   // Check if the kernel extension package is installed.
   auto results = SQL::selectAllFrom(
-      "packages", "package_filename", EQUALS, kKernelPackageFile);
+      "package_receipts", "path", EQUALS, kKernelPackageReceipt);
   if (results.size() == 0) {
     // The kernel package is not installed.
     return;
@@ -52,7 +53,8 @@ void loadKernelExtension() {
           "SELECT f.path AS path FROM (SELECT * FROM nvram WHERE name like "
           "'%panic%') AS nv JOIN (SELECT * FROM file WHERE "
           "directory='/Library/Logs/DiagnosticReports/' AND path like "
-          "'%/Kernel%' ORDER BY ctime DESC LIMIT 1) as f;").rows();
+          "'%/Kernel%' ORDER BY ctime DESC LIMIT 1) as f;")
+          .rows();
 
   // If a panic exists, check if it was caused by the osquery extension.
   if (results.size() == 1) {
@@ -90,6 +92,7 @@ void loadKernelExtension() {
     LOG(INFO) << "Could not autoload kernel extension";
   }
   CFRelease(directoryArray);
+  VLOG(1) << "Autoloaded osquery kernel extension";
 }
 
 } // namespace osquery

--- a/specs/darwin/package_receipts.table
+++ b/specs/darwin/package_receipts.table
@@ -1,4 +1,4 @@
-table_name("package_receipts")
+table_name("package_receipts", aliases=["packages"])
 description("OS X package receipt details.")
 schema([
     Column("package_id", TEXT, "Package domain identifier"),

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -33,7 +33,7 @@ KERNEL_APP_IDENTIFIER="com.facebook.osquery.kernel"
 LD_IDENTIFIER="com.facebook.osqueryd"
 LD_INSTALL="/Library/LaunchDaemons/$LD_IDENTIFIER.plist"
 OUTPUT_PKG_PATH="$BUILD_DIR/osquery-$APP_VERSION.pkg"
-KERNEL_OUTPUT_PKG_PATH="$BUILD_DIR/osquery-kernel-${BUILD_VERSION}-${APP_VERSION}.pkg"
+KERNEL_OUTPUT_PKG_PATH="$BUILD_DIR/osquery-kernel-${APP_VERSION}.pkg"
 AUTOSTART=false
 CLEAN=false
 
@@ -256,7 +256,7 @@ function main() {
     pkgbuild --root $KERNEL_INSTALL_PREFIX             \
              --scripts $KERNEL_SCRIPT_ROOT             \
              --identifier $KERNEL_APP_IDENTIFIER       \
-             --version ${BUILD_VERSION}-${APP_VERSION} \
+             --version ${APP_VERSION}                  \
              $KERNEL_OUTPUT_PKG_PATH 2>&1  1>/dev/null
     log "kernel package created at $KERNEL_OUTPUT_PKG_PATH"
   else


### PR DESCRIPTION
1. Use `path` within `package_receipts` to determine if the OS X kernel extension is installed.
2. Do not include the OS version within the package version.