### PR TITLE
Remove package gcc from arch linux provisioner

### DIFF
--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -16,7 +16,6 @@ function distro_main() {
   package gawk
   package xz
   package ruby
-  package gcc
   package bzip2
 }
 


### PR DESCRIPTION
Building osquery fails if the [multilib] repository is enabled resulting
in a conflict between gcc and gcc-multilib:

```
$ pacman -S gcc
resolving dependencies...
looking for conflicting packages...
:: gcc and gcc-multilib are in conflict. Remove gcc-multilib? [y/N]
error: unresolvable package conflicts detected
error: failed to prepare transaction (conflicting dependencies)
:: gcc and gcc-multilib are in conflict
```