### PR TITLE
Refactor events and remove 10/3600 indexes

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -424,13 +424,10 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @param start an inclusive time to begin searching.
    * @param stop an inclusive time to end searching.
-   * @param list_key optional key to bind to a specific index binning.
    *
    * @return List of 'index.step' index strings.
    */
-  std::set<std::string> getIndexes(EventTime start,
-                                   EventTime stop,
-                                   size_t list_key = 0);
+  std::set<std::string> getIndexes(EventTime start, EventTime stop);
 
   /**
    * @brief Expire indexes and eventually records.

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -402,7 +402,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return List of EventID, EventTime%s
    */
-  std::vector<EventRecord> getRecords(const std::set<std::string>& indexes);
+  std::vector<EventRecord> getRecords(const std::vector<std::string>& indexes);
 
   /**
    * @brief Get a unique storage-related EventID.
@@ -427,7 +427,7 @@ class EventSubscriberPlugin : public Plugin {
    *
    * @return List of 'index.step' index strings.
    */
-  std::set<std::string> getIndexes(EventTime start, EventTime stop);
+  std::vector<std::string> getIndexes(EventTime start, EventTime stop);
 
   /**
    * @brief Expire indexes and eventually records.

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -51,12 +51,6 @@ FLAG(uint64,
 // overriding in subclasses
 FLAG(uint64, events_max, 1000, "Maximum number of events per type to buffer");
 
-const std::vector<size_t> kEventTimeLists = {
-    1 * 60 * 60, // 1 hour
-    1 * 60, // 1 minute
-    10, // 10 seconds
-};
-
 static inline EventTime timeFromRecord(const std::string& record) {
   // Convert a stored index "as string bytes" to a time value.
   long long afinite;
@@ -68,7 +62,7 @@ static inline EventTime timeFromRecord(const std::string& record) {
 
 QueryData EventSubscriberPlugin::genTable(QueryContext& context) {
   // Stop is an unsigned (-1), our end of time equivalent.
-  EventTime start = 0, stop = -1;
+  EventTime start = 0, stop = 0;
   if (context.constraints["time"].getAll().size() > 0) {
     // Use the 'time' constraint to optimize backing-store lookups.
     for (const auto& constraint : context.constraints["time"].getAll()) {
@@ -135,103 +129,39 @@ void EventPublisherPlugin::fire(const EventContextRef& ec, EventTime time) {
 }
 
 std::set<std::string> EventSubscriberPlugin::getIndexes(EventTime start,
-                                                        EventTime stop,
-                                                        size_t list_key) {
+                                                        EventTime stop) {
   auto index_key = "indexes." + dbNamespace();
   std::set<std::string> indexes;
 
-  // Keep track of the tail/head of account time while bin searching.
-  EventTime start_max = stop, stop_min = stop, local_start, local_stop;
-  auto types = kEventTimeLists.size();
-  // List types are sized bins of time containing records for this namespace.
-  for (size_t i = 0; i < types; ++i) {
-    auto size = kEventTimeLists[i];
-    if (list_key > 0 && i != list_key) {
-      // A specific list_type was requested, only return bins of this key.
-      continue;
+  EventTime l_start = (start > 0) ? start / 60 : 0;
+  EventTime r_stop = (stop > 0) ? stop / 60 + 1 : 0;
+
+  std::string content;
+  getDatabaseValue(kEvents, index_key + ".60", content);
+  if (content.empty()) {
+    return indexes;
+  }
+
+  std::vector<std::string> bins, expirations;
+  boost::split(bins, content, boost::is_any_of(","));
+  for (const auto& bin : bins) {
+    auto step = timeFromRecord(bin);
+    auto step_start = step * 60;
+    auto step_stop = (step + 1) * 60;
+    if (step_stop < expire_time_) {
+      expirations.push_back(bin);
+    } else if (step_start < expire_time_) {
+      expireRecords("60", bin, false);
     }
 
-    std::string time_list;
-    auto list_type = boost::lexical_cast<std::string>(size);
-    getDatabaseValue(kEvents, index_key + "." + list_type, time_list);
-    if (time_list.empty()) {
-      // No events in this binning size.
-      return indexes;
+    if (step >= l_start && (r_stop == 0 || step < r_stop)) {
+      indexes.insert("60." + bin);
     }
+  }
 
-    if (list_key == 0 && i == (types - 1) && types > 1) {
-      // Relax the requested start/stop bounds.
-      if (start != start_max) {
-        start = (start / size) * size;
-        start_max = ((start / size) + 1) * size;
-        if (start_max < stop) {
-          start_max = start + kEventTimeLists[types - 2]; // local_start
-        }
-      }
-
-      if (stop != stop_min) {
-        stop = ((stop / size) + 1) * size;
-        stop_min = (stop / size) * size;
-        if (stop_min > start) {
-          stop_min = stop_min - kEventTimeLists[types - 1];
-        }
-      }
-    } else if (list_key > 0 || types == 1) {
-      // Relax the requested bounds to fit the requested/only index.
-      start = (start / size) * size;
-      start_max = ((start_max / size) + 1) * size;
-    }
-
-    // (1) The first iteration will have 1 range (start to start_max=stop).
-    // (2) Intermediate iterations will have 2 (start-start_max, stop-stop_min).
-    // For each iteration the range collapses based on the coverage using
-    // the first bin's start time and the last bin's stop time.
-    // (3) The last iteration's range includes relaxed bounds outside the
-    // requested start to stop range.
-    std::vector<std::string> all_bins, bins, expirations;
-    boost::split(all_bins, time_list, boost::is_any_of(","));
-    for (const auto& bin : all_bins) {
-      // Bins are identified by the binning size step.
-      auto step = timeFromRecord(bin);
-      // Check if size * step -> size * (step + 1) is within a range.
-      size_t bin_start = size * step;
-      size_t bin_stop = size * (step + 1);
-      if (expire_events_ && expire_time_ > 0) {
-        if (bin_stop <= expire_time_) {
-          // This entire bin will be expired.
-          expirations.push_back(bin);
-        } else if (bin_start < expire_time_) {
-          expireRecords(list_type, bin, false);
-        }
-      }
-
-      if (bin_start >= start && bin_stop <= start_max) {
-        bins.push_back(bin);
-      } else if ((bin_start >= stop_min && bin_stop <= stop) || stop == 0) {
-        bins.push_back(bin);
-      }
-    }
-
-    // Rewrite the index lists and delete each expired item.
-    if (!expirations.empty()) {
-      expireIndexes(list_type, all_bins, expirations);
-    }
-
-    if (!bins.empty()) {
-      // If more precision was achieved though this list's binning.
-      local_start = timeFromRecord(bins.front()) * size;
-      start_max = (local_start < start_max) ? local_start : start_max;
-      local_stop = (timeFromRecord(bins.back()) + 1) * size;
-      stop_min = (local_stop < stop_min) ? local_stop : stop_min;
-    }
-
-    for (const auto& bin : bins) {
-      indexes.insert(list_type + "." + bin);
-    }
-
-    if (start == start_max && stop == stop_min) {
-      break;
-    }
+  // Rewrite the index lists and delete each expired item.
+  if (!expirations.empty()) {
+    expireIndexes("60", bins, expirations);
   }
 
   // Update the new time that events expire to now - expiry.
@@ -385,59 +315,46 @@ std::vector<EventRecord> EventSubscriberPlugin::getRecords(
   return records;
 }
 
-Status EventSubscriberPlugin::recordEvent(EventID& eid, EventTime time) {
-  Status status;
-  std::string time_value = boost::lexical_cast<std::string>(time);
+Status EventSubscriberPlugin::recordEvent(EventID& eid, EventTime et) {
+  std::string time_value = boost::lexical_cast<std::string>(et);
 
   // The record is identified by the event type then module name.
   std::string index_key = "indexes." + dbNamespace();
   std::string record_key = "records." + dbNamespace();
   // The list key includes the list type (bin size) and the list ID (bin).
-  std::string list_key;
   std::string list_id;
 
-  for (const auto& time_list : kEventTimeLists) {
-    // The list_id is the MOST-Specific key ID, the bin for this list.
-    // If the event time was 13 and the time_list is 5 seconds, lid = 2.
-    list_id = boost::lexical_cast<std::string>(time / time_list);
-    // The list name identifies the 'type' of list.
-    list_key = boost::lexical_cast<std::string>(time_list);
-    // list_key = list_key + "." + list_id;
+  // The list_id is the MOST-Specific key ID, the bin for this list.
+  // If the event time was 13 and the time_list is 5 seconds, lid = 2.
+  list_id = boost::lexical_cast<std::string>(et / 60);
 
-    {
-      WriteLock lock(event_record_lock_);
-      // Append the record (eid, unix_time) to the list bin.
-      std::string record_value;
-      status = getDatabaseValue(
-          kEvents, record_key + "." + list_key + "." + list_id, record_value);
+  WriteLock lock(event_record_lock_);
+  // Append the record (eid, unix_time) to the list bin.
+  std::string record_value;
+  getDatabaseValue(kEvents, record_key + ".60." + list_id, record_value);
 
-      if (record_value.length() == 0) {
-        // This is a new list_id for list_key, append the ID to the indirect
-        // lookup for this list_key.
-        std::string index_value;
-        status =
-            getDatabaseValue(kEvents, index_key + "." + list_key, index_value);
-        if (index_value.length() == 0) {
-          // A new index.
-          index_value = list_id;
-        } else {
-          index_value += "," + list_id;
-        }
-        status =
-            setDatabaseValue(kEvents, index_key + "." + list_key, index_value);
-        record_value = eid + ":" + time_value;
-      } else {
-        // Tokenize a record using ',' and the EID/time using ':'.
-        record_value += "," + eid + ":" + time_value;
-      }
-      status = setDatabaseValue(
-          kEvents, record_key + "." + list_key + "." + list_id, record_value);
-      if (!status.ok()) {
-        LOG(ERROR) << "Could not put Event Record key: " << record_key;
-      }
+  if (record_value.length() == 0) {
+    // This is a new list_id for list_key, append the ID to the indirect
+    // lookup for this list_key.
+    std::string index_value;
+    getDatabaseValue(kEvents, index_key + ".60", index_value);
+    if (index_value.length() == 0) {
+      // A new index.
+      index_value = list_id;
+    } else {
+      index_value += "," + list_id;
     }
+    setDatabaseValue(kEvents, index_key + ".60", index_value);
+    record_value = eid + ":" + time_value;
+  } else {
+    // Tokenize a record using ',' and the EID/time using ':'.
+    record_value += "," + eid + ":" + time_value;
   }
-
+  auto status =
+      setDatabaseValue(kEvents, record_key + ".60." + list_id, record_value);
+  if (!status.ok()) {
+    LOG(ERROR) << "Could not put Event Record key: " << record_key;
+  }
   return Status(0, "OK");
 }
 

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -97,7 +97,7 @@ TEST_F(EventsDatabaseTests, test_record_indexing) {
   // An "all" range, will pick up everything in the largest index.
   auto indexes = sub->getIndexes(0, 3 * 3600);
   auto output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ("60.0, 60.1, 60.120, 60.60", output);
+  EXPECT_EQ("60.0, 60.1, 60.60, 60.120", output);
 
   // Restrict range to "most specific", which is an index by 10.
   indexes = sub->getIndexes(0, 5);
@@ -115,7 +115,7 @@ TEST_F(EventsDatabaseTests, test_record_indexing) {
   // Request specific lower and upper bounding.
   indexes = sub->getIndexes(2, (2 * 3600) + 62);
   output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ("60.0, 60.1, 60.120, 60.121, 60.60", output);
+  EXPECT_EQ("60.0, 60.1, 60.60, 60.120, 60.121", output);
 }
 
 TEST_F(EventsDatabaseTests, test_record_range) {
@@ -157,7 +157,7 @@ TEST_F(EventsDatabaseTests, test_record_range) {
 
   indexes = sub->getIndexes(110, 0);
   auto output = boost::algorithm::join(indexes, ", ");
-  EXPECT_EQ("60.1, 60.120, 60.2, 60.60", output);
+  EXPECT_EQ("60.1, 60.2, 60.60, 60.120", output);
   records = sub->getRecords(indexes);
   EXPECT_EQ(33U, records.size()); // (61) 110 - 139 + 3601, 7201
 }


### PR DESCRIPTION
Closes #2513.

This removes the 10s and 3600s indexes for events. The result is a simpler indexing algorithm at similar cost/time.