### PR TITLE
Build OpenSSL with no-asm to remove AVX2 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ ifeq ($(PLATFORM),Linux)
 	@ln -snf $(BUILD_DIR) build/linux
 	@ln -snf debug_$(BUILD_DIR) build/debug_linux
 endif
-
+	@export PYTHONPATH="$DEPS_DIR/lib/python2.7/site-packages"
 
 package: .setup
 	# Alias for packages (do not use CPack)

--- a/tools/provision/formula/asio.rb
+++ b/tools/provision/formula/asio.rb
@@ -3,9 +3,10 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Asio < AbstractOsqueryFormula
   desc "Cross-platform C++ Library for asynchronous programming"
   homepage "https://think-async.com/Asio"
-  url "https://downloads.sourceforge.net/project/asio/asio/1.10.6%20%28Stable%29/asio-1.10.6.tar.bz2"
-  sha256 "e0d71c40a7b1f6c1334008fb279e7361b32a063e020efd21e40d9d8ff037195e"
+  url "https://github.com/chriskohlhoff/asio/archive/asio-1-10-8.tar.gz"
+  sha256 "fc475c6b737ad92b944babdc3e5dcf5837b663f54ba64055dc3d8fc4a3061372"
   head "https://github.com/chriskohlhoff/asio.git"
+  version "1.10.8"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -23,13 +24,8 @@ class Asio < AbstractOsqueryFormula
 
   def install
     ENV.cxx11
+    ENV.append "CPPFLAGS", "-DOPENSSL_NO_SSL3"
 
-    if build.head?
-      cd "asio"
-      system "./autogen.sh"
-    else
-      system "autoconf" unless OS.mac?
-    end
     args = %W[
       --disable-dependency-tracking
       --disable-silent-rules
@@ -37,8 +33,9 @@ class Asio < AbstractOsqueryFormula
     ]
     args << "--enable-boost-coroutine" if build.with? "boost-coroutine"
 
+    cd "asio"
+    system "./autogen.sh"
     system "./configure", *args
     system "make", "install"
-    #pkgshare.install "src/examples"
   end
 end

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -7,6 +7,7 @@ class Openssl < AbstractOsqueryFormula
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2h.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2h.tar.gz"
   sha256 "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -22,10 +23,6 @@ class Openssl < AbstractOsqueryFormula
     sha256 "2c6d4960579b0d4fd46c6cbf135545116e76f2dbb7490e24cf330f2565770362"
   end
 
-  keg_only :provided_by_osx,
-    "Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries"
-
-  option :universal
   option "without-test", "Skip build-time tests (not recommended)"
 
   deprecated_option "without-check" => "without-test"
@@ -46,6 +43,8 @@ class Openssl < AbstractOsqueryFormula
     --prefix=#{prefix}
     --openssldir=#{openssldir}
     no-ssl2
+    no-ssl3
+    no-asm
     zlib-dynamic
     shared
     enable-cms
@@ -62,14 +61,7 @@ class Openssl < AbstractOsqueryFormula
               'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
               'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);' if OS.mac?
 
-    if build.universal?
-      ENV.permit_arch_flags
-      archs = Hardware::CPU.universal_archs
-    elsif MacOS.prefer_64_bit?
-      archs = [Hardware::CPU.arch_64_bit]
-    else
-      archs = [Hardware::CPU.arch_32_bit]
-    end
+    archs = [Hardware::CPU.arch_64_bit]
 
     dirs = []
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -48,6 +48,7 @@ function setup_brew() {
   export HOMEBREW_CACHE="$DEPS/.cache/"
   export HOMEBREW_MAKE_JOBS=$THREADS
   export HOMEBREW_NO_EMOJI=1
+  export HOMEBREW_BOTTLE_ARCH=core2
   export BREW="$DEPS/bin/brew"
   TAPS="$DEPS/Library/Taps/"
 
@@ -110,7 +111,7 @@ function brew_internal() {
   shift
   shift
 
-  if [[ "$TYPE" = "upstream" || "$TYPE" = "upstream-link" ]]; then
+  if [[ "$TYPE" = "upstream" || "$TYPE" = "upstream-link" || "$TYPE" = "uninstall" ]]; then
     FORMULA="$TOOL"
   else
     FORMULA="osquery/homebrew-osquery-local/${TOOL}"
@@ -126,6 +127,14 @@ function brew_internal() {
 
   # Add build arguments depending on requested from-source or default build.
   ARGS="$@"
+
+  if [[ "$TYPE" = "uninstall" ]]; then
+    if [[ ! "$INSTALLED" = "NAN" ]]; then
+      log "brew package $TOOL uninstalling version: ${STABLE}"
+      $BREW uninstall --force "${FORMULA}"
+    fi
+    return
+  fi
 
   # Configure additional arguments if installing from a local formula.
   ARGS="$ARGS --ignore-dependencies --env=inherit"
@@ -190,6 +199,10 @@ function local_brew_link() {
 
 function local_brew_unlink() {
   brew_internal "unlink" $@
+}
+
+function local_brew_uninstall() {
+  brew_internal "uninstall" $@
 }
 
 function brew_tool() {


### PR DESCRIPTION
To support machines without AVX2 features we need to avoid compiling and linking the dependent instructions found the ASM implementations of some OpenSSL crypto algorithms.

Additionally, we are removing the SSL3 methods from our OpenSSL build. The osquery TLS plugins explicitly define a cipher list that excludes SSL3, but as an extra measure (for plugins not using our transports) we remove it from ASIO and Thrift too.