### PR TITLE
Use vector.data() verus &vector[0] to get underlying vector buffers

### DIFF
--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -185,7 +185,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   mutable_argv.push_back('\0');
 
   BOOL status = ::CreateProcessA(exec_path.c_str(),
-                                 &mutable_argv[0],
+                                 mutable_argv.data(),
                                  NULL,
                                  NULL,
                                  TRUE,
@@ -250,7 +250,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
   }
 
   BOOL status = ::CreateProcessA(exec_path.c_str(),
-                                 &mutable_argv[0],
+                                 mutable_argv.data(),
                                  NULL,
                                  NULL,
                                  TRUE,

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -42,7 +42,7 @@ boost::optional<std::string> getEnvVar(const std::string &name) {
   buf.assign(kInitialBufferSize, '\0');
 
   DWORD value_len =
-      ::GetEnvironmentVariableA(name.c_str(), &buf[0], kInitialBufferSize);
+      ::GetEnvironmentVariableA(name.c_str(), buf.data(), kInitialBufferSize);
   if (value_len == 0) {
     // TODO(#1991): Do we want figure out a way to be more granular in terms of
     // the error to return?
@@ -55,7 +55,7 @@ boost::optional<std::string> getEnvVar(const std::string &name) {
   // returned size is greater than what we expect.
   if (value_len > kInitialBufferSize) {
     buf.assign(value_len, '\0');
-    value_len = ::GetEnvironmentVariableA(name.c_str(), &buf[0], value_len);
+    value_len = ::GetEnvironmentVariableA(name.c_str(), buf.data(), value_len);
     if (value_len == 0 || value_len > buf.size()) {
       // The size returned is greater than the size we expected. Currently, we
       // will not deal with this scenario and just return as if an error has
@@ -64,7 +64,7 @@ boost::optional<std::string> getEnvVar(const std::string &name) {
     }
   }
 
-  return std::string(&buf[0], value_len);
+  return std::string(buf.data(), value_len);
 }
 
 void cleanupDefunctProcesses() {}

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -121,7 +121,7 @@ TEST_F(FileOpsTests, test_fileIo) {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
     EXPECT_TRUE(fd.isValid());
     EXPECT_FALSE(fd.isSpecialFile());
-    EXPECT_EQ(expected_read_len, fd.read(&buf[0], expected_read_len));
+    EXPECT_EQ(expected_read_len, fd.read(buf.data(), expected_read_len));
     EXPECT_EQ(expected_buf_size, buf.size());
     for (ssize_t i = 0; i < expected_read_len; i++) {
       EXPECT_EQ(expected_read[i], buf[i]);
@@ -148,8 +148,8 @@ TEST_F(FileOpsTests, test_asyncIo) {
     EXPECT_FALSE(fd.isSpecialFile());
 
     std::vector<char> buf(expected_len);
-    EXPECT_EQ(expected_len, fd.read(&buf[0], expected_len));
-    EXPECT_EQ(0, ::memcmp(expected, &buf[0], expected_len));
+    EXPECT_EQ(expected_len, fd.read(buf.data(), expected_len));
+    EXPECT_EQ(0, ::memcmp(expected, buf.data(), expected_len));
   }
 
   {
@@ -158,7 +158,7 @@ TEST_F(FileOpsTests, test_asyncIo) {
     EXPECT_FALSE(fd.isSpecialFile());
 
     std::vector<char> buf(expected_len);
-    char* ptr = &buf[0];
+    char* ptr = buf.data();
     ssize_t part_bytes = 0;
     int iterations = 0;
     do {
@@ -170,7 +170,7 @@ TEST_F(FileOpsTests, test_asyncIo) {
     } while (part_bytes > 0);
 
     EXPECT_EQ(7, iterations);
-    EXPECT_EQ(0, ::memcmp(expected, &buf[0], expected_len));
+    EXPECT_EQ(0, ::memcmp(expected, buf.data(), expected_len));
   }
 }
 
@@ -212,8 +212,8 @@ TEST_F(FileOpsTests, test_seekFile) {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
     EXPECT_TRUE(fd.isValid());
 
-    EXPECT_EQ(expected_len, fd.read(&buffer[0], expected_len));
-    EXPECT_EQ(0, ::memcmp(&buffer[0], expected, expected_len));
+    EXPECT_EQ(expected_len, fd.read(buffer.data(), expected_len));
+    EXPECT_EQ(0, ::memcmp(buffer.data(), expected, expected_len));
   }
 }
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -469,7 +469,7 @@ static Status isUserCurrentUser(PSID user) {
   }
 
   std::vector<char> buffer(size);
-  ptu = (PTOKEN_USER) & buffer[0];
+  ptu = (PTOKEN_USER)buffer.data();
 
   /// Obtain the user SID behind the token handle
   ret = ::GetTokenInformation(token, TokenUser, (LPVOID)ptu, size, &size);
@@ -512,11 +512,11 @@ Status PlatformFile::isOwnerRoot() const {
   std::vector<char> admins_buf;
   admins_buf.assign(admins_buf_size, '\0');
 
-  PSID admins_sid = (PSID) & admins_buf[0];
+  PSID admins_sid = (PSID)admins_buf.data();
 
   if (!::CreateWellKnownSid(WinBuiltinAdministratorsSid,
                             nullptr,
-                            &admins_buf[0],
+                            admins_sid,
                             &admins_buf_size)) {
     return Status(-1, "CreateWellKnownSid failed");
   }
@@ -567,7 +567,7 @@ Status PlatformFile::isExecutable() const {
   std::vector<char> sd_buffer;
   sd_buffer.assign(sd_size, '\0');
 
-  PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR) & sd_buffer[0];
+  PSECURITY_DESCRIPTOR sd = (PSECURITY_DESCRIPTOR)sd_buffer.data();
   ret = ::GetUserObjectSecurity(handle_, &security_info, sd, sd_size, &sd_size);
   if (!ret) {
     return Status(-1, "GetUserObjectSecurity failed");
@@ -638,7 +638,7 @@ static Status isWriteDenied(PACL acl) {
   std::vector<char> sid_buffer;
   sid_buffer.assign(sid_buffer_size, '\0');
 
-  PSID world = (PSID) & sid_buffer[0];
+  PSID world = (PSID)sid_buffer.data();
 
   if (!::CreateWellKnownSid(WinWorldSid, nullptr, world, &sid_buffer_size)) {
     return Status(-1, "CreateWellKnownSid failed");
@@ -689,18 +689,18 @@ Status PlatformFile::isNonWritable() const {
   path_buf.assign(MAX_PATH + 1, '\0');
 
   if (::GetFinalPathNameByHandleA(
-          handle_, &path_buf[0], MAX_PATH, FILE_NAME_NORMALIZED) == 0) {
+          handle_, path_buf.data(), MAX_PATH, FILE_NAME_NORMALIZED) == 0) {
     return Status(-1, "GetFinalPathNameByHandleA failed");
   }
 
-  if (!::PathRemoveFileSpecA(&path_buf[0])) {
+  if (!::PathRemoveFileSpecA(path_buf.data())) {
     return Status(-1, "PathRemoveFileSpec");
   }
 
   PACL dir_dacl = nullptr;
   PSECURITY_DESCRIPTOR dir_sd = nullptr;
 
-  if (::GetNamedSecurityInfoA(&path_buf[0],
+  if (::GetNamedSecurityInfoA(path_buf.data(),
                               SE_FILE_OBJECT,
                               DACL_SECURITY_INFORMATION,
                               nullptr,
@@ -933,7 +933,7 @@ bool platformChmod(const std::string &path, mode_t perms) {
 
   DWORD sid_size = SECURITY_MAX_SID_SIZE;
   std::vector<char> world_buf(sid_size);
-  PSID world = &world_buf[0];
+  PSID world = (PSID)world_buf.data();
 
   if (!::CreateWellKnownSid(WinWorldSid, nullptr, world, &sid_size)) {
     return false;
@@ -977,7 +977,7 @@ bool platformChmod(const std::string &path, mode_t perms) {
   std::vector<char> mutable_path(path.begin(), path.end());
   mutable_path.push_back('\0');
 
-  if (::SetNamedSecurityInfoA(&mutable_path[0],
+  if (::SetNamedSecurityInfoA(mutable_path.data(),
                               SE_FILE_OBJECT,
                               DACL_SECURITY_INFORMATION,
                               nullptr,
@@ -1100,8 +1100,8 @@ boost::optional<std::string> getHomeDirectory() {
   if (value.is_initialized()) {
     return value;
   } else if (SUCCEEDED(::SHGetFolderPathA(
-                 nullptr, CSIDL_PROFILE, nullptr, 0, &profile[0]))) {
-    return std::string(&profile[0]);
+                 nullptr, CSIDL_PROFILE, nullptr, 0, profile.data()))) {
+    return std::string(profile.data());
   } else {
     return boost::none;
   }
@@ -1127,13 +1127,13 @@ static std::string normalizeDirPath(const fs::path &path) {
 
   // Obtain the full path of the fs::path object
   DWORD nret = ::GetFullPathNameA(
-      (LPCSTR)path.string().c_str(), MAX_PATH, &full_path[0], nullptr);
+      (LPCSTR)path.string().c_str(), MAX_PATH, full_path.data(), nullptr);
   if (nret == 0) {
     return std::string();
   }
 
   HANDLE handle = INVALID_HANDLE_VALUE;
-  handle = ::CreateFileA(&full_path[0],
+  handle = ::CreateFileA(full_path.data(),
                          GENERIC_READ,
                          FILE_SHARE_READ,
                          nullptr,
@@ -1146,7 +1146,7 @@ static std::string normalizeDirPath(const fs::path &path) {
 
   // Resolve any symbolic links (somewhat rare on Windows)
   nret = ::GetFinalPathNameByHandleA(
-      handle, &final_path[0], MAX_PATH, FILE_NAME_NORMALIZED);
+      handle, final_path.data(), MAX_PATH, FILE_NAME_NORMALIZED);
   ::CloseHandle(handle);
 
   if (nret == 0) {
@@ -1154,10 +1154,10 @@ static std::string normalizeDirPath(const fs::path &path) {
   }
 
   // NTFS is case insensitive, to normalize, make everything uppercase
-  ::CharUpperA(&final_path[0]);
+  ::CharUpperA(final_path.data());
 
   boost::system::error_code ec;
-  std::string normalized_path(&final_path[0], nret);
+  std::string normalized_path(final_path.data(), nret);
   if ((fs::is_directory(normalized_path, ec) && ec.value() == errc::success) &&
       normalized_path[nret - 1] != '\\') {
     normalized_path += "\\";


### PR DESCRIPTION
This pull request should resolve #2201. This PR changes use of `&vector[0]` to `vector.data()`, which is more clear about the intent to access the underlying vector buffer.