### PR TITLE
Optional randomization of shard ids for AWS Kinesis load balancing.

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -25,6 +25,12 @@ When working with AWS, osquery will look for credentials and region configuratio
 
 When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period`.
 
+Configuration flags for kinesis logger:
+
+````
+--aws_kinesis_random_partition_id VALUE         Use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Default is "false".
+````
+
 ### Kinesis Firehose
 
 Similarly for Kinesis Firehose delivery streams, the stream name must be specified with `aws_firehose_stream`, and the period can be configued with `aws_firehose_period`.

--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -25,7 +25,7 @@ When working with AWS, osquery will look for credentials and region configuratio
 
 When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period`.  
 
-Setting aws_kinesis_random_partition_key to true will use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  The default for this setting is "false".
+Setting aws_kinesis_random_partition_key to true will use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Note that using this setting will result in the logs of each host distributed across shards, so do not use it if you need logs from each host to be processed by a consistent shard.  The default for this setting is "false".
 
 ### Kinesis Firehose
 

--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -28,7 +28,7 @@ When logging to Kinesis Streams, the stream name must be specified with `aws_kin
 Configuration flags for kinesis logger:
 
 ````
---aws_kinesis_random_partition_id VALUE         Use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Default is "false".
+--aws_kinesis_random_partition_key VALUE         Use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Default is "false".
 ````
 
 ### Kinesis Firehose

--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -23,13 +23,9 @@ When working with AWS, osquery will look for credentials and region configuratio
 
 ### Kinesis Streams
 
-When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period`.
+When logging to Kinesis Streams, the stream name must be specified with `aws_kinesis_stream`, and the log flushing period can be configured with `aws_kinesis_period`.  
 
-Configuration flags for kinesis logger:
-
-````
---aws_kinesis_random_partition_key VALUE         Use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  Default is "false".
-````
+Setting aws_kinesis_random_partition_key to true will use random partition keys when sending data to kinesis. Using random values will load balance over stream shards if you are using multiple shards in a stream.  The default for this setting is "false".
 
 ### Kinesis Firehose
 

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -74,8 +74,9 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       boost::uuids::uuid uuid = boost::uuids::random_generator()();
       partition_key_ = boost::uuids::to_string(uuid);
     }
-    entry.WithPartitionKey(partition_key_).WithData(
-        Aws::Utils::ByteBuffer((unsigned char*)log.c_str(), log.length()));
+    entry.WithPartitionKey(partition_key_)
+        .WithData(
+            Aws::Utils::ByteBuffer((unsigned char*)log.c_str(), log.length()));
     entries.push_back(std::move(entry));
   }
 

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -34,27 +34,28 @@ FLAG(uint64,
      10,
      "Seconds between flushing logs to Kinesis (default 10)");
 FLAG(string, aws_kinesis_stream, "", "Name of Kinesis stream for logging")
-FLAG(bool, aws_kinesis_random_shardid, false, "Enable random kinesis shard ids");
+FLAG(bool,
+     aws_kinesis_random_shardid,
+     false,
+     "Enable random kinesis shard ids");
 
 // This is the max per AWS docs
 const size_t KinesisLogForwarder::kKinesisMaxRecords = 500;
 // Max size of log + partition key is 1MB. Max size of partition key is 256B.
 const size_t KinesisLogForwarder::kKinesisMaxLogBytes = 1000000 - 256;
 
-std::string random_string( size_t length )
-{
-    auto randchar = []() -> char
-    {
-        const char charset[] =
+std::string random_string(size_t length) {
+  auto randchar = []() -> char {
+    const char charset[] =
         "0123456789"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
-        const size_t max_index = (sizeof(charset) - 1);
-        return charset[ rand() % max_index ];
-    };
-    std::string str(length,0);
-    std::generate_n( str.begin(), length, randchar );
-    return str;
+    const size_t max_index = (sizeof(charset) - 1);
+    return charset[rand() % max_index];
+  };
+  std::string str(length, 0);
+  std::generate_n(str.begin(), length, randchar);
+  return str;
 }
 
 Status KinesisLoggerPlugin::setUp() {
@@ -81,8 +82,8 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       LOG(ERROR) << "Kinesis log too big, discarding!";
     }
     Aws::Kinesis::Model::PutRecordsRequestEntry entry;
-    if (FLAGS_aws_kinesis_random_shardid){
-      shard_id_=random_string(32);
+    if (FLAGS_aws_kinesis_random_shardid) {
+      shard_id_ = random_string(32);
     }
     entry.WithPartitionKey(shard_id_).WithData(
         Aws::Utils::ByteBuffer((unsigned char*)log.c_str(), log.length()));

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -26,8 +26,6 @@ namespace osquery {
 
 DECLARE_uint64(aws_kinesis_period);
 
-std::string random_string(size_t length);
-
 class KinesisLogForwarder : public BufferedLogForwarder {
  private:
   static const size_t kKinesisMaxLogBytes;
@@ -45,7 +43,7 @@ class KinesisLogForwarder : public BufferedLogForwarder {
               const std::string& log_type) override;
 
  private:
-  std::string shard_id_;
+  std::string partition_key_;
   std::shared_ptr<Aws::Kinesis::KinesisClient> client_{nullptr};
 
   FRIEND_TEST(KinesisTests, test_send);

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -26,6 +26,8 @@ namespace osquery {
 
 DECLARE_uint64(aws_kinesis_period);
 
+std::string random_string(size_t length);
+
 class KinesisLogForwarder : public BufferedLogForwarder {
  private:
   static const size_t kKinesisMaxLogBytes;

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -18,9 +18,9 @@
 
 #include <osquery/logger.h>
 
-#include "osquery/tests/test_util.h"
 #include "osquery/logger/plugins/aws_kinesis.h"
 #include "osquery/logger/plugins/aws_util.h"
+#include "osquery/tests/test_util.h"
 
 using namespace testing;
 
@@ -56,10 +56,10 @@ TEST_F(KinesisTests, test_send) {
   std::vector<std::string> logs{"foo"};
   Aws::Kinesis::Model::PutRecordsOutcome outcome;
   outcome.GetResult().SetFailedRecordCount(0);
-  EXPECT_CALL(
-      *client,
-      PutRecords(Property(&Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
-                          ElementsAre(MatchesEntry("foo", "fake_partition_key")))))
+  EXPECT_CALL(*client,
+              PutRecords(Property(
+                  &Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
+                  ElementsAre(MatchesEntry("foo", "fake_partition_key")))))
       .WillOnce(Return(outcome));
   EXPECT_EQ(Status(0), forwarder.send(logs, "results"));
 
@@ -71,11 +71,11 @@ TEST_F(KinesisTests, test_send) {
   outcome.GetResult().SetFailedRecordCount(1);
   outcome.GetResult().AddRecords(entry);
 
-  EXPECT_CALL(
-      *client,
-      PutRecords(Property(&Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
-                          ElementsAre(MatchesEntry("bar", "fake_partition_key"),
-                                      MatchesEntry("foo", "fake_partition_key")))))
+  EXPECT_CALL(*client,
+              PutRecords(Property(
+                  &Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
+                  ElementsAre(MatchesEntry("bar", "fake_partition_key"),
+                              MatchesEntry("foo", "fake_partition_key")))))
       .WillOnce(Return(outcome));
   EXPECT_EQ(Status(1, "Foo error"), forwarder.send(logs, "results"));
 }

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -49,7 +49,7 @@ class KinesisTests : public testing::Test {
 
 TEST_F(KinesisTests, test_send) {
   KinesisLogForwarder forwarder;
-  forwarder.shard_id_ = "fake_shard_id";
+  forwarder.partition_key_ = "fake_partition_key";
   auto client = std::make_shared<StrictMock<MockKinesisClient>>();
   forwarder.client_ = client;
 
@@ -59,7 +59,7 @@ TEST_F(KinesisTests, test_send) {
   EXPECT_CALL(
       *client,
       PutRecords(Property(&Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
-                          ElementsAre(MatchesEntry("foo", "fake_shard_id")))))
+                          ElementsAre(MatchesEntry("foo", "fake_partition_key")))))
       .WillOnce(Return(outcome));
   EXPECT_EQ(Status(0), forwarder.send(logs, "results"));
 
@@ -74,8 +74,8 @@ TEST_F(KinesisTests, test_send) {
   EXPECT_CALL(
       *client,
       PutRecords(Property(&Aws::Kinesis::Model::PutRecordsRequest::GetRecords,
-                          ElementsAre(MatchesEntry("bar", "fake_shard_id"),
-                                      MatchesEntry("foo", "fake_shard_id")))))
+                          ElementsAre(MatchesEntry("bar", "fake_partition_key"),
+                                      MatchesEntry("foo", "fake_partition_key")))))
       .WillOnce(Return(outcome));
   EXPECT_EQ(Status(1, "Foo error"), forwarder.send(logs, "results"));
 }


### PR DESCRIPTION
The AWS logging plugin sends shard_id_ as a partition key to AWS kinesis when pushing data.  The current implementation uses a static string as the shard id.  Kinesis uses these partition keys (i.e. shard ids) to load balance between shards in a stream.  By randomizing this value, you will get better performance on larger deployments using many shards in a Kinesis stream.  For more background on this, please read the following:

http://sdk.amazonaws.com/cpp/api/0.11.0-7-g6be9f8d/d5/d84/class_aws_1_1_kinesis_1_1_model_1_1_put_record_request.html#a1f230751b741869bb8a3d0618d055cb6

This feature can be enabled by setting the following config variable otherwise the functionality will remain the same:

````
"aws_kinesis_random_shardid": "true",
````