### PR TITLE
Log execution of a distributed query

### DIFF
--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -121,6 +121,8 @@ void Distributed::addResult(const DistributedQueryResult& result) {
 Status Distributed::runQueries() {
   while (getPendingQueryCount() > 0) {
     auto query = popRequest();
+    VLOG(1) << "Executing distributed query[" << query.id
+            << "]: " << query.query;
 
     auto sql = SQL(query.query);
     if (!sql.getStatus().ok()) {


### PR DESCRIPTION
Meets the minimum requirements asked of #2164, by logging execution of distributed queries.