### PR TITLE
Enable vagrant-cachier if it's installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,6 +130,14 @@ Vagrant.configure("2") do |config|
   targets.each do |name, target|
     box = target["box"]
     config.vm.define name do |build|
+      if Vagrant.has_plugin?("vagrant-cachier")
+         # Configure cached packages to be shared between instances of the same base box.
+         # More info on http://fgrehm.viewdocs.io/vagrant-cachier/usage
+         build.cache.scope = :box
+         build.cache.synced_folder_opts = {
+           type: :nfs,
+         }
+      end
       build.vm.box = box
       if name.start_with?('aws-')
         build.vm.provider :aws do |aws, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,6 +160,9 @@ Vagrant.configure("2") do |config|
             ".git/objects",
             ".git/modules/third-party/objects"
           ]
+      else
+        # Private network for NFS
+        build.vm.network :private_network, ip: "192.168.56.101"
       end
       if name == 'freebsd10'
         # configure the NICs
@@ -167,8 +170,6 @@ Vagrant.configure("2") do |config|
           vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
           vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
         end
-        # Private network for NFS
-        build.vm.network :private_network, ip: "192.168.56.101"
         build.vm.synced_folder ".", "/vagrant", type: "nfs"
         build.vm.provision "shell",
           inline: "pkg install -y gmake"


### PR DESCRIPTION
It's faster to provision the virtual machines if the cachier plugin is installed and enabled.
This PR enables cachier and NFS for cachier.