### PR TITLE
[Fix #2112] Remove forced benchmark skip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,9 +142,6 @@ else()
   endif()
 endif()
 
-# BUILD BUG: See issue #2112
-set(ENV{SKIP_BENCHMARKS} TRUE)
-
 # make debug (environment variable from Makefile)
 if(DEFINED ENV{DEBUG})
   set(DEBUG TRUE)

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -339,7 +339,7 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   # osquery benchmarks.
   if(NOT DEFINED ENV{SKIP_BENCHMARKS} AND NOT ${OSQUERY_BUILD_SDK_ONLY})
     add_executable(osquery_benchmarks main/benchmarks.cpp ${OSQUERY_BENCHMARKS})
-    ADD_DEFAULT_LINKS(osquery_benchmarks FALSE)
+    ADD_DEFAULT_LINKS(osquery_benchmarks TRUE)
     target_link_libraries(osquery_benchmarks benchmark libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_benchmarks "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")
     set(BENCHMARK_TARGET "$<TARGET_FILE:osquery_benchmarks>")


### PR DESCRIPTION
Google benchmark 1.0.0 is included with the 1.8.0 build redesign.