### PR TITLE
Refactor legacy runtime

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -112,11 +112,13 @@ function main() {
   fi
 
   log "running unified platform initialization"
+  brew_clear_cache
   if [[ "$BREW_TYPE" = "darwin" ]]; then
     platform_darwin_main
   else
     platform_linux_main
   fi
+  brew_clear_cache
 
   cd "$SCRIPT_DIR/../"
 
@@ -148,10 +150,9 @@ function platform_linux_main() {
 
   # Build a bottle for a legacy glibc.
   local_brew_tool glibc-legacy
+  local_brew_unlink glibc-legacy
+  local_brew_link glibc-legacy
   local_brew_postinstall glibc-legacy
-
-  # Need LZMA for final builds.
-  local_brew_tool xz
 
   # Additional GCC 5x bootstrapping.
   brew_tool gmp
@@ -160,10 +161,14 @@ function platform_linux_main() {
   brew_tool isl
 
   # GCC 5x.
-  local_brew_tool gcc --with-glibc-legacy --without-fortran
+  local_brew_tool gcc
   # Remove gcc-postinstall when GCC is next updated.
   local_brew_postinstall gcc
   set_deps_compilers gcc
+
+  # Need LZMA for final builds.
+  local_brew_tool zlib-legacy
+  local_brew_tool xz
 
   # GCC-compiled (C) dependencies.
   brew_tool pkg-config
@@ -203,7 +208,6 @@ function platform_linux_main() {
   local_brew_tool cmake --without-docs
 
   # Linux library secondary dependencies.
-  local_brew_tool libgpg-error
   local_brew_tool berkeley-db
   local_brew_tool popt
   local_brew_tool beecrypt
@@ -233,6 +237,7 @@ function platform_linux_main() {
   local_brew_dependency glog
 
   # Linux specific custom formulas.
+  local_brew_dependency libgpg-error
   local_brew_dependency libdevmapper
   local_brew_dependency libaptpkg
   local_brew_dependency libiptables

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -58,7 +58,6 @@ class AbstractOsqueryFormula < Formula
     ENV[name] = ENV.has_key?(name) ? value.to_s + ':' + ENV[name] : value.to_s
   end
 
-
   def self.method_added(name)
     return unless /install/.match(name.to_s)
     return if /inject/.match(name.to_s)

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -7,7 +7,17 @@ module SkipRelocation
   end
 end
 
+def legacy_prefix
+  Pathname.new(ENV["HOMEBREW_PREFIX"])/"legacy"
+end
+
+def default_prefix
+  Pathname.new(ENV["HOMEBREW_PREFIX"])
+end
+
 class AbstractOsqueryFormula < Formula
+  protected
+
   def initialize(*)
     super
 
@@ -21,6 +31,15 @@ class AbstractOsqueryFormula < Formula
     @setup = ENV.has_key?('ABSTRACT_OSQUERY_FORMULA')
     ENV['ABSTRACT_OSQUERY_FORMULA'] = '1'
     return @setup
+  end
+
+  class << self
+    def set_legacy
+      Object.const_set(
+        "HOMEBREW_PREFIX",
+        legacy_prefix
+      )
+    end
   end
 
   def reset(name)
@@ -39,6 +58,7 @@ class AbstractOsqueryFormula < Formula
     ENV[name] = ENV.has_key?(name) ? value.to_s + ':' + ENV[name] : value.to_s
   end
 
+
   def self.method_added(name)
     return unless /install/.match(name.to_s)
     return if /inject/.match(name.to_s)
@@ -52,18 +72,10 @@ class AbstractOsqueryFormula < Formula
     self.class_eval(inject_hook)
   end
 
-  def legacy
-    return Formula["glibc-legacy"]
-  end
-
-  def modern
-    return Formula["glibc"]
-  end
-
   def setup_inject
     return if setup
 
-    puts "Hello from setup osquery: #{name}"
+    puts "Hello from osquery setup: #{name}"
 
     # Reset compile flags for safety, we want to control them explicitly.
     reset "CFLAGS"
@@ -84,45 +96,46 @@ class AbstractOsqueryFormula < Formula
       prepend_path "LD_LIBRARY_PATH", prefix
 
       # Set the dynamic linker and library search path.
-      prepend "CFLAGS", "-isystem#{HOMEBREW_PREFIX}/include"
+      prepend "CFLAGS", "-isystem#{default_prefix}/include"
 
       # clang wants -L in the CFLAGS.
       # Several projects do not want this: pcre, RocksDB
       # These used to belong to !gcc but -lz wants the system libz.
-      prepend "CFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
-      prepend "CFLAGS", "-L#{legacy.lib}"
+      prepend "CFLAGS", "-L#{default_prefix}/lib"
+      prepend "CFLAGS", "-L#{legacy_prefix}/lib"
 
       # cmake wants this to have -I
-      prepend "CXXFLAGS", "-I#{HOMEBREW_PREFIX}/include"
-      prepend "CXXFLAGS", "-I#{legacy.include}"
+      prepend "CXXFLAGS", "-I#{default_prefix}/include"
+      prepend "CXXFLAGS", "-I#{legacy_prefix}/include"
 
       # This used to be in the GCC/not-GCC logic, pulling out to compile GCC
       # Using the system compilers with legacy runtime.
-      prepend "CFLAGS", "-isystem#{legacy.include}"
-      prepend "CXXFLAGS", "-isystem#{legacy.include}"
+      prepend "CFLAGS", "-isystem#{legacy_prefix}/include"
+      prepend "CXXFLAGS", "-isystem#{legacy_prefix}/include"
 
-      append "LDFLAGS", "-Wl,--dynamic-linker=#{legacy.lib}/ld-linux-x86-64.so.2"
-      append "LDFLAGS", "-Wl,-rpath,#{legacy.lib}"
+      append "LDFLAGS", "-Wl,--dynamic-linker=#{legacy_prefix}/lib/ld-linux-x86-64.so.2"
+      append "LDFLAGS", "-Wl,-rpath,#{legacy_prefix}/lib"
 
       # Add a runtime search path for the legacy C implementation.
-      append "LDFLAGS", "-Wl,-rpath,#{HOMEBREW_PREFIX}/lib"
-      # Adding this one line to help gcc too.
-      append "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
-      # We want the legacy path to be the last thing prepended.
-      prepend "LDFLAGS", "-L#{legacy.lib}"
+      append "LDFLAGS", "-Wl,-rpath,#{default_prefix}/lib"
 
-      prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"
-      prepend_path "LIBRARY_PATH", legacy.lib
+      # Adding this one line to help gcc too.
+      append "LDFLAGS", "-L#{default_prefix}/lib"
+      # We want the legacy path to be the last thing prepended.
+      prepend "LDFLAGS", "-L#{legacy_prefix}/lib"
+
+      prepend_path "LIBRARY_PATH", default_prefix/"lib"
+      prepend_path "LIBRARY_PATH", legacy_prefix/"lib"
 
       # This is already set to the PREFIX
-      prepend_path "LD_RUN_PATH", HOMEBREW_PREFIX/"lib"
+      prepend_path "LD_RUN_PATH", default_prefix/"lib"
 
       # Set the search path for header files.
-      prepend_path "CPATH", HOMEBREW_PREFIX/"include"
+      prepend_path "CPATH", default_prefix/"include"
     end
 
     if !OS.linux?
-      prepend_path "PATH", HOMEBREW_PREFIX/"bin"
+      prepend_path "PATH", default_prefix/"bin"
     end
 
     # Everyone receives:

--- a/tools/provision/formula/glibc-legacy.rb
+++ b/tools/provision/formula/glibc-legacy.rb
@@ -3,7 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class GlibcLegacy < AbstractOsqueryFormula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/download.html"
-  url "http://ftpmirror.gnu.org/glibc/glibc-2.13.tar.bz2"
+  url "https://ftp.heanet.ie/mirrors/gnu/glibc/glibc-2.13.tar.bz2"
   sha256 "0173c92a0545e6d99a46a4fbed2da00ba26556f5c6198e2f9f1631ed5318dbb2"
 
   bottle do
@@ -23,8 +23,7 @@ class GlibcLegacy < AbstractOsqueryFormula
   # Linux kernel headers 2.6.19 or later are required
   depends_on "linux-headers" => [:build, :recommended]
 
-  # osquery: Keep these side-by-side libraries in a Cellar.
-  keg_only "osquery runtime"
+  set_legacy
 
   def install
     ENV["CFLAGS"] = "-U_FORTIFY_SOURCE -fno-stack-protector -O2"
@@ -62,9 +61,6 @@ class GlibcLegacy < AbstractOsqueryFormula
   def post_install
     # Fix permissions
     chmod 0755, [lib/"ld-#{version}.so", lib/"libc-#{version}.so"]
-
-    # Install ld.so symlink.
-    ln_sf prefix, HOMEBREW_PREFIX/"legacy"
   end
 
   test do

--- a/tools/provision/formula/glibc.rb
+++ b/tools/provision/formula/glibc.rb
@@ -3,7 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Glibc < AbstractOsqueryFormula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/download.html"
-  url "http://ftpmirror.gnu.org/glibc/glibc-2.19.tar.bz2"
+  url "https://ftp.heanet.ie/mirrors/gnu/glibc/glibc-2.19.tar.bz2"
   sha256 "2e293f714187044633264cd9ce0183c70c3aa960a2f77812a6390a3822694d15"
 
   bottle do

--- a/tools/provision/formula/libgpg-error.rb
+++ b/tools/provision/formula/libgpg-error.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class LibgpgError < AbstractOsqueryFormula
   desc "Common error values for all GnuPG components"
   homepage "https://www.gnupg.org/related_software/libgpg-error/"
-  url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.22.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.22.tar.bz2"
-  sha256 "f2a04ee6317bdb41a625bea23fdc7f0b5a63fb677f02447c647ed61fb9e69d7b"
+  url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
+  sha256 "9268e1cc487de5e6e4460fca612a06e4f383072ac43ae90603e5e46783d3e540"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/xz.rb
+++ b/tools/provision/formula/xz.rb
@@ -8,6 +8,7 @@ class Xz < AbstractOsqueryFormula
   url "https://fossies.org/linux/misc/xz-5.2.2.tar.gz"
   mirror "http://tukaani.org/xz/xz-5.2.2.tar.gz"
   sha256 "73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/zlib-legacy.rb
+++ b/tools/provision/formula/zlib-legacy.rb
@@ -1,0 +1,56 @@
+require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
+
+class ZlibLegacy < AbstractOsqueryFormula
+  desc "General-purpose lossless data-compression library"
+  homepage "http://www.zlib.net/"
+  url "https://github.com/madler/zlib/archive/v1.2.3.tar.gz"
+  sha256 "2134178c123ea8252fd6afc9b794d9a2df480ccd030cc5db720a41883676fc2e"
+
+  keg_only :provided_by_osx
+
+  option :universal
+
+  # configure script fails to detect the right compiler when "cc" is
+  # clang, not gcc. zlib mantainers have been notified of the issue.
+  # See: https://github.com/Homebrew/homebrew-dupes/pull/228
+  patch :DATA if OS.mac?
+
+  # http://zlib.net/zlib_how.html
+  resource "test_artifact" do
+    url "http://zlib.net/zpipe.c"
+    version "20051211"
+    sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+  end
+
+  set_legacy
+
+  def install
+    ENV.universal_binary if build.universal?
+    system "./configure", "--prefix=#{prefix}", "--shared"
+    system "make", "install"
+  end
+
+  test do
+    testpath.install resource("test_artifact")
+    system ENV.cc, "zpipe.c", "-I#{include}", "-L#{lib}", "-lz", "-o", "zpipe"
+
+    touch "foo.txt"
+    output = ("./zpipe < foo.txt > foo.txt.z")
+    system output
+    assert File.exist?("foo.txt.z")
+  end
+end
+
+__END__
+diff --git a/configure b/configure
+index b77a8a8..54f33f7 100755
+--- a/configure
++++ b/configure
+@@ -159,6 +159,7 @@ case "$cc" in
+ esac
+ case `$cc -v 2>&1` in
+   *gcc*) gcc=1 ;;
++  *clang*) gcc=1 ;;
+ esac
+ 
+ show $cc -c $test.c

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -38,9 +38,10 @@ function setup_brew() {
   mkdir -p "$DEPS/Library/Taps/osquery/"
 
   FORMULA_TAP="$DEPS/Library/Taps/osquery/homebrew-osquery-local"
-  if [[ ! -e "$FORMULA_TAP" ]]; then
-    ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
+  if [[ -L "$FORMULA_TAP" ]]; then
+    rm -f "$FORMULA_TAP"
   fi
+  ln -sf "$FORMULA_DIR" "$FORMULA_TAP"
 
   export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
   export HOMEBREW_NO_AUTO_UPDATE=1
@@ -112,7 +113,7 @@ function brew_internal() {
   if [[ "$TYPE" = "upstream" || "$TYPE" = "upstream-link" ]]; then
     FORMULA="$TOOL"
   else
-    FORMULA="${FORMULA_DIR}/${TOOL}.rb"
+    FORMULA="osquery/homebrew-osquery-local/${TOOL}"
   fi
   INFO=`$BREW info --json=v1 "${FORMULA}"`
   INSTALLED=$(json_element "${INFO}" 'obj[0]["installed"][0]["version"]')
@@ -207,7 +208,7 @@ function brew_bottle() {
 function local_brew_postinstall() {
   TOOL=$1
   if [[ ! -z "$OSQUERY_BUILD_DEPS" ]]; then
-    $BREW postinstall "${FORMULA_DIR}/${TOOL}.rb"
+    $BREW postinstall "${FORMULA_TAP}/${TOOL}.rb"
   fi
 }
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -65,7 +65,6 @@ function setup_brew() {
     # Backwards compatibility for legacy environment.
     rm -f "$DEPS/legacy"
     mkdir -p "$DEPS/legacy"
-    local_brew_link glibc-legacy
   elif [[ ! -d "$DEPS/legacy" ]]; then
     mkdir -p "$DEPS/legacy"
   fi


### PR DESCRIPTION
This added zlib-legacy and reorganizes the legacy runtime directory to handle any formula install. As part of this we move xz and libgpg-error after the GCC install. 