### PR TITLE
Gate the default dependency path to Linux

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -88,19 +88,26 @@ macro(ADD_OSQUERY_LINK IS_CORE LINK)
 endmacro(ADD_OSQUERY_LINK)
 
 macro(ADD_OSQUERY_LINK_INTERNAL LINK LINK_PATHS LINK_SET)
+  # The relative linking set is used for static libraries.
   set(LINK_PATHS_RELATIVE
     "${BUILD_DEPS}/lib"
     ${LINK_PATHS}
     ${OS_LIB_DIRS}
     "$ENV{HOME}"
   )
+
+  # The system linking set is for legacy ABI compatibility links and libraries
+  # known to exist on the system.
   set(LINK_PATHS_SYSTEM
     ${LINK_PATHS}
     "${BUILD_DEPS}/legacy/lib"
-    # Allow the build to search the default deps include for libz.
-    "${BUILD_DEPS}/lib"
-    ${OS_LIB_DIRS}
   )
+  if(LINUX)
+    # Allow the build to search the 'default' dependency home for libgcc_s.
+    list(APPEND LINK_PATHS_SYSTEM "${BUILD_DEPS}/lib")
+  endif()
+  # The OS library paths are very important for system linking.
+  list(APPEND LINK_PATHS_SYSTEM ${OS_LIB_DIRS})
 
   if(NOT "${LINK}" MATCHES "(^[-/].*)")
     string(REPLACE " " ";" ITEMS "${LINK}")


### PR DESCRIPTION
Previously the dependencies' library path was added to `LINK_PATHS_SYSTEM` meaning dynamically-linked libraries could prefer our installed dependencies over those libraries available on the system. This was added to accommodate `libgcc_s` on Linux, which maintains an acceptable ABI.

On OS X the `liblzma` was included in our install path and linked as a mistake. This PR almost mitigates the issue. Eventually a refactor is needed to allow call sites to determine how they want to link: dynamic, dynamic system, or static. 