### PR TITLE
Bump LLVM to revision 1 and build with clang-rt

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -201,7 +201,7 @@ function platform_linux_main() {
   local_brew_tool cmake --without-docs
 
   # LLVM/Clang.
-  local_brew_tool llvm --with-clang --with-clang-extra --with-rtti
+  local_brew_tool llvm
   set_deps_compilers clang
 
   # Install custom formulas, build with LLVM/clang.

--- a/tools/provision/formula/llvm.rb
+++ b/tools/provision/formula/llvm.rb
@@ -22,6 +22,7 @@ end
 class Llvm < AbstractOsqueryFormula
   desc "Next-gen compiler infrastructure"
   homepage "http://llvm.org/"
+  revision 1
 
   stable do
     url "http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz"
@@ -61,7 +62,7 @@ class Llvm < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "09f9fc1aca8847513a25c92638ed7b6d8d36a19a79927e7b5fadd3d8a5b45ce7" => :x86_64_linux
+    sha256 "eea130400dafe6a31e09c9f6993e9efc775cfcb7d77b44ea94749d731edbe732" => :x86_64_linux
   end
 
   head do
@@ -108,15 +109,16 @@ class Llvm < AbstractOsqueryFormula
   keg_only :provided_by_osx
 
   option :universal
-  option "with-clang", "Build the Clang compiler and support libraries"
-  option "with-clang-extra-tools", "Build extra tools for Clang"
-  option "with-compiler-rt", "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
-  option "with-libcxx", "Build the libc++ standard library"
-  option "with-lld", "Build LLD linker"
+  option "without-clang", "Build the Clang compiler and support libraries"
+  option "without-clang-extra-tools", "Build extra tools for Clang"
+  option "without-compiler-rt", "Build Clang runtime support libraries for code sanitizers, builtins, and profiling"
+  option "without-rtti", "Build with C++ RTTI"
+  option "without-utils", "Install utility binaries"
+
   option "with-lldb", "Build LLDB debugger"
   option "with-python", "Build Python bindings against Homebrew Python"
-  option "with-rtti", "Build with C++ RTTI"
-  option "with-utils", "Install utility binaries"
+  option "with-libcxx", "Build the libc++ standard library"
+  option "with-lld", "Build LLD linker"
 
   deprecated_option "rtti" => "with-rtti"
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -113,50 +113,34 @@ function local_brew_postinstall() {
   fi
 }
 
-# local_brew_tool NAME
-#   This will build or install from a local formula.
-#   If the caller did not request a from-source build then osquery-hosted bottles are used.
-function local_brew_tool() {
-  TOOL=$1
+# local_brew_package TYPE NAME [ARGS, ...]
+#   1: tool/dependency
+#   2: formula name
+#   N: arguments to install
+function local_brew_package() {
+  TYPE="$1"
+  TOOL="$2"
+  shift
   shift
 
-  export HOMEBREW_OPTIMIZATION_LEVEL=-Os
-  log "brew (build) tool $TOOL"
-  ARGS="$@"
-  if [[ ! -z "$OSQUERY_BUILD_DEPS" ]]; then
-    ARGS="$ARGS -v --build-bottle --ignore-dependencies"
-    ARGS="$ARGS --env=inherit"
-    if [[ ! -z "$DEBUG" ]]; then
-      ARGS="$ARGS -d"
-    fi
-  else
-    ARGS="--ignore-dependencies --force-bottle"
-  fi
-
-  if [[ ! -z "$OSQUERY_BUILD_BOTTLES" ]]; then
-    $BREW bottle --skip-relocation "${FORMULA_TAP}/${TOOL}.rb"
-  else
-    $BREW install $ARGS "${FORMULA_DIR}/${TOOL}.rb"
-  fi
-}
-
-# local_brew NAME
-#   1: formula name
-function local_brew_dependency() {
-  TOOL="$1"
-  shift
-
-  FORMULA="${FORMULA_DIR}/$TOOL.rb"
+  FORMULA="${FORMULA_DIR}/${TOOL}.rb"
   INFO=`$BREW info --json=v1 "${FORMULA}"`
   INSTALLED=$(json_element "${INFO}" 'obj[0]["linked_keg"]')
   STABLE=$(json_element "${INFO}" 'obj[0]["versions"]["stable"]')
+  REVISION=$(json_element "${INFO}" 'obj[0]["revision"]')
+  if [[ ! "$REVISION" = "0" ]]; then
+    STABLE="${STABLE}_${REVISION}"
+  fi
 
   # Could improve this detection logic to remove from-bottle.
   FROM_BOTTLE=false
   ARGS="$@"
   if [[ ! -z "$OSQUERY_BUILD_DEPS" ]]; then
-    ARGS="$ARGS -v --build-bottle --cc=clang --ignore-dependencies"
+    ARGS="$ARGS -v --build-bottle --ignore-dependencies"
     ARGS="$ARGS --env=inherit"
+    if [[ "$TYPE" = "dependency" ]]; then
+      ARGS="$ARGS --cc=clang"
+    fi
     if [[ ! -z "$DEBUG" ]]; then
       ARGS="$ARGS -d"
     fi
@@ -177,6 +161,15 @@ function local_brew_dependency() {
   else
     log "brew local package $TOOL is already install: ${STABLE}"
   fi
+}
+
+function local_brew_tool() {
+  local_brew_package "tool" $@
+}
+
+function local_brew_dependency() {
+  # Essentially uses clang instead of GCC.
+  local_brew_package "dependency" $@
 }
 
 function package() {


### PR DESCRIPTION
This closes: #2308.

The sanitization frameworks are built and installed alongside LLVM and clang. The options osquery uses, and this new inclusion, are now opt-out within the LLVM formula.