### PR TITLE
Fix SQLite access after ASIO usage

### DIFF
--- a/osquery/tables/system/darwin/quicklook_cache.cpp
+++ b/osquery/tables/system/darwin/quicklook_cache.cpp
@@ -101,11 +101,12 @@ QueryData genQuicklookCache(QueryContext& context) {
   for (const auto& index : databases) {
     sqlite3* db = nullptr;
     auto rc = sqlite3_open_v2(
-        ("file://" + index).c_str(), &db,
+        index.c_str(), &db,
         (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
         nullptr);
     if (rc != SQLITE_OK || db == nullptr) {
-      VLOG(1) << "Cannot open " << index << " read only";
+      VLOG(1) << "Cannot open " << index << " read only: "
+              << rc << " " << getStringForSQLiteReturnCode(rc);
       if (db != nullptr) {
         free(db);
       }


### PR DESCRIPTION
Using the boost ASIO libraries before calling SQLite open causes the "file://" protocol to be rewritten with a prepended CWD.