### PR TITLE
Removed liblzma from osx deps to avoid an issue when creating/installing pkg files

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -81,7 +81,7 @@ if(NOT WINDOWS)
 endif()
 
 if(APPLE)
-  ADD_OSQUERY_LINK_CORE("liblzma libbz2")
+  ADD_OSQUERY_LINK_CORE("libbz2")
 else()
   if(NOT WINDOWS)
     ADD_OSQUERY_LINK_CORE("lzma")


### PR DESCRIPTION
After the `make deps` re-architecture, there has been an issue with creating osx pkg files due to a version dependency on liblzma.  The changes have caused osquery to use liblzma from the brew package xz which uses liblzma > 8.0.0.  When creating pkg files and installing them on a vanilla osx install, you will get the following error when running `sudo osqueryd` after install:

`dyld: Library not loaded: /usr/local/osquery/opt/xz/lib/liblzma.5.dylib
  Referenced from: /usr/local/bin/osqueryd
  Reason: Incompatible library version: osqueryd requires version 8.0.0 or later, but liblzma.5.dylib provides version 6.0.0`

It looks like the version of liblzma used during build is not being statically included correctly.  The simplest solution was to remove it from the cmakelists file and everything works.

Please let me know if there is a better solution.  I tried a few different things, but this seemed to be the simplest.

Also note:  I used the standard build procedure (and various others):
```
make depsclean
make distclean
make deps
make -j 10
make packages
```