### PR TITLE
Build documentation for brew-based build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ else
 endif
 CMAKE := PATH="$(DEPS_DIR)/bin:$(PATH)" CXXFLAGS="-L$(DEPS_DIR)/lib" \
 		cmake ../../
+DOCS_CMAKE := PATH="$(DEPS_DIR)/bin:$(PATH)" CXXFLAGS="-L$(DEPS_DIR)/lib" \
+		cmake ../
 
 DEFINES := CTEST_OUTPUT_ON_FAILURE=1
 .PHONY: docs build
@@ -41,7 +43,7 @@ all: .setup
 		$(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)
 
 docs: .setup
-	@cd build && $(CMAKE) && \
+	@cd build && $(DOCS_CMAKE) && \
 		$(DEFINES) $(MAKE) docs --no-print-directory $(MAKEFLAGS)
 
 debug: .setup

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -48,7 +48,8 @@ const std::string kSQLGlobRecursive = kSQLGlobWildcard + kSQLGlobWildcard;
  * @param content a reference to a string which will be populated with the
  * contents of the path indicated by the path parameter.
  * @param dry_run do not actually read the file content.
- * @param preserve_time Attempt to preserve file mtime and atime
+ * @param preserve_time Attempt to preserve file mtime and atime.
+ * @param blocking Request a blocking read.
  *
  * @return an instance of Status, indicating success or failure.
  */
@@ -68,6 +69,7 @@ Status forensicReadFile(const boost::filesystem::path& path,
  * @brief Return the status of an attempted file read.
  *
  * @param path the path of the file that you would like to read.
+ * @param blocking Request a blocking read.
  *
  * @return success iff the file would have been read. On success the status
  * message is the complete/absolute path.
@@ -75,14 +77,13 @@ Status forensicReadFile(const boost::filesystem::path& path,
 Status readFile(const boost::filesystem::path& path, bool blocking = false);
 
 /// Internal representation for predicate-based chunk reading.
-Status readFile(
-    const boost::filesystem::path& path,
-    size_t size,
-    size_t block_size,
-    bool dry_run,
-    bool preserve_time,
-    std::function<void(std::string& buffer, size_t size)> predicate,
-    bool blocking = false);
+Status readFile(const boost::filesystem::path& path,
+                size_t size,
+                size_t block_size,
+                bool dry_run,
+                bool preserve_time,
+                std::function<void(std::string& buffer, size_t size)> predicate,
+                bool blocking = false);
 
 /**
  * @brief Write text to disk.

--- a/tools/provision/formula/libaudit.rb
+++ b/tools/provision/formula/libaudit.rb
@@ -3,6 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libaudit < AbstractOsqueryFormula
   desc "Linux auditing framework"
   url "https://github.com/Distrotech/libaudit/archive/audit-2.4.2.tar.gz"
+  sha256 "63020c88b0f37a93438894e67e63ccede23d658277ecc6afb9d40e4043147d3f"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"


### PR DESCRIPTION
1. Fix `make docs` regression from build system redesign.
2. Fix filesystem documentation.
3. Add documentation to the wiki about the build system redesign.