### PR TITLE
add osx komplex query

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -278,6 +278,12 @@
       "interval": "86400",
       "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
       "value": "Artifact used by this malware"
+    },
+    "OSX_Komplex": {
+      "query": "select * from file where path = '/Users/Shared/.local/kext' or path = '/Users/Shared/com.apple.updates.plist' or path = '/Users/Shared/start.sh';",
+      "interval": "86400",
+      "description": "(http://researchcenter.paloaltonetworks.com/2016/09/unit42-sofacys-komplex-os-x-trojan/)",
+      "value": "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
> The “_main” function writes the data within ‘_Payload_1’, ‘_Payload_2’, and ‘_Payload_3’ variables to the following files, respectively:
/Users/Shared/.local/kextd (SHA256:
227b7fe495ad9951aebf0aae3c317c1ac526cdd255953f111341b0b11be3bbc5)
/Users/Shared/com.apple.updates.plist (SHA256:
1f22e8f489abff004a3c47210a9642798e1c53efc9d6f333a1072af4b11d71ef)
/Users/Shared/start.sh (SHA256:
d494e9f885ad2d6a2686424843142ddc680bb5485414023976b4d15e3b6be800)