### PR TITLE
Add -fpermissive and fixes using for anon struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
     -Wformat-security
     -Werror=format-security
     -Wabi-tag
+    -fpermissive
     -fstack-protector-all
     -fPIE
     -fpie

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -54,9 +54,9 @@ using PlatformHandle = int;
 using PlatformTimeType = struct timeval;
 #endif
 
-using PlatformTime = struct {
+typedef struct {
   PlatformTimeType times[2];
-};
+} PlatformTime;
 
 /// Constant for an invalid handle
 const PlatformHandle kInvalidHandle = (PlatformHandle)-1;


### PR DESCRIPTION
Previous error:
```
In file included from osquery/filesystem/filesystem.cpp:32:0:
osquery/filesystem/fileops.h:186:8: error: 'bool osquery::PlatformFile::getFileTimes(osquery::PlatformTime&)', declared using anonymous type, is used but never defined [-fpermissive]
In file included from osquery/filesystem/filesystem.cpp:32:0:
```