### PR TITLE
Attempt to query platform UUID on Linux

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -102,6 +102,7 @@ std::string getHostname() {
 }
 
 std::string generateNewUUID() {
+  LOG(INFO) << "Cannot retrieve platform UUID: generating an ephemeral UUID";
   boost::uuids::uuid uuid = boost::uuids::random_generator()();
   return boost::uuids::to_string(uuid);
 }
@@ -124,6 +125,11 @@ std::string generateHostUUID() {
     return generateNewUUID();
   }
 #else
+  std::string uuid;
+  if (readFile("/sys/class/dmi/id/product_uuid", uuid)) {
+    boost::algorithm::trim(uuid);
+    return uuid;
+  }
   return generateNewUUID();
 #endif
 }


### PR DESCRIPTION
Linux hosts should act like OS X and attempt to return the platform/motherboard UUID before generating an ephemeral. 