### PR TITLE
Remove gcc from arch provision

### DIFF
--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -64,9 +64,9 @@
 /// Newer versions of LibreSSL will lack SSL methods.
 extern "C" {
 #if defined(NO_SSL_TXT_SSLV3)
-SSL_METHOD* SSLv3_server_method(void);
-SSL_METHOD* SSLv3_client_method(void);
-SSL_METHOD* SSLv3_method(void);
+const SSL_METHOD* SSLv3_server_method(void);
+const SSL_METHOD* SSLv3_client_method(void);
+const SSL_METHOD* SSLv3_method(void);
 #endif
 void ERR_remove_state(unsigned long);
 }

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -16,7 +16,5 @@ function distro_main() {
   package gawk
   package xz
   package ruby
-  package gcc
   package bzip2
 }
-


### PR DESCRIPTION
Building osquery fails if the [multilib] repository is enabled resulting
in a conflict between gcc and gcc-multilib:

```
$ pacman -S gcc
resolving dependencies...
looking for conflicting packages...
:: gcc and gcc-multilib are in conflict. Remove gcc-multilib? [y/N]
error: unresolvable package conflicts detected
error: failed to prepare transaction (conflicting dependencies)
:: gcc and gcc-multilib are in conflict
```