### PR TITLE
Limit CTest runs to 600 seconds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,8 @@ endif()
 # Previously, this would find_package for Gtest.
 # We can supply the known include paths within each test as compile flags.
 enable_testing()
+set(CTEST_TEST_TIMEOUT 600)
+
 # Detect TR1 usage.
 include(CheckIncludeFileCXX)
 if(WINDOWS)


### PR DESCRIPTION
Simple, save some build resources in the case of a stuck test.