### PR TITLE
Properly intialize BufferedLogForwarder for TLS output plugin

### DIFF
--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -65,9 +65,17 @@ Status TLSLoggerPlugin::setUp() {
     // Could not generate a node key, continue logging to stderr.
     return Status(1, "No node key, TLS logging disabled.");
   }
+
   // Start the log forwarding/flushing thread.
   forwarder_ = std::make_shared<TLSLogForwarder>(node_key);
+  Status s = forwarder_->setUp();
+  if (!s.ok()) {
+    LOG(ERROR) << "Error initializing TLS logger: " << s.getMessage();
+    return s;
+  }
+
   Dispatcher::addService(forwarder_);
+
   return Status(0);
 }
 


### PR DESCRIPTION
Missing initialization of the BufferedLogForwarder was causing an underflow in
the count of buffered logs, and error messages as described in #2324. This
commit brings the initialization of the forwarder for TLS in line with
aws_kinesis and aws_firehose, removing that error.

Fixes #2324.