### PR TITLE
Add shutdown method to extensions

### DIFF
--- a/osquery.thrift
+++ b/osquery.thrift
@@ -68,6 +68,8 @@ service Extension {
     2:string item,
     /// The thrift-equivilent of an osquery::PluginRequest.
     3:ExtensionPluginRequest request),
+  /// Request that an extension shutdown (does not apply to managers).
+  void shutdown(),
 }
 
 /// The extension manager is run by the osquery core process.

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -99,6 +99,27 @@ void ExtensionWatcher::start() {
   }
 }
 
+void ExtensionManagerWatcher::start() {
+  // Watch each extension.
+  while (!interrupted()) {
+    watch();
+    pauseMilli(interval_);
+  }
+
+  // When interrupted, request each extension tear down.
+  const auto uuids = Registry::routeUUIDs();
+  for (const auto& uuid : uuids) {
+    try {
+      auto path = getExtensionSocket(uuid);
+      auto client = EXClient(path);
+      client.get()->shutdown();
+    } catch (const std::exception& e) {
+      VLOG(1) << "Extension UUID " << uuid << " shutdown request failed";
+      continue;
+    }
+  }
+}
+
 void ExtensionWatcher::exitFatal(int return_code) {
   // Exit the extension.
   // We will save the wanted return code and raise an interrupt.

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
@@ -54,6 +55,12 @@ void ExtensionHandler::call(ExtensionResponse& _return,
       _return.response.push_back(response_item);
     }
   }
+}
+
+void ExtensionHandler::shutdown() {
+  // Request a graceful shutdown of the Thrift listener.
+  VLOG(1) << "Extension " << uuid_ << " requested shutdown";
+  Initializer::requestShutdown(EXIT_SUCCESS);
 }
 
 void ExtensionManagerHandler::extensions(InternalExtensionList& _return) {

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -86,6 +86,9 @@ class ExtensionHandler : virtual public ExtensionIf {
             const std::string& item,
             const ExtensionPluginRequest& request);
 
+  /// Request an extension to shutdown.
+  void shutdown();
+
  protected:
   /// Transient UUID assigned to the extension after registering.
   RouteUUID uuid_;
@@ -180,6 +183,10 @@ class ExtensionManagerHandler : virtual public ExtensionManagerIf,
    */
   void getQueryColumns(ExtensionResponse& _return, const std::string& sql);
 
+ protected:
+  /// A shutdown request does not apply to ExtensionManagers.
+  void shutdown() {}
+
  private:
   /// Check if an extension exists by the name it registered.
   bool exists(const std::string& name);
@@ -208,7 +215,7 @@ class ExtensionWatcher : public InternalRunnable {
 
  public:
   /// The Dispatcher thread entry point.
-  void start();
+  void start() override;
 
   /// Perform health checks.
   virtual void watch();
@@ -233,8 +240,11 @@ class ExtensionManagerWatcher : public ExtensionWatcher {
   ExtensionManagerWatcher(const std::string& path, size_t interval)
       : ExtensionWatcher(path, interval, false) {}
 
+  /// The Dispatcher thread entry point.
+  void start() override;
+
   /// Start a specialized health check for an ExtensionManager.
-  void watch();
+  void watch() override;
 
  private:
   /// Allow extensions to fail for several intervals.


### PR DESCRIPTION
This alters the osquery.thrift spec to add a `::shutdown` method to the `Extension` class. The `ExtensionManager` inherits from this but includes a no-op shutdown method.

When an `ExtensionManager` (osquery core) stops, it optionally requests all `Extension`s to shutdown immediately. This helps quit extensions processes faster. The `osquery-python` extension will need to be rebuilt with the updated spec methods.