### PR TITLE
Check for plist existance before attempting parsing

### DIFF
--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -19,8 +19,8 @@
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
-#include <osquery/tables.h>
 #include <osquery/sql.h>
+#include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 
@@ -208,7 +208,7 @@ Status genAppsFromLaunchServices(std::set<std::string>& apps) {
   }
 
   auto LSCopyAllApplicationURLs =
-      (OSStatus (*)(CFArrayRef*))CFBundleGetFunctionPointerForName(
+      (OSStatus(*)(CFArrayRef*))CFBundleGetFunctionPointerForName(
           ls_bundle, CFSTR("_LSCopyAllApplicationURLs"));
   // If the symbol did not exist we will not have a handle.
   if (LSCopyAllApplicationURLs == nullptr) {
@@ -221,7 +221,7 @@ Status genAppsFromLaunchServices(std::set<std::string>& apps) {
   }
 
   @autoreleasepool {
-    for (id app in(__bridge NSArray*)ls_apps) {
+    for (id app in (__bridge NSArray*)ls_apps) {
       if (app != nil && [app isKindOfClass:[NSURL class]]) {
         apps.insert(std::string([[app path] UTF8String]) +
                     "/Contents/Info.plist");
@@ -270,6 +270,10 @@ QueryData genApps(QueryContext& context) {
 
   // For each found application (path with an Info.plist) parse the plist.
   for (const auto& path : apps) {
+    if (!osquery::pathExists(path)) {
+      continue;
+    }
+
     if (!osquery::parsePlist(path, tree).ok()) {
       TLOG << "Error parsing application plist: " << path;
       continue;
@@ -314,9 +318,9 @@ QueryData genAppSchemes(QueryContext& context) {
     CFURLRef default_app = nullptr;
     if (ls_bundle != nullptr) {
       auto _LSCopyDefaultApplicationURLForURL =
-          (CFURLRef (*)(CFURLRef, LSRolesMask, CFErrorRef*))
-          CFBundleGetFunctionPointerForName(
-              ls_bundle, CFSTR("LSCopyDefaultApplicationURLForURL"));
+          (CFURLRef(*)(CFURLRef, LSRolesMask, CFErrorRef*))
+              CFBundleGetFunctionPointerForName(
+                  ls_bundle, CFSTR("LSCopyDefaultApplicationURLForURL"));
       // If the symbol did not exist we will not have a handle.
       if (_LSCopyDefaultApplicationURLForURL != nullptr) {
         default_app =

--- a/osquery/tables/system/darwin/launchd.cpp
+++ b/osquery/tables/system/darwin/launchd.cpp
@@ -121,6 +121,10 @@ QueryData genLaunchd(QueryContext& context) {
       continue;
     }
 
+    if (!osquery::pathExists(path)) {
+      continue;
+    }
+
     if (!osquery::parsePlist(path, tree).ok()) {
       TLOG << "Error parsing launch daemon/agent plist: " << path;
       continue;


### PR DESCRIPTION
When parsing plists for `launchd`, `apps` and other OS X tables, the existence of a `*.app` does not mean an "application" still exists. The current `osquery::readPlist` and other methods will return nasty messages event if the `Info.plist` does not exists or happens to be a broken symlink. In these cases no row is returned.

This PR cleans up the potential verbose messages by not emitting false-positive plist-parsing errors.