### PR TITLE
Correct config-loaded meaning to be has-run-load

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -319,6 +319,7 @@ Status Config::load() {
   PluginResponse response;
   auto status = Registry::call("config", {{"action", "genConfig"}}, response);
   if (!status.ok()) {
+    loaded_ = true;
     return status;
   }
 
@@ -536,8 +537,6 @@ Status Config::update(const std::map<std::string, std::string>& config) {
       Registry::registry("event_publisher")->configure();
     }
   }
-
-  loaded_ = true;
 
   return Status(0, "OK");
 }


### PR DESCRIPTION
The `loaded_` member of configuration acts as a "has-run-load" check. This exists because `Config::update` may be called multiple times before the `Initializer` has completed a configuration load.