### PR TITLE
Windows: Copy required DLLs into the build directory

### DIFF
--- a/docs/wiki/development/windows-provisioning.md
+++ b/docs/wiki/development/windows-provisioning.md
@@ -23,7 +23,7 @@ The PowerShell script `provision.ps1` is used to prepare a clean Windows 10 64 b
 ## Building `osqueryd.exe` and `osqueryi.exe`
  
  * **Automated Process**
-   * Run `tools\make-win64-binaries.bat` from the `osquery` root directory. This will create the CMake build files, execute `MSBuild` to compile the shell, and copy over the required DLLs.
+   * Run `tools\make-win64-binaries.bat` from the `osquery` root directory. This will create the CMake build files and execute `cmake --build` to compile the shell and copy all required DLLs into the shell's output directory.
  * **Manual Process**
    * Open the Visual Studio 2015 solution, `OSQUERY.sln`
    * Select **Release** or **RelWithDebInfo** as the build configuration.

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -260,6 +260,26 @@ if(NOT ${OSQUERY_BUILD_SDK_ONLY})
   SET_OSQUERY_COMPILE(daemon "${CXX_COMPILE_FLAGS}")
   set_target_properties(daemon PROPERTIES OUTPUT_NAME osqueryd)
 
+  # TODO: Remove this once we address #2198
+  if(WINDOWS)
+    # Copy dynamic libraries needed to run shell/daemon
+    # into their respective build directories
+    foreach(ITEM 
+        "${linenoise.lib_library}"
+        "${glog_library}"
+        "${eay32_library}"
+        "${boost_system-vc140-mt-1_59_library}"
+        "${boost_regex-vc140-mt-1_59_library}"
+        "${boost_filesystem-vc140-mt-1_59_library}")
+      string(REGEX REPLACE "\\.lib$" ".dll" ITEM_DLL "${ITEM}")
+      string(REGEX REPLACE "/local/lib/" "/local/bin/" ITEM_DLL "${ITEM_DLL}")
+      add_custom_command(TARGET shell POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${ITEM_DLL} $<TARGET_FILE_DIR:shell>)
+      add_custom_command(TARGET daemon POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${ITEM_DLL} $<TARGET_FILE_DIR:daemon>)
+    endforeach()
+  endif()
+
   # Include the public API includes if make devel.
   install(TARGETS libosquery ARCHIVE DESTINATION lib COMPONENT devel OPTIONAL)
   install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/osquery"

--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -2,9 +2,5 @@ mkdir .\build\windows10
 cd .\build\windows10
 cmake ..\.. -G "Visual Studio 14 2015 Win64"
 
-"C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" .\osquery\shell.vcxproj /t:Build /p:Configuration=Release
-
-copy "C:\ProgramData\chocolatey\lib\linenoise-ng\local\bin\linenoise.dll" .\osquery\Release\linenoise.dll
-copy "C:\ProgramData\chocolatey\lib\glog\local\bin\glog.dll" .\osquery\Release\glog.dll
-copy "C:\ProgramData\chocolatey\lib\openssl\local\bin\libeay32.dll" .\osquery\Release\libeay32.dll
+cmake --build . --target shell --config Release
 


### PR DESCRIPTION
* Copy DLLs into shell and daemon build directories
* Update batch files to use `cmake --build` instead of msbuild
* Remove copy files commands from batch file
* Update readme to reflect new changes

This closes #2296.