### PR TITLE
Buffer the distributed queries to RocksDB for greater reliability

### DIFF
--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -270,7 +270,6 @@ class Distributed {
   Status flushCompleted();
 
  protected:
-  std::vector<DistributedQueryRequest> queries_;
   std::vector<DistributedQueryResult> results_;
 
  private:

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -194,7 +194,8 @@ DistributedQueryRequest Distributed::popRequest() {
   std::vector<std::string> distributed_queries;
   scanDatabaseKeys(kQueries, distributed_queries, kDistributedQueryPrefix);
   DistributedQueryRequest request;
-  request.id = distributed_queries.front().substr(kDistributedQueryPrefix.size());
+  request.id =
+    distributed_queries.front().substr(kDistributedQueryPrefix.size());
   getDatabaseValue(kQueries, distributed_queries.front(), request.query);
   deleteDatabaseValue(kQueries, distributed_queries.front());
   return request;

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -78,7 +78,6 @@ Status Distributed::pullUpdates() {
 }
 
 size_t Distributed::getPendingQueryCount() {
-  WriteLock lock(distributed_queries_mutex_);
   std::vector<std::string> distributed_queries;
   scanDatabaseKeys(kQueries, distributed_queries, dist_query_prefix);
   return distributed_queries.size();
@@ -181,7 +180,6 @@ Status Distributed::acceptWork(const std::string& work) {
         return Status(1,
                       "Distributed query does not have complete attributes.");
       }
-      WriteLock wlock(distributed_queries_mutex_);
       setDatabaseValue(kQueries,
         dist_query_prefix + node.first,
         queries.get<std::string>(node.first, ""));

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -195,7 +195,7 @@ DistributedQueryRequest Distributed::popRequest() {
   scanDatabaseKeys(kQueries, distributed_queries, kDistributedQueryPrefix);
   DistributedQueryRequest request;
   request.id =
-    distributed_queries.front().substr(kDistributedQueryPrefix.size());
+      distributed_queries.front().substr(kDistributedQueryPrefix.size());
   getDatabaseValue(kQueries, distributed_queries.front(), request.query);
   deleteDatabaseValue(kQueries, distributed_queries.front());
   return request;

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -176,13 +176,11 @@ Status Distributed::acceptWork(const std::string& work) {
     auto& queries = tree.get_child("queries");
     for (const auto& node : queries) {
       auto query = queries.get<std::string>(node.first, "");
-      if (query.empty() ||
-          node.first.empty()) {
+      if (query.empty() || node.first.empty()) {
         return Status(1,
                       "Distributed query does not have complete attributes.");
       }
-      setDatabaseValue(kQueries,
-        kDistributedQueryPrefix + node.first, query);
+      setDatabaseValue(kQueries, kDistributedQueryPrefix + node.first, query);
     }
   } catch (const pt::ptree_error& e) {
     return Status(1, "Error parsing JSON: " + std::string(e.what()));


### PR DESCRIPTION
We would like the queries buffered to RocksDB because if the system is killed before they've run but after they've been received, currently they will just be lost.