### PR TITLE
Use 'namespace' instead of '#define' for boost::filesystem

### DIFF
--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -22,7 +22,7 @@
 
 #include "osquery/core/conversions.h"
 
-#define fs boost::filesystem
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/networking/etc_protocols.cpp
+++ b/osquery/tables/networking/etc_protocols.cpp
@@ -22,7 +22,7 @@
 
 #include "osquery/core/conversions.h"
 
-#define fs boost::filesystem
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/networking/etc_services.cpp
+++ b/osquery/tables/networking/etc_services.cpp
@@ -22,7 +22,7 @@
 
 #include "osquery/core/conversions.h"
 
-#define fs boost::filesystem
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -28,7 +28,7 @@
 #include "osquery/filesystem/fileops.h"
 #include "osquery/tables/system/windows/registry.h"
 
-#define fs boost::filesystem
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace tables {


### PR DESCRIPTION
As per the feedback on my last pull request #2595, I've switched `#define fs boost::filesystem` to `namespace fs = boost::filesystem;` as directed on mine and similar files within the project.