### PR TITLE
Use ccache when available to speed up compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ elseif(CLANGXX_EXISTS)
   set(CMAKE_CXX_COMPILER "clang++")
 endif()
 
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+  LOG("Found ccache ${CCACHE_FOUND}")
+  LOG("Using ccache to speed up compilation")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
 if(WIN32)
   # TODO(#1985): We need to find the MSVC equivalents to the flags listed in the else section.
 else()


### PR DESCRIPTION
While hacking on osquery I found that the build does not use ccache if it's available.
This was a quick win to me. After a few compilations I got a clean build done in one minute (including dependencies).

Using ccache in the CI environment can also speed up the build.