### PR TITLE
Added memory_info table for Linux

### DIFF
--- a/osquery/tables/system/linux/memory_info.cpp
+++ b/osquery/tables/system/linux/memory_info.cpp
@@ -21,9 +21,9 @@
 namespace osquery {
 namespace tables {
 
-const std::string memInfoPath = {"/proc/meminfo"};
+const std::string kMemInfoPath = {"/proc/meminfo"};
 
-std::map<std::string, std::string> meminfoMap = {
+const std::map<std::string, std::string> kMemInfoMap = {
     {"memory_total", "MemTotal:"},
     {"memory_free", "MemFree:"},
     {"buffers", "Buffers:"},
@@ -40,14 +40,14 @@ QueryData getMemoryInfo(QueryContext& context) {
   Row r;
 
   std::string meminfo_content;
-  if (forensicReadFile(memInfoPath, meminfo_content).ok()) {
+  if (forensicReadFile(kMemInfoPath, meminfo_content).ok()) {
     // Able to read meminfo file, now grab info we want
     for (const auto& line : split(meminfo_content, "\n")) {
       std::vector<std::string> tokens;
       boost::split(
           tokens, line, boost::is_any_of("\t "), boost::token_compress_on);
       // Look for mapping
-      for (const auto& singleMap : meminfoMap) {
+      for (const auto& singleMap : kMemInfoMap) {
         if (line.find(singleMap.second) == 0) {
           r[singleMap.first] = INTEGER(std::stol(tokens[1]) * 1024l);
           break;

--- a/osquery/tables/system/linux/memory_info.cpp
+++ b/osquery/tables/system/linux/memory_info.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+
+#include <boost/algorithm/string.hpp>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+#include <osquery/filesystem.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+const std::string memInfoPath = {"/proc/meminfo"};
+
+std::map<std::string, std::string> meminfoMap = {
+    {"memory_total", "MemTotal:"},
+    {"memory_free", "MemFree:"},
+    {"buffers", "Buffers:"},
+    {"cached", "Cached:"},
+    {"swap_cached", "SwapCached:"},
+    {"active", "Active:"},
+    {"inactive", "Inactive:"},
+    {"swap_total", "SwapTotal:"},
+    {"swap_free", "SwapFree:"},
+};
+
+QueryData getMemoryInfo(QueryContext& context) {
+  QueryData results;
+  Row r;
+
+  std::string meminfo_content;
+  if (forensicReadFile(memInfoPath, meminfo_content).ok()) {
+    // Able to read meminfo file, now grab info we want
+    for (const auto& line : split(meminfo_content, "\n")) {
+      std::vector<std::string> tokens;
+      boost::split(
+          tokens, line, boost::is_any_of("\t "), boost::token_compress_on);
+      // Look for mapping
+      for (const auto& singleMap : meminfoMap) {
+        if (line.find(singleMap.second) == 0) {
+          r[singleMap.first] = INTEGER(std::stol(tokens[1]) * 1024l);
+          break;
+        }
+      }
+    }
+  }
+  results.push_back(r);
+  return results;
+}
+}
+}

--- a/specs/linux/memory_info.table
+++ b/specs/linux/memory_info.table
@@ -1,0 +1,17 @@
+table_name("memory_info")
+
+description("Main memory information, in bytes")
+
+schema([
+    Column("memory_total", INTEGER, "Total amount of physical RAM, in bytes"),
+    Column("memory_free", INTEGER, "The amount of physical RAM, in bytes, left unused by the system"),
+    Column("buffers", INTEGER, "The amount of physical RAM, in bytes, used for file buffers"),
+    Column("cached", INTEGER, "The amount of physical RAM, in bytes, used as cache memory"),
+    Column("swap_cached", INTEGER, "The amount of swap, in bytes, used as cache memory"),
+    Column("active", INTEGER, "The total amount of buffer or page cache memory, in bytes, that is in active use"),
+    Column("inactive", INTEGER, "The total amount of buffer or page cache memory, in bytes, that are free and available"),
+    Column("swap_total", INTEGER, "The total amount of swap available, in bytes"),
+    Column("swap_free", INTEGER, "The total amount of swap free, in bytes"),
+])
+
+implementation("memory_info@getMemoryInfo")


### PR DESCRIPTION
Added a memory_info table for Linux machines based on [this issue](https://github.com/facebook/osquery/issues/2028).  The `/proc/meminfo` file is read and a single row containing memory information is stored in the table.

I kept the memory in units of kilobytes just like the `meminfo` file uses.
I was wondering if it's fine to keep the data type as INTEGER or if I should use BIGINT. It looks like the INTEGER type is 64 bits for sqlite so I don't think this is an issue.
