### PR TITLE
Add 'type' to logged_in_users

### DIFF
--- a/specs/posix/logged_in_users.table
+++ b/specs/posix/logged_in_users.table
@@ -1,6 +1,7 @@
 table_name("logged_in_users")
 description("Users with an active shell on the system.")
 schema([
+    Column("type", TEXT, "Login type"),
     Column("user", TEXT, "User login name"),
     Column("tty", TEXT, "Device name"),
     Column("host", TEXT, "Remote hostname"),


### PR DESCRIPTION
To differentiate between a user-temp log line and logged-in-user we add `type`. To find the users set:
```sql
WHERE type = 'user'
```