### PR TITLE
Fixing "Terminated unexpectedly" whilst shutting service down issue

### DIFF
--- a/osquery/main/windows/daemon.cpp
+++ b/osquery/main/windows/daemon.cpp
@@ -231,6 +231,7 @@ void daemonEntry(int argc, char* argv[]) {
     if (kStopEvent != nullptr) {
       ::WaitForSingleObject(kStopEvent, INFINITE);
 
+      UpdateServiceStatus(0, SERVICE_STOPPED, 0, 3);
       runner.requestShutdown();
     }
 
@@ -253,6 +254,7 @@ void daemonEntry(int argc, char* argv[]) {
   if (kStopEvent != nullptr) {
     ::WaitForSingleObject(kStopEvent, INFINITE);
 
+    UpdateServiceStatus(0, SERVICE_STOPPED, 0, 3);
     runner.requestShutdown();
   }
 


### PR DESCRIPTION
Stopping **osquery daemon service** on Windows will succeed but result in "Terminated unexpectedly" error. This is because prior to requesting shutdown, we do not signal to the service control manager that the service has stopped.

To fix this, we update the service status both for the watcher and the worker (only if `--disable-watchdog` is triggered).