### PR TITLE
Bump rocksdb to 4.9

### DIFF
--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -4,7 +4,7 @@ class Rocksdb < AbstractOsqueryFormula
   desc "Persistent key-value store for fast storage environments"
   homepage "http://rocksdb.org"
   url "https://github.com/facebook/rocksdb/archive/v4.9.tar.gz"
-  sha256 "b6cf3d99b552fb5daae4710952640810d3d810aa677821a9c7166a870669c572"
+  sha256 "7c96c7e7facc11c15f57c608a3b256af79283accb5988d7b2f4f810e29c68c0b"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -3,7 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Rocksdb < AbstractOsqueryFormula
   desc "Persistent key-value store for fast storage environments"
   homepage "http://rocksdb.org"
-  url "https://github.com/facebook/rocksdb/archive/v4.6.1.tar.gz"
+  url "https://github.com/facebook/rocksdb/archive/v4.9.tar.gz"
   sha256 "b6cf3d99b552fb5daae4710952640810d3d810aa677821a9c7166a870669c572"
 
   bottle do


### PR DESCRIPTION
There are some API changes in 4.8 & 4.9.
I'm not sure if we're using those APIs yet. Let's see if the tests pass first.