### PR TITLE
Add autocompletion of table names in osqueryi

### DIFF
--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -103,11 +103,12 @@ char *copy_string(const std::string &str) {
 }
 
 char *completion_generator(const char *text, int state) {
-  const static std::vector<std::string> tables =
-      osquery::Registry::names("table");
+  static std::vector<std::string> tables;
   static size_t index;
 
   if (state == 0) {
+    // new completion attempt
+    tables = osquery::Registry::names("table");
     index = 0;
   }
 

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #ifdef WIN32
 #include <io.h>
@@ -91,12 +92,13 @@ int profile(int argc, char *argv[]) {
 // readline completion expects strings to be malloced. readline will free them
 // later.
 char *copy_string(const std::string &str) {
-  char *copy = NULL;
-  if ((copy = (char *)malloc(str.size() + 1)) == NULL) {
-    LOG(ERROR) << "Malloc failed. Exiting!";
-    exit(1);
+  char *copy = (char *)malloc(str.size() + 1);
+  if (copy == nullptr) {
+    LOG(ERROR)
+        << "Memory allocation failed during shell autocompletion. Exiting!";
+    osquery::Initializer::shutdown(EXIT_FAILURE);
   }
-  strcpy(copy, str.c_str());
+  strlcpy(copy, str.c_str(), str.size() + 1);
   return copy;
 }
 
@@ -117,7 +119,7 @@ char *completion_generator(const char *text, int state) {
       return copy_string(table);
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 char **table_completion_function(const char *text, int start, int end) {

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -94,8 +94,8 @@ int profile(int argc, char *argv[]) {
 char *copy_string(const std::string &str) {
   char *copy = (char *)malloc(str.size() + 1);
   if (copy == nullptr) {
-    LOG(ERROR)
-        << "Memory allocation failed during shell autocompletion. Exiting!";
+    fprintf(stderr,
+            "Memory allocation failed during shell autocompletion. Exiting!");
     osquery::Initializer::shutdown(EXIT_FAILURE);
   }
   strncpy(copy, str.c_str(), str.size() + 1);

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -98,7 +98,7 @@ char *copy_string(const std::string &str) {
         << "Memory allocation failed during shell autocompletion. Exiting!";
     osquery::Initializer::shutdown(EXIT_FAILURE);
   }
-  strlcpy(copy, str.c_str(), str.size() + 1);
+  strncpy(copy, str.c_str(), str.size() + 1);
   return copy;
 }
 

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -113,7 +113,7 @@ char *completion_generator(const char *text, int state) {
   }
 
   while (index < tables.size()) {
-    std::string table = tables[index];
+    const std::string &table = tables.at(index);
     ++index;
 
     if (boost::algorithm::starts_with(table, text)) {


### PR DESCRIPTION
Tab completion in osqueryi now attempts to use table names first,
falling back to normal filename completion when there are no
matches.