### PR TITLE
[Fix #2203] Restore extension respawn limits to 20s

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -358,9 +358,7 @@ void Initializer::initDaemon() const {
 #endif
 
   // Nice ourselves if using a watchdog and the level is not too permissive.
-  if (!FLAGS_disable_watchdog &&
-      FLAGS_watchdog_level >= WATCHDOG_LEVEL_DEFAULT &&
-      FLAGS_watchdog_level != WATCHDOG_LEVEL_DEBUG) {
+  if (!FLAGS_disable_watchdog && FLAGS_watchdog_level >= 0) {
     // Set CPU scheduling I/O limits.
     setToBackgroundPriority();
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -432,11 +432,12 @@ void WatcherWatcherRunner::start() {
   }
 }
 
-size_t getWorkerLimit(WatchdogLimitType name, int level) {
+size_t getWorkerLimit(WatchdogLimitType name) {
   if (kWatchdogLimits.count(name) == 0) {
     return 0;
   }
 
+  auto level = FLAGS_watchdog_level;
   // If no level was provided then use the default (config/switch).
   if (level == -1) {
     return kWatchdogLimits.at(name).disabled;

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -24,11 +24,6 @@
 
 #include "osquery/core/process.h"
 
-/// Define a special debug/testing watchdog level.
-#define WATCHDOG_LEVEL_DEBUG 3
-/// Define the default watchdog level, level below are considered permissive.
-#define WATCHDOG_LEVEL_DEFAULT 1
-
 namespace osquery {
 
 using ExtensionMap = std::map<std::string, std::shared_ptr<PlatformProcess>>;
@@ -300,6 +295,6 @@ class WatcherWatcherRunner : public InternalRunnable {
 };
 
 /// Get a performance limit by name and optional level.
-size_t getWorkerLimit(WatchdogLimitType limit, int level = -1);
+size_t getWorkerLimit(WatchdogLimitType limit);
 }
 


### PR DESCRIPTION
This removes the ability for Watcher and Initialization code to explicitly override watchdog limits.