### PR TITLE
add table for appcompat shims

### DIFF
--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+#include "osquery/tables/system/windows/registry.h"
+
+namespace osquery {
+namespace tables {
+
+struct sdb {
+	std::string description;
+	unsigned long long installTimestamp;
+	std::string path;
+	std::string type;
+};
+
+QueryData genShims(QueryContext& context) {
+  QueryData results;
+  QueryData sdbResults;
+  QueryData shimResults;
+  std::map<std::string, sdb> sdbs;
+  
+  queryKey(
+      "HKEY_LOCAL_MACHINE",
+      "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB",
+	  sdbResults);
+  for (const auto& rKey : sdbResults) {
+    QueryData appResults;
+	sdb sdb;
+    std::string subkey = rKey.at("subkey");
+	std::string sdbId = subkey.substr(subkey.find("{"), subkey.length());
+    // make sure it's a sane uninstall key
+    queryKey("HKEY_LOCAL_MACHINE", subkey, appResults);
+    for (const auto& aKey : appResults) {
+      if (aKey.at("name") == "DatabaseDescription") {
+		 sdb.description = aKey.at("data");
+      }
+	  if (aKey.at("name") == "DatabaseInstallTimeStamp") {
+		  // take this crazy windows timestamp to a unix timestamp
+		  sdb.installTimestamp = std::stoull(aKey.at("data"));
+		  sdb.installTimestamp = (sdb.installTimestamp / 10000000) - 11644473600;
+	  }
+	  if (aKey.at("name") == "DatabasePath") {
+		  sdb.path = aKey.at("data");
+	  }
+	  if (aKey.at("name") == "DatabaseType") {
+		  sdb.type = aKey.at("data");
+	  }
+    }
+	sdbs[sdbId] = sdb;
+  }
+
+  queryKey(
+	  "HKEY_LOCAL_MACHINE",
+	  "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom",
+	  shimResults);
+  for (const auto& rKey : shimResults) {
+	  QueryData appResults;
+	  std::string subkey = rKey.at("subkey");
+	  std::string executable = rKey.at("subkey").substr(rKey.at("subkey").rfind("\\")+1, rKey.at("subkey").length());
+	  // make sure it's a sane uninstall key
+	  queryKey("HKEY_LOCAL_MACHINE", subkey, appResults);
+	  for (const auto& aKey : appResults) {
+		  Row r;
+		  std::string sdbId = aKey.at("name").substr(0, aKey.at("name").length()-4);
+		  r["executable"] = executable;
+		  r["path"] = sdbs[sdbId].path;
+		  r["description"] = sdbs[sdbId].description;
+		  r["install_time"] = INTEGER(sdbs[sdbId].installTimestamp);
+		  r["type"] = sdbs[sdbId].type;
+		  r["sdb_id"] = sdbId;
+		  results.push_back(r);
+	  }
+  }
+
+  return results;
+}
+}
+}

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -72,11 +72,11 @@ QueryData genShims(QueryContext& context) {
   for (const auto& rKey : shimResults) {
     QueryData regResults;
     std::string subkey = rKey.at("subkey");
-	auto start = rKey.at("subkey").rfind("\\") + 1;
+	auto start = rKey.at("subkey").rfind("\\");
 	if (start == std::string::npos) {
 		continue;
 	}
-    std::string executable = rKey.at("subkey").substr(start, rKey.at("subkey").length());
+    std::string executable = rKey.at("subkey").substr(start + 1, rKey.at("subkey").length());
     // make sure it's a sane uninstall key
     queryKey("HKEY_LOCAL_MACHINE", subkey, regResults);
     for (const auto& aKey : regResults) {

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -72,11 +72,12 @@ QueryData genShims(QueryContext& context) {
   for (const auto& rKey : shimResults) {
     QueryData regResults;
     std::string subkey = rKey.at("subkey");
-	auto start = rKey.at("subkey").rfind("\\");
-	if (start == std::string::npos) {
-		continue;
-	}
-    std::string executable = rKey.at("subkey").substr(start + 1, rKey.at("subkey").length());
+    auto start = rKey.at("subkey").rfind("\\");
+    if (start == std::string::npos) {
+      continue;
+    }
+    std::string executable =
+        rKey.at("subkey").substr(start + 1, rKey.at("subkey").length());
     // make sure it's a sane uninstall key
     queryKey("HKEY_LOCAL_MACHINE", subkey, regResults);
     for (const auto& aKey : regResults) {

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -70,7 +70,7 @@ QueryData genShims(QueryContext& context) {
       "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom",
       shimResults);
   for (const auto& rKey : shimResults) {
-    QueryData appResults;
+    QueryData regResults;
     std::string subkey = rKey.at("subkey");
 	auto start = rKey.at("subkey").rfind("\\") + 1;
 	if (start == std::string::npos) {
@@ -78,8 +78,8 @@ QueryData genShims(QueryContext& context) {
 	}
     std::string executable = rKey.at("subkey").substr(start, rKey.at("subkey").length());
     // make sure it's a sane uninstall key
-    queryKey("HKEY_LOCAL_MACHINE", subkey, appResults);
-    for (const auto& aKey : appResults) {
+    queryKey("HKEY_LOCAL_MACHINE", subkey, regResults);
+    for (const auto& aKey : regResults) {
       Row r;
 	  std::string sdbId;
 	  if (aKey.at("name").length() > 4) {

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -36,13 +36,17 @@ QueryData genShims(QueryContext& context) {
            "NT\\CurrentVersion\\AppCompatFlags\\InstalledSDB",
            sdbResults);
   for (const auto& rKey : sdbResults) {
-    QueryData appResults;
+    QueryData regResults;
     sdb sdb;
     std::string subkey = rKey.at("subkey");
-    std::string sdbId = subkey.substr(subkey.find("{"), subkey.length());
+	auto start = subkey.find("{");
+	if (start == std::string::npos) {
+		continue;
+	}
+    std::string sdbId = subkey.substr(start, subkey.length());
     // make sure it's a sane uninstall key
-    queryKey("HKEY_LOCAL_MACHINE", subkey, appResults);
-    for (const auto& aKey : appResults) {
+    queryKey("HKEY_LOCAL_MACHINE", subkey, regResults);
+    for (const auto& aKey : regResults) {
       if (aKey.at("name") == "DatabaseDescription") {
         sdb.description = aKey.at("data");
       }
@@ -68,19 +72,27 @@ QueryData genShims(QueryContext& context) {
   for (const auto& rKey : shimResults) {
     QueryData appResults;
     std::string subkey = rKey.at("subkey");
-    std::string executable = rKey.at("subkey").substr(
-        rKey.at("subkey").rfind("\\") + 1, rKey.at("subkey").length());
+	auto start = rKey.at("subkey").rfind("\\") + 1;
+	if (start == std::string::npos) {
+		continue;
+	}
+    std::string executable = rKey.at("subkey").substr(start, rKey.at("subkey").length());
     // make sure it's a sane uninstall key
     queryKey("HKEY_LOCAL_MACHINE", subkey, appResults);
     for (const auto& aKey : appResults) {
       Row r;
-      std::string sdbId =
-          aKey.at("name").substr(0, aKey.at("name").length() - 4);
+	  std::string sdbId;
+	  if (aKey.at("name").length() > 4) {
+		 sdbId = aKey.at("name").substr(0, aKey.at("name").length() - 4);
+	  }
+	  if (sdbs.count(sdbId) == 0) {
+		  continue;
+	  }
       r["executable"] = executable;
-      r["path"] = sdbs[sdbId].path;
-      r["description"] = sdbs[sdbId].description;
-      r["install_time"] = INTEGER(sdbs[sdbId].installTimestamp);
-      r["type"] = sdbs[sdbId].type;
+      r["path"] = sdbs.at(sdbId).path;
+      r["description"] = sdbs.at(sdbId).description;
+      r["install_time"] = INTEGER(sdbs.at(sdbId).installTimestamp);
+      r["type"] = sdbs.at(sdbId).type;
       r["sdb_id"] = sdbId;
       results.push_back(r);
     }

--- a/specs/windows/appcompat_shims.table
+++ b/specs/windows/appcompat_shims.table
@@ -1,0 +1,14 @@
+table_name("appcompat_shims")
+description("Application Compatibility shims are a way to persist malware. This table presents the AppCompat Shim information from the registry in a nice format. http://files.brucon.org/2015/Tomczak_and_Ballenthin_Shims_for_the_Win.pdf")
+schema([
+    Column("executable", TEXT, "Name of the executable that is being shimmed. This is pulled from the registry."),
+    Column("path", TEXT, "This is the path to the SDB database."),
+    Column("description", TEXT, "Description of the SDB."),
+    Column("install_time", INTEGER, "Install time of the SDB"),
+    Column("type", TEXT, "Type of the SDB database."),
+    Column("sdb_id", TEXT, "Unique GUID of the SDB."),
+])
+implementation("appcompat_shims@genShims")
+examples([
+  "select * from appcompat_shims;",
+])


### PR DESCRIPTION
This adds a table that does some processing of the application compatibility shim information in the registry and presents it in a nice way. To get this same info without a table it would require two queries, and even then it would not be displayed in the best way.

http://files.brucon.org/2015/Tomczak_and_Ballenthin_Shims_for_the_Win.pdf