### PR TITLE
Path cosmetic updates/paths

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -241,7 +241,7 @@ endif()
 
 if(NOT DEFINED ENV{SKIP_TESTS})
   # osquery testing library (testing helper methods/libs).
-  add_library(libosquery_testing STATIC tests/test_util.cpp)
+  add_library(libosquery_testing STATIC tests/test_util.cpp tests/${PROCESS_FAMILY}/utils.cpp)
   add_dependencies(libosquery_testing libosquery)
   SET_OSQUERY_COMPILE(libosquery_testing "${CXX_COMPILE_FLAGS}")
   set_target_properties(libosquery_testing PROPERTIES OUTPUT_NAME osquery_testing)

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -70,6 +70,8 @@ enum {
 
 #ifdef __linux__
 #define OSQUERY_HOME "/etc/osquery"
+#elif defined(WIN32)
+#define OSQUERY_HOME "\\ProgramData\\osquery"
 #else
 #define OSQUERY_HOME "/var/osquery"
 #endif

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -295,12 +295,12 @@ Status platformIsTmpDir(const fs::path& dir) {
     return Status(0, "OK");
   }
 
-  return Status(1, "");
+  return Status(1, "Not temporary directory");
 }
 
 // Reduce this to be a lstat check for symlink stuff
 Status platformIsFileAccessible(const fs::path& path) {
-  struct stat file_stat, link_stat;
+  struct stat link_stat;
   if (::lstat(path.c_str(), &link_stat) < 0) {
     return Status(1, "File is not acccessible");
   }

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -136,7 +136,8 @@ TEST_F(FilesystemTests, test_list_files_valid_directory) {
   auto s = listFilesInDirectory(kEtcPath, results);
   // This directory may be different on OS X or Linux.
 
-  replaceGlobWildcards(std::string(kEtcHostsPath.string()));
+  std::string glob_pattern(kEtcHostsPath.string());
+  replaceGlobWildcards(glob_pattern);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_TRUE(contains(results, kEtcHostsPath.string()));

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -143,11 +143,11 @@ TEST_F(FilesystemTests, test_list_files_valid_directory) {
   auto s = listFilesInDirectory(kEtcPath, results);
   // This directory may be different on OS X or Linux.
 
-  std::string glob_pattern(kEtcHostsPath.string());
-  replaceGlobWildcards(glob_pattern);
+  std::string hosts_path(kEtcHostsPath.string());
+  replaceGlobWildcards(hosts_path);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_TRUE(contains(results, kEtcHostsPath.string()));
+  EXPECT_TRUE(contains(results, hosts_path));
 }
 
 TEST_F(FilesystemTests, test_canonicalization) {

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -74,18 +74,25 @@ class FilesystemTests : public testing::Test {
 };
 
 TEST_F(FilesystemTests, test_read_file) {
-  std::ofstream test_file(kTestWorkingDirectory + "fstests-file");
+  std::ofstream test_file((fs::path(kTestWorkingDirectory) / "fstests-file")
+                              .make_preferred()
+                              .string());
   test_file.write("test123\n", sizeof("test123"));
   test_file.close();
 
   std::string content;
-  auto s = readFile(kTestWorkingDirectory + "fstests-file", content);
+  auto s = readFile((fs::path(kTestWorkingDirectory) / "fstests-file")
+                        .make_preferred()
+                        .string(),
+                    content);
 
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(content, "test123" + kLineEnding);
 
-  remove(kTestWorkingDirectory + "fstests-file");
+  remove((fs::path(kTestWorkingDirectory) / "fstests-file")
+             .make_preferred()
+             .string());
 }
 
 TEST_F(FilesystemTests, test_read_limit) {

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -18,6 +18,8 @@
 
 #include "osquery/tests/test_util.h"
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 
 DECLARE_string(enroll_secret_path);
@@ -40,7 +42,9 @@ REGISTER(SimpleEnrollPlugin, "enroll", "test_simple");
 
 TEST_F(EnrollTests, test_enroll_secret_retrieval) {
   // Write an example secret (deploy key).
-  FLAGS_enroll_secret_path = kTestWorkingDirectory + "secret.txt";
+  FLAGS_enroll_secret_path = (fs::path(kTestWorkingDirectory) / "secret.txt")
+                                 .make_preferred()
+                                 .string();
   writeTextFile(FLAGS_enroll_secret_path, "test_secret\n", 0600, false);
   // Make sure the file content was read and trimmed.
   auto secret = getEnrollSecret();

--- a/osquery/tests/posix/utils.cpp
+++ b/osquery/tests/posix/utils.cpp
@@ -35,6 +35,6 @@ std::unique_ptr<PlatformProcess> launchTestServer(const std::string &port) {
     server.reset(new PlatformProcess(server_pid));
   }
 
-  return std::move(server);
+  return server;
 }
 }

--- a/osquery/tests/posix/utils.cpp
+++ b/osquery/tests/posix/utils.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+ 
+#include <boost/filesystem/operations.hpp>
+
+#include <osquery/core.h>
+
+#include "osquery/tests/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+std::string getUserId() {
+  return std::to_string(getuid());
+}
+
+std::unique_ptr<PlatformProcess> launchTestServer(const std::string &port) {
+  std::unique_ptr<PlatformProcess> server;
+
+  int server_pid = fork();
+  if (server_pid == 0) {
+    // Start a python TLS/HTTPS or HTTP server.
+    auto script = kTestDataPath + "/test_http_server.py --tls " + port;
+    execlp("sh", "sh", "-c", script.c_str(), nullptr);
+    ::exit(0);
+  } else if (server_pid > 0) {
+    server.reset(new PlatformProcess(server_pid));
+  }
+
+  return std::move(server);
+}
+}

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -34,8 +34,12 @@ namespace osquery {
 
 std::string kFakeDirectory = "";
 
+#ifdef DARWIN
+std::string kTestWorkingDirectory = "/private/tmp/osquery-tests";
+#else
 std::string kTestWorkingDirectory =
     (fs::temp_directory_path() / "osquery-tests").make_preferred().string();
+#endif
 
 /// Most tests will use binary or disk-backed content for parsing tests.
 #ifndef OSQUERY_BUILD_SDK
@@ -105,7 +109,7 @@ void initTesting() {
   // Set up the database instance for the unittests.
   DatabasePlugin::setAllowOpen(true);
 
-  // Initializing database plugin does not work 
+  // Initializing database plugin does not work on Windows
   DatabasePlugin::initPlugin();
 }
 

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -106,9 +106,7 @@ void initTesting() {
   DatabasePlugin::setAllowOpen(true);
 
   // Initializing database plugin does not work 
-#ifndef WIN32
   DatabasePlugin::initPlugin();
-#endif
 }
 
 void shutdownTesting() { DatabasePlugin::shutdown(); }

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -148,7 +148,7 @@ class TLSServerRunner : private boost::noncopyable {
 
  private:
   /// Current server PID.
-  pid_t server_{0};
+  std::unique_ptr<PlatformProcess> server_{nullptr};
 
   /// Current server TLS port.
   std::string port_;

--- a/osquery/tests/windows/utils.cpp
+++ b/osquery/tests/windows/utils.cpp
@@ -57,6 +57,6 @@ std::unique_ptr<PlatformProcess> launchTestServer(const std::string &port) {
     ::CloseHandle(pi.hProcess);
   }
 
-  return std::move(server);
+  return server;
 }
 }

--- a/osquery/tests/windows/utils.cpp
+++ b/osquery/tests/windows/utils.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+ 
+#include <lmcons.h>
+
+#include <boost/filesystem/operations.hpp>
+
+#include <osquery/core.h>
+
+#include "osquery/tests/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+
+std::string getUserId() {
+  std::vector<unsigned char> user_name(UNLEN + 1);
+  user_name.assign(UNLEN + 1, '\0');
+  DWORD size = user_name.size() - 1;
+
+  if (!::GetUserNameA((LPSTR) &user_name[0], &size)) {
+    return "";
+  }
+
+  return std::string((const char *)&user_name[0], size - 1);
+}
+
+std::unique_ptr<PlatformProcess> launchTestServer(const std::string &port) {
+  std::unique_ptr<PlatformProcess> server;
+
+  STARTUPINFOA si = { 0 };
+  PROCESS_INFORMATION pi = { 0 };
+
+  auto argv = "python " + kTestDataPath + "/test_http_server.py --tls " + port;
+  std::vector<char> mutable_argv(argv.begin(), argv.end());
+  si.cb = sizeof(si);
+
+  auto drive = getEnvVar("SystemDrive");
+  std::string python_path("");
+  if (drive.is_initialized()) {
+    python_path = *drive;
+  }
+
+  // Python is installed here if provisioning script is used
+  python_path += "\\tools\python2\\python.exe";
+  if (::CreateProcessA(python_path.c_str(), &mutable_argv[0], NULL, NULL, FALSE,
+                       0, NULL, NULL, &si, &pi)) {
+    server.reset(new PlatformProcess(pi.hProcess));
+    ::CloseHandle(pi.hThread);
+    ::CloseHandle(pi.hProcess);
+  }
+
+  return std::move(server);
+}
+}


### PR DESCRIPTION
* Added cosmetic changes to file paths by converting path as strings to paths as boost::filesystem::path objects (in platform agnostic locations)
* Added support for test utils in Windows

Closes #2001 