### PR TITLE
Add watcher column to osquery_info

### DIFF
--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -17,6 +17,7 @@
 #include <osquery/packs.h>
 #include <osquery/registry.h>
 #include <osquery/sql.h>
+#include <osquery/system.h>
 #include <osquery/tables.h>
 #include <osquery/filesystem.h>
 
@@ -219,6 +220,9 @@ QueryData genOsqueryInfo(QueryContext& context) {
   r["build_platform"] = STR(OSQUERY_BUILD_PLATFORM);
   r["build_distro"] = STR(OSQUERY_BUILD_DISTRO);
   r["start_time"] = INTEGER(Config::getInstance().getStartTime());
+  if (Initializer::isWorker()) {
+    r["watcher"] = INTEGER(PlatformProcess::getLauncherProcess()->pid());
+  }
 
   results.push_back(r);
   return results;

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -1,7 +1,7 @@
 table_name("osquery_info")
 description("Top level information about the running version of osquery.")
 schema([
-    Column("pid", INTEGER, "Process (or thread) ID"),
+    Column("pid", INTEGER, "Process (or thread/handle) ID"),
     Column("version", TEXT, "osquery toolkit version"),
     Column("config_hash", TEXT, "Hash of the working configuration state"),
     Column("config_valid", INTEGER, "1 if the config was loaded and considered valid, else 0"),
@@ -9,6 +9,7 @@ schema([
     Column("build_platform", TEXT, "osquery toolkit build platform"),
     Column("build_distro", TEXT, "osquery toolkit platform distribution name (os version)"),
     Column("start_time", INTEGER, "UNIX time in seconds when the process started"),
+    Column("watcher", INTEGER, "Process (or thread/handle) ID of optional watcher process")
 ])
 attributes(utility=True)
 implementation("osquery@genOsqueryInfo")


### PR DESCRIPTION
Knowing the watcher process when the daemon is using the watchdog is important.