### PR TITLE
Arch provisioning cleanup

### DIFF
--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -10,6 +10,7 @@
 function main_arch() {
   sudo pacman -Syu
 
+  package wget
   package asio
   package audit
   package boost
@@ -21,7 +22,6 @@ function main_arch() {
   package git
   package google-glog
   package lsb-release
-  package make
   package python
   package python-jinja
   package python-pip
@@ -34,7 +34,8 @@ function main_arch() {
 
   echo ""
   echo "The following packages need to be installed from the AUR:"
-  echo "rocksdb rocksdb-static cpp-netlib magic"
+  echo "rocksdb or rocksdb-static (if using rocksdb export BUILD_LINK_SHARED=True)"
+  echo "cpp-netlib and magic"
   echo ""
 }
 


### PR DESCRIPTION
- Removed make from provisioning since it is assumed to be installed on Arch systems
- Added wget to provisioning since it is required for install_aws_sdk further in the provisioning script
- Extended AUR dependencies text. Only one of rocksdb and rocksdb-static is required and when using rocksdb BUILD_LINK_SHARED should be set to True before building