### PR TITLE
Reduce several INFO logs to VLOGs and increase size-INTEGERs to BIGINT

### DIFF
--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -232,16 +232,18 @@ void EventSubscriberPlugin::expireCheck(bool cleanup) {
   size_t min_key = 0;
 
   {
+    auto limit = getEventsMax();
     std::vector<std::string> keys;
     scanDatabaseKeys(kEvents, keys, data_key);
-    if (keys.size() <= getEventsMax()) {
+    if (keys.size() <= limit) {
       return;
     }
 
     // There is an overflow of events buffered for this subscriber.
     LOG(WARNING) << "Expiring events for subscriber: " << getName()
-                 << " limit (" << getEventsMax()
-                 << ") exceeded: " << keys.size();
+                 << " (limit " << limit << ")";
+    VLOG(1) << "Subscriber events " << getName() << " exceeded limit " << limit
+            << " by: " << keys.size() - limit;
     // Inspect the N-FLAGS_events_max -th event's value and expire before the
     // time within the content.
     std::string last_key;

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+
 #include <string>
 
 #include <thrift/TOutput.h>
@@ -126,9 +127,9 @@ void ExtensionManagerHandler::registerExtension(
 
   // Every call to registerExtension is assigned a new RouteUUID.
   RouteUUID uuid = (uint16_t)rand();
-  LOG(INFO) << "Registering extension (" << info.name << ", " << uuid
-            << ", version=" << info.version << ", sdk=" << info.sdk_version
-            << ")";
+  VLOG(1) << "Registering extension (" << info.name << ", " << uuid
+          << ", version=" << info.version << ", sdk=" << info.sdk_version
+          << ")";
 
   if (!Registry::addBroadcast(uuid, registry).ok()) {
     LOG(WARNING) << "Could not add extension " << info.name

--- a/specs/darwin/disk_events.table
+++ b/specs/darwin/disk_events.table
@@ -6,7 +6,7 @@ schema([
     Column("name", TEXT, "Disk event name"),
     Column("bsd_name", TEXT, "Disk event BSD name"),
     Column("uuid", TEXT, "UUID of the volume inside DMG if available"),
-    Column("size", INTEGER, "Size of partition in bytes"),
+    Column("size", BIGINT, "Size of partition in bytes"),
     Column("ejectable", INTEGER, "1 if ejectable, 0 if not"),
     Column("mountable", INTEGER, "1 if mountable, 0 if not"),
     Column("writable", INTEGER, "1 if writable, 0 if not"),

--- a/specs/darwin/package_bom.table
+++ b/specs/darwin/package_bom.table
@@ -5,7 +5,7 @@ schema([
     Column("uid", INTEGER, "Expected user of file or directory"),
     Column("gid", INTEGER, "Expected group of file or directory"),
     Column("mode", INTEGER, "Expected permissions"),
-    Column("size", INTEGER, "Expected file size"),
+    Column("size", BIGINT, "Expected file size"),
     Column("modified_time", INTEGER, "Timestamp the file was installed"),
     Column("path", TEXT, "Path of package bom", required=True),
 ])

--- a/specs/darwin/quicklock_cache.table
+++ b/specs/darwin/quicklock_cache.table
@@ -7,7 +7,7 @@ schema([
     Column("volume_id", INTEGER, "Parsed volume ID from fs_id"),
     Column("inode", INTEGER, "Parsed file ID (inode) from fs_id"),
     Column("mtime", INTEGER, "Parsed version date field"),
-    Column("size", INTEGER, "Parsed version size field"),
+    Column("size", BIGINT, "Parsed version size field"),
     Column("label", TEXT, "Parsed version 'gen' field"),
     Column("last_hit_date", INTEGER,
       "Apple date format for last thumbnail cache hit"),


### PR DESCRIPTION
The goal here is to reduce several log messages that are difficult to aggregate and make use of. `LOG(INFO)` logs should be countable/reportable. That means in normal/non-exceptional cases they should not include variant information.