### PR TITLE
Fix code auditing job and disable homebrew auto-update

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,6 +3,7 @@ Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: true
+# AlignConsecutiveAssignments: false
 AlignEscapedNewlinesLeft: false
 AlignOperands:   true
 AlignTrailingComments: false # differs
@@ -16,6 +17,7 @@ AlwaysBreakAfterDefinitionReturnType: false
 AlwaysBreakTemplateDeclarations: true
 AlwaysBreakBeforeMultilineStrings: true
 BreakBeforeBinaryOperators: false # differs
+BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BinPackParameters: false
@@ -48,18 +50,17 @@ Standard: Cpp11
 IndentWidth: 2
 TabWidth: 8
 UseTab: Never
-BreakBeforeBraces: Attach
+SpaceAfterControlStatementKeyword: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpacesInAngles:  false
-SpaceInEmptyParentheses: false
-SpacesInCStyleCastParentheses: false
-SpaceAfterCStyleCast: false
-SpacesInContainerLiterals: true
-SpaceBeforeAssignmentOperators: true
-SpaceAfterControlStatementKeyword: true
 ContinuationIndentWidth: 4
 CommentPragmas:  '^ IWYU pragma:'
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-SpaceBeforeParens: ControlStatements
 ...

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ docs: .setup
 		$(DEFINES) $(MAKE) docs --no-print-directory $(MAKEFLAGS)
 
 format_master:
+	@echo "[+] clang-format (`which clang-format`) version: `clang-format --version`"
 	@$(PATH_SET) $(FORMAT_COMMAND)
 
 debug: .setup
@@ -82,9 +83,10 @@ test_debug_sdk: .setup
 		$(DEFINES) $(MAKE) test --no-print-directory $(MAKEFLAGS)
 
 check:
+	@echo "[+] cppcheck (`which cppcheck`) version: `cppcheck --version`"
 	@$(PATH_SET) cppcheck --quiet --enable=all --error-exitcode=0 \
 		-I ./include ./osquery
-	# We want check to produce an error if there are critical issues.
+	@# We want check to produce an error if there are critical issues.
 	@echo ""
 	@$(PATH_SET) cppcheck --quiet --enable=warning --error-exitcode=1 \
 		-I ./include ./osquery

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -54,8 +54,8 @@ Status writeTextFile(const fs::path& path,
                      int permissions,
                      bool force_permissions) {
   // Open the file with the request permissions.
-  PlatformFile output_fd(path.string(), PF_CREATE_ALWAYS | PF_WRITE | PF_APPEND,
-                         permissions);
+  PlatformFile output_fd(
+      path.string(), PF_CREATE_ALWAYS | PF_WRITE | PF_APPEND, permissions);
   if (!output_fd.isValid()) {
     return Status(1, "Could not create file: " + path.string());
   }
@@ -104,14 +104,13 @@ struct OpenReadableFile {
 #endif
 };
 
-Status readFile(
-    const fs::path& path,
-    size_t size,
-    size_t block_size,
-    bool dry_run,
-    bool preserve_time,
-    std::function<void(std::string& buffer, size_t size)> predicate,
-    bool blocking) {
+Status readFile(const fs::path& path,
+                size_t size,
+                size_t block_size,
+                bool dry_run,
+                bool preserve_time,
+                std::function<void(std::string& buffer, size_t size)> predicate,
+                bool blocking) {
   OpenReadableFile handle(path, blocking);
   if (handle.fd == nullptr || !handle.fd->isValid()) {
     return Status(1, "Cannot open file for reading: " + path.string());
@@ -195,7 +194,9 @@ Status readFile(const fs::path& path, bool blocking) {
   return readFile(path, blank, 0, true, false, blocking);
 }
 
-Status forensicReadFile(const fs::path& path, std::string& content, bool blocking) {
+Status forensicReadFile(const fs::path& path,
+                        std::string& content,
+                        bool blocking) {
   return readFile(path, content, 0, false, true, blocking);
 }
 
@@ -269,7 +270,8 @@ static void genGlobs(std::string path,
   }
 
   // Prune results based on settings/requested glob limitations.
-  auto end = std::remove_if(results.begin(), results.end(),
+  auto end = std::remove_if(results.begin(),
+                            results.end(),
                             [limits](const std::string& found) {
                               return !(((found[found.length() - 1] == '/' ||
                                          found[found.length() - 1] == '\\') &&
@@ -350,15 +352,15 @@ inline Status listInAbsoluteDirectory(const fs::path& path,
 Status listFilesInDirectory(const fs::path& path,
                             std::vector<std::string>& results,
                             bool recursive) {
-  return listInAbsoluteDirectory((path / ((recursive) ? "**" : "*")), results,
-                                 GLOB_FILES);
+  return listInAbsoluteDirectory(
+      (path / ((recursive) ? "**" : "*")), results, GLOB_FILES);
 }
 
 Status listDirectoriesInDirectory(const fs::path& path,
                                   std::vector<std::string>& results,
                                   bool recursive) {
-  return listInAbsoluteDirectory((path / ((recursive) ? "**" : "*")), results,
-                                 GLOB_FOLDERS);
+  return listInAbsoluteDirectory(
+      (path / ((recursive) ? "**" : "*")), results, GLOB_FOLDERS);
 }
 
 Status isDirectory(const fs::path& path) {

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -38,6 +38,9 @@ function setup_brew() {
     #git pull
   fi
 
+  # Create a local cache directory
+  mkdir -p "$DEPS/.cache"
+
   # Always update the location of the local tap link.
   log "refreshing local tap: homebrew-osquery-local"
   mkdir -p "$DEPS/Library/Taps/osquery/"
@@ -45,6 +48,9 @@ function setup_brew() {
     ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
   fi
 
+  export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
+  export HOMEBREW_NO_AUTO_UPDATE=1
+  export HOMEBREW_CACHE="$DEPS/.cache/"
   export HOMEBREW_MAKE_JOBS=$THREADS
   export HOMEBREW_NO_EMOJI=1
   export BREW="$DEPS/bin/brew"


### PR DESCRIPTION
Hopefully, this allows clang 3.6-3.9 to use our input `.clang-format` configuration.

There is a minor artifact around testing the code audit, a OS X clang-format version 3.9 is run against `./osquery/filesystem/filesystem.cpp` to assure no seesawing for Ubuntu's version 3.6.

This also adds "now-required" Homebrew auto-update disabling configuration to the `make deps` provisioning. Auto updating our Taps introduces scenarios which are difficult to test.