### PR TITLE
Prioritize reading node_invalid over error for host re-enrollment

### DIFF
--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -114,17 +114,23 @@ class TLSRequestHelper : private boost::noncopyable {
     }
 
     // Receive config or key rejection
-    if (output.count("error") > 0) {
-      return Status(1, "Request failed: " + output.get("error", "<unknown>"));
-    } else if (output.count("node_invalid") > 0) {
+    if (output.count("node_invalid") > 0) {
       auto invalid = output.get("node_invalid", "");
       if (invalid == "1" || invalid == "true" || invalid == "True") {
         if (!FLAGS_disable_reenrollment) {
           clearNodeKey();
         }
-        return Status(1, "Request failed: Invalid node key");
+
+        std::string status = "Request failed: Invalid node key";
+        if (output.count("error") > 0) {
+          status += ": " + output.get("error", "<unknown>");
+        }
+        return Status(1, status);
       }
+    } else if (output.count("error") > 0) {
+      return Status(1, "Request failed: " + output.get("error", "<unknown>"));
     }
+
     return Status(0, "OK");
   }
 

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -127,7 +127,9 @@ class TLSRequestHelper : private boost::noncopyable {
         }
         return Status(1, status);
       }
-    } else if (output.count("error") > 0) {
+    }
+
+    if (output.count("error") > 0) {
       return Status(1, "Request failed: " + output.get("error", "<unknown>"));
     }
 


### PR DESCRIPTION
A TLS server might like to return `"node_invalid": true` and an error string
indicating why the node was invalid. The old behavior caused `node_invalid` to
be ignored if `error` was specified, therefore making it impossible for
osqueryd to resolve the error.

With the new behavior, osqueryd can now re-enroll when a reason is provided.