### PR TITLE
Toggle --utc to true

### DIFF
--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -149,7 +149,7 @@ inline Status safeStrtoul(const std::string& rep,
                           size_t base,
                           unsigned long int& out) {
   char* end{nullptr};
-  out = strtol(rep.c_str(), &end, static_cast<int>(base));
+  out = strtoul(rep.c_str(), &end, static_cast<int>(base));
   if (end == nullptr || end == rep.c_str() || *end != '\0' || errno == ERANGE) {
     out = 0;
     return Status(1);

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -67,7 +67,7 @@ FLAG(string,
      "hostname",
      "Field used to identify the host running osquery (hostname, uuid)");
 
-FLAG(bool, utc, false, "Convert all UNIX times to UTC");
+FLAG(bool, utc, true, "Convert all UNIX times to UTC");
 
 #ifdef WIN32
 struct tm* gmtime_r(time_t* t, struct tm* result) {
@@ -167,14 +167,7 @@ std::string getAsciiTime() {
 }
 
 size_t getUnixTime() {
-  auto result = std::time(nullptr);
-  if (FLAGS_utc) {
-    struct tm now;
-    gmtime_r(&result, &now);
-
-    result = std::mktime(&now);
-  }
-  return result;
+  return std::time(nullptr);
 }
 
 Status checkStalePid(const std::string& content) {

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -21,12 +21,6 @@
 
 #include "osquery/tests/test_util.h"
 
-#define EXPECT_WITHIN_INCLUSIVE(lower, upper, val)                             \
-  do {                                                                         \
-    EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperGE, val, lower);         \
-    EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperLE, val, upper);         \
-  } while (0)
-
 namespace osquery {
 
 DECLARE_bool(utc);
@@ -43,32 +37,6 @@ TEST_F(ConversionsTests, test_conversion) {
   std::shared_ptr<Foobar> s2 = std::make_shared<Foobar>();
   boost::shared_ptr<Foobar> b2 = std_to_boost_shared_ptr(s2);
   EXPECT_EQ(s2.get(), b2.get());
-}
-
-TEST_F(ConversionsTests, test_utc) {
-  auto utc = FLAGS_utc;
-  FLAGS_utc = false;
-  auto t1 = getUnixTime();
-  auto at1 = std::time(nullptr);
-  EXPECT_WITHIN_INCLUSIVE(t1 - 10U, t1 + 10, static_cast<size_t>(at1));
-
-  FLAGS_utc = true;
-  auto t2 = getUnixTime();
-  auto rt2 = std::time(nullptr);
-
-#ifdef WIN32
-  std::vector<char> buffer;
-  buffer.assign(sizeof(std::tm), '\0');
-  std::tm* gt2 = (std::tm*)buffer.data();
-
-  EXPECT_EQ(0, gmtime_s(gt2, &rt2));
-#else
-  auto gt2 = std::gmtime(&rt2);
-#endif
-
-  auto at2 = std::mktime(gt2);
-  EXPECT_WITHIN_INCLUSIVE(t2 - 10, t2 + 10, static_cast<size_t>(at2));
-  FLAGS_utc = utc;
 }
 
 TEST_F(ConversionsTests, test_base64) {

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -25,8 +25,7 @@ namespace tables {
 
 QueryData genTime(QueryContext& context) {
   Row r;
-  // Request UNIX time (a wrapper around std::time).
-  auto local_time = std::time(nullptr);
+  time_t local_time = getUnixTime();
   auto osquery_time = getUnixTime();
   auto osquery_timestamp = getAsciiTime();
 
@@ -43,6 +42,7 @@ QueryData genTime(QueryContext& context) {
 
   struct tm local;
   localtime_r(&local_time, &local);
+  local_time = std::mktime(&local);
 
   char weekday[10] = {0};
   strftime(weekday, sizeof(weekday), "%A", &now);


### PR DESCRIPTION
As promised for 1.8.3, `--utc` will now be default. And `time.local_time` should become hidden.