### PR TITLE
Remove time-override for events add API

### DIFF
--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -28,6 +28,9 @@ FLAG(bool, enable_monitor, false, "Enable the schedule monitor");
 
 FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit")
 
+/// Used to bypass (optimize-out) the set-differential of query results.
+DECLARE_bool(events_optimize);
+
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
   // Snapshot the performance and times for the worker before running.
   auto pid = std::to_string(PlatformProcess::getCurrentProcess()->pid());
@@ -97,7 +100,7 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // Add this execution's set of results to the database-tracked named query.
   // We can then ask for a differential from the last time this named query
   // was executed by exact matching each row.
-  if (!sql.eventBased()) {
+  if (!FLAGS_events_optimize || !sql.eventBased()) {
     status = dbQuery.addNewResults(sql.rows(), diff_results);
     if (!status.ok()) {
       std::string line =

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -115,11 +115,6 @@ class SyslogEventPublisher
                                      SyslogEventContextRef& ec);
 
   /**
-   * @brief Parse a time string from rsyslog into time_t.
-   */
-  static time_t parseTimeString(const std::string& time_str);
-
-  /**
    * @brief Input stream for reading from the pipe.
    */
   std::fstream readStream_;
@@ -144,7 +139,6 @@ class SyslogEventPublisher
 
  private:
   FRIEND_TEST(SyslogTests, test_populate_event_context);
-  FRIEND_TEST(SyslogTests, test_parse_time_string);
 };
 
 /**

--- a/osquery/events/linux/tests/syslog_tests.cpp
+++ b/osquery/events/linux/tests/syslog_tests.cpp
@@ -14,8 +14,8 @@
 
 #include <boost/tokenizer.hpp>
 
-#include "osquery/tests/test_util.h"
 #include "osquery/events/linux/syslog.h"
+#include "osquery/tests/test_util.h"
 
 namespace osquery {
 
@@ -36,7 +36,9 @@ TEST_F(SyslogTests, test_populate_event_context) {
   Status status = pub.populateEventContext(line, ec);
 
   ASSERT_TRUE(status.ok());
-  ASSERT_EQ((time_t)1458681421, ec->time);
+  // Note: the time-parsing was removed to allow events to auto-assign.
+  ASSERT_EQ(0U, ec->time);
+  ASSERT_EQ("2016-03-22T21:17:01.701882+00:00", ec->fields.at("datetime"));
   ASSERT_EQ("vagrant-ubuntu-trusty-64", ec->fields.at("host"));
   ASSERT_EQ("6", ec->fields.at("severity"));
   ASSERT_EQ("cron", ec->fields.at("facility"));
@@ -46,7 +48,8 @@ TEST_F(SyslogTests, test_populate_event_context) {
 
   // Too few fields
 
-  std::string bad_line = R"("2016-03-22T21:17:01.701882+00:00","vagrant-ubuntu-trusty-64","6","cron",)";
+  std::string bad_line =
+      R"("2016-03-22T21:17:01.701882+00:00","vagrant-ubuntu-trusty-64","6","cron",)";
   ec = pub.createEventContext();
   status = pub.populateEventContext(bad_line, ec);
   ASSERT_FALSE(status.ok());
@@ -58,15 +61,6 @@ TEST_F(SyslogTests, test_populate_event_context) {
   status = pub.populateEventContext(bad_line, ec);
   ASSERT_FALSE(status.ok());
   ASSERT_NE(std::string::npos, status.getMessage().find("more"));
-}
-
-TEST_F(SyslogTests, test_parse_time_string) {
-  ASSERT_EQ((time_t)0,
-            SyslogEventPublisher::parseTimeString("1970-01-01T00:00:00.000000+00:00"));
-  ASSERT_EQ((time_t)1458927568,
-            SyslogEventPublisher::parseTimeString("2016-03-25T17:39:28.717070+00:00"));
-  ASSERT_EQ((time_t)1483228799,
-            SyslogEventPublisher::parseTimeString("2016-12-31T23:59:59.999000+00:00"));
 }
 
 TEST_F(SyslogTests, test_csv_separator) {

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -20,13 +20,33 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
+#include <osquery/logger.h>
+
 namespace osquery {
 
 DECLARE_uint64(events_expiry);
 DECLARE_uint64(events_max);
+DECLARE_bool(events_optimize);
 
 class EventsDatabaseTests : public ::testing::Test {
-  void SetUp() override { Registry::registry("config_parser")->setUp(); }
+  void SetUp() override {
+    Registry::registry("config_parser")->setUp();
+    optimize_ = FLAGS_events_optimize;
+    FLAGS_events_optimize = false;
+
+    std::vector<std::string> event_keys;
+    scanDatabaseKeys(kEvents, event_keys);
+    for (const auto& key : event_keys) {
+      deleteDatabaseValue(kEvents, key);
+    }
+  }
+
+  void TearDown() override {
+    FLAGS_events_optimize = optimize_;
+  }
+
+ private:
+  bool optimize_;
 };
 
 class DBFakeEventPublisher
@@ -36,7 +56,9 @@ class DBFakeEventPublisher
 
 class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
  public:
-  DBFakeEventSubscriber() { setName("DBFakeSubscriber"); }
+  DBFakeEventSubscriber() {
+    setName("DBFakeSubscriber");
+  }
   /// Add a fake event at time t
   Status testAdd(int t) {
     Row r;
@@ -75,146 +97,212 @@ TEST_F(EventsDatabaseTests, test_record_indexing) {
   // An "all" range, will pick up everything in the largest index.
   auto indexes = sub->getIndexes(0, 3 * 3600);
   auto output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ(output, "3600.0, 3600.1, 3600.2");
+  EXPECT_EQ("3600.0, 3600.1, 3600.2", output);
 
   // Restrict range to "most specific", which is an index by 10.
   indexes = sub->getIndexes(0, 5);
   output = boost::algorithm::join(indexes, ", ");
   // The order 10, 0th index include results with t = [0, 10).
-  EXPECT_EQ(output, "10.0");
+  EXPECT_EQ("10.0", output);
 
   // Get a mix of indexes for the lower bounding.
   indexes = sub->getIndexes(2, (3 * 3600));
   output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ(output, "10.0, 10.1, 3600.1, 3600.2, 60.1");
+  EXPECT_EQ("10.0, 10.1, 3600.1, 3600.2, 60.1", output);
 
   // Rare, but test ONLY intermediate indexes.
   // Provide an optional third parameter to getIndexes: 1 = 10,(60),3600.
   indexes = sub->getIndexes(2, (3 * 3600), 1);
   output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ(output, "60.0, 60.1, 60.120, 60.60");
+  EXPECT_EQ("60.0, 60.1, 60.120, 60.60", output);
 
   // Add specific indexes to the upper bound.
   status = sub->testAdd((2 * 3600) + 11);
   status = sub->testAdd((2 * 3600) + 61);
   indexes = sub->getIndexes(2 * 3600, (2 * 3600) + 62);
   output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ(output, "10.726, 60.120");
+  EXPECT_EQ("10.726, 60.120", output);
 
   // Request specific lower and upper bounding.
   indexes = sub->getIndexes(2, (2 * 3600) + 62);
   output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ(output, "10.0, 10.1, 10.726, 3600.1, 60.1, 60.120");
+  EXPECT_EQ("10.0, 10.1, 10.726, 3600.1, 60.1, 60.120", output);
 }
 
 TEST_F(EventsDatabaseTests, test_record_range) {
   auto sub = std::make_shared<DBFakeEventSubscriber>();
+  auto status = sub->testAdd(1);
+  status = sub->testAdd(2);
+  status = sub->testAdd(11);
+  status = sub->testAdd(61);
+  status = sub->testAdd((1 * 3600) + 1);
+  status = sub->testAdd((2 * 3600) + 1);
 
   // Search within a specific record range.
   auto indexes = sub->getIndexes(0, 10);
   auto records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 2U); // 1, 2
+  EXPECT_EQ(2U, records.size()); // 1, 2
 
   // Search within a large bound.
   indexes = sub->getIndexes(3, 3601);
   // This will include the 0-10 bucket meaning 1, 2 will show up.
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 5U); // 1, 2, 11, 61, 3601
+  EXPECT_EQ(5U, records.size()); // 1, 2, 11, 61, 3601
 
   // Get all of the records.
   indexes = sub->getIndexes(0, 3 * 3600);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 8U); // 1, 2, 11, 61, 3601, 7201, 7211, 7261
+  EXPECT_EQ(6U, records.size()); // 1, 2, 11, 61, 3601, 7201
 
   // stop = 0 is an alias for everything.
   indexes = sub->getIndexes(0, 0);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 8U);
+  EXPECT_EQ(6U, records.size());
+
+  for (size_t j = 0; j < 30; j++) {
+    // 110 is 10 below an index (60.2).
+    sub->testAdd(110 + j);
+  }
+
+  /**
+   * These tests are flaky because of issues within events indexing.
+   * See #2513 for the eventual fix.
+   * Assume an optimize step set the start to 110.
+   *
+   * indexes = sub->getIndexes(110, -1);
+   * auto output = boost::algorithm::join(indexes, ", ");
+   * EXPECT_EQ("10.11, 3600.1, 3600.2, 60.2", output);
+   * records = sub->getRecords(indexes);
+   * EXPECT_EQ(32U, records.size()); // 110 - 139 + 3601, 7201
+   */
 }
 
 TEST_F(EventsDatabaseTests, test_record_expiration) {
   auto sub = std::make_shared<DBFakeEventSubscriber>();
+  auto status = sub->testAdd(1);
+  status = sub->testAdd(2);
+  status = sub->testAdd(11);
+  status = sub->testAdd(61);
+  status = sub->testAdd((1 * 3600) + 1);
+  status = sub->testAdd((2 * 3600) + 1);
 
   // No expiration
   auto indexes = sub->getIndexes(0, 5000);
   auto records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 5U); // 1, 2, 11, 61, 3601
+  EXPECT_EQ(5U, records.size()); // 1, 2, 11, 61, 3601
 
   sub->expire_events_ = true;
   sub->expire_time_ = 10;
   indexes = sub->getIndexes(0, 5000);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 3U); // 11, 61, 3601
+  EXPECT_EQ(3U, records.size()); // 11, 61, 3601
 
   indexes = sub->getIndexes(0, 5000, 0);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 3U); // 11, 61, 3601
+  EXPECT_EQ(3U, records.size()); // 11, 61, 3601
 
   indexes = sub->getIndexes(0, 5000, 1);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 3U); // 11, 61, 3601
+  EXPECT_EQ(3U, records.size()); // 11, 61, 3601
 
   indexes = sub->getIndexes(0, 5000, 2);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 3U); // 11, 61, 3601
+  EXPECT_EQ(3U, records.size()); // 11, 61, 3601
 
   // Check that get/deletes did not act on cache.
   // This implies that RocksDB is flushing the requested delete records.
   sub->expire_time_ = 0;
   indexes = sub->getIndexes(0, 5000);
   records = sub->getRecords(indexes);
-  EXPECT_EQ(records.size(), 3U); // 11, 61, 3601
+  EXPECT_EQ(3U, records.size()); // 11, 61, 3601
 }
 
 TEST_F(EventsDatabaseTests, test_gentable) {
   auto sub = std::make_shared<DBFakeEventSubscriber>();
-  // Lie about the tool type to enable optimizations.
-  auto default_type = kToolType;
-  kToolType = ToolType::DAEMON;
-  ASSERT_EQ(sub->optimize_time_, 0U);
-  ASSERT_EQ(sub->expire_time_, 0U);
+  auto status = sub->testAdd(1);
+  status = sub->testAdd(2);
+  status = sub->testAdd(11);
+  status = sub->testAdd(61);
+  status = sub->testAdd((1 * 3600) + 1);
+  status = sub->testAdd((2 * 3600) + 1);
 
-  sub->testAdd(getUnixTime() - 1);
-  sub->testAdd(getUnixTime());
-  sub->testAdd(getUnixTime() + 1);
+  ASSERT_EQ(0U, sub->optimize_time_);
+  ASSERT_EQ(0U, sub->expire_time_);
+
+  auto t = getUnixTime();
+  sub->testAdd(t - 1);
+  sub->testAdd(t);
+  sub->testAdd(t + 1);
 
   // Test the expire workflow by creating a short expiration time.
   FLAGS_events_expiry = 10;
 
   std::vector<std::string> keys;
   scanDatabaseKeys("events", keys);
-  EXPECT_GT(keys.size(), 10U);
+  // 9 data records, 1 eid counter, 3 indexes, 15 index records.
+  // Depending on the moment, an additional 3 indexs may be introduced.
+  EXPECT_LE(28U, keys.size());
 
   // Perform a "select" equivalent.
   QueryContext context;
   auto results = sub->genTable(context);
 
   // Expect all non-expired results: 11, +
-  EXPECT_EQ(results.size(), 9U);
+  EXPECT_EQ(9U, results.size());
   // The expiration time is now - events_expiry.
-  EXPECT_GT(sub->expire_time_, getUnixTime() - (FLAGS_events_expiry * 2));
-  EXPECT_LT(sub->expire_time_, getUnixTime());
-  // The optimize time will be changed too.
-  ASSERT_GT(sub->optimize_time_, 0U);
-  // Restore the tool type.
-  kToolType = default_type;
+  EXPECT_LT(t - (FLAGS_events_expiry * 2), sub->expire_time_);
+  EXPECT_GT(t, sub->expire_time_);
+  // The optimize time will not be changed.
+  ASSERT_EQ(0U, sub->optimize_time_);
 
   results = sub->genTable(context);
-  EXPECT_EQ(results.size(), 3U);
+  EXPECT_EQ(3U, results.size());
 
   results = sub->genTable(context);
-  EXPECT_EQ(results.size(), 3U);
+  EXPECT_EQ(3U, results.size());
+
+  keys.clear();
+  scanDatabaseKeys("events", keys);
+  EXPECT_LE(10U, keys.size());
+}
+
+TEST_F(EventsDatabaseTests, test_optimize) {
+  auto sub = std::make_shared<DBFakeEventSubscriber>();
+  for (size_t i = 800; i < 800 + 10; ++i) {
+    sub->testAdd(i);
+  }
+
+  // Lie about the tool type to enable optimizations.
+  auto default_type = kToolType;
+  kToolType = ToolType::DAEMON;
+  FLAGS_events_optimize = true;
+
+  QueryContext context;
+  auto t = getUnixTime();
+  auto results = sub->genTable(context);
+  EXPECT_EQ(10U, results.size());
+  // Optimization will set the time NOW as the minimum event time.
+  // Thus it is not possible to set event in past.
+  EXPECT_GE(sub->optimize_time_ + 100, t);
+  EXPECT_LE(sub->optimize_time_ - 100, t);
+  // The last EID returned will also be stored for duplication checks.
+  EXPECT_EQ(10U, sub->optimize_eid_);
+
+  for (size_t i = t + 800; i < t + 800 + 10; ++i) {
+    sub->testAdd(i);
+  }
+  results = sub->genTable(context);
+  EXPECT_EQ(10U, results.size());
 
   // The optimize time should have been written to the database.
   // It should be the same as the current (relative) optimize time.
   std::string content;
-  getDatabaseValue("events", "optimize.DBFakePublisher.DBFakeSubscriber",
-                   content);
+  getDatabaseValue(
+      "events", "optimize.DBFakePublisher.DBFakeSubscriber", content);
   EXPECT_EQ(std::to_string(sub->optimize_time_), content);
 
-  keys.clear();
-  scanDatabaseKeys("events", keys);
-  EXPECT_LT(keys.size(), 30U);
+  // Restore the tool type.
+  kToolType = default_type;
 }
 
 TEST_F(EventsDatabaseTests, test_expire_check) {

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -185,7 +185,9 @@ bool ExtensionManagerHandler::exists(const std::string& name) {
 }
 }
 
-ExtensionRunnerCore::~ExtensionRunnerCore() { remove(path_); }
+ExtensionRunnerCore::~ExtensionRunnerCore() {
+  remove(path_);
+}
 
 void ExtensionRunnerCore::stop() {
   {

--- a/osquery/tables/events/darwin/disk_events.cpp
+++ b/osquery/tables/events/darwin/disk_events.cpp
@@ -9,9 +9,9 @@
  */
 
 #include <osquery/core.h>
+#include <osquery/events.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-#include <osquery/events.h>
 
 #include "osquery/events/darwin/diskarbitration.h"
 
@@ -53,12 +53,13 @@ Status DiskEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   r["filesystem"] = ec->filesystem;
   r["checksum"] = ec->checksum;
 
-  EventTime time = ec->time;
+  EventTime et = ec->time;
   if (ec->action == "add") {
-    boost::conversion::try_lexical_convert(ec->disk_appearance_time, time);
+    // Disk appearance time may be used in the future.
+    boost::conversion::try_lexical_convert(ec->disk_appearance_time, et);
   }
 
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -92,7 +92,7 @@ Status FileEventSubscriber::Callback(const FSEventsEventContextRef& ec,
   decorateFileEvent(
       ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
 
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/events/darwin/hardware_events.cpp
+++ b/osquery/tables/events/darwin/hardware_events.cpp
@@ -55,7 +55,7 @@ Status HardwareEventSubscriber::Callback(
   r["vendor"] = ec->vendor;
   r["serial"] = ec->serial;
   r["revision"] = ec->version;
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/events/darwin/process_events.cpp
+++ b/osquery/tables/events/darwin/process_events.cpp
@@ -121,7 +121,7 @@ Status ProcessEventSubscriber::Callback(
   r["path"] = ec->event.path;
   r["uptime"] = BIGINT(ec->uptime);
 
-  add(r, ec->time);
+  add(r);
 
   return Status(0, "OK");
 }

--- a/osquery/tables/events/darwin/process_file_events.cpp
+++ b/osquery/tables/events/darwin/process_file_events.cpp
@@ -98,7 +98,7 @@ Status ProcessFileEventSubscriber::Callback(
   r["path"] = ec->event.path;
   r["uptime"] = BIGINT(ec->uptime);
 
-  add(r, ec->time);
+  add(r);
 
   return Status(0, "OK");
 }

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -94,8 +94,8 @@ Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   if ((sc->mask & kFileAccessMasks) != kFileAccessMasks) {
     // Add hashing and 'join' against the file table for stat-information.
-    decorateFileEvent(ec->path,
-                      (ec->action == "CREATED" || ec->action == "UPDATED"), r);
+    decorateFileEvent(
+        ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
   } else {
     // The access event on Linux would generate additional events if stated.
     for (const auto& column : kCommonFileColumns) {
@@ -106,7 +106,7 @@ Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   // A callback is somewhat useless unless it changes the EventSubscriber
   // state or calls `add` to store a marked up event.
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -69,7 +69,7 @@ Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   r["serial"] =
       INTEGER(UdevEventPublisher::getValue(device, "ID_SERIAL_SHORT"));
   r["revision"] = INTEGER(UdevEventPublisher::getValue(device, "ID_REVISION"));
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
 }

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -178,7 +178,7 @@ Status ProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
       row_["cmdline_size"] = "1";
     }
 
-    add(row_, getUnixTime());
+    add(row_);
     Row().swap(row_);
   }
 

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -136,7 +136,7 @@ Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef&) {
       row_["remote_port"] = "0";
       // Parse the struct and emit the row.
       parseSockAddr(saddr, row_, (row_.at("action") == "bind"));
-      add(row_, getUnixTime());
+      add(row_);
       Row().swap(row_);
       waiting_for_saddr_ = false;
     }

--- a/osquery/tables/events/linux/syslog_events.cpp
+++ b/osquery/tables/events/linux/syslog_events.cpp
@@ -25,8 +25,10 @@ FLAG(uint64,
      60 * 60 * 24 * 30, // Keep 30 days by default
      "Timeout to expire event subscriber results");
 
-FLAG(uint64, syslog_events_max, 100000, "Maximum number of events per type to buffer");
-
+FLAG(uint64,
+     syslog_events_max,
+     100000,
+     "Maximum number of events per type to buffer");
 
 class SyslogEventSubscriber : public EventSubscriber<SyslogEventPublisher> {
  public:
@@ -36,8 +38,15 @@ class SyslogEventSubscriber : public EventSubscriber<SyslogEventPublisher> {
     subscribe(&SyslogEventSubscriber::Callback, sc);
     return Status(0, "OK");
   }
-  size_t getEventsExpiry() override { return FLAGS_syslog_events_expiry; }
-  size_t getEventsMax() override { return FLAGS_syslog_events_max; }
+
+  size_t getEventsExpiry() override {
+    return FLAGS_syslog_events_expiry;
+  }
+
+  size_t getEventsMax() override {
+    return FLAGS_syslog_events_max;
+  }
+
   Status Callback(const ECRef& ec, const SCRef& sc);
 };
 
@@ -45,9 +54,7 @@ REGISTER(SyslogEventSubscriber, "event_subscriber", "syslog");
 
 Status SyslogEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   Row r(ec->fields);
-
-  add(r, ec->time);
+  add(r);
   return Status(0, "OK");
 }
-
 }

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -56,7 +56,7 @@ Status UserEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   r["terminal"] = ec->fields["terminal"];
   r["uptime"] = INTEGER(tables::getUptime());
 
-  add(r, getUnixTime());
+  add(r);
   return Status(0, "OK");
 }
 } // namespace osquery

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -36,14 +36,14 @@ namespace tables {
 using FileEventSubscriber = EventSubscriber<FSEventsEventPublisher>;
 using FileEventContextRef = FSEventsEventContextRef;
 using FileSubscriptionContextRef = FSEventsSubscriptionContextRef;
-#define FILE_CHANGE_MASK                                                     \
-  kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemModified | \
+#define FILE_CHANGE_MASK                                                       \
+  kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemModified |   \
       kFSEventStreamEventFlagItemRenamed
 #elif __linux__
 using FileEventSubscriber = EventSubscriber<INotifyEventPublisher>;
 using FileEventContextRef = INotifyEventContextRef;
 using FileSubscriptionContextRef = INotifySubscriptionContextRef;
-#define FILE_CHANGE_MASK \
+#define FILE_CHANGE_MASK                                                       \
   ((IN_CREATE) | (IN_CLOSE_WRITE) | (IN_MODIFY) | (IN_MOVED_TO))
 #endif
 
@@ -186,7 +186,7 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
   }
 
   if (ec->action != "" && r.at("matches").size() > 0) {
-    add(r, ec->time);
+    add(r);
   }
 
   return Status(0, "OK");

--- a/specs/linux/syslog.table
+++ b/specs/linux/syslog.table
@@ -1,11 +1,12 @@
 table_name("syslog")
 schema([
-    Column("time", BIGINT),
-    Column("host", TEXT),
-    Column("severity", INTEGER),
-    Column("facility", TEXT),
-    Column("tag", TEXT),
-    Column("message", TEXT),
+    Column("time", BIGINT, "Current unix epoch time"),
+    Column("datetime", TEXT, "Time known to syslog"),
+    Column("host", TEXT, "Hostname configured for syslog"),
+    Column("severity", INTEGER, "Syslog severity"),
+    Column("facility", TEXT, "Syslog facility"),
+    Column("tag", TEXT, "The syslog tag"),
+    Column("message", TEXT, "The syslog message"),
 ])
 attributes(event_subscriber=True)
 implementation("syslog_events@SyslogEventSubscriber::genTable")


### PR DESCRIPTION
This will remove the use of current time for `syslog.time` and introduce a new column called `datetime`.

Events now uses an `optimize_id` alongside `optimize` to prevent returning colliding events added within the same second as the previous `genTable` call.