### PR TITLE
[Fix #2483] Lock registry manipulation while setting active plugins

### DIFF
--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -482,6 +482,7 @@ Status RegistryFactory::callTable(const std::string& table_name,
 
 Status RegistryFactory::setActive(const std::string& registry_name,
                                   const std::string& item_name) {
+  WriteLock lock(instance().mutex_);
   return registry(registry_name)->setActive(item_name);
 }
 


### PR DESCRIPTION
I'm hesitant to consider #2483 a true positive. However, this lock does not introduce circular locking and seems reasonable.

The high-level case:
1. Config Extension starts, responds to `ping`, is assigned a `uuid` and the `Initializer` flow continues.
2. (race) The extension dies and is deregistered immediately. 
3. (race) `Initializer` attempts to `setUp` and `setActive` the config plugin.
