### PR TITLE
Introduce 'external' project builds: make externals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ doxygen/latex
 *~
 \#*\#
 *.swp
+
+# Ignored components
+/external/*
+!/external/CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,7 @@ add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/gmock-1.7.0")
 
 add_subdirectory(osquery)
 add_subdirectory(tools/tests)
+add_subdirectory(external)
 
 # Include the kernel building targets/macros
 if(NOT ${OSQUERY_BUILD_SDK_ONLY})

--- a/docs/wiki/development/osquery-sdk.md
+++ b/docs/wiki/development/osquery-sdk.md
@@ -110,6 +110,33 @@ osquery>
 
 If the responsible shell or daemon process ends the extension will soon after detect the loss of communication and also shutdown. Read more about the lifecycle of extensions in the deployment guide.
 
+### Building external extensions
+
+Your "external" extension, in the sense that the code is developed and contained somewhere external from the osquery repository, can be built semi-automatically.
+
+1. Symlink your external extension directory (modules work too) into `./external`.
+2. Make sure the symlink contains either `extension_` or `module_` as a prefix.
+3. Run `make externals`.
+
+This will find and compile all `.*\.{cpp,c,mm}` files within your external directory. If you need something more complicated add a `CMakeLists.txt` to your directory and add your targets to the `externals` target.
+
+See [`CMake/CMakeLibs.cmake`](https://github.com/facebook/osquery/blob/master/CMake/CMakeLibs.cmake) for more information about the `ADD_OSQUERY_EXTENSION` CMake macro.
+
+Example:
+```
+(osquery) $ ln -s ~/git/fun-osquery-extension ./external/extension_fun
+(osquery) $ ls ./external/extension_fun/
+fun.cpp
+(osquery) $ make externals
+[...]
+[100%] Built target libosquery
+Scanning dependencies of target external_extension_awesome
+[100%] Building CXX object external/CMakeFiles/external_extension_fun.dir/extension_fun/fun.cpp.o
+[100%] Linking CXX executable external_extension_fun.ext
+[100%] Built target external_extension_fun
+[100%] Built target externals
+```
+
 ## Thrift API
 
 [Thrift](https://thrift.apache.org/) is a code-generation/cross-language service development framework. osquery uses thrift to allow plugin extensions for config retrieval, log export, table implementations, event subscribers, and event publishers. We also use thrift to wrap our SQL implementation using SQLite.

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,54 @@
+# -*- mode: cmake; -*-
+# - osquery external project builds
+#
+# Symlink directories for extensions or modules here.
+# If a directory includes: "extension_NAME" it is built as an extension.
+# If a directory includes: "module_NAME" it is built as a module.
+
+add_custom_target(externals)
+
+macro(SUBDIRLIST OUTPUT PWD)
+  file(GLOB children RELATIVE ${PWD} "${PWD}/*")
+  set(DIRS "")
+  foreach(child ${children})
+    get_filename_component(full_child "${PWD}/${child}" REALPATH)
+    if(IS_DIRECTORY "${full_child}")
+      list(APPEND DIRS "${PWD}/${child}")
+    elseif(NOT "${child}" STREQUAL "CMakeLists.txt")
+      WARNING_LOG("External project: ${full_child} must be a directory")
+    endif()
+  endforeach()
+  set(${OUTPUT} ${DIRS})
+endmacro()
+
+# Discover each directory, which contains the implementation for an extension
+# or module, usually symlinked.
+SUBDIRLIST(EXTERNAL_PROJECTS "${CMAKE_SOURCE_DIR}/external")
+
+# Each project may:
+#   1. Be named "external_PROJECT_NAME", all .cpp, .c, .mm files will be compiled.
+#   2. Be named "module_PROJECT_NAME", the same applies.
+#   3. Contain a "CMakeLists.txt", the project will be added to CMake's evaluation.
+foreach(external_project ${EXTERNAL_PROJECTS})
+  if(EXISTS "${external_project}/CMakeLists.txt")
+    add_subdirectory("${external_project}")
+  else()
+    file(GLOB_RECURSE PROJECT_FILES "${external_project}/*")
+    set(PROJECT_SOURCES "")
+    foreach(source ${PROJECT_FILES})
+      if(${source} MATCHES "^.*(cpp|c|mm)$")
+        list(APPEND PROJECT_SOURCES ${source})
+      endif()
+    endforeach()
+    get_filename_component(PROJECT_NAME "${external_project}" NAME)
+    if("${PROJECT_NAME}" MATCHES "(^extension_.*)")
+      ADD_OSQUERY_EXTENSION(external_${PROJECT_NAME} ${PROJECT_SOURCES})
+      add_dependencies(externals external_${PROJECT_NAME})
+    elseif("${PROJECT_NAME}" MATCHES "(^module_.*)")
+      ADD_OSQUERY_MODULE(external_${PROJECT_NAME} ${PROJECT_SOURCES})
+      add_dependencies(externals external_${PROJECT_NAME})
+    else()
+      WARNING_LOG("External project: ${external_project} is incorrectly named")
+    endif()
+  endif()
+endforeach()


### PR DESCRIPTION
Folks maintaining osquery extensions have asked for a simpler way of building and testing. This allows external extensions/modules to use the same build system reducing potential for runtime-linking crashes and simplifying extension/module development.

Closes #2084 