### PR TITLE
deps: CMake 3.6.1

### DIFF
--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -282,7 +282,7 @@ class Gcc < AbstractOsqueryFormula
       #{glibc.installed? ? "-nostdlib -L#{libgcc}" : "+"} -L#{HOMEBREW_PREFIX}/lib
 
       *link:
-      + --dynamic-linker #{HOMEBREW_PREFIX}/legacy/lib/ld.so -rpath #{HOMEBREW_PREFIX}/lib
+      + --dynamic-linker #{HOMEBREW_PREFIX}/legacy/lib/ld-2.13.so -rpath #{HOMEBREW_PREFIX}/lib
 
     EOS
   end


### PR DESCRIPTION
CMake 3.6.0 no longer builds because the patch (https://gitlab.kitware.com/cmake/cmake/merge_requests/34.patch) was updated and the `sha256` no longer matches. This updates the deps to install 3.6.1, which does not need a patch.