### PR TITLE
Load VS variables for amd64 native build prior to launching cmake

### DIFF
--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -1,3 +1,6 @@
+call "%VS140COMNTOOLS%vcvarsqueryregistry.bat" 64bit
+call "%VCINSTALLDIR%vcvarsall.bat" amd64
+
 mkdir .\build\windows10
 cd .\build\windows10
 cmake ..\.. -G "Visual Studio 14 2015 Win64"


### PR DESCRIPTION
This will load VS build variables for a native amd64 build prior to launching CMake. This should close #2354. 