### PR TITLE
The watcher process should apply memory limits to itself

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -249,8 +249,8 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   # osquery core set of unit tests build with SDK.
   add_executable(osquery_tests main/tests.cpp ${OSQUERY_TESTS})
   TARGET_OSQUERY_LINK_WHOLE(osquery_tests libosquery)
-  target_link_libraries(osquery_tests gtest libosquery_testing)
-  SET_OSQUERY_COMPILE(osquery_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
+  target_link_libraries(osquery_tests gtest gmock libosquery_testing)
+  SET_OSQUERY_COMPILE(osquery_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=1")
   add_test(osquery_tests osquery_tests)
 
   # osquery kernel tests.
@@ -258,8 +258,8 @@ if(NOT DEFINED ENV{SKIP_TESTS})
     add_executable(osquery_kernel_tests main/tests.cpp ${OSQUERY_KERNEL_TESTS})
     TARGET_OSQUERY_LINK_WHOLE(osquery_kernel_tests libosquery)
     TARGET_OSQUERY_LINK_WHOLE(osquery_kernel_tests libosquery_additional)
-    target_link_libraries(osquery_kernel_tests gtest libosquery_testing)
-    SET_OSQUERY_COMPILE(osquery_kernel_tests "${CXX_COMPILE_FLAGS} -DKERNEL_TEST=1 -DGTEST_HAS_TR1_TUPLE=0")
+    target_link_libraries(osquery_kernel_tests gtest gmock libosquery_testing)
+    SET_OSQUERY_COMPILE(osquery_kernel_tests "${CXX_COMPILE_FLAGS} -DKERNEL_TEST=1 -DGTEST_HAS_TR1_TUPLE=1")
   endif()
 
   # osquery benchmarks.
@@ -300,8 +300,8 @@ if(NOT DEFINED ENV{SKIP_TESTS})
     add_executable(osquery_tables_tests main/tests.cpp ${OSQUERY_TABLES_TESTS})
     TARGET_OSQUERY_LINK_WHOLE(osquery_tables_tests libosquery)
     TARGET_OSQUERY_LINK_WHOLE(osquery_tables_tests libosquery_additional)
-    target_link_libraries(osquery_tables_tests gtest libosquery_testing)
-    SET_OSQUERY_COMPILE(osquery_tables_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
+    target_link_libraries(osquery_tables_tests gtest gmock libosquery_testing)
+    SET_OSQUERY_COMPILE(osquery_tables_tests "${CXX_COMPILE_FLAGS} -DGTEST_HAS_TR1_TUPLE=1")
     add_test(osquery_tables_tests osquery_tables_tests)
   endif()
 

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -51,27 +51,5 @@ boost::optional<std::string> getEnvVar(const std::string& name) {
 
 void cleanupDefunctProcesses() { ::waitpid(-1, nullptr, WNOHANG); }
 
-ProcessState checkChildProcessStatus(const PlatformProcess& process,
-                                     int& status) {
-  int process_status = 0;
-
-  pid_t result = ::waitpid(process.nativeHandle(), &process_status, WNOHANG);
-  if (result < 0) {
-    return PROCESS_ERROR;
-  }
-
-  if (result == 0) {
-    return PROCESS_STILL_ALIVE;
-  }
-
-  if (WIFEXITED(process_status)) {
-    status = WEXITSTATUS(process_status);
-    return PROCESS_EXITED;
-  }
-
-  // process's state has changed but the state isn't that which we expect!
-  return PROCESS_STATE_CHANGE;
-}
-
 void setToBackgroundPriority() { setpriority(PRIO_PGRP, 0, 10); }
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -67,7 +67,7 @@ class PlatformProcess : private boost::noncopyable {
 
   PlatformProcess(const PlatformProcess& src) = delete;
   PlatformProcess(PlatformProcess&& src) noexcept;
-  ~PlatformProcess();
+  virtual ~PlatformProcess();
 
   PlatformProcess& operator=(const PlatformProcess& process) = delete;
   bool operator==(const PlatformProcess& process) const;
@@ -90,6 +90,8 @@ class PlatformProcess : private boost::noncopyable {
 
   /// Returns whether the PlatformProcess object is valid
   bool isValid() const { return (id_ != kInvalidPid); }
+
+  virtual ProcessState checkStatus(int& status) const;
 
   /// Returns the current process
   static std::shared_ptr<PlatformProcess> getCurrentProcess();
@@ -127,17 +129,17 @@ class PlatformProcess : private boost::noncopyable {
   PlatformPidType id_;
 };
 
-/// Causes the current thread to sleep for a specified time in milliseconds
+/// Causes the current thread to sleep for a specified time in milliseconds.
 void sleepFor(unsigned int msec);
 
-/// Set the enviroment variable name with value value
+/// Set the enviroment variable name with value value.
 bool setEnvVar(const std::string& name, const std::string& value);
 
-/// Unsets the environment variable specified by name
+/// Unsets the environment variable specified by name.
 bool unsetEnvVar(const std::string& name);
 
 /**
- * @brief Returns the value of the specified environment variable name
+ * @brief Returns the value of the specified environment variable name.
  *
  * If the environment variable does not exist, boost::none is returned.
  */
@@ -147,13 +149,9 @@ boost::optional<std::string> getEnvVar(const std::string& name);
 /// processes).
 bool isLauncherProcessDead(PlatformProcess& launcher);
 
-/// Non-blocking check on the state of a specificed child process.
-ProcessState checkChildProcessStatus(const osquery::PlatformProcess& process,
-                                     int& status);
-
-/// Waits for defunct processes to terminate
+/// Waits for defunct processes to terminate.
 void cleanupDefunctProcesses();
 
-/// Sets the current process to run with background scheduling priority
+/// Sets the current process to run with background scheduling priority.
 void setToBackgroundPriority();
 }

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -1,0 +1,260 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/testing.h"
+#include "osquery/core/watcher.h"
+
+using namespace testing;
+
+namespace osquery {
+
+class WatcherTests : public testing::Test {};
+
+/**
+ * @brief Begin with a mock watcher runner.
+ *
+ * The Watcher class implements a small static state and provides several 'free'
+ * static methods for state manipulation.
+ *
+ * The WatcherRunner class implements the state machine of a watchdog process
+ * as a Runnable, in a dedicated thread. We begin testing by exercising parts
+ * of that state machine.
+ */
+class MockWatcherRunner : public WatcherRunner {
+ public:
+  MockWatcherRunner(int argc, char** argv, bool use_worker)
+      : WatcherRunner(argc, argv, use_worker) {}
+
+  /// The state machine requested the 'worker' to stop.
+  MOCK_CONST_METHOD1(stopChild, void(const PlatformProcess& child));
+
+  /// The state machine is inspecting the 'worker' health and performance.
+  MOCK_CONST_METHOD1(isChildSane, Status(const PlatformProcess& child));
+
+ private:
+  FRIEND_TEST(WatcherTests, test_watcher);
+};
+
+/**
+ * @brief A scoped implementation of a cross-platform process.
+ *
+ * During the WorkerRunner exercises an external cross-platform process
+ * representation is provided. To better control the WorkerRunner state machine
+ * we will manipulate operating system abstractions to control process state.
+ */
+class FakePlatformProcess : public PlatformProcess {
+ public:
+  /// Simplified ctor set for our use cases.
+  FakePlatformProcess(PlatformPidType id) : PlatformProcess(id) {}
+
+  ProcessState checkStatus(int& _status) const {
+    _status = status_;
+    return state_;
+  }
+
+ private:
+  /// Allow our friend test classes to emulate the operating system's PoV.
+  void setStatus(ProcessState state, int status) {
+    state_ = state;
+    status_ = status;
+  }
+
+ private:
+  ProcessState state_{PROCESS_STILL_ALIVE};
+  int status_{0};
+
+ private:
+  FRIEND_TEST(WatcherTests, test_watcherrunner_watch);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_stop);
+};
+
+TEST_F(WatcherTests, test_watcherrunner_watch) {
+  MockWatcherRunner runner(0, nullptr, false);
+
+  // Use the cross-platform abstractions to inspect the current test process.
+  auto test_process = PlatformProcess::getCurrentProcess();
+  // Initialize a scoped (fake) process abstraction.
+  auto fake_test_process = FakePlatformProcess(test_process->pid());
+
+  // The ::watch method is a single iteration of worker health checking.
+  // Unless the watcher has entered a shutdown phase, every iteration should
+  // check the worker sanity.
+  EXPECT_CALL(runner, isChildSane(_)).WillOnce(Return(Status(0)));
+
+  // The above expectation returns a sane child state.
+  // This ::watch iteration should NOT attempt to stop the worker.
+  EXPECT_CALL(runner, stopChild(_)).Times(0);
+
+  // When triggering a watch, set the assumed process status.
+  fake_test_process.setStatus(PROCESS_STILL_ALIVE, 0);
+
+  // Trigger our expectations.
+  EXPECT_TRUE(runner.watch(fake_test_process));
+}
+
+TEST_F(WatcherTests, test_watcherrunner_stop) {
+  MockWatcherRunner runner(0, nullptr, false);
+
+  auto test_process = PlatformProcess::getCurrentProcess();
+  auto fake_test_process = FakePlatformProcess(test_process->pid());
+
+  EXPECT_CALL(runner, isChildSane(_)).Times(0);
+  EXPECT_CALL(runner, stopChild(_)).Times(0);
+
+  // Now set the process status to an error state.
+  fake_test_process.setStatus(PROCESS_ERROR, 0);
+
+  // Trigger our expectations, the watch method will now return false.
+  EXPECT_FALSE(runner.watch(fake_test_process));
+}
+
+class MockWithWatchWatcherRunner : public WatcherRunner {
+ public:
+  MockWithWatchWatcherRunner(int argc, char** argv, bool use_worker)
+      : WatcherRunner(argc, argv, use_worker) {}
+
+  /// This super-mock now mocks the watch method.
+  MOCK_CONST_METHOD1(watch, bool(const PlatformProcess& child));
+
+  MOCK_CONST_METHOD2(isWatcherHealthy,
+                     Status(const PlatformProcess& watcher,
+                            PerformanceState& watcher_state));
+
+  /// The state machine is starting, and is forking a managed extension.
+  MOCK_METHOD1(createExtension, bool(const std::string& extension));
+
+  /// The state machine is starting, and is forking the managed 'worker'.
+  MOCK_METHOD0(createWorker, void());
+};
+
+TEST_F(WatcherTests, test_watcherrunner_loop) {
+  // This time construct the runner with a use_worker=true.
+  MockWithWatchWatcherRunner runner(0, nullptr, true);
+
+  // Use a method introduced for testing purposes to request a single run of
+  // the WatcherRunner's thread entry point.
+  runner.runOnce();
+
+  // Watch will be called once, for the worker only, since there are no
+  // extensions configured.
+  EXPECT_CALL(runner, watch(_)).WillOnce(Return(true));
+  // Since the watch method is configured to return true, no worker is created.
+  EXPECT_CALL(runner, createWorker()).Times(0);
+  // The single-loop must check if itself is health.
+  EXPECT_CALL(runner, isWatcherHealthy(_, _)).WillOnce(Return(Status(0)));
+
+  runner.start();
+}
+
+TEST_F(WatcherTests, test_watcherrunner_loop_failure) {
+  MockWithWatchWatcherRunner runner(0, nullptr, true);
+  runner.runOnce();
+
+  // Now the watch method returns false, indicating the previous worker failed
+  // performance checked and was stopped.
+  EXPECT_CALL(runner, watch(_)).WillOnce(Return(false));
+  // Since the watch failed, the thread should spawn another worker.
+  EXPECT_CALL(runner, createWorker()).Times(1);
+  EXPECT_CALL(runner, isWatcherHealthy(_, _)).WillOnce(Return(Status(0)));
+
+  runner.start();
+}
+
+TEST_F(WatcherTests, test_watcherrunner_loop_disabled) {
+  // Now construct without using a worker.
+  MockWithWatchWatcherRunner runner(0, nullptr, false);
+  runner.runOnce();
+
+  // There is no worker process, nothing should be watched.
+  EXPECT_CALL(runner, watch(_)).Times(0);
+  // Without a worker process, the watcher does not watch itself.
+  EXPECT_CALL(runner, isWatcherHealthy(_, _)).Times(0);
+
+  runner.start();
+}
+
+class FakeWatcherRunner : public WatcherRunner {
+ public:
+  FakeWatcherRunner(int argc, char** argv, bool use_worker)
+      : WatcherRunner(argc, argv, use_worker) {}
+
+  /**
+  * @brief What the runner's internals will use as process state.
+  *
+  * Internal calls to getProcessRow will return this structure.
+  */
+  void setProcessRow(QueryData qd) { qd_ = std::move(qd); }
+
+  /// The tests do not have access to the processes table.
+  QueryData getProcessRow(pid_t pid) const override { return qd_; }
+
+ private:
+  QueryData qd_;
+};
+
+TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
+  FakeWatcherRunner runner(0, nullptr, true);
+
+  // Construct a process state, assume this would have been returned from the
+  // processes table, which the WorkerRunner normally uses internally.
+  Row r;
+  r["parent"] = INTEGER(1);
+  r["user_time"] = INTEGER(100);
+  r["system_time"] = INTEGER(100);
+  r["resident_size"] = INTEGER(100);
+  runner.setProcessRow({r});
+
+  // Hold the process and process state externally.
+  // Normally the WatcherRunner's entry point will persist these and use them
+  // as input to the next testable method to compare changes.
+  auto test_process = PlatformProcess::getCurrentProcess();
+  PerformanceState state;
+  // The inputs are sane.
+  EXPECT_TRUE(runner.isWatcherHealthy(*test_process, state));
+  // Calling the method again should internally detect no change, this means
+  // the state is still normal.
+  EXPECT_TRUE(runner.isWatcherHealthy(*test_process, state));
+
+  // The state should track the initial memory value.
+  EXPECT_EQ(100U, state.initial_footprint);
+
+  // The measurement of latency applies an interval value normalization.
+  auto iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
+  EXPECT_EQ(100U / iv, state.user_time);
+  EXPECT_EQ(0U, state.sustained_latency);
+
+  // Now we can alter the performance.
+  // Let us emulate the watcher having just allocated 1G of memory.
+  r["resident_size"] = INTEGER(1024 * 1024 * 1024);
+  runner.setProcessRow({r});
+
+  auto status = runner.isWatcherHealthy(*test_process, state);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.getMessage(), "Memory limits exceeded");
+
+  // Now emulate a rapid increase in CPU requirements.
+  r["user_time"] = INTEGER(1024 * 1024 * 1024);
+  runner.setProcessRow({r});
+  runner.isWatcherHealthy(*test_process, state);
+  EXPECT_EQ(1U, state.sustained_latency);
+
+  // And again, the CPU continues to increase from the system perspective.
+  r["system_time"] = INTEGER(1024 * 1024 * 1024);
+  runner.setProcessRow({r});
+  runner.isWatcherHealthy(*test_process, state);
+  EXPECT_EQ(2U, state.sustained_latency);
+}
+}

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -197,11 +197,18 @@ void WatcherRunner::start() {
       Watcher::removeExtensionPath(failed_extension);
     }
 
-    auto status = isWatcherHealthy(*watcher, watcher_state);
-    if (!status.ok()) {
-      Initializer::requestShutdown(EXIT_CATASTROPHIC,
-                                   "Watcher has become unhealthy: " +
-                                       status.getMessage());
+    if (use_worker_) {
+      auto status = isWatcherHealthy(*watcher, watcher_state);
+      if (!status.ok()) {
+        Initializer::requestShutdown(EXIT_CATASTROPHIC,
+                                     "Watcher has become unhealthy: " +
+                                         status.getMessage());
+        break;
+      }
+    }
+
+    if (run_once_) {
+      // A test harness can end the thread immediately.
       break;
     }
     pauseMilli(getWorkerLimit(INTERVAL) * 1000);
@@ -210,8 +217,7 @@ void WatcherRunner::start() {
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {
   int process_status = 0;
-
-  ProcessState result = checkChildProcessStatus(child, process_status);
+  ProcessState result = child.checkStatus(process_status);
   if (Watcher::fatesBound()) {
     // A signal was handled while the watcher was watching.
     return false;
@@ -225,7 +231,7 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
     auto status = isChildSane(child);
     if (!status.ok()) {
       LOG(WARNING) << "osqueryd worker (" << child.pid()
-                   << "):" << status.getMessage();
+                   << "): " << status.getMessage();
       stopChild(child);
       return false;
     }
@@ -312,8 +318,7 @@ static bool exceededCyclesLimit(const PerformanceChange& change) {
 
 Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
                                        PerformanceState& watcher_state) const {
-  auto rows =
-      SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(watcher.pid()));
+  auto rows = getProcessRow(watcher.pid());
   if (rows.size() == 0) {
     // Could not find worker process?
     return Status(1, "Cannot find watcher process");
@@ -327,9 +332,12 @@ Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
   return Status(0);
 }
 
+QueryData WatcherRunner::getProcessRow(pid_t pid) const {
+  return SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(pid));
+}
+
 Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
-  auto rows =
-      SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child.pid()));
+  auto rows = getProcessRow(child.pid());
   if (rows.size() == 0) {
     // Could not find worker process?
     return Status(1, "Cannot find worker process");

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -39,6 +39,13 @@ struct LimitDefinition {
   size_t disabled;
 };
 
+struct PerformanceChange {
+  size_t sustained_latency;
+  size_t footprint;
+  size_t iv;
+  pid_t parent;
+};
+
 using WatchdogLimitMap = std::map<WatchdogLimitType, LimitDefinition>;
 
 const WatchdogLimitMap kWatchdogLimits = {
@@ -161,6 +168,9 @@ bool WatcherRunner::ok() {
 void WatcherRunner::start() {
   // Set worker performance counters to an initial state.
   Watcher::resetWorkerCounters(0);
+  // Hold the current process (watcher) for inspection too.
+  auto watcher = PlatformProcess::getCurrentProcess();
+  PerformanceState watcher_state;
 
   // Enter the watch loop.
   do {
@@ -186,14 +196,22 @@ void WatcherRunner::start() {
     for (const auto& failed_extension : failing_extensions) {
       Watcher::removeExtensionPath(failed_extension);
     }
+
+    auto status = isWatcherHealthy(*watcher, watcher_state);
+    if (!status.ok()) {
+      Initializer::requestShutdown(EXIT_CATASTROPHIC,
+                                   "Watcher has become unhealthy: " +
+                                       status.getMessage());
+      break;
+    }
     pauseMilli(getWorkerLimit(INTERVAL) * 1000);
   } while (!interrupted() && ok());
 }
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {
-  int status = 0;
+  int process_status = 0;
 
-  ProcessState result = checkChildProcessStatus(child, status);
+  ProcessState result = checkChildProcessStatus(child, process_status);
   if (Watcher::fatesBound()) {
     // A signal was handled while the watcher was watching.
     return false;
@@ -204,7 +222,10 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
     return false;
   } else if (result == PROCESS_STILL_ALIVE) {
     // If the inspect finds problems it will stop/restart the worker.
-    if (!isChildSane(child)) {
+    auto status = isChildSane(child);
+    if (!status.ok()) {
+      LOG(WARNING) << "osqueryd worker (" << child.pid()
+                   << "):" << status.getMessage();
       stopChild(child);
       return false;
     }
@@ -213,7 +234,7 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
 
   if (result == PROCESS_EXITED) {
     // If the worker process existed, store the exit code.
-    Watcher::instance().worker_status_ = status;
+    Watcher::instance().worker_status_ = process_status;
   }
 
   return true;
@@ -226,84 +247,117 @@ void WatcherRunner::stopChild(const PlatformProcess& child) const {
   cleanupDefunctProcesses();
 }
 
-bool WatcherRunner::isChildSane(const PlatformProcess& child) const {
+PerformanceChange getChange(const Row& r, PerformanceState& state) {
+  PerformanceChange change;
+
+  // IV is the check interval in seconds, and utilization is set per-second.
+  change.iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
+  UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
+  try {
+    change.parent = AS_LITERAL(BIGINT_LITERAL, r.at("parent"));
+    user_time = AS_LITERAL(BIGINT_LITERAL, r.at("user_time")) / change.iv;
+    system_time = AS_LITERAL(BIGINT_LITERAL, r.at("system_time")) / change.iv;
+    change.footprint = AS_LITERAL(BIGINT_LITERAL, r.at("resident_size"));
+  } catch (const std::exception& e) {
+    state.sustained_latency = 0;
+  }
+
+  // Check the difference of CPU time used since last check.
+  if (user_time - state.user_time > getWorkerLimit(UTILIZATION_LIMIT) ||
+      system_time - state.system_time > getWorkerLimit(UTILIZATION_LIMIT)) {
+    state.sustained_latency++;
+  } else {
+    state.sustained_latency = 0;
+  }
+  // Update the current CPU time.
+  state.user_time = user_time;
+  state.system_time = system_time;
+
+  // Check if the sustained difference exceeded the acceptable latency limit.
+  change.sustained_latency = state.sustained_latency;
+
+  // Set the memory footprint as the amount of resident bytes allocated
+  // since the process image was created (estimate).
+  // A more-meaningful check would limit this to writable regions.
+  if (state.initial_footprint == 0) {
+    state.initial_footprint = change.footprint;
+  }
+
+  // Set the measured/limit-applied footprint to the post-launch allocations.
+  if (change.footprint < state.initial_footprint) {
+    change.footprint = 0;
+  } else {
+    change.footprint = change.footprint - state.initial_footprint;
+  }
+
+  return change;
+}
+
+static bool exceededMemoryLimit(const PerformanceChange& change) {
+  if (change.footprint == 0) {
+    return false;
+  }
+
+  return (change.footprint > getWorkerLimit(MEMORY_LIMIT) * 1024 * 1024);
+}
+
+static bool exceededCyclesLimit(const PerformanceChange& change) {
+  if (change.sustained_latency == 0) {
+    return false;
+  }
+
+  auto latency = change.sustained_latency * change.iv;
+  return (latency >= getWorkerLimit(LATENCY_LIMIT));
+}
+
+Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
+                                       PerformanceState& watcher_state) const {
+  auto rows =
+      SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(watcher.pid()));
+  if (rows.size() == 0) {
+    // Could not find worker process?
+    return Status(1, "Cannot find watcher process");
+  }
+
+  auto change = getChange(rows[0], watcher_state);
+  if (exceededMemoryLimit(change)) {
+    return Status(1, "Memory limits exceeded");
+  }
+
+  return Status(0);
+}
+
+Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
   auto rows =
       SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(child.pid()));
   if (rows.size() == 0) {
     // Could not find worker process?
-    return false;
+    return Status(1, "Cannot find worker process");
   }
 
-  // Get the performance state for the worker or extension.
-  size_t sustained_latency = 0;
-  // Compare CPU utilization since last check.
-  size_t footprint = 0;
-  pid_t parent = 0;
-  // IV is the check interval in seconds, and utilization is set per-second.
-  auto iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
-
+  PerformanceChange change;
   {
     WatcherLocker locker;
     auto& state = Watcher::getState(child);
-    UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
-    try {
-      parent = AS_LITERAL(BIGINT_LITERAL, rows[0].at("parent"));
-      user_time = AS_LITERAL(BIGINT_LITERAL, rows[0].at("user_time")) / iv;
-      system_time = AS_LITERAL(BIGINT_LITERAL, rows[0].at("system_time")) / iv;
-      footprint = AS_LITERAL(BIGINT_LITERAL, rows[0].at("resident_size"));
-    } catch (const std::exception& e) {
-      state.sustained_latency = 0;
-    }
-
-    // Check the difference of CPU time used since last check.
-    if (user_time - state.user_time > getWorkerLimit(UTILIZATION_LIMIT) ||
-        system_time - state.system_time > getWorkerLimit(UTILIZATION_LIMIT)) {
-      state.sustained_latency++;
-    } else {
-      state.sustained_latency = 0;
-    }
-    // Update the current CPU time.
-    state.user_time = user_time;
-    state.system_time = system_time;
-
-    // Check if the sustained difference exceeded the acceptable latency limit.
-    sustained_latency = state.sustained_latency;
-
-    // Set the memory footprint as the amount of resident bytes allocated
-    // since the process image was created (estimate).
-    // A more-meaningful check would limit this to writable regions.
-    if (state.initial_footprint == 0) {
-      state.initial_footprint = footprint;
-    }
-
-    // Set the measured/limit-applied footprint to the post-launch allocations.
-    if (footprint < state.initial_footprint) {
-      footprint = 0;
-    } else {
-      footprint = footprint - state.initial_footprint;
-    }
+    change = getChange(rows[0], state);
   }
 
   // Only make a decision about the child sanity if it is still the watcher's
   // child. It's possible for the child to die, and its pid reused.
-  if (parent != PlatformProcess::getCurrentProcess()->pid()) {
+  if (change.parent != PlatformProcess::getCurrentProcess()->pid()) {
     // The child's parent is not the watcher.
     Watcher::reset(child);
     // Do not stop or call the child insane, since it is not our child.
-    return true;
+    return Status(0);
   }
 
-  if (sustained_latency > 0 &&
-      sustained_latency * iv >= getWorkerLimit(LATENCY_LIMIT)) {
-    LOG(WARNING) << "osqueryd worker (" << child.pid()
-                 << ") system performance limits exceeded";
-    return false;
+  if (exceededCyclesLimit(change)) {
+    return Status(1, "System performance limits exceeded");
   }
   // Check if the private memory exceeds a memory limit.
-  if (footprint > 0 && footprint > getWorkerLimit(MEMORY_LIMIT) * 1024 * 1024) {
-    LOG(WARNING) << "osqueryd worker (" << child.pid()
-                 << ") memory limits exceeded: " << footprint;
-    return false;
+  if (exceededMemoryLimit(change)) {
+    return Status(
+        1, "Memory limits exceeded: " + std::to_string(change.footprint));
   }
 
   // The worker is sane, no action needed.
@@ -312,7 +366,7 @@ bool WatcherRunner::isChildSane(const PlatformProcess& child) const {
     relayStatusLogs();
   }
 
-  return true;
+  return Status(0);
 }
 
 void WatcherRunner::createWorker() {

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -228,6 +228,7 @@ class WatcherLocker {
  public:
   /// Construct and gain watcher lock.
   WatcherLocker() { Watcher::lock(); }
+
   /// Destruct and release watcher lock.
   ~WatcherLocker() { Watcher::unlock(); }
 };
@@ -256,26 +257,37 @@ class WatcherRunner : public InternalRunnable {
  private:
   /// Dispatcher (this service thread's) entry point.
   void start();
+
   /// Boilerplate function to sleep for some configured latency
   bool ok();
+
   /// Begin the worker-watcher process.
   bool watch(const PlatformProcess& child) const;
+
   /// Inspect into the memory, CPU, and other worker/extension process states.
-  bool isChildSane(const PlatformProcess& child) const;
+  Status isChildSane(const PlatformProcess& child) const;
+
+  /// Inspect into the memory and CPU of the watcher process.
+  Status isWatcherHealthy(const PlatformProcess& watcher,
+                          PerformanceState& watcher_state) const;
 
  private:
   /// Fork and execute a worker process.
   void createWorker();
+
   /// Fork an extension process.
   bool createExtension(const std::string& extension);
+
   /// If a worker/extension has otherwise gone insane, stop it.
   void stopChild(const PlatformProcess& child) const;
 
  private:
   /// Keep the invocation daemon's argc to iterate through argv.
   int argc_{0};
+
   /// When a worker child is spawned the argv will be scrubbed.
   char** argv_{nullptr};
+
   /// Spawn/monitor a worker process.
   bool use_worker_{false};
 };
@@ -297,4 +309,3 @@ class WatcherWatcherRunner : public InternalRunnable {
 /// Get a performance limit by name and optional level.
 size_t getWorkerLimit(WatchdogLimitType limit);
 }
-

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -75,6 +75,20 @@ bool PlatformProcess::kill() const {
   return (::TerminateProcess(id_, 0) != FALSE);
 }
 
+ProcessState PlatformProcess::checkStatus(int &status) const {
+  DWORD exit_code = 0;
+  if (!::GetExitCodeProcess(nativeHandle(), &exit_code)) {
+    return PROCESS_ERROR;
+  }
+
+  if (exit_code == STILL_ACTIVE) {
+    return PROCESS_STILL_ALIVE;
+  }
+
+  status = exit_code;
+  return PROCESS_EXITED;
+}
+
 std::shared_ptr<PlatformProcess> PlatformProcess::getCurrentProcess() {
   HANDLE handle =
       ::OpenProcess(PROCESS_ALL_ACCESS, FALSE, ::GetCurrentProcessId());

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -69,21 +69,5 @@ boost::optional<std::string> getEnvVar(const std::string &name) {
 
 void cleanupDefunctProcesses() {}
 
-ProcessState checkChildProcessStatus(const PlatformProcess &process,
-                                     int &status) {
-  DWORD exit_code = 0;
-  if (!::GetExitCodeProcess(process.nativeHandle(), &exit_code)) {
-    return PROCESS_ERROR;
-  }
-
-  if (exit_code == STILL_ACTIVE) {
-    return PROCESS_STILL_ALIVE;
-  }
-
-  status = exit_code;
-  return PROCESS_EXITED;
-}
-
 void setToBackgroundPriority() {}
 }
-

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -8,6 +8,11 @@
  *
  */
 
+#ifdef GTEST_HAS_TR1_TUPLE
+#undef GTEST_HAS_TR1_TUPLE
+#define GTEST_HAS_TR1_TUPLE 0
+#endif
+
 #include <stdexcept>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
There is a slight refactor of the watcher logic such that it can be applied to either a worker process and worker state OR a watcher process and state.

For the watcher we only apply a basic memory/RSS check.