### PR TITLE
Rename the function main_arch() to distro_main()

### DIFF
--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -7,7 +7,7 @@
 #  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
 
-function main_arch() {
+function distro_main() {
   do_sudo pacman -Syu
 
   package wget


### PR DESCRIPTION
As per you changes in tools/provision.sh line 83-85

```
if [[ -z "$SKIP_DISTRO_MAIN" ]]; then
      distro_main
fi
```

the name of function in tools/provision/arch.sh should be distro_main()