### PR TITLE
Windows Daemon/Shell: Windows Processes Table

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -46,7 +46,17 @@ namespace osquery {
  * types they are storing, and more importantly how they are treated at query
  * time.
  */
+
+#ifdef WIN32
+// TEXT is also defined in windows.h, we should not re-define it
+#define SQL_TEXT(x) boost::lexical_cast<std::string>(x)
+#else
+// For everything except Windows, aldo define TEXT() to be compatible with 
+// existing tables
+#define SQL_TEXT(x) boost::lexical_cast<std::string>(x)
 #define TEXT(x) boost::lexical_cast<std::string>(x)
+#endif
+
 /// See the affinity type documentation for TEXT.
 #define INTEGER(x) boost::lexical_cast<std::string>(x)
 /// See the affinity type documentation for TEXT.

--- a/osquery/tables/system/system_utils.cpp
+++ b/osquery/tables/system/system_utils.cpp
@@ -10,8 +10,6 @@
 
 #include <osquery/sql.h>
 
-#include "osquery/tables/system/system_utils.h"
-
 namespace osquery {
 namespace tables {
 

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <map>
+#include <string>
+#include <sstream>
+
+#include <stdlib.h>
+
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/tables/system/windows/system_util.h"
+
+namespace osquery {
+namespace tables {
+ 
+std::set<long> getProcList(const QueryContext &context) {
+  std::set<long> pidlist;
+  if (context.constraints.count("pid") > 0 &&
+    context.constraints.at("pid").exists(EQUALS)) {
+    for (const auto &pid : context.constraints.at("pid").getAll<int>(EQUALS)) {
+      if (pid > 0) {
+        pidlist.insert(pid);
+      }
+    }
+    return pidlist;
+  } else {
+    WmiRequest request("SELECT ProcessId FROM Win32_Process");
+    if (request.ok()) {
+      for (auto const& result : request.results()) {
+        pidlist.insert(result.GetLong("ProcessId"));
+      }
+    }
+    return pidlist;
+  }
+}
+
+
+void genProcess(long pid, QueryData& results_data) {
+  std::stringstream ss;
+  ss << "SELECT * FROM Win32_Process WHERE ProcessId=" << pid;
+
+  WmiRequest request(ss.str());
+  if (request.ok()) {
+    std::vector<WmiResultItem> &results = request.results();
+    if (results.size() == 1) {
+      Row r;
+
+      r["pid"] = BIGINT(results[0].GetLong("ProcessId"));
+      r["name"] = SQL_TEXT(results[0].GetString("Name"));
+      r["path"] = SQL_TEXT(results[0].GetString("ExecutablePath"));
+      r["cmdline"] = SQL_TEXT(results[0].GetString("CommandLine"));
+      r["state"] = SQL_TEXT(results[0].GetString("ExecutionState"));
+      r["parent"] = BIGINT(results[0].GetLong("ParentProcessId"));
+      r["nice"] = INTEGER(results[0].GetLong("Priority"));
+
+      results_data.push_back(r);
+    }
+  }
+}
+
+QueryData genProcesses(QueryContext& context) {
+  QueryData results;
+
+  auto pidlist = getProcList(context);
+  for (const auto& pid : pidlist) {
+    genProcess(pid, results);
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/windows/system_util.cpp
+++ b/osquery/tables/system/windows/system_util.cpp
@@ -119,7 +119,9 @@ WmiRequest::WmiRequest(const std::string& query) {
   IWbemClassObject *result = nullptr;
   ULONG result_count = 0;
 
-  while (enum_->Next(WBEM_INFINITE, 1, &result, &result_count) == S_OK) {
+  while (SUCCEEDED(enum_->Next(WBEM_INFINITE, 1, &result, &result_count))) {
+    // WmiResultItem will take ownership of result
+    // and call result->Release() when it goes out of scope
     results_.push_back(WmiResultItem(result));
   }
 

--- a/osquery/tables/system/windows/system_util.cpp
+++ b/osquery/tables/system/windows/system_util.cpp
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "osquery/tables/system/windows/system_util.h"
+
+namespace osquery {
+namespace tables {
+  
+static std::wstring string_to_wstring(const std::string &src) {
+  std::vector<wchar_t> buffer;
+  size_t new_size = src.size() + 1;
+
+  buffer.assign(new_size, L'\0');
+
+  size_t converted_chars = 0;
+
+  // TODO(audit): Make sure this is doing the right thing
+  if (::mbstowcs_s(&converted_chars, &buffer[0], new_size, src.c_str(),
+                   _TRUNCATE) != 0) {
+    return std::wstring(L"");
+  }
+
+  return std::wstring(buffer.begin(), buffer.end());
+}
+
+static std::string BSTR_to_string(const BSTR src) {
+  if (src == nullptr) {
+    return std::string("");
+  }
+
+  std::vector<char> buffer;
+
+  // TODO(audit): Make sure this is doing the right thing
+  int size =
+      ::WideCharToMultiByte(CP_UTF8, 0, src, -1, nullptr, 0, nullptr, nullptr);
+  if (size <= 0) {
+    return std::string("");
+  }
+
+  buffer.assign(size, '\0');
+  if (WideCharToMultiByte(CP_UTF8, 0, src, -1, &buffer[0], size, nullptr,
+                          nullptr) == 0) {
+    return std::string("");
+  }
+
+  return std::string(buffer.begin(), buffer.end());
+}
+
+WmiResultItem::WmiResultItem(WmiResultItem&& src) {
+  result_ = nullptr;
+  std::swap(result_, src.result_);
+}
+
+WmiResultItem::~WmiResultItem() {
+  if (result_ != nullptr) {
+    result_->Release();
+    result_ = nullptr;
+  }
+}
+
+void WmiResultItem::PrintType(const std::string& name) const {
+  std::wstring property_name = string_to_wstring(name);
+
+  VARIANT value;
+  HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
+  if (hr != S_OK) {
+    std::cerr << "Failed: " << name << "\n";
+  } else {
+    std::cout << "Name=" << name << ", Type=" << value.vt << "\n";
+    if (value.vt == VT_I4) {
+      std::cout << "  Value=" << value.lVal << "\n";
+    } else if (value.vt == VT_BSTR) {
+      std::wcout << "  Value=" << value.bstrVal << "\n";
+    }
+  }
+}
+
+long WmiResultItem::GetLong(const std::string& name) const {
+  std::wstring property_name = string_to_wstring(name);
+
+  VARIANT value;
+  HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
+  if (hr != S_OK || value.vt != VT_I4) {
+    return -1;
+  }
+  return value.lVal;
+}
+
+std::string WmiResultItem::GetString(const std::string& name) const {
+  std::wstring property_name = string_to_wstring(name);
+
+  VARIANT value;
+  HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
+  if (hr != S_OK || value.vt != VT_BSTR) {
+    return std::string("");
+  }
+  return BSTR_to_string(value.bstrVal);
+}
+
+WmiRequest::WmiRequest(const std::string& query) {
+  std::wstring wql = string_to_wstring(query);
+
+  HRESULT hr = E_FAIL;
+
+  hr = ::CoInitializeEx(0, COINIT_MULTITHREADED);
+  hr = ::CoInitializeSecurity(
+    nullptr, -1, nullptr, nullptr, RPC_C_AUTHN_LEVEL_DEFAULT,
+    RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE, nullptr);
+  hr = ::CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID *)&locator_);
+  if (hr != S_OK) {
+    locator_ = nullptr;
+    return;
+  }
+
+  hr = locator_->ConnectServer(L"ROOT\\CIMV2", nullptr, nullptr, nullptr, 0, nullptr, nullptr, &services_);
+  if (hr != S_OK) {
+    services_ = nullptr;
+    return;
+  }
+
+  hr = services_->ExecQuery(L"WQL", (BSTR)wql.c_str(), WBEM_FLAG_FORWARD_ONLY, nullptr, &enum_);
+  if (hr != S_OK) {
+    enum_ = nullptr;
+    return;
+  }
+
+  IWbemClassObject *result = nullptr;
+  ULONG result_count = 0;
+
+  while (enum_->Next(WBEM_INFINITE, 1, &result, &result_count) == S_OK) {
+    results_.push_back(WmiResultItem(result));
+  }
+
+  status_ = true;
+}
+
+WmiRequest::WmiRequest(WmiRequest&& src) {
+  locator_ = nullptr;
+  std::swap(locator_, src.locator_);
+
+  services_ = nullptr;
+  std::swap(services_, src.services_);
+
+  enum_ = nullptr;
+  std::swap(enum_, src.enum_);
+}
+
+WmiRequest::~WmiRequest() {
+  results_.clear();
+
+  if (enum_ != nullptr) {
+    enum_->Release();
+    enum_ = nullptr;
+  }
+
+  if (services_ != nullptr) {
+    services_->Release();
+    services_ = nullptr;
+  }
+
+  if (locator_ != nullptr) {
+    locator_->Release();
+    locator_ = nullptr;
+  }
+
+  ::CoUninitialize();
+}
+}
+}

--- a/osquery/tables/system/windows/system_util.h
+++ b/osquery/tables/system/windows/system_util.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+#define _WIN32_DCOM
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <WbemIdl.h>
+
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+ 
+class WmiResultItem {
+ public:
+  explicit WmiResultItem(IWbemClassObject *result) : result_(result) {};
+  WmiResultItem(WmiResultItem&& src);
+  ~WmiResultItem();
+
+  long GetLong(const std::string& name) const;
+  std::string GetString(const std::string& name) const;
+  void PrintType(const std::string& name) const;
+
+ private:
+   IWbemClassObject *result_{ nullptr };
+};
+
+class WmiRequest {
+ public:
+  explicit WmiRequest(const std::string& query);
+  WmiRequest(WmiRequest&& src);
+  ~WmiRequest();
+
+  bool ok() { return status_; }
+  std::vector<WmiResultItem>& results() { return results_; }
+
+ private:
+   bool status_{ false };
+   std::vector<WmiResultItem> results_;
+
+   IWbemLocator *locator_{ nullptr };
+   IWbemServices *services_{ nullptr };
+   IEnumWbemClassObject *enum_{ nullptr };
+};
+}
+}

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -37,6 +37,7 @@ void genFileInfo(const fs::path& path,
                  const fs::path& parent,
                  const std::string& pattern,
                  QueryData& results) {
+#ifndef WIN32
   // Must provide the path, filename, directory separate from boost path->string
   // helpers to match any explicit (query-parsed) predicate constraints.
   struct stat file_stat, link_stat;
@@ -86,6 +87,7 @@ void genFileInfo(const fs::path& path,
   r["is_char"] = (S_ISCHR(file_stat.st_mode)) ? "1" : "0";
   r["is_block"] = (S_ISBLK(file_stat.st_mode)) ? "1" : "0";
   results.push_back(r);
+#endif
 }
 
 QueryData genFile(QueryContext& context) {

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -46,21 +46,21 @@ QueryData genTime(QueryContext& context) {
   char iso_8601[21] = {0};
   strftime(iso_8601, sizeof(iso_8601), "%FT%TZ", gmt);
 
-  r["weekday"] = TEXT(weekday);
+  r["weekday"] = SQL_TEXT(weekday);
   r["year"] = INTEGER(now->tm_year + 1900);
   r["month"] = INTEGER(now->tm_mon + 1);
   r["day"] = INTEGER(now->tm_mday);
   r["hour"] = INTEGER(now->tm_hour);
   r["minutes"] = INTEGER(now->tm_min);
   r["seconds"] = INTEGER(now->tm_sec);
-  r["timezone"] = TEXT(timezone);
+  r["timezone"] = SQL_TEXT(timezone);
   r["local_time"] = INTEGER(local_time);
-  r["local_timezone"] = TEXT(local_timezone);
+  r["local_timezone"] = SQL_TEXT(local_timezone);
   r["unix_time"] = INTEGER(osquery_time);
-  r["timestamp"] = TEXT(osquery_timestamp);
+  r["timestamp"] = SQL_TEXT(osquery_timestamp);
   // Date time is provided in ISO 8601 format, then duplicated in iso_8601.
-  r["datetime"] = TEXT(iso_8601);
-  r["iso_8601"] = TEXT(iso_8601);
+  r["datetime"] = SQL_TEXT(iso_8601);
+  r["iso_8601"] = SQL_TEXT(iso_8601);
 
   QueryData results;
   results.push_back(r);


### PR DESCRIPTION
This PR includes the code for a Windows processes table and changes to other tables we need for daemon and shell to run. The Windows processes table uses WMI as a backend to gather process information. This commit does not include the CMake changes to build these tables, that is coming in a future PR. 