### PR TITLE
Improve scheduled/differential query performance and logging

### DIFF
--- a/osquery/database/query.cpp
+++ b/osquery/database/query.cpp
@@ -10,15 +10,13 @@
 
 #include <algorithm>
 
+#include <osquery/logger.h>
+
 #include "osquery/database/query.h"
 
 namespace osquery {
 
 Status Query::getPreviousQueryResults(QueryData& results) {
-  if (!isQueryNameInDatabase()) {
-    return Status(0, "Query name not found in database");
-  }
-
   std::string raw;
   auto status = getDatabaseValue(kQueries, name_, raw);
   if (!status.ok()) {
@@ -43,35 +41,62 @@ bool Query::isQueryNameInDatabase() {
   return std::find(names.begin(), names.end(), name_) != names.end();
 }
 
+static inline void saveQuery(const std::string& name,
+                             const std::string& query) {
+  setDatabaseValue(kQueries, "query." + name, query);
+}
+
+bool Query::isNewQuery() {
+  std::string query;
+  getDatabaseValue(kQueries, "query." + name_, query);
+  return (query != query_.query);
+}
+
 Status Query::addNewResults(const QueryData& qd) {
   DiffResults dr;
   return addNewResults(qd, dr, false);
 }
 
-Status Query::addNewResults(const QueryData& qd, DiffResults& dr) {
-  return addNewResults(qd, dr, true);
-}
-
 Status Query::addNewResults(const QueryData& current_qd,
                             DiffResults& dr,
                             bool calculate_diff) {
-  // Get the rows from the last run of this query name.
-  QueryData previous_qd;
-  auto status = getPreviousQueryResults(previous_qd);
-  if (!status.ok()) {
-    return status;
+  // The current results are 'fresh' when not calculating a differential.
+  bool fresh_results = !calculate_diff;
+  if (!isQueryNameInDatabase()) {
+    // This is the first encounter of the scheduled query.
+    fresh_results = true;
+    LOG(INFO) << "Storing initial results for new scheduled query: " << name_;
+    saveQuery(name_, query_.query);
+  } else if (isNewQuery()) {
+    // This query is 'new' in that the previous results may be invalid.
+    LOG(INFO) << "Scheduled query has been updated: " + name_;
+    saveQuery(name_, query_.query);
   }
 
-  // Calculate the differential between previous and current query results.
-  if (calculate_diff) {
+  // Use a 'target' avoid copying the query data when serializing and saving.
+  // If a differential is requested and needed the target remains the original
+  // query data, otherwise the content is moved to the differential's added set.
+  const auto* target_gd = &current_qd;
+  if (!fresh_results && calculate_diff) {
+    // Get the rows from the last run of this query name.
+    QueryData previous_qd;
+    auto status = getPreviousQueryResults(previous_qd);
+    if (!status.ok()) {
+      return status;
+    }
+
+    // Calculate the differential between previous and current query results.
     dr = diff(previous_qd, current_qd);
+    fresh_results = (!dr.added.empty() || !dr.removed.empty());
+  } else {
+    dr.added = std::move(current_qd);
+    target_gd = &dr.added;
   }
 
-  if (previous_qd.size() == 0 || dr.added.size() != 0 ||
-      dr.removed.size() != 0) {
+  if (fresh_results) {
     // Replace the "previous" query data with the current.
     std::string json;
-    status = serializeQueryDataJSON(current_qd, json);
+    auto status = serializeQueryDataJSON(*target_gd, json);
     if (!status.ok()) {
       return status;
     }

--- a/osquery/database/query.h
+++ b/osquery/database/query.h
@@ -38,7 +38,6 @@ class Query {
   explicit Query(const std::string& name, const ScheduledQuery& q)
       : query_(q), name_(name) {}
 
- public:
   /**
    * @brief Serialize the data in RocksDB into a useful data structure
    *
@@ -51,7 +50,6 @@ class Query {
    */
   Status getPreviousQueryResults(QueryData& results);
 
- public:
   /**
    * @brief Get the names of all historical queries.
    *
@@ -63,15 +61,20 @@ class Query {
    */
   static std::vector<std::string> getStoredQueryNames();
 
- public:
   /**
-   * @brief Checking if a given scheduled query exists in the database.
+   * @brief Check if a given scheduled query exists in the database.
    *
    * @return true if the scheduled query already exists in the database.
    */
   bool isQueryNameInDatabase();
 
- public:
+  /**
+   * @brief Check if a query (not query name) is 'new' or altered.
+   *
+   * @return true if the scheduled query has not been altered.
+   */
+  bool isNewQuery();
+
   /**
    * @brief Add a new set of results to the persistent storage.
    *
@@ -85,7 +88,6 @@ class Query {
    */
   Status addNewResults(const QueryData& qd);
 
- public:
   /**
    * @brief Add a new set of results to the persistent storage and get back
    * the differential results.
@@ -99,26 +101,10 @@ class Query {
    *
    * @return the success or failure of the operation.
    */
-  Status addNewResults(const QueryData& qd, DiffResults& dr);
-
- private:
-  /**
-   * @brief Add a new set of results to the persistent storage and get back
-   * the differential results, using a custom database handle.
-   *
-   * This method is the same as Query::addNewResults, but with the addition of a
-   * parameter which allows you to pass a custom RocksDB database handle.
-   *
-   * @param qd the QueryData object containing query results to store.
-   * @param dr an output to a DiffResults object populated based on last run.
-   *
-   * @return the success or failure of the operation.
-   */
   Status addNewResults(const QueryData& qd,
                        DiffResults& dr,
-                       bool calculate_diff);
+                       bool calculate_diff = true);
 
- public:
   /**
    * @brief The most recent result set for a scheduled query.
    *

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -111,7 +111,7 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
     diff_results.added = std::move(sql.rows());
   }
 
-  if (diff_results.added.size() == 0 && diff_results.removed.size() == 0) {
+  if (diff_results.added.empty() && diff_results.removed.empty()) {
     // No diff results or events to emit.
     return;
   }


### PR DESCRIPTION
This PR includes a reorganization of `Query` and the internal database storage of query results and their change/differential calculation.

First, the class now includes detection of when a query with the same name changes. If you alter a query by including new columns or restricting the predicate, the results may change. It is possible to invalidate all results since differential calculation is "dumb" and does not understand column/key alterations.

A log line is also generated when query results are saved for the first time. This is helpful in debugging and altering on situations where the internal database becomes unavailable. The observed result will be a "fresh" select of the entire table.

Second, there is a small memory optimization for new table scans. Previously, new scans would result in two copies of the table data simultaneously. 