### PR TITLE
[Fix #2281] Avoid ctor ambiguity in table header

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -622,7 +622,7 @@ class TablePlugin : public Plugin {
   virtual TableColumns columns() const { return TableColumns(); }
 
   /// Define a map of target columns to optional aliases.
-  virtual ColumnAliasSet columnAliases() const { return {}; }
+  virtual ColumnAliasSet columnAliases() const { return ColumnAliasSet(); }
 
   /**
    * @brief Generate a complete table representation.


### PR DESCRIPTION
I am not sure if this fixes "all" of the OSX 10.9 build problems. But from a quick search for ctor ambiguity, this seemed like the only instance, aside from `std::vector<...>`.