### PR TITLE
Update to AWS-SDK-CPP version 0.14.x

### DIFF
--- a/osquery/logger/plugins/aws_util.h
+++ b/osquery/logger/plugins/aws_util.h
@@ -28,6 +28,8 @@
 
 namespace osquery {
 
+using RegionName = const char* const;
+
 /**
  * @brief Client factory for the netlib HTTP client
  */
@@ -139,23 +141,23 @@ void initAwsSdk();
 /**
  * @brief Retrieve the Aws::Region from the aws_region flag
  *
- * @param region The Aws::Region to place the result in
+ * @param region The output string containing the region name.
  *
- * @return 0 if successful, 1 if the region was not recognized
+ * @return 0 if successful, 1 if the region was not recognized.
  */
-Status getAWSRegion(Aws::Region& region, bool sts = false);
+Status getAWSRegion(std::string& region, bool sts = false);
 
 /**
- * @brief Instantiate an AWS client with the appropriate osquery configs
+ * @brief Instantiate an AWS client with the appropriate osquery configs,
  *
  * This will pull the region and authentication configs from the appropriate
  * places (i.e. using getAWSRegion, OsqueryAWSCredentialsProviderChain),
  * instantiating whichever type of AWS client is passed as the template
  * parameter.
  *
- * @param client Pointer to the client object to instantiate
+ * @param client Pointer to the client object to instantiate.
  *
- * @return 0 if successful, 1 if there was a problem reading configs
+ * @return 0 if successful, 1 if there was a problem reading configs.
  */
 template <class Client>
 Status makeAWSClient(std::shared_ptr<Client>& client, bool sts = true) {

--- a/osquery/logger/plugins/tests/aws_util_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_util_tests.cpp
@@ -31,7 +31,9 @@ static const char* kAwsSecretKeyEnvVar = "AWS_SECRET_ACCESS_KEY";
 
 class AwsUtilTests : public testing::Test {
  public:
-  void SetUp() override { initAwsSdk(); }
+  void SetUp() override {
+    initAwsSdk();
+  }
 };
 
 TEST_F(AwsUtilTests, test_get_credentials) {
@@ -99,61 +101,61 @@ TEST_F(AwsUtilTests, test_get_credentials) {
 }
 
 TEST_F(AwsUtilTests, test_get_region) {
-  Aws::Region region;
+  std::string region;
 
-  // Test good region flag
+  // Test valid region flag.
   FLAGS_aws_region = "us-west-1";
   ASSERT_EQ(Status(0), getAWSRegion(region));
-  ASSERT_EQ(Aws::Region::US_WEST_1, region);
+  ASSERT_EQ(std::string(Aws::Region::US_WEST_1), region);
 
-  // Test bad region flag
+  // Test invalid region flag.
   FLAGS_aws_region = "foo";
   ASSERT_EQ(Status(1, "Invalid aws_region specified: foo"),
             getAWSRegion(region));
 
-  // Test good sts region flag
+  // Reset aws_region flag.
+  FLAGS_aws_region = "";
+
+  // Test valid STS region flag.
   FLAGS_aws_sts_region = "us-east-1";
   ASSERT_EQ(Status(0), getAWSRegion(region, true));
-  ASSERT_EQ(Aws::Region::US_EAST_1, region);
+  ASSERT_EQ(std::string(Aws::Region::US_EAST_1), region);
 
-  // Test bad sts region flag
+  // Test invalid STS region flag.
   FLAGS_aws_sts_region = "bar";
   ASSERT_EQ(Status(1, "Invalid aws_region specified: bar"),
             getAWSRegion(region, true));
 
-  FLAGS_aws_region = "";
+  // Reset STS and profile flags.
+  FLAGS_aws_sts_region = "";
+  FLAGS_aws_profile_name = "";
 
   // Test no credential file, should default to us-east-1
   std::string profile_path = kTestDataPath + "credentials";
   setenv(kAwsProfileFileEnvVar, profile_path.c_str(), true);
-  FLAGS_aws_profile_name = "";
-
   ASSERT_EQ(Status(0), getAWSRegion(region));
-  ASSERT_EQ(Aws::Region::US_EAST_1, region);
+  ASSERT_EQ(std::string(Aws::Region::US_EAST_1), region);
 
-  // Set a bad path for the credentials file, with profile name provided,
-  // should error
+  // Set an invalid path for the credentials file with a profile name provided,
   profile_path = kTestDataPath + "credentials";
   setenv(kAwsProfileFileEnvVar, profile_path.c_str(), true);
   FLAGS_aws_profile_name = "test";
-
   ASSERT_FALSE(getAWSRegion(region).ok());
 
-  // Set a good path for the credentials file, with profile name
+  // Set a valid path for the credentials file with profile name.
   profile_path = kTestDataPath + "aws/credentials";
   setenv(kAwsProfileFileEnvVar, profile_path.c_str(), true);
   FLAGS_aws_profile_name = "test";
-
   ASSERT_EQ(Status(0), getAWSRegion(region));
-  ASSERT_EQ(Aws::Region::EU_CENTRAL_1, region);
+  ASSERT_EQ(std::string(Aws::Region::EU_CENTRAL_1), region);
 
   FLAGS_aws_profile_name = "default";
   ASSERT_EQ(Status(0), getAWSRegion(region));
-  ASSERT_EQ(Aws::Region::US_WEST_2, region);
+  ASSERT_EQ(std::string(Aws::Region::US_WEST_2), region);
 
   // Should default to "default" and give same result as just above
   FLAGS_aws_profile_name = "";
   ASSERT_EQ(Status(0), getAWSRegion(region));
-  ASSERT_EQ(Aws::Region::US_WEST_2, region);
+  ASSERT_EQ(std::string(Aws::Region::US_WEST_2), region);
 }
 }

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -80,7 +80,7 @@ function main() {
   if [[ -f "$OS_SCRIPT" ]]; then
     log "found $OS provision script: $OS_SCRIPT"
     source "$OS_SCRIPT"
-    if [[ -z "$SKIP_DISTRO_MAIN" ]]; then
+    if [[ -z "$SKIP_DISTRO_MAIN" && "$1" = "build" ]]; then
       distro_main
     fi
   else
@@ -100,6 +100,14 @@ function main() {
   # This will install a local tap using a symbol to the formula subdir here.
   export PATH="$DEPS_DIR/bin:$PATH"
   setup_brew "$DEPS_DIR" "$BREW_TYPE"
+
+  if [[ "$1" = "bottle" ]]; then
+    brew_bottle "$2"
+    return
+  elif [[ "$1" = "install" ]]; then
+    local_brew_dependency "$2"
+    return
+  fi
 
   if [[ ! -z "$OSQUERY_BUILD_DEPS" ]]; then
     log "[notice]"

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -3,9 +3,8 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class AwsSdkCpp < AbstractOsqueryFormula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/0.13.8.tar.gz"
-  sha256 "ea3e618980f41dedfc2a6b187846a2bd747d9b6d9b95f733e04bec76cbeb1a46"
-  revision 1
+  url "https://github.com/aws/aws-sdk-cpp/archive/0.14.4.tar.gz"
+  #sha256 "ea3e618980f41dedfc2a6b187846a2bd747d9b6d9b95f733e04bec76cbeb1a46"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -41,7 +41,9 @@ function setup_brew() {
   # Always update the location of the local tap link.
   log "refreshing local tap: homebrew-osquery-local"
   mkdir -p "$DEPS/Library/Taps/osquery/"
-  ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
+  if [[ ! -e "$FORMULA_TAP" ]]; then
+    ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
+  fi
 
   export HOMEBREW_MAKE_JOBS=$THREADS
   export HOMEBREW_NO_EMOJI=1
@@ -168,6 +170,11 @@ function brew_tool() {
 
 function brew_link() {
   brew_internal "upstream-link" $@
+}
+
+function brew_bottle() {
+  TOOL=$1
+  $BREW bottle --skip-relocation "${FORMULA_TAP}/${TOOL}.rb"
 }
 
 function local_brew_postinstall() {


### PR DESCRIPTION
1. Remove `AWS::Region` enum for version 0.14.x
2. Fix re-install of deps symlink.
3. Add helper `bottle` and `install` macros to the provision script.