### PR TITLE
Adding detection query for Java_Adwind Trojan

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -266,6 +266,12 @@
       "interval": "86400",
       "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
       "value": "Artifact used by this malware"
+    },
+    "Java_Adwind_Trojan": {
+      "query": "select * from launchd where name like 'org.%.plist' and program_arguments like '/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java -Dapple.awt.UIElement=true -jar /Users/%/.%';",
+      "interval": "86400",
+      "description": "(https://blog.malwarebytes.com/threat-analysis/2016/07/cross-platform-malware-adwind-infects-mac/)",
+      "value": "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Malwarebytes recently did a writeup of a crossplatform Java based trojan: https://blog.malwarebytes.com/threat-analysis/2016/07/cross-platform-malware-adwind-infects-mac/

Unfortunately the trojan seems to use randomly generated strings for filenames and plist names so the detection rule is a bit long, but I've tested it on an actual infected VM and it works as advertised :)