### PR TITLE
Fix minor sandboxes performance issues and plist parsing exceptions

### DIFF
--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -193,8 +193,13 @@ Status parsePlist(const fs::path& path, pt::ptree& tree) {
       [stream close];
       return Status(1, error_message);
     }
-    // Parse the plist data into a core foundation dictionary-literal.
-    status = filterPlist(plist_data, tree);
+
+    @try {
+      // Parse the plist data into a core foundation dictionary-literal.
+      status = filterPlist(plist_data, tree);
+    } @catch (NSException* exception) {
+      status = Status(1, "Plist data is corrupted");
+    }
     [stream close];
   }
   return status;

--- a/osquery/tables/system/darwin/sandboxes.cpp
+++ b/osquery/tables/system/darwin/sandboxes.cpp
@@ -11,9 +11,9 @@
 #include <boost/filesystem.hpp>
 
 #include <osquery/core.h>
-#include <osquery/tables.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
+#include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 
@@ -44,21 +44,21 @@ void genSandboxContainer(const fs::path& container, QueryData& results) {
     return;
   }
 
-  auto info = tree.get_child("SandboxProfileDataValidationInfo");
+  auto& info = tree.get_child("SandboxProfileDataValidationInfo");
   if (info.count("SandboxProfileDataValidationParametersKey") == 0) {
     return;
   }
 
   Row r;
-  info = info.get_child("SandboxProfileDataValidationParametersKey");
-  r["label"] = info.get("application_container_id", "");
-  r["user"] = info.get("_USER", "");
+  auto& key_info = info.get_child("SandboxProfileDataValidationParametersKey");
+  r["label"] = key_info.get("application_container_id", "");
+  r["user"] = key_info.get("_USER", "");
   r["enabled"] = INTEGER(tree.get(
       "SandboxProfileDataValidationEntitlementsKey.com.apple.security.app-"
       "sandbox",
       0));
-  r["build_id"] = info.get("sandbox_build_id", "");
-  r["bundle_path"] = info.get("application_bundle", "");
+  r["build_id"] = key_info.get("sandbox_build_id", "");
+  r["bundle_path"] = key_info.get("application_bundle", "");
   r["path"] = container.string();
   results.push_back(r);
 }


### PR DESCRIPTION
It's possible to create ill-formatted plist content that crashes osquery worker processes. This can lead to "blinding" of table content if a table never finishes executing because of an unhandled exception.