### PR TITLE
Prefer the osquery dependencies root for Python tests

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -27,6 +27,10 @@ import unittest
 import utils
 import pexpect
 
+# While this path can be variable, in practice is lives statically.
+OSQUERY_DEPENDENCIES = "/usr/local/osquery"
+sys.path = [OSQUERY_DEPENDENCIES + "/lib/python2.7/site-packages"] + sys.path
+
 try:
     from pexpect.replwrap import REPLWrapper
 except ImportError as e:


### PR DESCRIPTION
While `make test` should have set the `PYTHONPATH`, tooling calling the tests directly should always prefer the dependencies static path.