### PR TITLE
Swap removed and added for logs

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -59,12 +59,6 @@ bool DatabasePlugin::kDBHandleOptionAllowOpen(false);
 bool DatabasePlugin::kDBHandleOptionRequireWrite(false);
 std::atomic<bool> DatabasePlugin::kCheckingDB(false);
 
-/////////////////////////////////////////////////////////////////////////////
-// Row - the representation of a row in a set of database results. Row is a
-// simple map where individual column names are keys, which map to the Row's
-// respective value
-/////////////////////////////////////////////////////////////////////////////
-
 Status serializeRow(const Row& r, pt::ptree& tree) {
   try {
     for (auto& i : r) {
@@ -114,11 +108,6 @@ Status deserializeRowJSON(const std::string& json, Row& r) {
   }
   return deserializeRow(tree, r);
 }
-
-/////////////////////////////////////////////////////////////////////////////
-// QueryData - the representation of a database query result set. It's a
-// vector of rows
-/////////////////////////////////////////////////////////////////////////////
 
 Status serializeQueryData(const QueryData& q, pt::ptree& tree) {
   for (const auto& r : q) {
@@ -174,39 +163,37 @@ Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
   return deserializeQueryData(tree, qd);
 }
 
-/////////////////////////////////////////////////////////////////////////////
-// DiffResults - the representation of two diffed QueryData result sets.
-// Given and old and new QueryData, DiffResults indicates the "added" subset
-// of rows and the "removed" subset of Rows
-/////////////////////////////////////////////////////////////////////////////
-
 Status serializeDiffResults(const DiffResults& d, pt::ptree& tree) {
-  pt::ptree added;
-  auto status = serializeQueryData(d.added, added);
-  if (!status.ok()) {
-    return status;
-  }
-  tree.add_child("added", added);
-
+  // Serialize and add "removed" first.
+  // A property tree is somewhat ordered, this provides a loose contract to
+  // the logger plugins and their aggregations, allowing them to parse chunked
+  // lines. Note that the chunking is opaque to the database functions.
   pt::ptree removed;
-  status = serializeQueryData(d.removed, removed);
+  auto status = serializeQueryData(d.removed, removed);
   if (!status.ok()) {
     return status;
   }
   tree.add_child("removed", removed);
+
+  pt::ptree added;
+  status = serializeQueryData(d.added, added);
+  if (!status.ok()) {
+    return status;
+  }
+  tree.add_child("added", added);
   return Status(0, "OK");
 }
 
 Status deserializeDiffResults(const pt::ptree& tree, DiffResults& dr) {
-  if (tree.count("added") > 0) {
-    auto status = deserializeQueryData(tree.get_child("added"), dr.added);
+  if (tree.count("removed") > 0) {
+    auto status = deserializeQueryData(tree.get_child("removed"), dr.removed);
     if (!status.ok()) {
       return status;
     }
   }
 
-  if (tree.count("removed") > 0) {
-    auto status = deserializeQueryData(tree.get_child("removed"), dr.removed);
+  if (tree.count("added") > 0) {
+    auto status = deserializeQueryData(tree.get_child("added"), dr.added);
     if (!status.ok()) {
       return status;
     }
@@ -254,11 +241,6 @@ DiffResults diff(const QueryData& old, const QueryData& current) {
                       std::back_inserter(r.removed));
   return r;
 }
-
-/////////////////////////////////////////////////////////////////////////////
-// QueryLogItem - the representation of a log result occuring when a
-// scheduled query yields operating system state change.
-/////////////////////////////////////////////////////////////////////////////
 
 inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
                                           pt::ptree& tree) {

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -262,7 +262,7 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
       "\"calendarTime\":\"no_time\",\"unixTime\":\"0\",\"columns\":{\"test_"
-      "column\":\"test_new_value\\n\"},\"action\":\"removed\"}";
+      "column\":\"test_value\"},\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }
 }

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -247,8 +247,8 @@ std::pair<pt::ptree, DiffResults> getSerializedDiffResults() {
   diff_results.removed = qd.second;
 
   pt::ptree root;
-  root.add_child("added", qd.first);
   root.add_child("removed", qd.first);
+  root.add_child("added", qd.first);
 
   return std::make_pair(root, diff_results);
 }


### PR DESCRIPTION
A swapped order of "added" and "removed" for log events makes sense. It does not change the API but allows for easier parsing of chunked logs.