### PR TITLE
Add ability to provision Arch Linux

### DIFF
--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -59,6 +59,9 @@ def _platform():
                 if fileContents.find("DISTRIB_ID=Ubuntu") != -1:
                     return ("debian", "ubuntu")
 
+                if fileContents.find("DISTRIB_ID=Arch") != -1:
+                    return ("arch", "arch")
+
         if os.path.exists(DEBIAN_VERSION):
             return ("debian", "debian")
     else:
@@ -113,6 +116,12 @@ def _distro(osType):
                 return results[0]
     elif osType == "fedora":
         with open(SYSTEM_RELEASE, "r") as fd:
+          contents = fd.read()
+          results = contents.split()
+          if len(results) > 2:
+            return results[2]
+    elif osType == "arch":
+        with open("/etc/arch-release", "r") as fd:
           contents = fd.read()
           results = contents.split()
           if len(results) > 2:

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -75,6 +75,10 @@ function main() {
     log "detected freebsd ($DISTRO)"
     source "$SCRIPT_DIR/provision/freebsd.sh"
     main_freebsd
+  elif [[ $OS = "arch" ]]; then
+    log "detected arch ($DISTRO)"
+    source "$SCRIPT_DIR/provision/arch.sh"
+    main_arch
   elif [[ $OS = "fedora" ]]; then
     log "detected fedora ($DISTRO)"
     source "$SCRIPT_DIR/provision/fedora.sh"

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+function main_arch() {
+  sudo pacman -Syu
+
+  package asio
+  package audit
+  package boost
+  package boost-libs
+  package clang
+  package cmake
+  package doxygen
+  package gflags
+  package git
+  package google-glog
+  package lsb-release
+  package make
+  package python
+  package python-jinja
+  package python-pip
+  package sleuthkit
+  package snappy
+  package thrift
+  package yara
+
+  install_aws_sdk
+
+  echo ""
+  echo "The following packages need to be installed from the AUR:"
+  echo "rocksdb rocksdb-static cpp-netlib magic"
+  echo ""
+}
+

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -635,6 +635,13 @@ function package() {
       log "installing $1"
       sudo pkg install -y $1
     fi
+  elif [[ $OS = "arch" ]]; then
+    if pacman -Qq $1 >/dev/null; then
+      log "$1 is already installed. skipping."
+    else
+      log "installing $1"
+      sudo pacman -S --noconfirm $1
+    fi
   fi
 }
 
@@ -664,6 +671,13 @@ function remove_package() {
     if ! pkg info -q $1; then
       log "removing $1"
       sudo pkg delete -y $1
+    else
+      log "Removing: $1 is not installed. skipping."
+    fi
+  elif [[ $OS = "arch" ]]; then
+    if ! pacman -Qq $1 >/dev/null; then
+      log "removing $1"
+      sudo pacman -R --noconfirm $1
     else
       log "Removing: $1 is not installed. skipping."
     fi


### PR DESCRIPTION
This will install the necessary packages. I had issues compiling which I was able to get around with the following diff (not included in the pull request):

```
00:20:17 tenforward (arch-linux-provisioner) ~/Documents/Git/osquery $ git diff
diff --git a/osquery/remote/transports/tls.cpp b/osquery/remote/transports/tls.cpp
index 4273293..f181af9 100644
--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -30,12 +30,12 @@ SSL_CTX* TLSv1_2_method(void) { return nullptr; }
 SSL_CTX* TLSv1_2_server_method(void) { return nullptr; }
 #endif
 #if defined(NO_SSL_TXT_SSLV3)
-SSL_METHOD* SSLv3_server_method(void) { return nullptr; }
-SSL_METHOD* SSLv3_client_method(void) { return nullptr; }
-SSL_METHOD* SSLv3_method(void) { return nullptr; }
-SSL_METHOD* SSLv2_server_method(void) { return nullptr; }
-SSL_METHOD* SSLv2_client_method(void) { return nullptr; }
-SSL_METHOD* SSLv2_method(void) { return nullptr; }
+const SSL_METHOD* SSLv3_server_method(void) { return nullptr; }
+const SSL_METHOD* SSLv3_client_method(void) { return nullptr; }
+const SSL_METHOD* SSLv3_method(void) { return nullptr; }
+const SSL_METHOD* SSLv2_server_method(void) { return nullptr; }
+const SSL_METHOD* SSLv2_client_method(void) { return nullptr; }
+const SSL_METHOD* SSLv2_method(void) { return nullptr; }
 #endif
 #endif
 }
diff --git a/osquery/remote/transports/tls.h b/osquery/remote/transports/tls.h
index 751c416..55038dc 100644
--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -27,9 +27,9 @@
 /// Newer versions of LibreSSL will lack SSL methods.
 extern "C" {
 #if defined(NO_SSL_TXT_SSLV3)
-SSL_METHOD* SSLv3_server_method(void);
-SSL_METHOD* SSLv3_client_method(void);
-SSL_METHOD* SSLv3_method(void);
+const SSL_METHOD* SSLv3_server_method(void);
+const SSL_METHOD* SSLv3_client_method(void);
+const SSL_METHOD* SSLv3_method(void);
 #endif
 void ERR_remove_state(unsigned long);
 }

```