### PR TITLE
Introduce table 'attributes'

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -169,7 +169,9 @@ struct DiffResults {
   }
 
   /// not equals operator
-  bool operator!=(const DiffResults& comp) const { return !(*this == comp); }
+  bool operator!=(const DiffResults& comp) const {
+    return !(*this == comp);
+  }
 };
 
 /**
@@ -272,7 +274,7 @@ struct QueryPerformance {
 };
 
 /**
- * @brief represents the relevant parameters of a scheduled query.
+ * @brief Represents the relevant parameters of a scheduled query.
  *
  * Within the context of osqueryd, a scheduled query may have many relevant
  * attributes. Those attributes are represented in this data structure.
@@ -298,7 +300,9 @@ struct ScheduledQuery {
   }
 
   /// not equals operator
-  bool operator!=(const ScheduledQuery& comp) const { return !(*this == comp); }
+  bool operator!=(const ScheduledQuery& comp) const {
+    return !(*this == comp);
+  }
 };
 
 /**
@@ -336,7 +340,9 @@ struct QueryLogItem {
   }
 
   /// not equals operator
-  bool operator!=(const QueryLogItem& comp) const { return !(*this == comp); }
+  bool operator!=(const QueryLogItem& comp) const {
+    return !(*this == comp);
+  }
 };
 
 /**
@@ -475,10 +481,14 @@ class DatabasePlugin : public Plugin {
   bool checkDB();
 
   /// Require all DBHandle accesses to open a read and write handle.
-  static void setRequireWrite(bool rw) { kDBHandleOptionRequireWrite = rw; }
+  static void setRequireWrite(bool rw) {
+    kDBHandleOptionRequireWrite = rw;
+  }
 
   /// Allow DBHandle creations.
-  static void setAllowOpen(bool ao) { kDBHandleOptionAllowOpen = ao; }
+  static void setAllowOpen(bool ao) {
+    kDBHandleOptionAllowOpen = ao;
+  }
 
  public:
   /// Control availability of the RocksDB handle (default false).

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -52,11 +52,12 @@ Status getQueryColumnsExternal(const std::string& q, TableColumns& columns);
 /// External (extensions) SQL implementation plugin provider for "sql" registry.
 class ExternalSQLPlugin : SQLPlugin {
  public:
-  Status query(const std::string& q, QueryData& results) const {
+  Status query(const std::string& q, QueryData& results) const override {
     return queryExternal(q, results);
   }
 
-  Status getQueryColumns(const std::string& q, TableColumns& columns) const {
+  Status getQueryColumns(const std::string& q,
+                         TableColumns& columns) const override {
     return getQueryColumnsExternal(q, columns);
   }
 };

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -23,7 +23,7 @@ namespace osquery {
 DECLARE_int32(value_max);
 
 /**
- * @brief The core interface to executing osquery SQL commands
+ * @brief The core interface to executing osquery SQL commands.
  *
  * @code{.cpp}
  *   auto sql = SQL("SELECT * FROM time");
@@ -43,37 +43,37 @@ DECLARE_int32(value_max);
 class SQL {
  public:
   /**
-   * @brief Instantiate an instance of the class with a query
+   * @brief Instantiate an instance of the class with a query.
    *
-   * @param q An osquery SQL query
+   * @param q An osquery SQL query.
    */
   explicit SQL(const std::string& q);
 
   /**
-   * @brief Accessor for the rows returned by the query
+   * @brief Accessor for the rows returned by the query.
    *
-   * @return A QueryData object of the query results
+   * @return A QueryData object of the query results.
    */
   const QueryData& rows() const;
 
   /**
-   * @brief Accessor to switch off of when checking the success of a query
+   * @brief Accessor to switch off of when checking the success of a query.
    *
-   * @return A bool indicating the success or failure of the operation
+   * @return A bool indicating the success or failure of the operation.
    */
   bool ok();
 
   /**
-   * @brief Get the status returned by the query
+   * @brief Get the status returned by the query.
    *
-   * @return The query status
+   * @return The query status.
    */
   const Status& getStatus() const;
 
   /**
-   * @brief Accessor for the message string indicating the status of the query
+   * @brief Accessor for the message string indicating the status of the query.
    *
-   * @return The message string indicating the status of the query
+   * @return The message string indicating the status of the query.
    */
   std::string getMessageString();
 
@@ -91,11 +91,11 @@ class SQL {
 
   /**
    * @brief Get all with constraint, 'SELECT * ... where', results given
-   * a virtual table name and single constraint
+   * a virtual table name and single constraint.
    *
    * @param table The name of the virtual table.
    * @param column Table column name to apply constraint.
-   * @param op The SQL comparitive operator.
+   * @param op The SQL comparative operator.
    * @param expr The constraint expression.
    * @return A QueryData object of the 'SELECT *...' query results.
    */
@@ -106,16 +106,16 @@ class SQL {
 
  protected:
   /**
-   * @brief Private default constructor
+   * @brief Private default constructor.
    *
-   * The osquery::SQL class should only ever be instantiated with a query
+   * The osquery::SQL class should only ever be instantiated with a query.
    */
-  SQL(){};
+  SQL() {}
 
-  /// the internal member which holds the results of the query
+  /// The internal member which holds the results of the query.
   QueryData results_;
 
-  /// the internal member which holds the status of the query
+  /// The internal member which holds the status of the query.
   Status status_;
 };
 
@@ -139,6 +139,7 @@ class SQLPlugin : public Plugin {
  public:
   /// Run a SQL query string against the SQL implementation.
   virtual Status query(const std::string& q, QueryData& results) const = 0;
+
   /// Use the SQL implementation to parse a query string and return details
   /// (name, type) about the columns.
   virtual Status getQueryColumns(const std::string& q,
@@ -154,6 +155,7 @@ class SQLPlugin : public Plugin {
   virtual Status attach(const std::string& name) {
     return Status(0, "Not used");
   }
+
   /// Tables may be detached by name.
   virtual void detach(const std::string& name) {}
 
@@ -162,7 +164,7 @@ class SQLPlugin : public Plugin {
 };
 
 /**
- * @brief Execute a query
+ * @brief Execute a query.
  *
  * This is a lower-level version of osquery::SQL. Prefer to use osquery::SQL.
  *
@@ -188,32 +190,19 @@ class SQLPlugin : public Plugin {
 Status query(const std::string& query, QueryData& results);
 
 /**
- * @brief Analyze a query, providing information about the result columns
+ * @brief Analyze a query, providing information about the result columns.
  *
  * This function asks SQLite to determine what the names and types are of the
  * result columns of the provided query. Only table columns (not expressions or
  * subqueries) can have their types determined. Types that are not determined
  * are indicated with the string "UNKNOWN".
  *
- * @param q the query to analyze
- * @param columns the vector to fill with column information
+ * @param q the query to analyze.
+ * @param columns the vector to fill with column information.
  *
- * @return status indicating success or failure of the operation
+ * @return status indicating success or failure of the operation.
  */
 Status getQueryColumns(const std::string& q, TableColumns& columns);
-
-/*
- * @brief A mocked subclass of SQL useful for testing
- */
-class MockSQL : public SQL {
- public:
-  explicit MockSQL() : MockSQL(QueryData{}) {}
-  explicit MockSQL(const QueryData& results) : MockSQL(results, Status()) {}
-  explicit MockSQL(const QueryData& results, const Status& status) {
-    results_ = results;
-    status_ = status;
-  }
-};
 
 CREATE_LAZY_REGISTRY(SQLPlugin, "sql");
 }

--- a/osquery/database/query.h
+++ b/osquery/database/query.h
@@ -23,25 +23,20 @@ namespace osquery {
 extern const std::string kQueryNameNotFoundError;
 
 /**
- * @brief A class that is used to interact with the historical on-disk storage
- * for a given query.
+ * @brief Interact with the historical on-disk storage for a given query.
  */
 class Query {
  public:
   /**
-   * @brief Constructor which sets up necessary parameters of a Query object
+   * @brief Constructor which sets up necessary parameters of a Query object.
    *
    * Given a query, this constructor calculates the value of columnFamily_,
    * which can be accessed via the getColumnFamilyName getter method.
    *
-   * @param q a SheduledQuery struct
+   * @param q a SheduledQuery struct.
    */
   explicit Query(const std::string& name, const ScheduledQuery& q)
       : query_(q), name_(name) {}
-
-  /////////////////////////////////////////////////////////////////////////////
-  // Data access methods
-  /////////////////////////////////////////////////////////////////////////////
 
  public:
   /**
@@ -50,47 +45,43 @@ class Query {
    * This method retrieves the data from RocksDB and returns the data in a
    * HistoricalQueryResults struct.
    *
-   * @param hQR the output HistoricalQueryResults struct
+   * @param hQR the output HistoricalQueryResults struct.
    *
-   * @return the success or failure of the operation
+   * @return the success or failure of the operation.
    */
   Status getPreviousQueryResults(QueryData& results);
 
  public:
   /**
-   * @brief Get the names of all historical queries that are stored in RocksDB
+   * @brief Get the names of all historical queries.
    *
    * If you'd like to perform some database maintenance, getStoredQueryNames()
    * allows you to get a vector of the names of all queries which are
    * currently stored in RocksDB
    *
-   * @return a vector containing the string names of all scheduled queries
-   * which currently exist in the database
+   * @return a vector containing the string names of all scheduled queries.
    */
   static std::vector<std::string> getStoredQueryNames();
 
  public:
   /**
-   * @brief Accessor method for checking if a given scheduled query exists in
-   * the database
+   * @brief Checking if a given scheduled query exists in the database.
    *
-   * @return does the scheduled query which is already exists in the database
+   * @return true if the scheduled query already exists in the database.
    */
   bool isQueryNameInDatabase();
 
  public:
   /**
-   * @brief Add a new set of results to the persistant storage
+   * @brief Add a new set of results to the persistent storage.
    *
    * Given the results of the execution of a scheduled query, add the results
-   * to the database using addNewResults
+   * to the database using addNewResults.
    *
-   * @param qd the QueryData object, which has the results of the query which
-   * you would like to store
-   * @param unix_time the time that the query was executed
+   * @param qd the QueryData object, which has the results of the query.
+   * @param unix_time the time that the query was executed.
    *
-   * @return an instance of osquery::Status indicating the success or failure
-   * of the operation
+   * @return the success or failure of the operation.
    */
   Status addNewResults(const QueryData& qd);
 
@@ -103,10 +94,10 @@ class Query {
    * to the database using addNewResults and get back a data structure
    * indicating what rows in the query's results have changed.
    *
-   * @param qd the QueryData object containing query results to store
-   * @param dr an output to a DiffResults object populated based on last run
+   * @param qd the QueryData object containing query results to store.
+   * @param dr an output to a DiffResults object populated based on last run.
    *
-   * @return the success or failure of the operation
+   * @return the success or failure of the operation.
    */
   Status addNewResults(const QueryData& qd, DiffResults& dr);
 
@@ -116,12 +107,12 @@ class Query {
    * the differential results, using a custom database handle.
    *
    * This method is the same as Query::addNewResults, but with the addition of a
-   * parameter which allows you to pass a custom RocksDB database handle
+   * parameter which allows you to pass a custom RocksDB database handle.
    *
-   * @param qd the QueryData object containing query results to store
-   * @param dr an output to a DiffResults object populated based on last run
+   * @param qd the QueryData object containing query results to store.
+   * @param dr an output to a DiffResults object populated based on last run.
    *
-   * @return the success or failure of the operation
+   * @return the success or failure of the operation.
    */
   Status addNewResults(const QueryData& qd,
                        DiffResults& dr,
@@ -129,19 +120,15 @@ class Query {
 
  public:
   /**
-   * @brief A getter for the most recent result set for a scheduled query
+   * @brief The most recent result set for a scheduled query.
    *
-   * @param qd the output QueryData object
+   * @param qd the output QueryData object.
    *
-   * @return the success or failure of the operation
+   * @return the success or failure of the operation.
    */
   Status getCurrentResults(QueryData& qd);
 
  private:
-  /////////////////////////////////////////////////////////////////////////////
-  // Private members
-  /////////////////////////////////////////////////////////////////////////////
-
   /// The scheduled query and internal
   ScheduledQuery query_;
 
@@ -149,10 +136,6 @@ class Query {
   std::string name_;
 
  private:
-  /////////////////////////////////////////////////////////////////////////////
-  // Unit tests which can access private members
-  /////////////////////////////////////////////////////////////////////////////
-
   FRIEND_TEST(QueryTests, test_private_members);
   FRIEND_TEST(QueryTests, test_add_and_get_current_results);
   FRIEND_TEST(QueryTests, test_is_query_name_in_database);

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -14,6 +14,8 @@
 
 #include <osquery/dispatcher.h>
 
+#include "osquery/sql/sqlite_util.h"
+
 namespace osquery {
 
 /// A Dispatcher service thread that watches an ExtensionManagerHandler.
@@ -39,6 +41,8 @@ class SchedulerRunner : public InternalRunnable {
   /// Maximum number of steps.
   unsigned long int timeout_;
 };
+
+SQLInternal monitor(const std::string& name, const ScheduledQuery& query);
 
 /// Start querying according to the config's schedule
 void startScheduler();

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -21,8 +21,6 @@ namespace osquery {
 
 DECLARE_bool(disable_logging);
 
-extern SQL monitor(const std::string& name, const ScheduledQuery& query);
-
 class SchedulerTests : public testing::Test {
   void SetUp() override {
     logging_ = FLAGS_disable_logging;
@@ -80,8 +78,8 @@ TEST_F(SchedulerTests, test_monitor) {
 TEST_F(SchedulerTests, test_config_results_purge) {
   // Set a query time for now (time is only important relative to a week ago).
   auto query_time = osquery::getUnixTime();
-  setDatabaseValue(kPersistentSettings, "timestamp.test_query",
-                   std::to_string(query_time));
+  setDatabaseValue(
+      kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
   // Store a meaningless saved query interval splay.
   setDatabaseValue(kPersistentSettings, "interval.test_query", "11");
   // Store meaningless query differential results.
@@ -113,8 +111,8 @@ TEST_F(SchedulerTests, test_config_results_purge) {
 
   // Update the timestamp to have run a week and a day ago.
   query_time -= (84600 * (7 + 1));
-  setDatabaseValue(kPersistentSettings, "timestamp.test_query",
-                   std::to_string(query_time));
+  setDatabaseValue(
+      kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
 
   // Trigger another purge.
   Config::getInstance().purge();

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -30,8 +30,9 @@ class ExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-        std::make_tuple("example_text", TEXT_TYPE, DEFAULT),
-        std::make_tuple("example_integer", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("example_text", TEXT_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple(
+            "example_integer", INTEGER_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -64,8 +65,8 @@ class ComplexExampleTable : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-        std::make_tuple("flag_test", TEXT_TYPE, DEFAULT),
-        std::make_tuple("database_test", TEXT_TYPE, DEFAULT),
+        std::make_tuple("flag_test", TEXT_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("database_test", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 

--- a/osquery/examples/example_module.cpp
+++ b/osquery/examples/example_module.cpp
@@ -16,8 +16,9 @@ class ExampleTable : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-      std::make_tuple("example_text", TEXT_TYPE, DEFAULT),
-      std::make_tuple("example_integer", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("example_text", TEXT_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple(
+            "example_integer", INTEGER_TYPE, ColumnOptions::DEFAULT),
     };
   }
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -476,8 +476,8 @@ Status getQueryColumnsExternal(const std::string& manager_path,
   // Translate response map: {string: string} to a vector: pair(name, type).
   for (const auto& column : response.response) {
     for (const auto& col : column) {
-      columns.push_back(
-          std::make_tuple(col.first, columnTypeName(col.second), DEFAULT));
+      columns.push_back(std::make_tuple(
+          col.first, columnTypeName(col.second), ColumnOptions::DEFAULT));
     }
   }
 
@@ -539,7 +539,8 @@ Status getExtensions(const std::string& manager_path,
 
   // Convert from Thrift-internal list type to RouteUUID/ExtenionInfo type.
   for (const auto& ext : ext_list) {
-    extensions[ext.first] = {ext.second.name, ext.second.version,
+    extensions[ext.first] = {ext.second.name,
+                             ext.second.version,
                              ext.second.min_sdk_version,
                              ext.second.sdk_version};
   }

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -23,8 +23,8 @@ class BenchmarkTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-      std::make_tuple("test_int", INTEGER_TYPE, DEFAULT),
-      std::make_tuple("test_text", TEXT_TYPE, DEFAULT),
+        std::make_tuple("test_int", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("test_text", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -103,8 +103,8 @@ class BenchmarkLongTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-      std::make_tuple("test_int", INTEGER_TYPE, DEFAULT),
-      std::make_tuple("test_text", TEXT_TYPE, DEFAULT),
+        std::make_tuple("test_int", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("test_text", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -139,8 +139,8 @@ class BenchmarkWideTablePlugin : public TablePlugin {
   TableColumns columns() const override {
     TableColumns cols;
     for (int i = 0; i < 20; i++) {
-      cols.push_back(
-        std::make_tuple("test_" + std::to_string(i), INTEGER_TYPE, DEFAULT));
+      cols.push_back(std::make_tuple(
+          "test_" + std::to_string(i), INTEGER_TYPE, ColumnOptions::DEFAULT));
     }
     return cols;
   }
@@ -179,8 +179,8 @@ static void SQL_select_metadata(benchmark::State& state) {
   auto dbc = SQLiteDBManager::get();
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select count(*) from sqlite_temp_master;", results,
-                  dbc->db());
+    queryInternal(
+        "select count(*) from sqlite_temp_master;", results, dbc->db());
   }
 }
 

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -12,9 +12,9 @@
 
 #include <osquery/core.h>
 #include <osquery/logger.h>
+#include <osquery/registry.h>
 #include <osquery/sql.h>
 #include <osquery/tables.h>
-#include <osquery/registry.h>
 
 namespace osquery {
 
@@ -115,9 +115,10 @@ Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
     auto status = this->getQueryColumns(request.at("query"), columns);
     // Convert columns to response
     for (const auto& column : columns) {
-      response.push_back({{"n", std::get<0>(column)},
-                          {"t", columnTypeName(std::get<1>(column))},
-                          {"o", INTEGER(std::get<2>(column))}});
+      response.push_back(
+          {{"n", std::get<0>(column)},
+           {"t", columnTypeName(std::get<1>(column))},
+           {"o", INTEGER(static_cast<size_t>(std::get<2>(column)))}});
     }
     return status;
   } else if (request.at("action") == "attach") {
@@ -142,8 +143,8 @@ Status getQueryColumns(const std::string& q, TableColumns& columns) {
 
   // Convert response to columns
   for (const auto& item : response) {
-    columns.push_back(
-        make_tuple(item.at("n"), columnTypeName(item.at("t")), DEFAULT));
+    columns.push_back(make_tuple(
+        item.at("n"), columnTypeName(item.at("t")), ColumnOptions::DEFAULT));
   }
   return status;
 }

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -32,8 +32,8 @@ class TestTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const {
     return {
-      std::make_tuple("test_int", INTEGER_TYPE, DEFAULT),
-      std::make_tuple("test_text", TEXT_TYPE, DEFAULT),
+        std::make_tuple("test_int", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("test_text", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -119,6 +119,16 @@ TEST_F(SQLiteUtilTests, test_affected_tables) {
   EXPECT_EQ(dbc->affected_tables_.size(), 0U);
 }
 
+TEST_F(SQLiteUtilTests, test_table_attributes_event_based) {
+  auto sql_internal = SQLInternal("select * from process_events");
+  EXPECT_TRUE(sql_internal.ok());
+  EXPECT_TRUE(sql_internal.eventBased());
+
+  sql_internal = SQLInternal("select * from time");
+  EXPECT_TRUE(sql_internal.ok());
+  EXPECT_FALSE(sql_internal.eventBased());
+}
+
 TEST_F(SQLiteUtilTests, test_get_query_columns) {
   auto dbc = getTestDBC();
   TableColumns results;
@@ -127,9 +137,11 @@ TEST_F(SQLiteUtilTests, test_get_query_columns) {
   auto status = getQueryColumnsInternal(query, results, dbc->db());
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(2U, results.size());
-  EXPECT_EQ(std::make_tuple(std::string("seconds"), INTEGER_TYPE, DEFAULT),
+  EXPECT_EQ(std::make_tuple(
+                std::string("seconds"), INTEGER_TYPE, ColumnOptions::DEFAULT),
             results[0]);
-  EXPECT_EQ(std::make_tuple(std::string("version"), TEXT_TYPE, DEFAULT),
+  EXPECT_EQ(std::make_tuple(
+                std::string("version"), TEXT_TYPE, ColumnOptions::DEFAULT),
             results[1]);
 
   query = "SELECT * FROM foo";

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -26,8 +26,8 @@ class sampleTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("foo", INTEGER_TYPE, DEFAULT),
-        std::make_tuple("bar", TEXT_TYPE, DEFAULT),
+        std::make_tuple("foo", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("bar", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 };
@@ -41,9 +41,10 @@ class optionsTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("id", INTEGER_TYPE, INDEX | REQUIRED),
-        std::make_tuple("username", TEXT_TYPE, OPTIMIZED),
-        std::make_tuple("name", TEXT_TYPE, DEFAULT),
+        std::make_tuple(
+            "id", INTEGER_TYPE, ColumnOptions::INDEX | ColumnOptions::REQUIRED),
+        std::make_tuple("username", TEXT_TYPE, ColumnOptions::OPTIMIZED),
+        std::make_tuple("name", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -53,15 +54,18 @@ class optionsTablePlugin : public TablePlugin {
 
 TEST_F(VirtualTableTests, test_tableplugin_options) {
   auto table = std::make_shared<optionsTablePlugin>();
-  EXPECT_EQ(INDEX | REQUIRED, std::get<2>(table->columns()[0]));
+  EXPECT_EQ(ColumnOptions::INDEX | ColumnOptions::REQUIRED,
+            std::get<2>(table->columns()[0]));
 
   PluginResponse response;
   PluginRequest request = {{"action", "columns"}};
   EXPECT_TRUE(table->call(request, response).ok());
-  EXPECT_EQ(INTEGER(INDEX | REQUIRED), response[0]["op"]);
+  auto index_required =
+      static_cast<size_t>(ColumnOptions::INDEX | ColumnOptions::REQUIRED);
+  EXPECT_EQ(INTEGER(index_required), response[0]["op"]);
 
   response = table->routeInfo();
-  EXPECT_EQ(INTEGER(INDEX | REQUIRED), response[0]["op"]);
+  EXPECT_EQ(INTEGER(index_required), response[0]["op"]);
 
   std::string expected_statement =
       "(`id` INTEGER PRIMARY KEY, `username` TEXT, `name` TEXT) WITHOUT ROWID";
@@ -72,8 +76,8 @@ class aliasesTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("username", TEXT_TYPE, DEFAULT),
-        std::make_tuple("name", TEXT_TYPE, DEFAULT),
+        std::make_tuple("username", TEXT_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("name", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -100,20 +104,22 @@ TEST_F(VirtualTableTests, test_tableplugin_aliases) {
   PluginRequest request = {{"action", "columns"}};
   EXPECT_TRUE(table->call(request, response).ok());
 
+  auto default_option = static_cast<size_t>(ColumnOptions::DEFAULT);
   PluginResponse expected_response = {
       {{"id", "column"},
        {"name", "username"},
        {"type", "TEXT"},
-       {"op", INTEGER(DEFAULT)}},
+       {"op", INTEGER(default_option)}},
       {{"id", "column"},
        {"name", "name"},
        {"type", "TEXT"},
-       {"op", INTEGER(DEFAULT)}},
+       {"op", INTEGER(default_option)}},
       {{"alias", "aliases1"}, {"id", "alias"}},
       {{"alias", "aliases2"}, {"id", "alias"}},
       {{"id", "columnAlias"}, {"name", "name1"}, {"target", "name"}},
       {{"id", "columnAlias"}, {"name", "name2"}, {"target", "name"}},
       {{"id", "columnAlias"}, {"name", "user_name"}, {"target", "username"}},
+      {{"attributes", "0"}, {"id", "attributes"}},
   };
   EXPECT_EQ(response, expected_response);
 
@@ -174,8 +180,8 @@ class pTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("x", INTEGER_TYPE, DEFAULT),
-        std::make_tuple("y", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("x", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("y", INTEGER_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -194,8 +200,8 @@ class kTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("x", INTEGER_TYPE, DEFAULT),
-        std::make_tuple("z", INTEGER_TYPE, DEFAULT),
+        std::make_tuple("x", INTEGER_TYPE, ColumnOptions::DEFAULT),
+        std::make_tuple("z", INTEGER_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -275,10 +281,14 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   }
 
   std::vector<QueryData> union_results = {
-      makeResult("x", {"1", "2"}),   makeResult("k.x", {"1", "2"}),
-      makeResult("k.x", {"1", "2"}), makeResult("k.x", {"1", "2"}),
-      makeResult("k.x", {"1", "2"}), makeResult("k.x", {"1", "2"}),
-      makeResult("k.x", {"1", "2"}), makeResult("p.x", {"1"}),
+      makeResult("x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("k.x", {"1", "2"}),
+      makeResult("p.x", {"1"}),
       makeResult("p.x", {"1"}),
   };
 
@@ -294,7 +304,7 @@ class jsonTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("data", TEXT_TYPE, DEFAULT),
+        std::make_tuple("data", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 
@@ -369,7 +379,7 @@ class cacheTablePlugin : public TablePlugin {
  private:
   TableColumns columns() const override {
     return {
-        std::make_tuple("data", TEXT_TYPE, DEFAULT),
+        std::make_tuple("data", TEXT_TYPE, ColumnOptions::DEFAULT),
     };
   }
 

--- a/specs/darwin/quicklock_cache.table
+++ b/specs/darwin/quicklock_cache.table
@@ -15,5 +15,5 @@ schema([
     Column("icon_mode", BIGINT, "Thumbnail icon mode"),
     Column("cache_path", TEXT, "Path to cache data"),
 ])
-attributes(cachable=True)
+attributes(cacheable=True)
 implementation("quicklook_cache@genQuicklookCache")

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -81,6 +81,14 @@ NON_CACHEABLE = [
     "OPTIMIZED",
 ]
 
+TABLE_ATTRIBUTES = {
+    "event_subscriber": "EVENT_BASED",
+    "user_data": "USER_BASED",
+    "cacheable": "CACHEABLE",
+    "utility": "UTILITY",
+    "kernel_required": "KERNEL_REQUIRED",
+}
+
 
 def to_camel_case(snake_case):
     """ convert a snake_case string to camelCase """
@@ -192,7 +200,7 @@ class TableState(Singleton):
             for option in column.options:
                 # Only allow explicitly-defined options.
                 if option in COLUMN_OPTIONS:
-                    column_options.append(COLUMN_OPTIONS[option])
+                    column_options.append("ColumnOptions::" + COLUMN_OPTIONS[option])
                     all_options.append(COLUMN_OPTIONS[option])
             column.options_set = " | ".join(column_options)
             if len(column.aliases) > 0:
@@ -240,6 +248,7 @@ class TableState(Singleton):
             aliases=self.aliases,
             has_options=self.has_options,
             has_column_aliases=self.has_column_aliases,
+            attribute_set=[TABLE_ATTRIBUTES[attr] for attr in self.attributes],
         )
 
         with open(path, "w+") as file_h:

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -37,7 +37,7 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 {% for column in schema %}\
       std::make_tuple("{{column.name}}", {{column.type.affinity}},\
 {% if column.options|length > 0 %} {{column.options_set}}\
-{% else %} DEFAULT\
+{% else %} ColumnOptions::DEFAULT\
 {% endif %}\
 ),
 {% endfor %}\
@@ -69,6 +69,14 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
     };
   }
 {% endif %}\
+
+  TableAttributes attributes() const override {
+    return \
+{% for attribute in attribute_set %}\
+      TableAttributes::{{attribute}} |\
+{% endfor %}\
+      TableAttributes::NONE;
+  }
 
   QueryData generate(QueryContext& request) override {
 {% if class_name != "" %}\

--- a/tools/codegen/templates/foreign.cpp.in
+++ b/tools/codegen/templates/foreign.cpp.in
@@ -28,7 +28,7 @@ auto {{table_name_cc}}Register = []() {
 {% for column in schema %}\
         std::make_tuple("{{column.name}}", {{column.type.affinity}},\
 {% if column.options|length > 0 %} {{column.options_set}}\
-{% else %} DEFAULT\
+{% else %} ColumnOptions::DEFAULT\
 {% endif %}\
 ),
 {% endfor %}\


### PR DESCRIPTION
Table attributes allow virtual tables to make decisions about how their data should be used. With attributes, the table may alert call-sites that the query logic does not make sense.

More importantly, some of the attributes may be made available to the higher-level call-sites external from the virtual table implementations. For this we amend `SQLInternal` to expose an `::eventBased` check. When used in the context of the scheduler, the results can skip the intermediate differential DB store and differential set difference operations. This should lead to enhanced performance and save some hosts from stopping their workers when the "re-insert" into RocksDB causes several compactions to occur.