### PR TITLE
Restrict regular file checking of TLS pinned cert to Windows

### DIFF
--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -117,11 +117,12 @@ http::client TLSTransport::getClient() {
       options.openssl_verify_path(server_certificate_file_);
 
       // On Windows, we cannot set openssl_certificate to a directory
-      if (status.type() == fs::regular_file) {
-        options.openssl_certificate(server_certificate_file_);
-      } else {
+      if (isPlatform(PlatformType::TYPE_WINDOWS) &&
+          status.type() != fs::regular_file) {
         LOG(WARNING) << "Cannot set a non-regular file as a certificate: "
                      << server_certificate_file_;
+      } else {
+        options.openssl_certificate(server_certificate_file_);
       }
     }
   }


### PR DESCRIPTION
On OS X and Linux, we can use a directory for server certificate pinning. A restriction of regular files was added for Windows but did not include a platform check.