### PR TITLE
Fix for AWS ami role auth with cpp-netlib custom redirect condition

### DIFF
--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -131,6 +131,15 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
     switch (request.GetMethod()) {
     case Aws::Http::HttpMethod::HTTP_GET:
       resp = client.get(req);
+      if (resp.status() == 301 || resp.status() == 302) {
+        VLOG(1) << "Attempting custom redirect as cpp-netlib does not support redirects";
+        for (const auto& header : resp.headers()) {
+          if (header.first == "Location") {
+            req.uri(header.second);
+            resp = client.get(req);
+          }
+        }
+      }
       break;
     case Aws::Http::HttpMethod::HTTP_POST:
       resp = client.post(req, body, request.GetContentType());

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
       resp = client.get(req);
       if (resp.status() == 301 || resp.status() == 302) {
         VLOG(1) << "Attempting custom redirect as cpp-netlib does not support "
-                           "redirects";
+                   "redirects";
         for (const auto& header : resp.headers()) {
           if (header.first == "Location") {
             req.uri(header.second);
@@ -303,14 +303,13 @@ Status getAWSRegionFromProfile(std::string& region) {
 void initAwsSdk() {
   static std::once_flag once_flag;
   try {
-    std::call_once(once_flag,
-                   []() {
-                     Aws::SDKOptions options;
-                     options.httpOptions.httpClientFactory_create_fn = []() {
-                       return std::make_shared<NetlibHttpClientFactory>();
-                     };
-                     Aws::InitAPI(options);
-                   });
+    std::call_once(once_flag, []() {
+      Aws::SDKOptions options;
+      options.httpOptions.httpClientFactory_create_fn = []() {
+        return std::make_shared<NetlibHttpClientFactory>();
+      };
+      Aws::InitAPI(options);
+    });
   } catch (const std::system_error& e) {
     LOG(ERROR) << "call_once was not executed for initAwsSdk";
   }

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -133,6 +133,8 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
       resp = client.get(req);
       if (resp.status() == 301 || resp.status() == 302) {
         VLOG(1) << "Attempting custom redirect as cpp-netlib does not support redirects";
+        VLOG(1) << "Attempting custom redirect as cpp-netlib does not support "
+                           "redirects";
         for (const auto& header : resp.headers()) {
           if (header.first == "Location") {
             req.uri(header.second);

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -132,7 +132,6 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
     case Aws::Http::HttpMethod::HTTP_GET:
       resp = client.get(req);
       if (resp.status() == 301 || resp.status() == 302) {
-        VLOG(1) << "Attempting custom redirect as cpp-netlib does not support redirects";
         VLOG(1) << "Attempting custom redirect as cpp-netlib does not support "
                            "redirects";
         for (const auto& header : resp.headers()) {


### PR DESCRIPTION
When osquery flipped over to cpp-netlib for aws http connections, a hidden bug occurred which did not pop up until recently.  This bug caused aws ami role authentication via the auth provider `InstanceProfileCredentialsProvider` to stop working.  Here is a short description of the bug.

1. Osquery switched to using cpp-netlib instead of the aws core http lib (libcurl)
2. Aws changed their ami role credentials endpoint from http://blablabla/security-credentials to http://blablabla/security-credentials/ (notice the trailing slash).  
3. Aws sdk uses the non slash version and now gets a 301 redirect for the new url.
4. cpp-netlib has a redirect issue when run in asyc mode.  This issues causes netlib to not follow redirects even when its set to. Info can be found in this issue https://github.com/cpp-netlib/cpp-netlib/issues/588

In order to fix this issue, I added a custom single level redirect path when we get a status code of 301 or 302.  Its not the prettiest fix, but it should hold till netlib issues a fix.  If you guys can think of something nicer, let me know and Ill change this PR around.

@zwass , do you know if aws sdk has mock auth methods we could use to add checks for this in our tests?  I figure you know better than me =)
