### PR TITLE
[Fix #2274] Relax return code checks for osqueryd tests

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -437,9 +437,10 @@ def flaky(gen):
             worked = gen(this)
             return True
         except Exception as e:
-            exc_type, exc_obj, exc_tb = sys.exc_info()
-            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-            exceptions.append((e, fname, exc_tb.tb_lineno))
+            import traceback
+            exc_type, exc_obj, tb = sys.exc_info()
+            exceptions.append((e))
+            print (traceback.format_tb(tb)[1])
         return False
     def wrapper(this):
         for i in range(3):
@@ -447,12 +448,12 @@ def flaky(gen):
                 return True
         i = 1
         for exc in exceptions:
-            print("Test (attempt %d) %s::%s failed: %s (%s:%d)" % (
+            print("Test (attempt %d) %s::%s failed: %s" % (
                 i,
                 this.__class__.__name__,
-                gen.__name__,  str(exc[0]), exc[1], exc[2]))
+                gen.__name__,  str(exc[0])))
             i += 1
-        raise exceptions[0][0]
+        raise Exception(exceptions[0][0])
     return wrapper
 
 

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -90,13 +90,16 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         # An interrupt signal will cause the daemon to stop.
         daemon = self._run_daemon({
             "disable_watchdog": True,
+            "ephemeral": True,
+            "disable_database": True,
+            "disable_logging": True,
         })
         self.assertTrue(daemon.isAlive())
 
         # Send a SIGINT
         os.kill(daemon.pid, signal.SIGINT)
         self.assertTrue(daemon.isDead(daemon.pid, 10))
-        self.assertEqual(daemon.retcode, 128 + signal.SIGINT)
+        self.assertTrue(daemon.retcode in [128 + signal.SIGINT, -2])
 
     @test_base.flaky
     def test_6_logger_mode(self):


### PR DESCRIPTION
This also adds more debugging information to the test failure outputs. 