### PR TITLE
Adding check for nullptr before dereferencing.  This fixes #2185

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -17,7 +17,7 @@
 #include <glob.h>
 #include <pwd.h>
 #include <sys/time.h>
-#endif 
+#endif
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem/fstream.hpp>
@@ -76,7 +76,7 @@ Status writeTextFile(const fs::path& path,
 
 struct OpenReadableFile {
  public:
-  explicit OpenReadableFile(const fs::path &path) {
+  explicit OpenReadableFile(const fs::path& path) {
 #ifndef WIN32
     dropper_ = DropPrivileges::get();
     if (dropper_->dropToParent(path)) {
@@ -107,7 +107,7 @@ Status readFile(
     bool preserve_time,
     std::function<void(std::string& buffer, size_t size)> predicate) {
   OpenReadableFile handle(path);
-  if (!handle.fd->isValid()) {
+  if (handle.fd == nullptr || !handle.fd->isValid()) {
     return Status(1, "Cannot open file for reading: " + path.string());
   }
 
@@ -262,7 +262,7 @@ static void genGlobs(std::string path,
 
   // Prune results based on settings/requested glob limitations.
   auto end = std::remove_if(results.begin(), results.end(),
-                            [limits](const std::string &found) {
+                            [limits](const std::string& found) {
                               return !(((found[found.length() - 1] == '/' ||
                                          found[found.length() - 1] == '\\') &&
                                         limits & GLOB_FOLDERS) ||
@@ -293,8 +293,8 @@ inline void replaceGlobWildcards(std::string& pattern, GlobLimits limits) {
 
   // Relative paths are a bad idea, but we try to accommodate.
   if ((pattern.size() == 0 || ((pattern[0] != '/' && pattern[0] != '\\') &&
-       (pattern.size() > 3 && pattern[1] != ':' && pattern[2] != '\\' &&
-        pattern[2] != '/'))) &&
+                               (pattern.size() > 3 && pattern[1] != ':' &&
+                                pattern[2] != '\\' && pattern[2] != '/'))) &&
       pattern[0] != '~') {
     pattern = (fs::initial_path() / pattern).make_preferred().string();
   }
@@ -341,15 +341,15 @@ inline Status listInAbsoluteDirectory(const fs::path& path,
 Status listFilesInDirectory(const fs::path& path,
                             std::vector<std::string>& results,
                             bool recursive) {
-  return listInAbsoluteDirectory(
-      (path / ((recursive) ? "**" : "*")), results, GLOB_FILES);
+  return listInAbsoluteDirectory((path / ((recursive) ? "**" : "*")), results,
+                                 GLOB_FILES);
 }
 
 Status listDirectoriesInDirectory(const fs::path& path,
                                   std::vector<std::string>& results,
                                   bool recursive) {
-  return listInAbsoluteDirectory(
-      (path / ((recursive) ? "**" : "*")), results, GLOB_FOLDERS);
+  return listInAbsoluteDirectory((path / ((recursive) ? "**" : "*")), results,
+                                 GLOB_FOLDERS);
 }
 
 Status isDirectory(const fs::path& path) {
@@ -400,8 +400,8 @@ bool safePermissions(const std::string& dir,
   } else if (result.ok()) {
     // Do not load modules from /tmp-like directories.
     return false;
-  } 
-  
+  }
+
   PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
   if (!fd.isValid()) {
     return false;
@@ -443,7 +443,8 @@ const std::string& osqueryHomeDirectory() {
           (fs::path(*home_directory) / ".osquery").make_preferred().string();
     } else {
       // Fail over to a temporary directory (used for the shell).
-      homedir = (fs::temp_directory_path() / "osquery").make_preferred().string();
+      homedir =
+          (fs::temp_directory_path() / "osquery").make_preferred().string();
     }
   }
 
@@ -482,4 +483,3 @@ Status parseJSONContent(const std::string& content, pt::ptree& tree) {
   return Status(0, "OK");
 }
 }
-

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -42,18 +42,18 @@ PlatformFile::PlatformFile(const std::string& path, int mode, int perms) {
   }
 
   switch (PF_GET_OPTIONS(mode)) {
-  case PF_GET_OPTIONS(PF_CREATE_ALWAYS) :
+  case PF_GET_OPTIONS(PF_CREATE_ALWAYS):
     oflag |= O_CREAT;
     may_create = true;
     break;
-  case PF_GET_OPTIONS(PF_CREATE_NEW) :
+  case PF_GET_OPTIONS(PF_CREATE_NEW):
     oflag |= O_CREAT | O_EXCL;
     may_create = true;
     break;
-  case PF_GET_OPTIONS(PF_OPEN_EXISTING) :
+  case PF_GET_OPTIONS(PF_OPEN_EXISTING):
     check_existence = true;
     break;
-  case PF_GET_OPTIONS(PF_TRUNCATE) :
+  case PF_GET_OPTIONS(PF_TRUNCATE):
     if (mode & PF_WRITE) {
       oflag |= O_TRUNC;
     }
@@ -108,7 +108,7 @@ Status PlatformFile::isOwnerRoot() const {
   }
 
   uid_t owner_id = getFileOwner(handle_);
-  if (owner_id == (uid_t) - 1) {
+  if (owner_id == (uid_t)-1) {
     return Status(-1, "fstat error");
   }
 
@@ -124,7 +124,7 @@ Status PlatformFile::isOwnerCurrentUser() const {
   }
 
   uid_t owner_id = getFileOwner(handle_);
-  if (owner_id == (uid_t) - 1) {
+  if (owner_id == (uid_t)-1) {
     return Status(-1, "fstat error");
   }
 
@@ -309,4 +309,3 @@ Status platformIsFileAccessible(const fs::path& path) {
   return Status(0, "OK");
 }
 }
-


### PR DESCRIPTION
Added a check for nullptr before de-reference, which was causing segfaults when running as root.  This commit also bundles in formatting fixes from clang.