### PR TITLE
[Fix #1690] Use INDEX options in constraint cost evaluation

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -549,6 +549,7 @@ class RegistryHelper : public RegistryHelperCore {
 
  private:
   FRIEND_TEST(EventsTests, test_event_subscriber_configure);
+  FRIEND_TEST(VirtualTableTests, test_indexing_costs);
 };
 
 /// Helper definition for a shared pointer to a Plugin.

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -809,6 +809,7 @@ class TablePlugin : public Plugin {
   friend class RegistryFactory;
   FRIEND_TEST(VirtualTableTests, test_tableplugin_columndefinition);
   FRIEND_TEST(VirtualTableTests, test_tableplugin_statement);
+  FRIEND_TEST(VirtualTableTests, test_indexing_costs);
 };
 
 /// Helper method to generate the virtual table CREATE statement.


### PR DESCRIPTION
Previously, scans of tables with columns marked `index=True` were assumed the same cost as all tables. This is not true, scanning tables with an index, using that index in the predicate, should yield lower costs.