### PR TITLE
Better fault-tolerant defaults for systemd service

### DIFF
--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -9,10 +9,9 @@ ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStart=/usr/bin/osqueryd \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE
-Restart=on-abort
+Restart=on-failure
 KillMode=process
 KillSignal=SIGTERM
-SendSIGKILL=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When using the default osqueryd.service file I am unable to restart the osqueryd service without it failing on me:

```
19:47:54 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl restart osqueryd
19:48:00 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl status osqueryd
● osqueryd.service - The osquery Daemon
   Loaded: loaded (/etc/systemd/system/osqueryd.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Sun 2016-07-17 19:48:02 EDT; 640ms ago
  Process: 12147 ExecStart=/usr/bin/osqueryd --config_path /etc/osquery/osquery.conf (code=exited, status=78)
 Main PID: 12147 (code=exited, status=78)

Jul 17 19:47:56 tenforward systemd[1]: Stopped The osquery Daemon.
Jul 17 19:47:56 tenforward systemd[1]: Started The osquery Daemon.
Jul 17 19:47:56 tenforward osqueryd[12147]: osqueryd started [version=1.8.0-3-gb9a5313]
Jul 17 19:47:56 tenforward osqueryd[12147]: E0717 19:47:56.153245 12156 init.cpp:558] [Ref #1629] osqueryd initialize failed: Could not initialize database
Jul 17 19:48:02 tenforward systemd[1]: osqueryd.service: Main process exited, code=exited, status=78/n/a
Jul 17 19:48:02 tenforward systemd[1]: osqueryd.service: Unit entered failed state.
Jul 17 19:48:02 tenforward systemd[1]: osqueryd.service: Failed with result 'exit-code'.
```

Instead if on-failure is used, systemd is able to recover from the failure:
```
19:49:07 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl restart osqueryd
19:49:12 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl status osqueryd
● osqueryd.service - The osquery Daemon
   Loaded: loaded (/etc/systemd/system/osqueryd.service; disabled; vendor preset: disabled)
   Active: active (running) since Sun 2016-07-17 19:49:12 EDT; 1s ago
 Main PID: 15156 (osqueryd)
    Tasks: 3 (limit: 512)
   Memory: 2.9M
      CPU: 54ms
   CGroup: /system.slice/osqueryd.service
           └─15156 /usr/bin/osqueryd --config_path /etc/osquery/osquery.conf

Jul 17 19:49:12 tenforward systemd[1]: Stopped The osquery Daemon.
Jul 17 19:49:12 tenforward systemd[1]: Started The osquery Daemon.
Jul 17 19:49:12 tenforward osqueryd[15156]: osqueryd started [version=1.8.0-3-gb9a5313]
Jul 17 19:49:12 tenforward osqueryd[15156]: E0717 19:49:12.806702 15163 init.cpp:558] [Ref #1629] osqueryd initialize failed: Could not initialize database
19:49:14 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl status osqueryd
● osqueryd.service - The osquery Daemon
   Loaded: loaded (/etc/systemd/system/osqueryd.service; disabled; vendor preset: disabled)
   Active: active (running) since Sun 2016-07-17 19:49:19 EDT; 23s ago
 Main PID: 15624 (osqueryd)
    Tasks: 10 (limit: 512)
   Memory: 8.2M
      CPU: 129ms
   CGroup: /system.slice/osqueryd.service
           ├─15624 /usr/bin/osqueryd --config_path /etc/osquery/osquery.conf
           └─15642 osqueryd: worker                                         

Jul 17 19:49:19 tenforward systemd[1]: osqueryd.service: Service hold-off time over, scheduling restart.
Jul 17 19:49:19 tenforward systemd[1]: Stopped The osquery Daemon.
Jul 17 19:49:19 tenforward systemd[1]: Started The osquery Daemon.
Jul 17 19:49:19 tenforward osqueryd[15624]: osqueryd started [version=1.8.0-3-gb9a5313]
```

Also, according to the man page systemd.kill SendSIGKILL is yes by default:
```
SendSIGKILL=
    Specifies whether to send SIGKILL to remaining processes after a timeout, if the normal shutdown procedure left processes of the service around. Takes a boolean value. Defaults to
    "yes".
```

It's worth mentioning I had to add the following to the osqueryd.service file when creating a bundled package for the Arch Linux AUR:
```
SuccessExitStatus=143
PIDFile=/var/osquery/osqueryd.pidfile
```

If I don't include those directives I get the following when attempting to cleanly stop osqueryd:
```
20:10:36 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl stop osqueryd.service                                                                                                     
20:10:40 tenforward (master) ~/Documents/Git/osquery-git $ sudo systemctl status osqueryd.service                                                                                                   
● osqueryd.service - The osquery Daemon
   Loaded: loaded (/etc/systemd/system/osqueryd.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Sun 2016-07-17 20:10:40 EDT; 3s ago
 Main PID: 15624 (code=exited, status=143)
   CGroup: /system.slice/osqueryd.service
           └─15642 osqueryd: worker                                         

Jul 17 19:49:19 tenforward systemd[1]: osqueryd.service: Service hold-off time over, scheduling restart.
Jul 17 19:49:19 tenforward systemd[1]: Stopped The osquery Daemon.
Jul 17 19:49:19 tenforward systemd[1]: Started The osquery Daemon.
Jul 17 19:49:19 tenforward osqueryd[15624]: osqueryd started [version=1.8.0-3-gb9a5313]
Jul 17 20:10:38 tenforward systemd[1]: Stopping The osquery Daemon...
Jul 17 20:10:40 tenforward systemd[1]: osqueryd.service: Main process exited, code=exited, status=143/n/a
Jul 17 20:10:40 tenforward systemd[1]: Stopped The osquery Daemon.
Jul 17 20:10:40 tenforward systemd[1]: osqueryd.service: Unit entered failed state.
Jul 17 20:10:40 tenforward systemd[1]: osqueryd.service: Failed with result 'exit-code'.
```