### PR TITLE
Introduce --audit_allow_sockets for Linux socket_events

### DIFF
--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -20,6 +20,12 @@ How does this work? Let's walk through 3 configuration options. These can be set
 
 On Linux a companion table `user_events` is included that provides several authentication-based events. If you are enabling process auditing it should be trivial to also include this table.
 
+#### Linux socket auditing
+
+Another audit-based table is provided on Linux: `socket_events`. This table reports events for the syscalls `bind` and `connect`. This table is not enabled with process events by default because it introduces considerable added load on the system.
+
+Use `--audit_allow_sockets` to enable the associated event subscriber.
+
 ## OS X process auditing
 
 osquery does not (yet?) support audit on Darwin platforms. It is possible to enable process auditing using a kernel extension. The extension can be downloaded and installed from the [http://osquery.io/downloads](http://osquery.io/downloads) page. It must be kept up to date alongside the osquery daemon and shell since there are automatic API restrictions applied. If you are running a 1.7.5 daemon, a 1.7.5 extension is needed otherwise the extension will not be used. If you are interested in the extension's design and development please check out the [kernel](../development/kernel.md) development guide.

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -22,15 +22,25 @@ namespace osquery {
 #define AUDIT_SYSCALL_BIND 49
 #define AUDIT_SYSCALL_CONNECT 42
 
+FLAG(bool,
+     audit_allow_sockets,
+     false,
+     "Allow the audit publisher to install socket-related rules");
+
 // Depend on the external getUptime table method.
 namespace tables {
 extern long getUptime();
 }
 
+// Depend on the external decodeAuditValue audit-related process events method.
+extern std::string decodeAuditValue(const std::string& s);
+
 class SocketEventSubscriber : public EventSubscriber<AuditEventPublisher> {
  public:
-  /// Decorating syscall events with socket information on Linux is expensive.
-  SocketEventSubscriber() : EventSubscriber(false) {}
+  /// This subscriber depends on a configuration boolean.
+  Status setUp() override {
+    return Status((FLAGS_audit_allow_sockets) ? 0 : 1);
+  }
 
   /// The process event subscriber declares an audit event type subscription.
   Status init() override;
@@ -147,7 +157,7 @@ Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef&) {
   }
 
   row_["pid"] = ec->fields["pid"];
-  row_["path"] = ec->fields["exe"];
+  row_["path"] = decodeAuditValue(ec->fields["exe"]);
   // TODO: This is a hex value.
   row_["fd"] = ec->fields["a0"];
   // The open/bind success status.


### PR DESCRIPTION
1. Enable the `socket_events` table in Linux if `--audit_allow_sockets` is enabled.
2. Fix a path parsing error within the existing/disabled `socket_events` table.