### PR TITLE
Add missing host_identifier in TLS enrollment request documentation

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -40,7 +40,8 @@ The most basic TLS-based server should implement 3 HTTP POST endpoints. This API
 **Enrollment** request POST body:
 ```json
 {
-  "enroll_secret": "..." // Optional.
+  "enroll_secret": "...", // Optional.
+  "host_identifier": "..." // Determined by the --host_identifier flag
 }
 ```
 


### PR DESCRIPTION
Make the documentation consistent with [the code](https://github.com/facebook/osquery/blob/master/osquery/remote/enroll/plugins/tls.cpp#L88).