### PR TITLE
[windows] fix deallocation mismatches

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -260,10 +260,10 @@ void queryKey(const std::string& hive,
     }
     results.push_back(r);
     if (regLinkStr != nullptr) {
-      delete[] (regLinkStr);
+      delete[](regLinkStr);
     }
   }
-  delete[] (bpDataBuff);
+  delete[](bpDataBuff);
   RegCloseKey(hRegistryHandle);
 };
 

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -260,10 +260,10 @@ void queryKey(const std::string& hive,
     }
     results.push_back(r);
     if (regLinkStr != nullptr) {
-      delete (regLinkStr);
+      delete[] (regLinkStr);
     }
   }
-  delete (bpDataBuff);
+  delete[] (bpDataBuff);
   RegCloseKey(hRegistryHandle);
 };
 


### PR DESCRIPTION
When we allocate an array using the new …[…] syntax, we should deallocate it using delete[]. In these cases, we needed to change delete to delete[]. If we use the wrong form of delete to match our allocation with new, we have undefined behavior.