### PR TITLE
Add extensions SDK incompatibility checking

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -147,6 +147,19 @@ extern const std::string kVersion;
 /// The SDK version removes any git revision hash (1.6.1-g0000 becomes 1.6.1).
 extern const std::string kSDKVersion;
 
+/**
+ * @breif Compare osquery SDK/extenion/core version strings.
+ *
+ * SDK versions are in major.minor.patch-commit-hash form. We provide a helper
+ * method for performing version comparisons to allow gating and compatibility
+ * checks throughout the code.
+ *
+ * @param v version to check
+ * @param sdk (optional) the SDK version to check against.
+ * return true if the input version is at least the SDK version.
+ */
+bool versionAtLeast(const std::string& v, const std::string& sdk = kSDKVersion);
+
 /// Identifies the build platform of either the core extension.
 extern const std::string kSDKPlatform;
 

--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -22,7 +22,7 @@ DECLARE_string(extensions_timeout);
 DECLARE_bool(disable_extensions);
 
 /// A millisecond internal applied to extension initialization.
-extern const size_t kExtensionInitializeLatencyUS;
+extern const size_t kExtensionInitializeLatency;
 
 /**
  * @brief Helper struct for managing extenion metadata.

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -263,28 +263,7 @@ bool Pack::checkVersion(const std::string& version) const {
     return true;
   }
 
-  auto required_version = split(version, ".");
-  auto build_version = split(kSDKVersion, ".");
-
-  size_t index = 0;
-  for (const auto& chunk : build_version) {
-    if (required_version.size() <= index) {
-      return true;
-    }
-    try {
-      if (std::stoi(chunk) < std::stoi(required_version[index])) {
-        return false;
-      } else if (std::stoi(chunk) > std::stoi(required_version[index])) {
-        return true;
-      }
-    } catch (const std::invalid_argument& /* e */) {
-      if (chunk.compare(required_version[index]) < 0) {
-        return false;
-      }
-    }
-    index++;
-  }
-  return true;
+  return versionAtLeast(version, kSDKVersion);
 }
 
 bool Pack::checkDiscovery() {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -495,9 +495,9 @@ void Initializer::initActivePlugin(const std::string& type,
   // Use a delay, meaning the amount of milliseconds waited for extensions.
   size_t delay = 0;
   // The timeout is the maximum milliseconds in seconds to wait for extensions.
-  size_t timeout = atoi(FLAGS_extensions_timeout.c_str()) * 1000000;
-  if (timeout < kExtensionInitializeLatencyUS * 10) {
-    timeout = kExtensionInitializeLatencyUS * 10;
+  size_t timeout = atoi(FLAGS_extensions_timeout.c_str()) * 1000;
+  if (timeout < kExtensionInitializeLatency * 10) {
+    timeout = kExtensionInitializeLatency * 10;
   }
 
   // Attempt to set the request plugin as active.
@@ -514,8 +514,8 @@ void Initializer::initActivePlugin(const std::string& type,
       break;
     }
     // The plugin is not local and is not active, wait and retry.
-    delay += kExtensionInitializeLatencyUS;
-    sleepFor(kExtensionInitializeLatencyUS / 1000);
+    delay += kExtensionInitializeLatency;
+    sleepFor(kExtensionInitializeLatency);
   } while (delay < timeout);
 
   LOG(ERROR) << "Cannot activate " << name << " " << type

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -12,6 +12,8 @@
 
 #include <osquery/core.h>
 
+#include "osquery/core/conversions.h"
+
 // If CMake/gmake did not define a build version set the version to 1.0.
 // clang-format off
 #if !defined(OSQUERY_BUILD_VERSION)
@@ -33,4 +35,34 @@ const std::string kVersion = STR(OSQUERY_BUILD_VERSION);
 const std::string kSDKVersion = OSQUERY_SDK_VERSION;
 const std::string kSDKPlatform = OSQUERY_PLATFORM;
 const PlatformType kPlatformType = static_cast<PlatformType>(OSQUERY_PLATFORM_MASK);
+
+bool versionAtLeast(const std::string& v, const std::string& sdk) {
+  if (v == "0.0.0" || sdk == "0.0.0") {
+    // This is a please-pass check.
+    return true;
+  }
+
+  auto required_version = split(v, ".");
+  auto build_version = split(sdk, ".");
+
+  size_t index = 0;
+  for (const auto& chunk : build_version) {
+    if (required_version.size() <= index) {
+      return true;
+    }
+    try {
+      if (std::stoi(chunk) < std::stoi(required_version[index])) {
+        return false;
+      } else if (std::stoi(chunk) > std::stoi(required_version[index])) {
+        return true;
+      }
+    } catch (const std::invalid_argument& /* e */) {
+      if (chunk.compare(required_version[index]) < 0) {
+        return false;
+      }
+    }
+    index++;
+  }
+  return true;
+}
 }


### PR DESCRIPTION
This is not an API change, but does begin to enforce API change incompatibility checks for extensions. The first may be 1.8.2 and 1.8.2+ unless we revert a number container size for `RouteUUID`.