### PR TITLE
deps: Bump xz revision and bottle hash on Linux

### DIFF
--- a/tools/provision/formula/xz.rb
+++ b/tools/provision/formula/xz.rb
@@ -13,7 +13,7 @@ class Xz < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "97f36060a0cb74e0500ca2cc4eeb69d6cf448410edca91d3d1547c4fd4e10e8a" => :x86_64_linux
+    sha256 "dc9fac54c8ba9092914d7c0c39e9432a16048f425d7fa6b68a4a2e0e2bd1989d" => :x86_64_linux
   end
 
   option :universal


### PR DESCRIPTION
Seems like the Linux xz revision was bumped and we forgot to update a bottle.