### PR TITLE
Use TLSTransport HTTP client in aws_util

### DIFF
--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
   uri.SetPath(Aws::Http::URI::URLEncodePath(uri.GetPath()));
   Aws::String url = uri.GetURIString();
 
-  http::client client;
+  http::client client = TLSTransport().getClient();
   http::client::request req(url);
 
   for (const auto& requestHeader : request.GetHeaders()) {

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -104,7 +104,6 @@ class TLSTransport : public Transport {
  public:
   TLSTransport();
 
- protected:
   boost::network::http::client getClient();
 
  private:


### PR DESCRIPTION
This allows aws_util to support the various flags and special configurations
that TLSTransport implements.