### PR TITLE
Remove extensions retry and introduce watcher retry

### DIFF
--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -302,6 +302,9 @@ class WatcherRunner : public InternalRunnable {
   /// If set, the ::start method will run once and return.
   bool run_once_{false};
 
+  /// Similarly to the uncontrolled worker restarted, count each extension.
+  std::map<std::string, size_t> extension_restarts_;
+
  private:
   FRIEND_TEST(WatcherTests, test_watcherrunner_watch);
   FRIEND_TEST(WatcherTests, test_watcherrunner_stop);

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -211,7 +211,7 @@ void ExtensionManagerWatcher::watch() {
       LOG(INFO) << "Extension UUID " << uuid << " ping failed";
 
       // Immediate fail non-writable paths.
-      failures_[uuid] = 3;
+      failures_[uuid] += 1;
     }
 #else
     if (isWritable(path)) {
@@ -225,7 +225,7 @@ void ExtensionManagerWatcher::watch() {
       }
     } else {
       // Immediate fail non-writable paths.
-      failures_[uuid] = 3;
+      failures_[uuid] += 1;
       continue;
     }
 
@@ -239,7 +239,7 @@ void ExtensionManagerWatcher::watch() {
   }
 
   for (const auto& uuid : failures_) {
-    if (uuid.second >= 3) {
+    if (uuid.second > 0) {
       LOG(INFO) << "Extension UUID " << uuid.first << " has gone away";
       Registry::removeBroadcast(uuid.first);
       failures_[uuid.first] = 0;


### PR DESCRIPTION
There is a bit of a "logic race" in the `Watcher` and `ExtensionManagerWatcher`.

When using an `extensions_autoload` the `Watcher` (watchdog) will start extensions automatically. It will also monitor these processes such that they don't run away with CPU/memory. If these processes are killed with/without the control of the `Watcher` it will try to "restart" the process by fork/execing again.

If the `ExtensionManagerWatcher` has not yet recognized the extension as "missing" there will be an extension registry collision. The two data sets involved are rather unique: the watcher knows what paths you want to load, the extension manager knows a name and assigned UUID. Without significant refactoring/redesign there's no realistic way to merge these sets. In this case a collision will cause the extension process to gracefully fail. The `Watcher` will see this and consider the launch attempt a failure since it started/stopped too quickly (and it would be correct).

To solve for this race, we extend the amount of time the Watcher applies before attempting to launch another extension, as well as the time applied before considering an extension "unlaunchable". You can still introduce the race if you set `--extensions_interval` to a value `9` or greater. 