### PR TITLE
Fix up doxygen docs and require correct docs in CI

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -744,6 +744,11 @@ WARN_FORMAT            = "$file:$line: $text"
 
 WARN_LOGFILE           =
 
+# If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop
+# when a warning is encountered.
+
+WARN_AS_ERROR          = YES
+
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -135,6 +135,7 @@ class Config : private boost::noncopyable {
   /**
    * @brief Add a file
    *
+   * @param source source of config file
    * @param category is the category which the file exists in
    * @param path is the file path to add
    */
@@ -449,8 +450,8 @@ class ConfigParserPlugin : public Plugin {
   /**
    * @brief Return a list of top-level config keys to receive in updates.
    *
-   * The ::update method will receive a map of these keys with a JSON-parsed
-   * property tree of configuration data.
+   * The ConfigParserPlugin::update method will receive a map of these keys
+   * with a JSON-parsed property tree of configuration data.
    *
    * @return A list of string top-level JSON keys.
    */
@@ -464,6 +465,7 @@ class ConfigParserPlugin : public Plugin {
    * update. Every config parser will receive a map of merged data for each key
    * they requested in keys().
    *
+   * @param source source of the config data
    * @param config A JSON-parsed property tree map.
    * @return Failure if the parser should no longer receive updates.
    */
@@ -477,8 +479,8 @@ class ConfigParserPlugin : public Plugin {
    * @brief Accessor for parser-manipulated data.
    *
    * Parsers should be used generically, for places within the code base that
-   * request a parser (check for its existence), should only use this ::getData
-   * accessor.
+   * request a parser (check for its existence), should only use this
+   * ConfigParserPlugin::getData accessor.
    *
    * More complex parsers that require dynamic casting are not recommended.
    */

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -224,7 +224,7 @@ bool addUniqueRowToQueryData(QueryData& q, const Row& r);
 
 /**
  * @brief Construct a new QueryData from an existing one, replacing all
- * non-ASCII characters with their \u encoding.
+ * non-ASCII characters with their \\u encoding.
  *
  * This function is intended as a workaround for
  * https://svn.boost.org/trac/boost/ticket/8883,
@@ -384,7 +384,7 @@ Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
  * a list of actions.
  *
  * @param i the QueryLogItem to serialize
- * @param json the output JSON string
+ * @param items vector of JSON output strings
  *
  * @return Status indicating the success or failure of the operation
  */
@@ -451,9 +451,9 @@ class DatabasePlugin : public Plugin {
   /**
    * @brief Shutdown the database and release initialization resources.
    *
-   * Assume that a plugin may override ::tearDown and choose to close resources
+   * Assume that a plugin may override #tearDown and choose to close resources
    * when the registry is stopping. Most plugins will implement a mutex around
-   * initialization and destruction and assume ::setUp and ::tearDown will
+   * initialization and destruction and assume #setUp and #tearDown will
    * dictate the flow in most situations.
    */
   virtual ~DatabasePlugin() {}
@@ -494,9 +494,9 @@ class DatabasePlugin : public Plugin {
   /**
    * @brief Allow the initializer to check the active database plugin.
    *
-   * Unlink the initializer's ::initActivePlugin helper method, the database
-   * plugin should always be within the core. There is no need to discover
-   * the active plugin via the registry or extensions API.
+   * Unlink the initializer's Initializer::initActivePlugin helper method, the
+   * database plugin should always be within the core. There is no need to
+   * discover the active plugin via the registry or extensions API.
    *
    * The database should setUp in preparation for accesses.
    */

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -114,7 +114,7 @@ class InternalRunnable : private boost::noncopyable,
    * @brief Check if the thread's entrypoint (run) executed.
    *
    * It is possible for the Runnable to be allocated without the thread context.
-   * ::hasRun makes a much better guess at the state of the thread.
+   * #hasRun makes a much better guess at the state of the thread.
    * If it has run then stop must be called.
    */
   bool hasRun() { return run_; }

--- a/include/osquery/enroll.h
+++ b/include/osquery/enroll.h
@@ -45,13 +45,8 @@ class EnrollPlugin : public Plugin {
   /**
    * @brief Perform enrollment on the request of a config/logger.
    *
-   * The single 'enroll' plugin request action will call EnrollPlugin::enroll,
-   * the requester may include an optional "force" key to ask the enroll plugin
-   * to perhaps re-request an enrollment rather than doing a cache lookup.
-   * This force functionality is optional and implemented/described by each
-   * enroll plugin.
+   * The single 'enroll' plugin request action will call EnrollPlugin::enroll
    *
-   * @param force An optionally-supported/used request to force re-enrollment.
    * @return An enrollment secret or key material or identifier.
    */
   virtual std::string enroll() = 0;
@@ -69,8 +64,7 @@ class EnrollPlugin : public Plugin {
  * exists in the backing store, the result will be cached.
  *
  * @param enroll_plugin Name of the enroll plugin to use if no node_key set.
- * @param force Optionally bypass cache and force call the enroll plugin.
- * @return node_key A unique, often private, node secret key.
+ * @return A unique, often private, node secret key.
  */
 std::string getNodeKey(const std::string& enroll_plugin);
 

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -344,7 +344,7 @@ class EventSubscriberPlugin : public Plugin {
    * is important to added EventTime as it relates to "when the event occurred".
    *
    * @param r An osquery Row element.
-   * @param time The time the added event occurred.
+   * @param event_time The time the added event occurred.
    *
    * @return Was the element added to the backing store.
    */
@@ -600,7 +600,7 @@ class EventFactory : private boost::noncopyable {
    *
    * The registration is mostly abstracted using osquery's registry.
    *
-   * @param event_pub If for some reason the caller needs access to the
+   * @param pub If for some reason the caller needs access to the
    * EventPublisher instance they can register-by-instance.
    *
    * Access to the EventPublisher instance is not discouraged, but using the
@@ -639,7 +639,8 @@ class EventFactory : private boost::noncopyable {
    * Create a Subscription from a given SubscriptionContext and EventCallback
    * and add that Subscription to the EventPublisher associated identifier.
    *
-   * @param type_id The string for an EventPublisher receiving the Subscription.
+   * @param type_id ID string for an EventPublisher receiving the Subscription.
+   * @param name_id ID string for the EventSubscriber.
    * @param sc A SubscriptionContext related to the EventPublisher.
    * @param cb When the EventPublisher fires an event the SubscriptionContext
    * will be evaluated, if the event matches optional specifics in the context
@@ -675,7 +676,7 @@ class EventFactory : private boost::noncopyable {
    * Otherwise it will call end on the publisher and assume the run loop will
    * tear down and remove.
    *
-   * @param event_pub The string label for the EventPublisher.
+   * @param pub The string label for the EventPublisher.
    *
    * @return Did the EventPublisher deregister cleanly.
    */
@@ -740,7 +741,7 @@ class EventFactory : private boost::noncopyable {
    * See EventFactory::deregisterEventPublisher for actions taken during
    * deregistration.
    *
-   * @param should_end Reset the "is ending" state if False.
+   * @param join if true, threads will be joined
    */
   static void end(bool join = false);
 

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -79,7 +79,7 @@ Status pingExtension(const std::string& path);
  * is used. This allows appropriate extensions to expose plugin requirements.
  *
  * An 'appropriate' extension is one within the `extensions_autoload` search
- * path with file ownership equivilent or greater (root) than the osquery
+ * path with file ownership equivalent or greater (root) than the osquery
  * process requesting autoload.
  */
 void loadExtensions();
@@ -87,7 +87,7 @@ void loadExtensions();
 /**
  * @brief Load extensions from a delimited search path string.
  *
- * @param paths A colon-delimited path variable, e.g: '/path1:/path2'.
+ * @param loadfile Path to file containing newline delimited file paths
  */
 Status loadExtensions(const std::string& loadfile);
 
@@ -102,7 +102,7 @@ void loadModules();
 /**
  * @brief Load extenion modules from a delimited search path string.
  *
- * @param paths A colon-delimited path variable, e.g: '/path1:/path2'.
+ * @param loadfile Path to file containing newline delimited file paths
  */
 Status loadModules(const std::string& loadfile);
 

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -44,9 +44,11 @@ const std::string kSQLGlobRecursive = kSQLGlobWildcard + kSQLGlobWildcard;
  * @brief Read a file from disk.
  *
  * @param path the path of the file that you would like to read.
+ * @param size Number of bytes to read from file.
  * @param content a reference to a string which will be populated with the
  * contents of the path indicated by the path parameter.
  * @param dry_run do not actually read the file content.
+ * @param preserve_time Attempt to preserve file mtime and atime
  *
  * @return an instance of Status, indicating success or failure.
  */
@@ -190,6 +192,8 @@ Status resolveFilePattern(const boost::filesystem::path& pattern,
  * For example: /tmp/% becomes /private/tmp/% on OS X systems. And /tmp/%.
  *
  * @param pattern the input and output filesystem glob pattern.
+ * @param limits osquery::GlobLimits to apply (currently only recognizes
+ * osquery::GLOB_NO_CANON)
  */
 void replaceGlobWildcards(std::string& pattern, GlobLimits limits = GLOB_ALL);
 
@@ -254,7 +258,7 @@ Status parseJSON(const boost::filesystem::path& path,
 /**
  * @brief Parse JSON content into a property tree.
  *
- * @param path JSON string data.
+ * @param content JSON string data.
  * @param tree output property tree.
  *
  * @return an instance of Status, indicating success or failure if malformed.

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -129,7 +129,7 @@ class LoggerPlugin : public Plugin {
   /**
    * @brief A feature method to decide if Glog should stop handling statuses.
    *
-   * Return true if this logger plugin's ::logStatus method should handle Glog
+   * Return true if this logger plugin's #logStatus method should handle Glog
    * statuses exclusively. If true then Glog will stop writing status lines
    * to the configured log path.
    *
@@ -241,7 +241,7 @@ void initLogger(const std::string& name, bool forward_all = false);
  * Note that this method should only be used to log results. If you'd like to
  * log normal osquery operations, use Google Logging.
  *
- * @param s the string to log
+ * @param message the string to log
  * @param category a category/metadata key
  *
  * @return Status indicating the success or failure of the operation
@@ -286,7 +286,7 @@ Status logQueryLogItem(const QueryLogItem& item, const std::string& receiver);
 /**
  * @brief Log raw results from a query (or a snapshot scheduled query).
  *
- * @param results the unmangled results from the query planner.
+ * @param item the unmangled results from the query planner.
  *
  * @return Status indicating the success or failure of the operation
  */

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -182,7 +182,7 @@ class Plugin : private boost::noncopyable {
   /// Allow the plugin to introspect into the registered name (for logging).
   void setName(const std::string& name) { name_ = name; }
 
-  /// Force callsites to use ::getName to access the plugin item's name.
+  /// Force callsites to use #getName to access the plugin item's name.
   virtual const std::string& getName() const { return name_; }
 
  public:
@@ -424,6 +424,7 @@ class RegistryHelper : public RegistryHelperCore {
    * @endcode
    *
    * @param item_name An identifier for this registry plugin.
+   * @param internal If true, the plugin does not broadcast.
    * @return A success/failure status.
    */
   template <class Item>
@@ -479,7 +480,6 @@ class RegistryHelper : public RegistryHelperCore {
    * @brief Add an existing plugin to this registry, used for testing only.
    *
    * @param item A PluginType-cased registry item.
-   * @param item_name An identifier for this registry plugin.
    * @return A success/failure status.
    */
   Status add(const std::shared_ptr<RegistryType>& item) {
@@ -509,7 +509,7 @@ using PluginRegistryHelper = RegistryHelper<Plugin>;
 using PluginRegistryHelperRef = std::shared_ptr<PluginRegistryHelper>;
 
 /**
- * @basic A workflow manager for opening a module path and appending to the
+ * @brief A workflow manager for opening a module path and appending to the
  * core registry.
  *
  * osquery Registry modules are part of the extensions API, in that they use

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -181,7 +181,7 @@ class SQLPlugin : public Plugin {
  *   }
  * @endcode
  *
- * @param q the query to execute
+ * @param query the query to execute
  * @param results A QueryData structure to emit result rows on success.
  * @return A status indicating query success.
  */

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -90,7 +90,7 @@ class Initializer : private boost::noncopyable {
    * form of event handler threads or thrift service and client pools, a stop
    * request should behave nicely and request these services stop.
    *
-   * Use shutdown whenever you would normally call ::exit.
+   * Use shutdown whenever you would normally call stdlib exit.
    *
    * @param retcode the requested return code for the process.
    */
@@ -99,7 +99,7 @@ class Initializer : private boost::noncopyable {
   /**
    * @brief Forcefully request the application to stop.
    *
-   * See ::requestShutdown, this overloaded alternative allows the caller to
+   * See #requestShutdown, this overloaded alternative allows the caller to
    * also log a reason/message to the system log. This is intended for extreme
    * failure cases and thus requires an explicit error code.
    *
@@ -115,7 +115,7 @@ class Initializer : private boost::noncopyable {
    * @brief Cleanly wait for all services and components to shutdown.
    *
    * Enter a join of all services followed by a sync wait for event loops.
-   * If the main thread is out of actions it can call ::waitForShutdown.
+   * If the main thread is out of actions it can call #waitForShutdown.
    */
   static void waitForShutdown();
 

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -473,7 +473,7 @@ struct QueryContext : private boost::noncopyable {
    * any operator or for a specific operator, usually equality (EQUALS).
    *
    * @param column The name of a column within this table.
-   * @param optional op Check for a specific constraint operator.
+   * @param op Check for a specific constraint operator (default EQUALS).
    * @return true if a constraint exists, false if empty or no operator match.
    */
   bool hasConstraint(const std::string& column,


### PR DESCRIPTION
This change causes Doxygen to error if there are unrecognized commands, or
undocumented/incorrect parameters in documented functions. It does not require
that every function be fully documented, just that those that are do not have
errors.

Old documentation with problems was fixed to comply.