### PR TITLE
Add librpm build and RPM tables

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -54,17 +54,12 @@ else()
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_LINUX_TABLES_TESTS})
 
   if(REDHAT_BASED)
-    # TODO #2169: Linking librpm and librpmio prevents osquery from keeping
-    # a 2.13 glibc ABI. Statically linking the libraries introduces too many
-    # implicit dependencies.
-
     # CentOS specific tables
     # file(GLOB OSQUERY_REDHAT_TABLES "*/centos/*.cpp")
     # ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_redhat
     #   ${OSQUERY_REDHAT_TABLES}
     # )
 
-    # ADD_OSQUERY_LINK_ADDITIONAL("librpm librpmio")
   elseif(DEBIAN_BASED)
     # Ubuntu specific tables
     # file(GLOB OSQUERY_UBUNTU_TABLES "*/ubuntu/*.cpp")
@@ -83,6 +78,7 @@ else()
   ADD_OSQUERY_LINK_ADDITIONAL("tsk")
 
   ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg lzma lz4 bz2")
+  ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio beecrypt popt db")
 endif()
 
 if(APPLE OR LINUX)

--- a/specs/blacklist
+++ b/specs/blacklist
@@ -28,9 +28,5 @@ freebsd:yara
 freebsd:system_controls
 freebsd:smbios_tables
 
-# Blacklisted while RPM libraries are ported:
-rpm_package_files
-rpm_packages
-
 # Blacklisting as an example:
 example

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -158,10 +158,11 @@ function platform_linux_main() {
   brew_tool mpfr
   brew_tool libmpc
   brew_tool isl
-  brew_tool berkeley-db
 
   # GCC 5x.
   local_brew_tool gcc --with-glibc-legacy --without-fortran
+  # Remove gcc-postinstall when GCC is next updated.
+  local_brew_postinstall gcc
   set_deps_compilers gcc
 
   # GCC-compiled (C) dependencies.
@@ -191,11 +192,7 @@ function platform_linux_main() {
   brew_tool m4
   brew_tool bison
 
-  # Need libgpg-error for final build.
-  local_brew_tool libgpg-error
-
   # More LLVM dependencies.
-  brew_tool popt
   brew_tool autoconf
   brew_tool automake
 
@@ -204,6 +201,12 @@ function platform_linux_main() {
   local_brew_tool python
   local_brew_postinstall python
   local_brew_tool cmake --without-docs
+
+  # Linux library secondary dependencies.
+  local_brew_tool libgpg-error
+  local_brew_tool berkeley-db
+  local_brew_tool popt
+  local_brew_tool beecrypt
 
   # LLVM/Clang.
   local_brew_tool llvm
@@ -230,24 +233,15 @@ function platform_linux_main() {
   local_brew_dependency glog
 
   # Linux specific custom formulas.
-  local_brew_dependency libdevmapper -vd
+  local_brew_dependency libdevmapper
   local_brew_dependency libaptpkg
   local_brew_dependency libiptables
   local_brew_dependency libgcrypt
-  local_brew_dependency libcryptsetup -vd
+  local_brew_dependency libcryptsetup
   local_brew_dependency libudev
   local_brew_dependency libaudit
   local_brew_dependency libdpkg
-
-  ## The following section is a work in progress for librpm.
-  # This will need NSS and NSPR
-  # brew_tool nspr
-  # local_brew_link nspr
-  # brew_tool nss
-  # Maybe autopoint for autogen.sh?
-  # brew_tool gettext
-  # brew_tool libarchive
-  # local_brew_dependency librpm
+  local_brew_dependency librpm
 
   # Restore the compilers to GCC for the remainder of provisioning.
   set_deps_compilers gcc

--- a/tools/provision/amazon.sh
+++ b/tools/provision/amazon.sh
@@ -20,6 +20,7 @@ function distro_main() {
   package gcc
   package gcc-c++
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -20,6 +20,7 @@ function distro_main() {
   package gcc
   package gcc-c++
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -19,6 +19,7 @@ function distro_main() {
   package ruby-irb
   package gcc
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -130,6 +130,7 @@ class AbstractOsqueryFormula < Formula
     append "CXXFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
 
     self.audit
+    reset "DEBUG"
   end
 
   def audit

--- a/tools/provision/formula/beecrypt.rb
+++ b/tools/provision/formula/beecrypt.rb
@@ -1,0 +1,55 @@
+require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
+
+class Beecrypt < AbstractOsqueryFormula
+  desc "C/C++ cryptography library"
+  homepage "http://beecrypt.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
+  sha256 "286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
+
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "1b902db64ebf9a1941f1a016233c80915b936d5ea0850e41f9d116ebc7c48a0c" => :x86_64_linux
+  end
+
+  depends_on "libtool" => :build
+
+  # Allow us to set architecture and environment flags.
+  patch :DATA
+
+  def install
+    args = [
+      "--disable-dependency-tracking",
+      "--disable-openmp",
+      "--without-java",
+      "--without-python",
+      "--without-cplusplus",
+      "--with-arch=x86_64",
+    ]
+
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+end
+__END__
+diff --git a/configure.ac b/configure.ac
+index 2eec209..1db6184 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -13,12 +13,7 @@ AC_PROG_AWK
+ AC_ARG_ENABLE(expert-mode, [  --enable-expert-mode      follow user-defined CFLAGS settings [[default=no]]],[
+   ac_enable_expert_mode=yes
+   ],[
+-  if test "X$CFLAGS" != "X"; then
+-    echo "enabling expert mode"
+-    ac_enable_expert_mode=yes
+-  else
+-    ac_enable_expert_mode=no
+-  fi
++  ac_enable_expert_mode=no
+   ])
+
+ AC_ARG_ENABLE(debug, [  --enable-debug          creates debugging code [[default=no]]],[

--- a/tools/provision/formula/berkeley-db.rb
+++ b/tools/provision/formula/berkeley-db.rb
@@ -1,0 +1,46 @@
+require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
+
+class BerkeleyDb < AbstractOsqueryFormula
+  desc "High performance key/value database"
+  homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
+  url "http://download.oracle.com/berkeley-db/db-6.1.26.tar.gz"
+  sha256 "dd1417af5443f326ee3998e40986c3c60e2a7cfb5bfa25177ef7cadb2afb13a6"
+  revision 1
+
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "1b902db64ebf9a1941f1a016233c80915b936d5ea0850e41f9d116ebc7c48a0c" => :x86_64_linux
+  end
+
+  option "with-java", "Compile with Java support."
+  option "with-sql", "Compile with SQL support."
+
+  deprecated_option "enable-sql" => "with-sql"
+
+  def install
+    # BerkeleyDB dislikes parallel builds
+    ENV.deparallelize
+    # --enable-compat185 is necessary because our build shadows
+    # the system berkeley db 1.x
+    args = %W[
+      --disable-debug
+      --prefix=#{prefix}
+      --mandir=#{man}
+      --enable-cxx
+      --enable-compat185
+    ]
+    args << "--enable-java" if build.with? "java"
+    args << "--enable-sql" if build.with? "sql"
+
+    # BerkeleyDB requires you to build everything from the build_unix subdirectory
+    cd "build_unix" do
+      system "../dist/configure", *args
+      system "make", "install"
+
+      # use the standard docs location
+      doc.parent.mkpath
+      mv prefix/"docs", doc
+    end
+  end
+end

--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -3,41 +3,41 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Librpm < AbstractOsqueryFormula
   desc "The RPM Package Manager (RPM) development libraries"
   homepage "http://rpm.org/"
-  url "http://rpm.org/releases/testing/rpm-4.13.0-rc1.tar.bz2"
+  sha256 "8d65bc5df3056392d7fdfbe00e8f84eb0e828582aa96ef4d6b6afac35a07e8b3"
+  url "https://github.com/rpm-software-management/rpm/archive/rpm-4.13.0-rc1.tar.gz"
   version "4.13.0-rc1"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
-    prefix "/usr/local/osquery"
-    cellar "/usr/local/osquery/Cellar"
+    cellar :any_skip_relocation
     sha256 "038a8f25463cfd002d734dd2ddcfbc564373f35237fcc499f98638d9f3f75345" => :x86_64_linux
   end
 
+  depends_on "berkeley-db"
+  depends_on "beecrypt"
+  depends_on "popt"
+
   def install
-    ENV.append_to_cflags "-I#{Formula["nss"].include}"
-    ENV.append_to_cflags "-I#{Formula["nspr"].include}"
+    ENV.append "CFLAGS", "-I#{HOMEBREW_PREFIX}/include/beecrypt"
 
     args = [
-      "--disable-plugins",
-      "--disable-nls",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
-      "--without-nss",
-      "--without-archive",
-      "--disable-python",
-      "--disable-ndb",
-      "--disable-nss",
-      "--disable-shared",
-      "--without-beecrypt",
-      "--without-external-db",
+      "--with-external-db",
+      "--without-selinux",
       "--without-lua",
       "--without-cap",
-      "--without-selinux",
-      "--without-libintl-prefix",
-      "--without-libiconv-prefix",
-      ""
+      "--without-archive",
+      "--disable-nls",
+      "--disable-rpath",
+      "--disable-plugins",
+      "--disable-shared",
+      "--disable-python",
+      "--enable-static",
+      "--with-beecrypt",
     ]
 
+    system "./autogen.sh", "--noconfigure"
     system "./configure", "--prefix=#{prefix}", *args
     system "make"
     system "make", "install"

--- a/tools/provision/formula/popt.rb
+++ b/tools/provision/formula/popt.rb
@@ -1,0 +1,24 @@
+require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
+
+class Popt < AbstractOsqueryFormula
+  desc "Library like getopt(3) with a number of enhancements"
+  homepage "http://rpm5.org"
+  url "http://rpm5.org/files/popt/popt-1.16.tar.gz"
+  sha256 "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
+  revision 1
+
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "038a8f25463cfd002d734dd2ddcfbc564373f35237fcc499f98638d9f3f75345" => :x86_64_linux
+  end
+
+  option :universal
+
+  def install
+    ENV.universal_binary if build.universal?
+    system "./configure", "--disable-debug", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -19,6 +19,7 @@ function distro_main() {
   package ruby-irb
   package gcc
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -20,6 +20,7 @@ function distro_main() {
   package gcc
   package gcc-c++
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -19,6 +19,7 @@ function distro_main() {
   package ruby-irb
   package gcc
   package bzip2
+  package gettext-devel
 
   package rpm-devel
   package rpm-build


### PR DESCRIPTION
This restores the RPM tables to the Linux build.

1. Add `popt`, `berkeley-db`, `beecrypt`, and `librpm` to the Linux dependency list.
2. Link the resultant dependencies into `libosquery_additional`.
3. Remove the blacklist for `rpm_packages` and `rpm_package_files`.
4. Add the RPM table implementation to all Linux builds, ungated from CentOS/RHEL-based systems.
5. Add a new class to help discovery the RPM database. Like everything else librpm-based, this may be changed with environment variables.

For this build extension, `popt` and `libdb` were already part of the build, now they are tightly controlled and linked. Beecrypt is added as a possible RPM digest implementation over the default NSPR/NSS. It may be possible to replace this with the already-included gcrypt in the future.