### PR TITLE
deps: Add ccache to provision

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -208,6 +208,7 @@ function platform_linux_main() {
   local_brew_tool cmake --without-docs
   local_brew_tool zzuf
   local_brew_tool cppcheck
+  local_brew_tool ccache
 
   # Linux library secondary dependencies.
   local_brew_tool berkeley-db
@@ -277,6 +278,7 @@ function platform_darwin_main() {
   local_brew_tool cmake --without-docs
   local_brew_tool zzuf
   local_brew_tool cppcheck
+  local_brew_tool ccache
 
   # List of LLVM-compiled dependencies.
   local_brew_dependency boost

--- a/tools/provision/formula/ccache.rb
+++ b/tools/provision/formula/ccache.rb
@@ -1,0 +1,61 @@
+require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
+
+class Ccache < AbstractOsqueryFormula
+  desc "Object-file caching compiler wrapper"
+  homepage "https://ccache.samba.org/"
+  url "https://www.samba.org/ftp/ccache/ccache-3.3.1.tar.xz"
+  sha256 "c6d87a49cc6d7639636d289ed9a5f560bc2acf7ab698fe8ee14e9c9f15ba41c6"
+
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "de5a5e43ceb9b925a94fe0b5788fdca0ae58ae12eb48819a765cd3ad6c9a65f7" => :el_capitan
+    sha256 "7e2f7acbedf1466376a4cbe6ca90e0cc1ce1d3cebbd31bd0cd10447ffd333bb1" => :x86_64_linux
+  end
+
+  head do
+    url "https://github.com/ccache/ccache.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  def install
+    system "./autogen.sh" if build.head?
+    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--with-bundled-zlib"
+    system "make"
+    system "make", "install"
+
+    libexec.mkpath
+
+    %w[
+      clang
+      clang++
+      cc
+      gcc gcc2 gcc3 gcc-3.3 gcc-4.0 gcc-4.2 gcc-4.3 gcc-4.4 gcc-4.5 gcc-4.6 gcc-4.7 gcc-4.8 gcc-4.9 gcc-5 gcc-6
+      c++ c++3 c++-3.3 c++-4.0 c++-4.2 c++-4.3 c++-4.4 c++-4.5 c++-4.6 c++-4.7 c++-4.8 c++-4.9 c++-5 c++-6
+      g++ g++2 g++3 g++-3.3 g++-4.0 g++-4.2 g++-4.3 g++-4.4 g++-4.5 g++-4.6 g++-4.7 g++-4.8 g++-4.9 g++-5 g++-6
+    ].each do |prog|
+      libexec.install_symlink bin/"ccache" => prog
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    To install symlinks for compilers that will automatically use
+    ccache, prepend this directory to your PATH:
+      #{opt_libexec}
+    If this is an upgrade and you have previously added the symlinks to
+    your PATH, you may need to modify it to the path specified above so
+    it points to the current version.
+    NOTE: ccache can prevent some software from compiling.
+    ALSO NOTE: The brew command, by design, will never use ccache.
+    EOS
+  end
+
+  test do
+    ENV.prepend_path "PATH", opt_libexec
+    assert_equal "#{opt_libexec}/gcc", shell_output("which gcc").chomp
+    system "#{bin}/ccache", "-s"
+  end
+end


### PR DESCRIPTION
We plan to use `ccache` on the AWS build hosts. The easiest way to configure these are through the existing provision script.