### PR TITLE
Efficiency improvements to processes table on Windows

### DIFF
--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -131,8 +131,7 @@ QueryData genProcesses(QueryContext& context) {
   if (pidlist.size() > 0) {
     std::vector<std::string> constraints;
     for (const auto& pid : pidlist) {
-      constraints.push_back("ProcessId=" +
-                            boost::lexical_cast<std::string>(pid));
+      constraints.push_back("ProcessId=" + std::to_string(pid));
     }
     if (constraints.size() > 0) {
       query += " WHERE " + boost::algorithm::join(constraints, " OR ");

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -32,7 +32,7 @@
 namespace osquery {
 namespace tables {
 
-std::set<long> getProcList(const QueryContext& context) {
+std::set<long> getSelectedPids(const QueryContext& context) {
   std::set<long> pidlist;
   if (context.constraints.count("pid") > 0 &&
       context.constraints.at("pid").exists(EQUALS)) {
@@ -41,107 +41,102 @@ std::set<long> getProcList(const QueryContext& context) {
         pidlist.insert(pid);
       }
     }
-    return pidlist;
-  } else {
-    WmiRequest request("SELECT ProcessId FROM Win32_Process");
-    if (request.getStatus().ok()) {
-      long placeHolder;
-      Status s;
-      for (auto const& result : request.results()) {
-        s = result.GetLong("ProcessId", placeHolder);
-        if (!s.ok()) {
-          continue;
-        }
-        pidlist.insert(placeHolder);
-      }
-    }
-    return pidlist;
   }
+
+  /// If there are no constraints, pidlist will be an empty set
+  return pidlist;
 }
 
-void genProcess(long pid, QueryData& results_data) {
+void genProcess(const WmiResultItem& result, QueryData& results_data) {
+  Row r;
+  Status s;
+  long pid;
+  long lPlaceHolder;
+  std::string sPlaceHolder;
+  HANDLE hProcess;
+
   // We store the current processes PID, as there are API calls which are more
   // efficient for populating process info for the current process.
   auto currentPid = GetCurrentProcessId();
 
-  std::stringstream ss;
-  ss << "SELECT * FROM Win32_Process WHERE ProcessId=" << pid;
-
-  WmiRequest request(ss.str());
-  if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
-    if (results.size() == 1) {
-      Row r;
-      Status s;
-      long pid;
-      long lPlaceHolder;
-      std::string sPlaceHolder;
-      HANDLE hProcess;
-
-      s = results[0].GetLong("ProcessId", pid);
-      r["pid"] = s.ok() ? BIGINT(pid) : BIGINT(-1);
-      if (pid == currentPid) {
-        hProcess = GetCurrentProcess();
-      } else {
-        hProcess = OpenProcess(
-            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
-      }
-
-      results[0].GetString("Name", r["name"]);
-      results[0].GetString("ExecutablePath", r["path"]);
-      results[0].GetString("CommandLine", r["cmdline"]);
-      results[0].GetString("ExecutionState", r["state"]);
-      results[0].GetLong("ParentProcessId", lPlaceHolder);
-      r["parent"] = BIGINT(lPlaceHolder);
-      results[0].GetLong("Priority", lPlaceHolder);
-      r["nice"] = INTEGER(lPlaceHolder);
-      r["on_disk"] = osquery::pathExists(r["path"]).toString();
-
-      std::vector<char> fileName(MAX_PATH);
-      fileName.assign(MAX_PATH + 1, '\0');
-      if (pid == currentPid) {
-        GetModuleFileName(nullptr, fileName.data(), MAX_PATH);
-      } else {
-        GetModuleFileNameEx(hProcess, nullptr, fileName.data(), MAX_PATH);
-      }
-      r["cwd"] = SQL_TEXT(fileName.data());
-      r["root"] = r["cwd"];
-
-      r["pgroup"] = "-1";
-      r["uid"] = "-1";
-      r["euid"] = "-1";
-      r["suid"] = "-1";
-      r["gid"] = "-1";
-      r["egid"] = "-1";
-      r["sgid"] = "-1";
-      r["start_time"] = "0";
-
-      // We pre-populate the info, in the event the API calls fail.
-      results[0].GetString("UserModeTime", sPlaceHolder);
-      long long llHolder;
-      osquery::safeStrtoll(sPlaceHolder, 10, llHolder);
-      r["user_time"] = BIGINT(llHolder / 10000000);
-      results[0].GetString("KernelModeTime", sPlaceHolder);
-      osquery::safeStrtoll(sPlaceHolder, 10, llHolder);
-      r["system_time"] = BIGINT(llHolder / 10000000);
-
-      results[0].GetString("PrivatePageCount", sPlaceHolder);
-      r["wired_size"] = BIGINT(sPlaceHolder);
-      results[0].GetString("WorkingSetSize", sPlaceHolder);
-      r["resident_size"] = sPlaceHolder;
-      results[0].GetString("VirtualSize", sPlaceHolder);
-      r["total_size"] = BIGINT(sPlaceHolder);
-      results_data.push_back(r);
-    }
+  s = result.GetLong("ProcessId", pid);
+  r["pid"] = s.ok() ? BIGINT(pid) : BIGINT(-1);
+  if (pid == currentPid) {
+    hProcess = GetCurrentProcess();
   }
+  else {
+    hProcess = OpenProcess(
+      PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
+  }
+
+  result.GetString("Name", r["name"]);
+  result.GetString("ExecutablePath", r["path"]);
+  result.GetString("CommandLine", r["cmdline"]);
+  result.GetString("ExecutionState", r["state"]);
+  result.GetLong("ParentProcessId", lPlaceHolder);
+  r["parent"] = BIGINT(lPlaceHolder);
+  result.GetLong("Priority", lPlaceHolder);
+  r["nice"] = INTEGER(lPlaceHolder);
+  r["on_disk"] = osquery::pathExists(r["path"]).toString();
+
+  std::vector<char> fileName(MAX_PATH);
+  fileName.assign(MAX_PATH + 1, '\0');
+  if (pid == currentPid) {
+    GetModuleFileName(nullptr, fileName.data(), MAX_PATH);
+  }
+  else {
+    GetModuleFileNameEx(hProcess, nullptr, fileName.data(), MAX_PATH);
+  }
+  r["cwd"] = SQL_TEXT(fileName.data());
+  r["root"] = r["cwd"];
+
+  r["pgroup"] = "-1";
+  r["uid"] = "-1";
+  r["euid"] = "-1";
+  r["suid"] = "-1";
+  r["gid"] = "-1";
+  r["egid"] = "-1";
+  r["sgid"] = "-1";
+  r["start_time"] = "0";
+
+  // We pre-populate the info, in the event the API calls fail.
+  result.GetString("UserModeTime", sPlaceHolder);
+  long long llHolder;
+  osquery::safeStrtoll(sPlaceHolder, 10, llHolder);
+  r["user_time"] = BIGINT(llHolder / 10000000);
+  result.GetString("KernelModeTime", sPlaceHolder);
+  osquery::safeStrtoll(sPlaceHolder, 10, llHolder);
+  r["system_time"] = BIGINT(llHolder / 10000000);
+
+  result.GetString("PrivatePageCount", sPlaceHolder);
+  r["wired_size"] = BIGINT(sPlaceHolder);
+  result.GetString("WorkingSetSize", sPlaceHolder);
+  r["resident_size"] = sPlaceHolder;
+  result.GetString("VirtualSize", sPlaceHolder);
+  r["total_size"] = BIGINT(sPlaceHolder);
+  results_data.push_back(r);
 }
 
 QueryData genProcesses(QueryContext& context) {
   QueryData results;
 
-  auto pidlist = getProcList(context);
-  for (const auto& pid : pidlist) {
-    genProcess(pid, results);
+  WmiRequest request("SELECT * FROM Win32_Process");
+  if (request.getStatus().ok()) {
+    auto pidlist = getSelectedPids(context);
+    for (const auto& item : request.results()) {
+      long pid = 0;
+      if (item.GetLong("ProcessId", pid).ok()) {
+        /*
+         * Only generate information about the process if the pidlist set is
+         * empty (implies that there are no constraints) or pid exists in
+         * pidlist
+         */
+        if (pidlist.size() == 0 ||
+            (pidlist.size() > 0 && pidlist.find(pid) != pidlist.end())) {
+          genProcess(item, results);
+        }
+      }
+    }
   }
 
   return results;

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -120,14 +120,15 @@ void genProcess(const WmiResultItem& result, QueryData& results_data) {
 
 QueryData genProcesses(QueryContext& context) {
   QueryData results;
-  
+
   std::string query = "SELECT * FROM Win32_Process";
 
   auto pidlist = getSelectedPids(context);
   if (pidlist.size() > 0) {
     std::vector<std::string> constraints;
     for (const auto& pid : pidlist) {
-      constraints.push_back("ProcessId=" + boost::lexical_cast<std::string>(pid));
+      constraints.push_back("ProcessId=" +
+                            boost::lexical_cast<std::string>(pid));
     }
     if (constraints.size() > 0) {
       query += " WHERE " + boost::algorithm::join(constraints, " OR ");


### PR DESCRIPTION
Removed the need for a WMI query for _every_ captured process ID.

<pre>
PS > measure-command { & .\osqueryi.exe 'select * from processes;' --json }


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 178
Ticks             : 1788286
TotalDays         : 2.06977546296296E-06
TotalHours        : 4.96746111111111E-05
TotalMinutes      : 0.00298047666666667
TotalSeconds      : 0.1788286
TotalMilliseconds : 178.8286
</pre>

Closes #2574 