### PR TITLE
Changed the naming convention of the tls server file to match osx

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -130,7 +130,7 @@ function main() {
 
   if [[ $OSQUERY_TLS_CERT_CHAIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_SRC ]]; then
     log "tls server certs file setup"
-    cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_VAR_DIR/tls-server-certs.pem
+    cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/tls-server-certs.pem
   fi
   
   if [[ $DISTRO = "xenial" ]]; then

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -130,7 +130,7 @@ function main() {
 
   if [[ $OSQUERY_TLS_CERT_CHAIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_SRC ]]; then
     log "tls server certs file setup"
-    cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/tls_server_certs.pem
+    cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_VAR_DIR/tls-server-certs.pem
   fi
   
   if [[ $DISTRO = "xenial" ]]; then


### PR DESCRIPTION
I changed the underbars to dashes in the tls server file which gets baked into packages.  This change was to make it match the naming standard used in the current osx package creation script.  

I also changed the storage location to be in var instead of etc since it is also stored there in osx.  

This should make configs a bit more cross platform.