### PR TITLE
Adding Aobo Keylogger and OSX_Keydnap to osx-attacks

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -242,6 +242,18 @@
       "interval": "86400",
       "description": "(https://www.elitekeyloggers.com/elite-keylogger-mac)",
       "value": "Artifact used by this malware"
+    },
+    "Aobo_Keylogger": {
+      "query": "select * from launchd where name like 'com.ab.kl%.plist';",
+      "interval": "86400",
+      "description": "(http://aobo.cc/aobo-mac-os-x-keylogger.html)",
+      "value": "Artifact used by this malware"
+    },
+    "OSX_Keydnap": {
+      "query": "select * from launchd where name = 'com.apple.iCloud.sync.daemon';",
+      "interval": "86400",
+      "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
+      "value": "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Adding detection for the following malware:

Aobo: http://aobo.cc/aobo-mac-os-x-keylogger.html
Keydnap: http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)