### PR TITLE
[Fix #2599] Read from Linux SMI sysfs node for SMBIOS

### DIFF
--- a/osquery/tables/system/linux/smbios_utils.h
+++ b/osquery/tables/system/linux/smbios_utils.h
@@ -33,19 +33,26 @@ class LinuxSMBIOSParser : public SMBIOSParser {
   /// Parse the SMBIOS address from an EFI systab file.
   void readFromSystab(const std::string& systab);
 
+  /// Parse the SMBIOS content from sysfs.
+  void readFromSysfs(const std::string& sysfs_dmi);
+
   /// Cross version/boot read initializer.
   bool discover();
 
   /// Check if the read was successful.
-  bool valid() { return (data_ != nullptr && table_data_ != nullptr); }
+  bool valid() {
+    return (table_data_ != nullptr);
+  }
 
  public:
   virtual ~LinuxSMBIOSParser() {
     if (data_ != nullptr) {
       free(data_);
+      data_ = nullptr;
     }
     if (table_data_ != nullptr) {
       free(table_data_);
+      table_data_ = nullptr;
     }
   }
 

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -86,6 +86,11 @@ void SMBIOSParser::tables(std::function<void(size_t index,
       break;
     }
 
+    if (header->length == 0 && header->handle == 0) {
+      // Reached the end (null-padded content).
+      break;
+    }
+
     // The SMBIOS structure may have unformatted, double-NULL delimited
     // trailing data, which are usually strings.
     auto next_table = table + header->length;


### PR DESCRIPTION
This also fixes odd behavior in Linux when reading a 'regular' file from /sys that only returns a max of a page-read in bytes.