### PR TITLE
docs: Windows 10 badge/install/flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ The tools make low-level operating system analytics and monitoring both performa
 |----------|---------------|---|---|---|
 OS X 10.9    | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.9/) | | **Homepage:** | https://osquery.io
 OS X 10.10/11| [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.11/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildOSX10.11/) | | **Downloads:** | https://osquery.io/downloads
-CentOS 6.5   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/) | | **Tables:** | https://osquery.io/tables
-CentOS 7.0   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/) | | **Packs:** | https://osquery.io/packs
+CentOS 6.x   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS6/) | | **Tables:** | https://osquery.io/tables
+CentOS 7.x   | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildCentOS7/) | | **Packs:** | https://osquery.io/packs
 Ubuntu 12.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu12/) | | **Guide:** | https://osquery.readthedocs.org
 Ubuntu 14.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu14/) | | [![Slack Status](https://osquery-slack.herokuapp.com/badge.svg)](https://osquery-slack.herokuapp.com) | https://osquery-slack.herokuapp.com
 Ubuntu 16.04 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu16/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildUbuntu16/) | | |
+Windows 10 | [![Build Status](https://jenkins.osquery.io/job/osqueryMasterBuildWindows10/badge/icon)](https://jenkins.osquery.io/job/osqueryMasterBuildWindows10/) | | |
 
 #### What is osquery?
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -79,6 +79,10 @@ The higher the level the more strict the limits become. The "debug" level disabl
 
 Attempt to convert all UNIX calendar times to UTC. In version 1.8.0 this will be `true` by default.
 
+**Windows Only**
+
+Windows builds include a `--install` and `--uninstall` that will create a Windows service using the `osqueryd.exe` binary and preserve an optional `--flagfile` if provided.
+
 ### Backing storage control flags
 
 `--database_in_memory=false`
@@ -310,6 +314,10 @@ affects both the query result log and the status logs. **Warning**: If run as ro
 
 Maximum returned row value size.
 
+`--logger_syslog_facility`
+
+Set the syslog facility (number) 0-23 for the results log. When using the **syslog** logger plugin the default facility is 19 at the `LOG_INFO` level, which does not log to `/var/log/system`.
+
 ## Distributed query service flags
 
 `--distributed_plugin=tls`
@@ -323,6 +331,18 @@ Disable distributed queries functionality. By default, this is set to `true` (th
 `--distributed_interval=60`
 
 In seconds, the amount of time that osqueryd will wait between periodically checking in with a distributed query server to see if there are any queries to execute.
+
+## Syslog consumption
+
+There is a `syslog` virtual table that uses Events and a **rsyslog** configuration to capture results *from* syslog. Please see the [Syslog Consumption](../deployment/syslog.md) deployment page for more information.
+
+`--syslog_pipe_path=/var/osquery/syslog_pipe`
+
+Path to the named pipe used for forwarding **rsyslog** events.
+
+`--syslog_rate_limit=100`
+
+Maximum number of logs to ingest per run (~100ms between runs). Use this as a fail-safe to prevent osquery from becoming overloaded when syslog is spammed.
 
 ## Shell-only flags
 

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -1,5 +1,3 @@
-## Downloads
-
 Distro-specific packages are built for each supported operating system.
 These packages contain the osquery daemon, shell, example configuration and startup scripts. Note that the `/etc/init.d/osqueryd` script does not automatically start the daemon until a configuration file is created*.
 
@@ -23,7 +21,7 @@ The default packages create the following structure:
 /usr/bin/osqueryi
 ```
 
-### yum-based Distros
+## yum-based Distros
 
 We publish two packages, osquery and osquery-latest**, in a yum repository for CentOS/RHEL 6.3-6.6 and 7.0-7.1 built from our Jenkins build hosts. You may install the "auto-repo-add" RPM or add the repository target:
 
@@ -41,7 +39,7 @@ $ sudo rpm -ivh https://osquery-packages.s3.amazonaws.com/centos6/noarch/osquery
 $ sudo yum install osquery
 ```
 
-### dpkg-based Distros
+## dpkg-based Distros
 
 We publish the same two packages, osquery and osquery-latest, in an apt repository for Ubuntu 16.04 (xenial), 14.04 (trusty), 12.04 (precise):
 

--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -1,6 +1,4 @@
-### Supported OS Versions
-
-Continuous integration currently tests stable release versions of osquery against 10.9 and 10.10 (as listed under the _Build_status_ column on the project [README](https://github.com/facebook/osquery/blob/master/README.md)). There are no reported issues which block expected core functionality on 10.11.  
+Continuous integration currently tests stable release versions of osquery against 10.9 and 10.11 (as listed under the _Build_status_ column on the project [README](https://github.com/facebook/osquery/blob/master/README.md)). There are no reported issues which block expected core functionality on 10.12.
 
 Each tagged release of osquery may be installed on all versions of OS X.
 
@@ -26,24 +24,8 @@ The default package creates the following structure:
 
 This package does NOT install a LaunchDaemon to start **osqueryd**. You may use the `osqueryctl start` script to copy the sample launch daemon job plist and associated configuration into place.
 
-## Homebrew Installation
+### Post installation steps
 
-The easiest way to install osquery on OS X is via Homebrew. Check the [Homebrew](http://brew.sh/) homepage for installation instructions.
-
-Run the following:
-
-```bash
-$ brew update
-$ brew install osquery
-```
-
-To update osquery:
-
-```bash
-$ brew update
-$ brew upgrade osquery
-```
-###### Post installation steps
 Only applies if you have never installed and run osqueryd on this Mac.
 
 After completing the brew installation run the following commands. If you are using the chef recipe to install osquery then these steps are not necessary, the [recipe](http://osquery.readthedocs.io/en/stable/deployment/configuration/#chef-os-x) has this covered.

--- a/docs/wiki/installation/install-windows.md
+++ b/docs/wiki/installation/install-windows.md
@@ -1,0 +1,13 @@
+As of osquery 1.8.2+ the Windows builds are feature-complete but provide a limited set of tables compared to OS X and Linux.
+
+## Chocolatey
+
+Each osquery tag (release) is published to **chocolatey** for our supported versions: [https://chocolatey.org/packages/osquery/](https://chocolatey.org/packages/osquery/)
+
+## Running osquery
+
+The default install location is `C:\ProgramData\osquery`. The Chocolatey package will also use the `.\osqueryd.exe`'s `--install` and `--uninstall` optional switches to install an osquery service.
+
+We recommend configuring large fleets with Chef or SCCM.
+
+In the future, the osquery repository will include scripts for creating packages and wrapping a helper [`manage-osqueryd.ps1`](https://github.com/facebook/osquery/blob/master/tools/manage-osqueryd.ps1) tool.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ pages:
 - Installation:
   - Install on OS X: installation/install-osx.md
   - Install on Linux: installation/install-linux.md
+  - Install on Windows: installation/install-windows.md
   - Install on FreeBSD: installation/install-freebsd.md
   - Command Line Flags: installation/cli-flags.md
   - 'Optional: Custom Packages': installation/custom-packages.md
@@ -28,7 +29,7 @@ pages:
   - YARA Scanning: deployment/yara.md
   - Process Auditing: deployment/process-auditing.md
   - Remote Settings: deployment/remote.md
-  - Syslog: deployment/syslog.md
+  - Syslog Consumption: deployment/syslog.md
   - Debugging: deployment/debugging.md
 - Development:
   - Building osquery: development/building.md
@@ -41,5 +42,5 @@ pages:
   - Writing Tests: development/unit-tests.md
   - Adding CLI Arguments: development/options-arguments.md
   - Reading/Writing Files: development/reading-files.md
-  - Kernel: development/kernel.md
   - Windows Provisioning: development/windows-provisioning.md
+  - Kernel: development/kernel.md


### PR DESCRIPTION
1. Add a `Windows 10` badge to the README.
2. Add Windows-related osquery flags to the wiki.
3. Add a basic Windows-install guide to the wiki.
4. Document the **syslog** logger plugin and the **syslog** event publisher flags.
5. Remove references to **brew** as a recommended method of install for OS X.