### PR TITLE
Improve dispatcher tests

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -80,6 +80,10 @@ class InterruptableRunnable {
   virtual void pauseMilli(std::chrono::milliseconds milli);
 
  private:
+  /// Testing only, the interruptible will bypass initial interruption check.
+  void mustRun() { bypass_check_ = true; }
+
+ private:
   /**
    * @brief Protect interruption checking and resource tear down.
    *
@@ -94,6 +98,19 @@ class InterruptableRunnable {
 
   /// Use an interruption point to exit a pause if the thread was interrupted.
   RunnerInterruptPoint point_;
+
+ private:
+  /// Testing only, track the interruptible check for interruption.
+  bool checked_{false};
+
+  /// Testing only, require that the interruptible bypass the first check.
+  std::atomic<bool> bypass_check_{false};
+
+ private:
+  FRIEND_TEST(DispatcherTests, test_run);
+  FRIEND_TEST(DispatcherTests, test_independent_run);
+  FRIEND_TEST(DispatcherTests, test_interruption);
+  FRIEND_TEST(BufferedLogForwarderTests, test_async);
 };
 
 class InternalRunnable : private boost::noncopyable,
@@ -182,6 +199,10 @@ class Dispatcher : private boost::noncopyable {
   static void removeService(const InternalRunnable* service);
 
  private:
+  /// For testing only, reset the stopping status for unittests.
+  void resetStopping() { stopping_ = false; }
+
+ private:
   /// The set of shared osquery service threads.
   std::vector<InternalThreadRef> service_threads_;
 
@@ -209,6 +230,7 @@ class Dispatcher : private boost::noncopyable {
 
  private:
   friend class InternalRunnable;
-  friend class ExtensionsTest;
+  friend class ExtensionsTests;
+  friend class DispatcherTests;
 };
 }

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -15,7 +15,7 @@
 namespace osquery {
 
 class DispatcherTests : public testing::Test {
-  void TearDown() override {}
+  void TearDown() override { Dispatcher::instance().resetStopping(); }
 };
 
 TEST_F(DispatcherTests, test_singleton) {
@@ -26,8 +26,108 @@ TEST_F(DispatcherTests, test_singleton) {
 
 class TestRunnable : public InternalRunnable {
  public:
-  int* i;
-  explicit TestRunnable(int* i) : i(i) {}
-  virtual void start() { ++*i; }
+  explicit TestRunnable() {}
+
+  virtual void start() override {
+    WriteLock lock(mutex_);
+    ++i;
+  }
+
+  void reset() {
+    WriteLock lock(mutex_);
+    i = 0;
+  }
+
+  size_t count() {
+    WriteLock lock(mutex_);
+    return i;
+  }
+
+ private:
+  static size_t i;
+
+ private:
+  Mutex mutex_;
 };
+
+size_t TestRunnable::i{0};
+
+TEST_F(DispatcherTests, test_service_count) {
+  auto runnable = std::make_shared<TestRunnable>();
+
+  auto service_count = Dispatcher::instance().serviceCount();
+  // The service exits after incrementing.
+  auto s = Dispatcher::addService(runnable);
+  EXPECT_TRUE(s);
+
+  // Wait for the service to stop.
+  Dispatcher::joinServices();
+
+  // Make sure the service is removed.
+  EXPECT_EQ(service_count, Dispatcher::instance().serviceCount());
+}
+
+TEST_F(DispatcherTests, test_run) {
+  auto runnable = std::make_shared<TestRunnable>();
+  runnable->mustRun();
+  runnable->reset();
+
+  // The service exits after incrementing.
+  Dispatcher::addService(runnable);
+  Dispatcher::joinServices();
+  EXPECT_EQ(1U, runnable->count());
+  EXPECT_TRUE(runnable->hasRun());
+
+  // This runnable cannot be executed again.
+  auto s = Dispatcher::addService(runnable);
+  EXPECT_FALSE(s);
+
+  Dispatcher::joinServices();
+  EXPECT_EQ(1U, runnable->count());
+}
+
+TEST_F(DispatcherTests, test_independent_run) {
+  // Nothing stops two instances of the same service from running.
+  auto r1 = std::make_shared<TestRunnable>();
+  auto r2 = std::make_shared<TestRunnable>();
+  r1->mustRun();
+  r2->mustRun();
+  r1->reset();
+
+  Dispatcher::addService(r1);
+  Dispatcher::addService(r2);
+  Dispatcher::joinServices();
+
+  EXPECT_EQ(2U, r1->count());
+}
+
+class BlockingTestRunnable : public InternalRunnable {
+ public:
+  explicit BlockingTestRunnable() {}
+
+  virtual void start() override {
+    // Wow that's a long sleep!
+    pauseMilli(100 * 1000);
+  }
+};
+
+TEST_F(DispatcherTests, test_interruption) {
+  auto r1 = std::make_shared<BlockingTestRunnable>();
+  r1->mustRun();
+  Dispatcher::addService(r1);
+
+  // This service would normally wait for 100 seconds.
+  r1->interrupt();
+
+  Dispatcher::joinServices();
+  EXPECT_TRUE(r1->hasRun());
+}
+
+TEST_F(DispatcherTests, test_stop_dispatcher) {
+  Dispatcher::stopServices();
+
+  auto r1 = std::make_shared<TestRunnable>();
+  auto s = Dispatcher::addService(r1);
+  EXPECT_FALSE(s);
+}
 }

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -57,12 +57,12 @@ void BufferedLogForwarder::check() {
   // For each index, accumulate the log line into the result or status set.
   std::vector<std::string> results, statuses;
   iterate(indexes, ([&results, &statuses, this](std::string& index) {
-            std::string value;
-            auto& target = isResultIndex(index) ? results : statuses;
-            if (getDatabaseValue(kLogs, index, value)) {
-              target.push_back(std::move(value));
-            }
-          }));
+    std::string value;
+    auto& target = isResultIndex(index) ? results : statuses;
+    if (getDatabaseValue(kLogs, index, value)) {
+      target.push_back(std::move(value));
+    }
+  }));
 
   // If any results/statuses were found in the flushed buffer, send.
   if (results.size() > 0) {
@@ -72,11 +72,11 @@ void BufferedLogForwarder::check() {
     } else {
       // Clear the results logs once they were sent.
       iterate(indexes, ([this](std::string& index) {
-                if (!isResultIndex(index)) {
-                  return;
-                }
-                deleteValueWithCount(kLogs, index);
-              }));
+        if (!isResultIndex(index)) {
+          return;
+        }
+        deleteValueWithCount(kLogs, index);
+      }));
     }
   }
 
@@ -87,11 +87,11 @@ void BufferedLogForwarder::check() {
     } else {
       // Clear the status logs once they were sent.
       iterate(indexes, ([this](std::string& index) {
-                if (!isStatusIndex(index)) {
-                  return;
-                }
-                deleteValueWithCount(kLogs, index);
-              }));
+        if (!isStatusIndex(index)) {
+          return;
+        }
+        deleteValueWithCount(kLogs, index);
+      }));
     }
   }
 
@@ -156,7 +156,6 @@ void BufferedLogForwarder::purge() {
       LOG(ERROR) << "Error deleting value during buffered log purge";
     }
   });
-
 }
 
 void BufferedLogForwarder::start() {

--- a/osquery/logger/plugins/buffered.h
+++ b/osquery/logger/plugins/buffered.h
@@ -146,6 +146,7 @@ class BufferedLogForwarder : public InternalRunnable {
  protected:
   /// Return whether the string is a result index
   bool isResultIndex(const std::string& index);
+
   /// Return whether the string is a status index
   bool isStatusIndex(const std::string& index);
 
@@ -156,11 +157,13 @@ class BufferedLogForwarder : public InternalRunnable {
  protected:
   /// Generate a result index string to use with the backing store
   std::string genResultIndex(size_t time = 0);
+
   /// Generate a status index string to use with the backing store
   std::string genStatusIndex(size_t time = 0);
 
  private:
   std::string genIndexPrefix(bool results);
+
   std::string genIndex(bool results, size_t time = 0);
 
   /**
@@ -170,6 +173,7 @@ class BufferedLogForwarder : public InternalRunnable {
   Status addValueWithCount(const std::string& domain,
                            const std::string& key,
                            const std::string& value);
+
   /**
    * @brief Delete a database value while maintaining count
    *


### PR DESCRIPTION
This improves dispatcher tests by allowing units to act like component tests and use embedded `std::thread`-based osquery APIs. A unit may force a 'service' to run by joining the `Dispatcher` before deconstructing.