### PR TITLE
Count subscriber events correctly in osquery_events

### DIFF
--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -128,7 +128,6 @@ void EventPublisherPlugin::fire(const EventContextRef& ec, EventTime time) {
   for (const auto& subscription : subscriptions_) {
     auto es = EventFactory::getEventSubscriber(subscription->subscriber_name);
     if (es != nullptr && es->state() == SUBSCRIBER_RUNNING) {
-      es->event_count_++;
       fireCallback(subscription, ec);
     }
   }
@@ -434,9 +433,13 @@ Status EventSubscriberPlugin::recordEvent(EventID& eid, EventTime time) {
   return Status(0, "OK");
 }
 
-size_t EventSubscriberPlugin::getEventsExpiry() { return FLAGS_events_expiry; }
+size_t EventSubscriberPlugin::getEventsExpiry() {
+  return FLAGS_events_expiry;
+}
 
-size_t EventSubscriberPlugin::getEventsMax() { return FLAGS_events_max; }
+size_t EventSubscriberPlugin::getEventsMax() {
+  return FLAGS_events_max;
+}
 
 EventID EventSubscriberPlugin::getEventID() {
   Status status;
@@ -534,6 +537,7 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
   status = setDatabaseValue(kEvents, event_key, data);
   // Record the event in the indexing bins, using the index time.
   recordEvent(eid, event_time);
+  event_count_++;
   return status;
 }
 

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -10,8 +10,9 @@
 
 #include <osquery/config.h>
 #include <osquery/core.h>
-#include <osquery/extensions.h>
 #include <osquery/events.h>
+#include <osquery/extensions.h>
+#include <osquery/filesystem.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/packs.h>
@@ -19,7 +20,6 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
-#include <osquery/filesystem.h>
 
 #include "osquery/core/process.h"
 
@@ -44,12 +44,12 @@ QueryData genOsqueryEvents(QueryContext& context) {
     if (pubref != nullptr) {
       r["subscriptions"] = INTEGER(pubref->numSubscriptions());
       r["events"] = INTEGER(pubref->numEvents());
-      r["restarts"] = INTEGER(pubref->restartCount());
+      r["refreshes"] = INTEGER(pubref->restartCount());
       r["active"] = (pubref->hasStarted() && !pubref->isEnding()) ? "1" : "0";
     } else {
       r["subscriptions"] = "0";
       r["events"] = "0";
-      r["restarts"] = "0";
+      r["refreshes"] = "0";
       r["active"] = "-1";
     }
     results.push_back(r);
@@ -61,7 +61,7 @@ QueryData genOsqueryEvents(QueryContext& context) {
     r["name"] = subscriber;
     r["type"] = "subscriber";
     // Subscribers will never 'restart'.
-    r["restarts"] = "0";
+    r["refreshes"] = "0";
 
     auto subref = EventFactory::getEventSubscriber(subscriber);
     if (subref != nullptr) {

--- a/specs/utility/osquery_events.table
+++ b/specs/utility/osquery_events.table
@@ -8,7 +8,7 @@ schema([
       "Number of subscriptions the publisher received or subscriber used"),
     Column("events", INTEGER,
       "Number of events emitted or received since osquery started"),
-    Column("restarts", INTEGER, "Publisher only: number of runloop restarts"),
+    Column("refreshes", INTEGER, "Publisher only: number of runloop restarts"),
     Column("active", INTEGER,
       "1 if the publisher or subscriber is active else 0"),
 ])


### PR DESCRIPTION
There are two significant changes here:
1. This moves the location of `event_count_++` from within the publisher's `::fire` call to the subscriber's `::add` call. All subscriptions will be fired, but a subscriber may not "add" an event every time. Now the `events` count in the `osquery_events` meta table better reflects a subscriber's state.
2. The `restarts` column was confusing, it really counts an opaque concept of "refreshing" the publisher's runloop. It's still not the best verb.