### PR TITLE
Create temp directory and fail over to user home

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -472,6 +472,7 @@ const std::string& osqueryHomeDirectory() {
     // Fail over to a temporary directory (used for the shell).
     auto temp =
         fs::temp_directory_path(ec) / fs::unique_path("osquery%%%%%%%%", ec);
+    boost::filesystem::create_directories(temp, ec);
     homedir = temp.make_preferred().string();
   }
 

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -18,8 +18,9 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
-#include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
+
+#include <osquery/filesystem.h>
 
 #include "osquery/core/process.h"
 #include "osquery/filesystem/fileops.h"
@@ -263,8 +264,13 @@ boost::optional<std::string> getHomeDirectory() {
   auto user = ::getpwuid(getuid());
   auto homedir = getEnvVar("HOME");
   if (homedir.is_initialized()) {
-    return homedir;
-  } else if (user != nullptr && user->pw_dir != nullptr) {
+    // Fail over to the users home directory if HOME is not writable.
+    if (isWritable(*homedir)) {
+      return homedir;
+    }
+  }
+
+  if (user != nullptr && user->pw_dir != nullptr) {
     return std::string(user->pw_dir);
   } else {
     return boost::none;


### PR DESCRIPTION
Two fixes to home directory assumptions:

1. If you have `HOME` set by `sudo` and it cannot be accessed, fall back to using effective user's home directory.
2. If a temporary directory is used it should be created before returning and caching.