### PR TITLE
Fix mismatched free/delete in QueryContext dtor

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -456,7 +456,7 @@ struct QueryContext : private boost::noncopyable {
   /// If the context was created without content, it is ephemeral.
   ~QueryContext() {
     if (!enable_cache_ && table_ != nullptr) {
-      free(table_);
+      delete table_;
     }
   }
 


### PR DESCRIPTION
The `QueryContext` dtor is not calling the dtor for `VirtualTableContent`, which is a fairly large structure.