### PR TITLE
Use LOG(INFO) and set INFO as default logging mode

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -303,7 +303,8 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
       argc_, argv_, (tool == ToolType::SHELL));
 
   if (tool == ToolType::SHELL) {
-    if (Flag::isDefault("database_path")) {
+    if (Flag::isDefault("database_path") &&
+        Flag::isDefault("disable_database")) {
       // The shell should not use a database by default, but should use the DB
       // specified by database_path if it is set
       FLAGS_disable_database = true;

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -8,9 +8,9 @@
  *
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #ifndef WIN32
 #include <grp.h>
@@ -69,12 +69,12 @@ FLAG(string,
 FLAG(bool, utc, false, "Convert all UNIX times to UTC");
 
 #ifdef WIN32
-struct tm *gmtime_r(time_t *t, struct tm *result) {
+struct tm* gmtime_r(time_t* t, struct tm* result) {
   _gmtime64_s(result, t);
   return result;
 }
 
-struct tm *localtime_r(time_t *t, struct tm *result) {
+struct tm* localtime_r(time_t* t, struct tm* result) {
   _localtime64_s(result, t);
   return result;
 }
@@ -215,8 +215,8 @@ Status checkStalePid(const std::string& content) {
 
     return Status(1, "osqueryd (" + content + ") is already running");
   } else {
-    LOG(INFO) << "Found stale process for osqueryd (" << content
-              << ") removing pidfile";
+    VLOG(1) << "Found stale process for osqueryd (" << content
+            << ") removing pidfile";
   }
 
   return Status(0, "OK");
@@ -249,8 +249,10 @@ Status createPidFile() {
   }
 
   // If no pidfile exists or the existing pid was stale, write, log, and run.
-  auto pid = boost::lexical_cast<std::string>(PlatformProcess::getCurrentProcess()->pid());
-  LOG(INFO) << "Writing osqueryd pid (" << pid << ") to " << pidfile_path.string();
+  auto pid = boost::lexical_cast<std::string>(
+      PlatformProcess::getCurrentProcess()->pid());
+  VLOG(1) << "Writing osqueryd pid (" << pid << ") to "
+          << pidfile_path.string();
   auto status = writeTextFile(pidfile_path, pid, 0644);
   return status;
 }
@@ -259,11 +261,19 @@ Status createPidFile() {
 
 #if defined(__linux__)
 #include <sys/fsuid.h>
-static inline int _fs_set_group(gid_t gid) { return setfsgid(gid) * 0; }
-static inline int _fs_set_user(uid_t uid) { return setfsuid(uid) * 0; }
+static inline int _fs_set_group(gid_t gid) {
+  return setfsgid(gid) * 0;
+}
+static inline int _fs_set_user(uid_t uid) {
+  return setfsuid(uid) * 0;
+}
 #else
-static inline int _fs_set_group(gid_t gid) { return setegid(gid); }
-static inline int _fs_set_user(uid_t uid) { return seteuid(uid); }
+static inline int _fs_set_group(gid_t gid) {
+  return setegid(gid);
+}
+static inline int _fs_set_user(uid_t uid) {
+  return seteuid(uid);
+}
 #endif
 
 bool DropPrivileges::dropToParent(const fs::path& path) {

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -10,8 +10,9 @@
 
 #include <osquery/config.h>
 #include <osquery/core.h>
-#include <osquery/extensions.h>
 #include <osquery/events.h>
+#include <osquery/extensions.h>
+#include <osquery/filesystem.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/packs.h>
@@ -19,7 +20,6 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
-#include <osquery/filesystem.h>
 
 #include "osquery/core/process.h"
 
@@ -222,6 +222,8 @@ QueryData genOsqueryInfo(QueryContext& context) {
   r["start_time"] = INTEGER(Config::getInstance().getStartTime());
   if (Initializer::isWorker()) {
     r["watcher"] = INTEGER(PlatformProcess::getLauncherProcess()->pid());
+  } else {
+    r["watcher"] = "-1";
   }
 
   results.push_back(r);
@@ -248,8 +250,7 @@ QueryData genOsquerySchedule(QueryContext& context) {
 
         // Report optional performance information.
         Config::getInstance().getPerformanceStats(
-            name,
-            [&r](const QueryPerformance& perf) {
+            name, [&r](const QueryPerformance& perf) {
               r["executions"] = BIGINT(perf.executions);
               r["last_executed"] = BIGINT(perf.last_executed);
               r["output_size"] = BIGINT(perf.output_size);


### PR DESCRIPTION
This is fairly important, it changes the default mode for what status events are logged to `INFO`. It had been set to `WARNING` and `INFO` was relatively unused.

This also removes expected support for RocksDB 'in-memory' databases. If a shell-user requests a database via CLI flags it will now work.