### PR TITLE
Add OS X example config

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -280,7 +280,11 @@ if(NOT ${OSQUERY_BUILD_SDK_ONLY})
     DESTINATION bin COMPONENT main)
 
   # make install (config files)
-  install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf"
+  if(APPLE)
+    install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.osx.conf"
+  else()
+    install(FILES "${CMAKE_SOURCE_DIR}/tools/deployment/osquery.example.conf"
+  endif()
     DESTINATION "${CMAKE_INSTALL_PREFIX}/share/osquery/" COMPONENT main)
   install(DIRECTORY DESTINATION "${CMAKE_INSTALL_PREFIX}/var/osquery")
 

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -44,7 +44,7 @@ NEWSYSLOG_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.conf"
 NEWSYSLOG_DST="/private/var/osquery/$LD_IDENTIFIER.conf"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/private/var/osquery/packs/"
-OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
+OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.osx.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/private/var/osquery/osquery.example.conf"
 OSQUERY_CONFIG_SRC=""
 OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
@@ -109,8 +109,8 @@ function usage() {
     -a start the daemon when the package is installed
     -x force the daemon to start fresh, removing any results previously stored in the database
   This will generate an OSX package with:
-  (1) An example config /var/osquery/osquery.example.config
-  (2) An optional config /var/osquery/osquery.config if [-c] is used
+  (1) An example config /var/osquery/osquery.example.conf
+  (2) An optional config /var/osquery/osquery.conf if [-c] is used
   (3) A LaunchDaemon plist /var/osquery/com.facebook.osqueryd.plist
   (4) The osquery toolset /usr/local/bin/osquery*
 

--- a/tools/deployment/osquery.example.osx.conf
+++ b/tools/deployment/osquery.example.osx.conf
@@ -1,0 +1,92 @@
+{
+  // Configure the daemon below:
+  "options": {
+    // Select the osquery config plugin.
+    "config_plugin": "filesystem",
+
+    // Select the osquery logging plugin.
+    "logger_plugin": "filesystem",
+
+    // The log directory stores info, warning, and errors.
+    // If the daemon uses the 'filesystem' logging retriever then the log_dir
+    // will also contain the query results.
+    //"logger_path": "/var/log/osquery",
+
+    // Set 'disable_logging' to true to prevent writing any info, warning, error
+    // logs. If a logging plugin is selected it will still write query results.
+    //"disable_logging": "false",
+
+    // Query differential results are logged as change-events to assist log
+    // aggregation operations like searching and transactions.
+    // Set 'log_result_events' to log differentials as transactions.
+    //"log_result_events": "true",
+
+    // Splay the scheduled interval for queries.
+    // This is very helpful to prevent system performance impact when scheduling
+    // large numbers of queries that run a smaller or similar intervals.
+    //"schedule_splay_percent": "10",
+
+    // Write the pid of the osqueryd process to a pidfile/mutex.
+    //"pidfile": "/var/osquery/osquery.pidfile",
+
+    // Clear events from the osquery backing store after a number of seconds.
+    "events_expiry": "3600",
+
+    // A filesystem path for disk-based backing storage used for events and
+    // query results differentials. See also 'use_in_memory_database'.
+    //"database_path": "/var/osquery/osquery.db",
+
+    // Comma-delimited list of table names to be disabled.
+    // This allows osquery to be launched without certain tables.
+    //"disable_tables": "foo_bar,time",
+
+    // Enable debug or verbose debug output when logging.
+    "verbose": "false",
+
+    // The number of threads for concurrent query schedule execution.
+    "worker_threads": "2",
+
+    // Enable schedule profiling, this will fill in averages and totals for
+    // system/user CPU time and memory for every query in the schedule.
+    // Add a query: "select * from osquery_schedule" to record the performances.
+    "enable_monitor": "true"
+  },
+
+  // Define a schedule of queries:
+  "schedule": {
+    // This is a simple example query that outputs basic system information.
+    "system_info": {
+      // The exact query to run.
+      "query": "SELECT hostname, cpu_brand, physical_memory FROM system_info;",
+      // The interval in seconds to run this query, not an exact interval.
+      "interval": 3600
+    }
+  },
+
+  // Decorators are normal queries that append data to every query.
+  "decorators": {
+    "load": [
+      "SELECT uuid AS host_uuid FROM system_info;",
+      "SELECT user AS username FROM logged_in_users ORDER BY time DESC LIMIT 1;"
+    ]
+  },
+
+  // Add default osquery packs or install your own.
+  //
+  // There are several 'default' packs installed with 'make install' or via
+  // packages and/or Homebrew.
+  //
+  // Linux:        /usr/share/osquery/packs
+  // OS X:         /var/osquery/packs
+  // Homebrew:     /usr/local/share/osquery/packs
+  // make install: {PREFIX}/share/osquery/packs
+  //
+  "packs": {
+    // "osquery-monitoring": "/var/osquery/packs/osquery-monitoring.conf",
+    // "incident-response": "/var/osquery/packs/incident-response.conf",
+    // "it-compliance": "/var/osquery/packs/it-compliance.conf",
+    // "osx-attacks": "/var/osquery/packs/osx-attacks.conf",
+    // "vuln-management": "/var/osquery/packs/vuln-management.conf",
+    // "hardware-monitoring": "/var/osquery/packs/hardware-monitoring.conf"
+  }
+}

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -126,6 +126,20 @@ class OsqueryiTest(unittest.TestCase):
         print (proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)
 
+    def test_config_check_example_osx(self):
+        '''Test that the OS X example config passes'''
+        example_path = "deployment/osquery.example.osx.conf"
+        proc = test_base.TimeoutRunner([
+                self.binary,
+                "--config_check",
+                "--config_path=%s/../%s" % (test_base.SCRIPT_DIR, example_path)
+            ],
+            SHELL_TIMEOUT)
+        self.assertEqual(proc.stdout, "")
+        print (proc.stdout)
+        print (proc.stderr)
+        self.assertEqual(proc.proc.poll(), 0)
+
     def test_meta_commands(self):
         '''Test the supported meta shell/help/info commands'''
         commands = [


### PR DESCRIPTION
Adds osquery.example.osx.conf to account for variance in ‘packs’
directory location between OS X and other platforms
