### PR TITLE
[Fix #2549] Windows: use all CPUs with minimal verbosity

### DIFF
--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -6,7 +6,7 @@ cd .\build\windows10
 cmake ..\.. -G "Visual Studio 14 2015 Win64"
 
 for %%t in (shell,daemon,osquery_tests,osquery_additional_tests,osquery_tables_tests) do (
-  cmake --build . --target %%t --config Release
+  cmake --build . --target %%t --config Release -- /maxcpucount /verbosity:minimal
   if errorlevel 1 goto end
 )
 


### PR DESCRIPTION
This will make the Windows build host use all CPUs and suppress most of the useless stdout.