### PR TITLE
Initialize VirtualTableContent attributes

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -460,7 +460,7 @@ struct VirtualTableContent {
 
   /// Attributes are copied into the content such that they can be quickly
   /// passed to the SQL and optional Query for inspection.
-  TableAttributes attributes;
+  TableAttributes attributes{TableAttributes::NONE};
 
   /**
    * @brief Table column aliases structure.


### PR DESCRIPTION
I found that an uninitialized `TableAttributes` may lead to undefined behavior while testing with older extensions that append to the schema. Pre-1.8.0 routes are equivalent to `::NONE`.