### PR TITLE
Add virtual table: Windows services

### DIFF
--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -1,0 +1,144 @@
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <Winsvc.h>
+#include <string>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#pragma comment(lib, "Advapi32.lib")
+
+namespace osquery {
+namespace tables {
+
+const std::string kSvcStartType[] = {
+    "BOOT_START", "SYSTEM_START", "AUTO_START", "DEMAND_START", "DISABLED"};
+
+const std::string kSvcStatus[] = {"UNKNOWN",
+                                  "STOPPED",
+                                  "START_PENDING",
+                                  "STOP_PENDING",
+                                  "RUNNING",
+                                  "CONTINUE_PENDING",
+                                  "PAUSE_PENDING",
+                                  "PAUSED"};
+
+const std::map<int, std::string> kServiceType = {
+    {0x00000010, "OWN_PROCESS"},
+    {0x00000020, "SHARE_PROCESS"},
+    {0x00000100, "INTERACTIVE_PROCESS"},
+    {0x00000110, "OWN_PROCESS   (Interactive)"},
+    {0x00000120, "SHARE_PROCESS (Interactive)"}};
+
+SC_HANDLE schSCManager;
+
+BOOL QuerySvcInfo(ENUM_SERVICE_STATUS_PROCESS& svc, Row& r) {
+  SC_HANDLE schService;
+  LPQUERY_SERVICE_CONFIG lpsc = nullptr;
+  LPSERVICE_DESCRIPTION lpsd = nullptr;
+  DWORD cbBufSize = 0;
+
+  schService =
+      OpenService(schSCManager, svc.lpServiceName, SERVICE_QUERY_CONFIG);
+
+  if (schService == NULL) {
+    TLOG << "OpenService failed (" << GetLastError() << ")";
+    return FALSE;
+  }
+
+  (void)QueryServiceConfig(schService, NULL, 0, &cbBufSize);
+  lpsc = (LPQUERY_SERVICE_CONFIG)LocalAlloc(LMEM_FIXED, cbBufSize);
+  if (!QueryServiceConfig(schService, lpsc, cbBufSize, &cbBufSize)) {
+    TLOG << "QueryServiceConfig failed (" << GetLastError() << ")";
+  }
+
+  (void)QueryServiceConfig2(
+      schService, SERVICE_CONFIG_DESCRIPTION, NULL, 0, &cbBufSize);
+  lpsd = (LPSERVICE_DESCRIPTION)LocalAlloc(LMEM_FIXED, cbBufSize);
+  if (!QueryServiceConfig2(schService,
+                           SERVICE_CONFIG_DESCRIPTION,
+                           (LPBYTE)lpsd,
+                           cbBufSize,
+                           &cbBufSize)) {
+    TLOG << "QueryServiceConfig2 failed (" << GetLastError() << ")";
+  }
+
+  r["name"] = SQL_TEXT(svc.lpServiceName);
+  r["display_name"] = SQL_TEXT(svc.lpDisplayName);
+  r["status"] = SQL_TEXT(kSvcStatus[svc.ServiceStatusProcess.dwCurrentState]);
+  r["pid"] = INTEGER(svc.ServiceStatusProcess.dwProcessId);
+  r["win32_exit_code"] = INTEGER(svc.ServiceStatusProcess.dwWin32ExitCode);
+  r["service_exit_code"] =
+      INTEGER(svc.ServiceStatusProcess.dwServiceSpecificExitCode);
+  r["start_type"] = SQL_TEXT(kSvcStartType[lpsc->dwStartType]);
+  r["path"] = SQL_TEXT(lpsc->lpBinaryPathName);
+  r["user_account"] = SQL_TEXT(lpsc->lpServiceStartName);
+
+  if (lpsd->lpDescription != NULL)
+    r["description"] = SQL_TEXT(lpsd->lpDescription);
+
+  if (kServiceType.count(lpsc->dwServiceType) > 0)
+    r["service_type"] = SQL_TEXT(kServiceType.at(lpsc->dwServiceType));
+  else
+    r["service_type"] = SQL_TEXT("UNKNOWN");
+
+  LocalFree(lpsc);
+  LocalFree(lpsd);
+  CloseServiceHandle(schService);
+  return TRUE;
+}
+
+QueryData genServices(QueryContext& context) {
+  void* buf = NULL;
+  DWORD BytesNeeded = 0;
+  DWORD serviceCount = 0;
+  Row r;
+  QueryData results;
+
+  schSCManager = OpenSCManagerW(NULL, NULL, GENERIC_READ);
+  if (schSCManager == NULL) {
+    TLOG << "EnumServiceStatusEx failed (" << GetLastError() << ")";
+    return {};
+  }
+
+  (void)EnumServicesStatusEx(schSCManager,
+                             SC_ENUM_PROCESS_INFO,
+                             SERVICE_WIN32,
+                             SERVICE_STATE_ALL,
+                             NULL,
+                             0,
+                             &BytesNeeded,
+                             &serviceCount,
+                             NULL,
+                             NULL);
+
+  buf = malloc(BytesNeeded);
+  if (EnumServicesStatusEx(schSCManager,
+                           SC_ENUM_PROCESS_INFO,
+                           SERVICE_WIN32,
+                           SERVICE_STATE_ALL,
+                           (LPBYTE)buf,
+                           BytesNeeded,
+                           &BytesNeeded,
+                           &serviceCount,
+                           NULL,
+                           NULL)) {
+    ENUM_SERVICE_STATUS_PROCESS* services = (ENUM_SERVICE_STATUS_PROCESS*)buf;
+    for (DWORD i = 0; i < serviceCount; ++i) {
+      if (QuerySvcInfo(services[i], r)) {
+        results.push_back(r);
+      }
+      r.clear();
+    }
+  } else {
+    TLOG << "EnumServiceStatusEx failed (" << GetLastError() << ")";
+  }
+
+  free(buf);
+  CloseServiceHandle(schSCManager);
+  return results;
+}
+}
+}

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -115,9 +115,8 @@ BOOL QuerySvcInfo(const SC_HANDLE& schSCManager,
 QueryData genServices(QueryContext& context) {
   SC_HANDLE schSCManager;
   void* buf = nullptr;
-  DWORD BytesNeeded = 0;
+  DWORD bytesNeeded = 0;
   DWORD serviceCount = 0;
-  Row r;
   QueryData results;
 
   schSCManager = OpenSCManager(nullptr, nullptr, GENERIC_READ);
@@ -132,28 +131,28 @@ QueryData genServices(QueryContext& context) {
                              SERVICE_STATE_ALL,
                              nullptr,
                              0,
-                             &BytesNeeded,
+                             &bytesNeeded,
                              &serviceCount,
                              nullptr,
                              nullptr);
 
-  buf = malloc(BytesNeeded);
+  buf = malloc(bytesNeeded);
   if (EnumServicesStatusEx(schSCManager,
                            SC_ENUM_PROCESS_INFO,
                            SERVICE_WIN32,
                            SERVICE_STATE_ALL,
                            (LPBYTE)buf,
-                           BytesNeeded,
-                           &BytesNeeded,
+                           bytesNeeded,
+                           &bytesNeeded,
                            &serviceCount,
                            nullptr,
                            nullptr)) {
     ENUM_SERVICE_STATUS_PROCESS* services = (ENUM_SERVICE_STATUS_PROCESS*)buf;
     for (DWORD i = 0; i < serviceCount; ++i) {
+      Row r;
       if (QuerySvcInfo(schSCManager, services[i], r)) {
         results.push_back(r);
       }
-      r.clear();
     }
   } else {
     TLOG << "EnumServiceStatusEx failed (" << GetLastError() << ")";

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -13,6 +13,7 @@
 #include <Winsvc.h>
 #include <string>
 
+#include "osquery/tables/system/windows/registry.h"
 #include <osquery/core.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
@@ -93,6 +94,16 @@ BOOL QuerySvcInfo(const SC_HANDLE& schSCManager,
     r["service_type"] = SQL_TEXT(kServiceType.at(lpsc->dwServiceType));
   } else {
     r["service_type"] = SQL_TEXT("UNKNOWN");
+  }
+
+  QueryData regResults;
+  queryKey("HKEY_LOCAL_MACHINE",
+           "SYSTEM\\CurrentControlSet\\Services\\" + r["name"] + "\\Parameters",
+           regResults);
+  for (const auto& aKey : regResults) {
+    if (aKey.at("name") == "ServiceDll") {
+      r["module_path"] = SQL_TEXT(aKey.at("data"));
+    }
   }
 
   free(lpsc);

--- a/specs/windows/services.table
+++ b/specs/windows/services.table
@@ -10,6 +10,7 @@ schema([
     Column("win32_exit_code", INTEGER, "The error code that the service uses to report an error that occurs when it is starting or stopping"),
     Column("service_exit_code", INTEGER, "The service-specific error code that the service returns when an error occurs while the service is starting or stopping"),
     Column("path", TEXT, "Path to Service Executable"),
+    Column("module_path", TEXT, "Path to ServiceDll"),
     Column("description", TEXT, "Service Description"),
     Column("user_account", TEXT, "The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName."),
 ])

--- a/specs/windows/services.table
+++ b/specs/windows/services.table
@@ -1,0 +1,19 @@
+table_name("services")
+description("LaunchAgents and LaunchDaemons from default search paths.")
+schema([
+    Column("name", TEXT, "Service name"),
+    Column("service_type", TEXT, "Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)"),
+    Column("display_name", TEXT, "Service Display name"),
+    Column("status", TEXT, "Service Current status: STOPPED, START_PENDING, STOP_PENDING, RUNNING, CONTINUE_PENDING, PAUSE_PENDING, PAUSED"),
+    Column("pid", INTEGER, "the Process ID of the service"),
+    Column("start_type", TEXT, "Service start type: BOOT_START, SYSTEM_START, AUTO_START, DEMAND_START, DISABLED"),
+    Column("win32_exit_code", INTEGER, "The error code that the service uses to report an error that occurs when it is starting or stopping"),
+    Column("service_exit_code", INTEGER, "The service-specific error code that the service returns when an error occurs while the service is starting or stopping"),
+    Column("path", TEXT, "Path to Service Executable"),
+    Column("description", TEXT, "Service Description"),
+    Column("user_account", TEXT, "The name of the account that the service process will be logged on as when it runs. This name can be of the form Domain\UserName. If the account belongs to the built-in domain, the name can be of the form .\UserName."),
+])
+implementation("system/windows/services@genServices")
+examples([
+  "select * from services",
+])

--- a/specs/windows/services.table
+++ b/specs/windows/services.table
@@ -1,5 +1,5 @@
 table_name("services")
-description("LaunchAgents and LaunchDaemons from default search paths.")
+description("Lists all installed Windows Services and its relevant data")
 schema([
     Column("name", TEXT, "Service name"),
     Column("service_type", TEXT, "Service Type: OWN_PROCESS, SHARE_PROCESS and maybe Interactive (can interact with the desktop)"),


### PR DESCRIPTION
**New Virtual table for Windows (issue #2540)**

### Currently implemented properties:
**Process Info:**
- [x] service name
- [x] display name
- [x] ServiceType
- [x] state
- [x] WIN32_EXIT_CODE
- [x] SERVICE_EXIT_CODE
- [x] PID
- [ ] CHECKPOINT
- [ ] WAIT_HINT
- [ ] Flags
- [ ] **Extra info:**
	- [ ] CanPauseAndContinue
	- [ ] CanShutdown
	- [ ] CanStop

**Service Config Info:**
- [x] start mode
- [x] image path
- [x] module path
- [x] description
- [x] account
- [ ] load order group
- [ ] DependentServices
- [ ] ServicesDependedOn
- [ ] error control


### Output of Measure-Command:
PS C:\Users\ExtremeGTX>Measure-Command {osqueryi.exe "select * from services;"}

Seconds           : 0
Milliseconds      : 238
Ticks             : 2384709
TotalDays         : 2.76007986111111E-06
TotalHours        : 6.62419166666667E-05
TotalMinutes      : 0.003974515
TotalSeconds      : 0.2384709
TotalMilliseconds : 238.4709
