### PR TITLE
Fix dependency building for bottle cache misses

### DIFF
--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -4,6 +4,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
   url "https://github.com/aws/aws-sdk-cpp/archive/0.13.8.tar.gz"
+  sha256 "ea3e618980f41dedfc2a6b187846a2bd747d9b6d9b95f733e04bec76cbeb1a46"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -33,7 +34,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
       system "make", "install"
     end
 
-    lib.install Dir[lib/"mac/Release/*"].select { |f| File.file? f }
+    lib.install Dir[lib/"mac/Release/*"].select { |f| File.file? f } if OS.mac?
   end
 
   test do

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -134,18 +134,18 @@ function local_brew_package() {
 
   # Could improve this detection logic to remove from-bottle.
   FROM_BOTTLE=false
+
+  # Add build arguments depending on requested from-source or default build.
   ARGS="$@"
-  if [[ ! -z "$OSQUERY_BUILD_DEPS" ]]; then
-    ARGS="$ARGS -v --build-bottle --ignore-dependencies"
-    ARGS="$ARGS --env=inherit"
-    if [[ "$TYPE" = "dependency" ]]; then
-      ARGS="$ARGS --cc=clang"
-    fi
-    if [[ ! -z "$DEBUG" ]]; then
-      ARGS="$ARGS -d"
-    fi
-  else
-    ARGS="--ignore-dependencies --force-bottle"
+  ARGS="$ARGS --build-bottle --ignore-dependencies --env=inherit"
+  if [[ -z "$OSQUERY_BUILD_DEPS" ]]; then
+    ARGS="$ARGS --force-bottle"
+  fi
+  if [[ "$TYPE" = "dependency" ]]; then
+    ARGS="$ARGS --cc=clang"
+  fi
+  if [[ ! -z "$DEBUG" ]]; then
+    ARGS="$ARGS -vd"
   fi
 
   export HOMEBREW_OPTIMIZATION_LEVEL=-Os


### PR DESCRIPTION
When a `make deps` dependency encounters a cache miss, the from-source build is triggered. This must mimic the from-source CLI arguments to brew.

This commit also improves the `aws-sdk-cpp` formula.