### PR TITLE
Fix update of event pub/sub plugins when config fails to load

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -538,6 +538,8 @@ Status Config::update(const std::map<std::string, std::string>& config) {
     }
   }
 
+  loaded_ = true;
+
   return Status(0, "OK");
 }
 


### PR DESCRIPTION
…artup time. The use-case is a TLS back-end server that cannot provide a configuration before an enrollment, or after an enrollment has expired. Because of the sequence in which modules are initialized, config request goes first, which fails. Since Config::loaded_ is only ever set to true if the Config::load succeeds, it remains set to false because of the config request failure. On subsequent successful config requests, the event monitoring publishers/subscribers are never updated. Thus, event monitoring cannot be enabled at all.

The fix is to set the Config::loaded_ variable to true after a subsequent config::update call succeeds.