### PR TITLE
[Fix #2482] Use atomic member in Dispatcher tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,24 +163,24 @@ if(DEFINED ENV{DEBUG})
   WARNING_LOG("Setting DEBUG build")
 elseif(DEFINED ENV{SANITIZE})
   # make sanitize (cannot make debug sanitize)
+  set(SANITIZE_BLACKLIST "${CMAKE_SOURCE_DIR}/tools/tests/sanitize_blacklist.txt")
   add_compile_options(
     -g
-    -O1
     -fstandalone-debug
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls
+    -fsanitize-blacklist=${SANITIZE_BLACKLIST}
   )
-  add_definitions(-DNDEBUG)
-  if(DEFINED ENV{SANITIZE_THREAD})
+  if (DEFINED ENV{SANITIZE_THREAD})
     add_compile_options(-fsanitize=thread)
   else()
-    add_compile_options(-fsanitize=address)
-    if (NOT APPLE)
-      add_compile_options(-fsanitize=leak)
-    endif()
+    add_compile_options(
+      -fsanitize=address
+      -fsanitize=leak
+    )
   endif()
-  set(SANITIZE_BLACKLIST "${CMAKE_SOURCE_DIR}/tools/tests/sanitize_blacklist.txt")
-  add_definitions(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
+
+  set(ENV{ASAN_OPTIONS} "detect_container_overflow=0")
 else()
   set(DEBUG FALSE)
   if(WINDOWS)
@@ -260,13 +260,13 @@ if(WINDOWS)
     if(${flag_var} MATCHES "/MD")
       string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
     endif(${flag_var} MATCHES "/MD")
-    
+
     # Ignore unused parameter messages for C-based projects (e.g. sqlite3)
     if (flag_var MATCHES "^CMAKE_C_FLAGS*")
       set(${flag_var} "${${flag_var}} /wd4101")
     endif(flag_var MATCHES "^CMAKE_C_FLAGS*")
   endforeach(flag_var)
-  
+
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
 endif()
 

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -30,7 +30,6 @@
 
 namespace pt = boost::property_tree;
 
-
 namespace osquery {
 
 /**

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -156,7 +156,7 @@ TEST_F(ProcessTests, test_launchWorker) {
             static_cast<int>(kExpectedWorkerArgsCount),
             &argv[0]);
     for (size_t i = 0; i < argv.size(); i++) {
-      delete argv[i];
+      delete[] argv[i];
     }
 
     EXPECT_NE(nullptr, process.get());

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -29,28 +29,22 @@ class TestRunnable : public InternalRunnable {
   explicit TestRunnable() {}
 
   virtual void start() override {
-    WriteLock lock(mutex_);
     ++i;
   }
 
   void reset() {
-    WriteLock lock(mutex_);
     i = 0;
   }
 
   size_t count() {
-    WriteLock lock(mutex_);
     return i;
   }
 
  private:
-  static size_t i;
-
- private:
-  Mutex mutex_;
+  static std::atomic<size_t> i;
 };
 
-size_t TestRunnable::i{0};
+std::atomic<size_t> TestRunnable::i{0};
 
 TEST_F(DispatcherTests, test_service_count) {
   auto runnable = std::make_shared<TestRunnable>();

--- a/tools/tests/sanitize_blacklist.txt
+++ b/tools/tests/sanitize_blacklist.txt
@@ -13,6 +13,7 @@ fun:*SetArgv*
 fun:google::RawLog__SetLastTime
 
 # Thrift
+fun:*TServerSocket*
 fun:apache::thrift::transport::TServerSocket::listen
 fun:apache::thrift::transport::TServerSocket::notify
 fun:apache::thrift::transport::TServerSocket::interrupt


### PR DESCRIPTION
This fixes the `Dispatcher` and `Process` tests so they pass `make sanitize` with TSAN.