### PR TITLE
Print UTC for blank timezones in utilities/time

### DIFF
--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -64,8 +64,16 @@ QueryData genTime(QueryContext& context) {
   r["minutes"] = INTEGER(now.tm_min);
   r["seconds"] = INTEGER(now.tm_sec);
   r["timezone"] = SQL_TEXT(timezone);
+  if (r["timezone"].empty()) {
+    r["timezone"] = "UTC";
+  }
+
   r["local_time"] = INTEGER(local_time);
   r["local_timezone"] = SQL_TEXT(local_timezone);
+  if (r["local_timezone"].empty()) {
+    r["local_timezone"] = "UTC";
+  }
+
   r["unix_time"] = INTEGER(osquery_time);
   r["timestamp"] = SQL_TEXT(osquery_timestamp);
   // Date time is provided in ISO 8601 format, then duplicated in iso_8601.


### PR DESCRIPTION
On the Windows 10 test build environment the time was set to UTC, which resulted in a blank timezone. This is fine, but it should mimic the results/style for POSIX. A simple hack is applied to check for blank timezones, where the assumption is no timezone = Z.