### PR TITLE
Always update the local tap symlink for make deps

### DIFF
--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -33,13 +33,15 @@ function setup_brew() {
   if [[ ! -d "$DEPS/.git" ]]; then
     log "setting up new brew in $DEPS"
     git clone $BREW_REPO "$DEPS"
-    log "installing local tap: homebrew-osquery-local"
-    mkdir -p "$DEPS/Library/Taps/osquery/"
-    ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
   else
     log "checking for updates to brew"
     #git pull
   fi
+
+  # Always update the location of the local tap link.
+  log "refreshing local tap: homebrew-osquery-local"
+  mkdir -p "$DEPS/Library/Taps/osquery/"
+  ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
 
   export HOMEBREW_MAKE_JOBS=$THREADS
   export HOMEBREW_NO_EMOJI=1


### PR DESCRIPTION
There's weird behavior when maintaining multiple osquery checkouts and modifying the dependency formulas because the "local" tap is nothing but an installed symlink to the formulas within our `./tools` directory.