### PR TITLE
Remove process_file_events subscriber from Linux

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -95,6 +95,8 @@ File accesses on Linux using inotify may induce unexpected and unwanted performa
 
 To enable access monitoring for the above set of directories in 'homes' and the single 'etc'.
 
+### Process File Accesses on OS X
+
 It is possible to monitor for file accesses by process using the osquery OS X kernel module. File accesses induce a LOT of stress on the system and are more or less useless giving the context from userland monitoring systems (aka, not having the process that caused the modification).
 
-If the kernel extension is running, the `process_file_events` table will be populated using the same **file_paths** key in the osquery config. This implementation of access monitoring includes process PIDs and should not cause CPU or memory latency outside of the normal kernel extension/module guarantees. See [../development/kernel.md](Kernel) for more information.
+If the OS X kernel extension is running, the `process_file_events` table will be populated using the same **file_paths** key in the osquery config. This implementation of access monitoring includes process PIDs and should not cause CPU or memory latency outside of the normal kernel extension/module guarantees. See [../development/kernel.md](Kernel) for more information.

--- a/osquery/tables/events/darwin/process_file_events.cpp
+++ b/osquery/tables/events/darwin/process_file_events.cpp
@@ -8,12 +8,12 @@
  *
  */
 
-#include "osquery/events/kernel.h"
-
 #include <osquery/config.h>
 #include <osquery/events.h>
-#include <osquery/logger.h>
 #include <osquery/filesystem.h>
+#include <osquery/logger.h>
+
+#include "osquery/events/kernel.h"
 
 namespace osquery {
 


### PR DESCRIPTION
The `process_file_events` subscriber was included on Darwin and Linux, but it is only used (combined with a table) on Darwin. This moves the subscriber implementation into Darwin-only build folders from CMake's point of view.