### PR TITLE
Add PYTHONPATH to brew environment for Python postinstall

### DIFF
--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -135,6 +135,7 @@ class AbstractOsqueryFormula < Formula
 
     if !OS.linux?
       prepend_path "PATH", default_prefix/"bin"
+      prepend_path "PYTHONPATH", default_prefix/"lib/python2.7/site-packages"
     end
 
     # Everyone receives:


### PR DESCRIPTION
When running the `python` `postinstall`, having `PYTHONPATH` set to the local `site-packages` fixes an initial install bug for OS X.