### PR TITLE
Add dropToUser method to privileges dropper interface

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -196,6 +196,9 @@ class DropPrivileges : private boost::noncopyable {
   /// See DropPrivileges::dropToParent but explicitly set the UID and GID.
   bool dropTo(uid_t uid, gid_t gid);
 
+  /// See DropPrivileges::dropToParent but for a user's UID and GID.
+  bool dropTo(const std::string& user);
+
   /// Check if effective privileges do not match real.
   bool dropped() {
     return (getuid() != geteuid() || getgid() != getegid());

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -21,6 +21,7 @@
 #define DEBUG
 #endif
 
+#include <osquery/system.h>
 #include <osquery/tables.h>
 
 namespace osquery {
@@ -76,6 +77,9 @@ void extractAptSourceInfo(pkgCache::PkgFileIterator src,
 
 QueryData genAptSrcs(QueryContext& context) {
   QueryData results;
+
+  auto dropper = DropPrivileges::get();
+  dropper->dropTo("nobody");
 
   // Load our apt configuration into memory
   // Note: _config comes from apt-pkg/configuration.h

--- a/osquery/tables/system/linux/deb_packages.cpp
+++ b/osquery/tables/system/linux/deb_packages.cpp
@@ -22,6 +22,7 @@ extern "C" {
 
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
+#include <osquery/system.h>
 #include <osquery/tables.h>
 
 namespace osquery {
@@ -160,6 +161,9 @@ QueryData genDebPackages(QueryContext &context) {
     TLOG << "Cannot find DPKG database: " << kDPKGPath;
     return results;
   }
+
+  auto dropper = DropPrivileges::get();
+  dropper->dropTo("nobody");
 
   struct pkg_array packages;
   dpkg_setup(&packages);

--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -19,6 +19,7 @@
 
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
+#include <osquery/system.h>
 #include <osquery/tables.h>
 
 namespace osquery {
@@ -87,6 +88,9 @@ class RpmEnvironmentManager : public boost::noncopyable {
 QueryData genRpmPackages(QueryContext& context) {
   QueryData results;
 
+  auto dropper = DropPrivileges::get();
+  dropper->dropTo("nobody");
+
   // Isolate RPM/package inspection to the canonical: /usr/lib/rpm.
   RpmEnvironmentManager env_manager;
 
@@ -132,6 +136,9 @@ QueryData genRpmPackages(QueryContext& context) {
 
 QueryData genRpmPackageFiles(QueryContext& context) {
   QueryData results;
+
+  auto dropper = DropPrivileges::get();
+  dropper->dropTo("nobody");
 
   // Isolate RPM/package inspection to the canonical: /usr/lib/rpm.
   RpmEnvironmentManager env_manager;

--- a/osquery/tables/system/linux/tests/users_tests.cpp
+++ b/osquery/tables/system/linux/tests/users_tests.cpp
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <pwd.h>
+
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/system.h>
+
+#include "osquery/tests/test_util.h"
+
+namespace osquery {
+
+class UsersTests : public testing::Test {};
+
+TEST_F(UsersTests, test_nobody_drop_username) {
+  if (getuid() != 0) {
+    LOG(WARNING) << "Not root, skipping (username) deprivilege testing";
+    return;
+  }
+
+  auto nobody = getpwnam("nobody");
+  auto nobody_uid = nobody->pw_uid;
+  ASSERT_NE(geteuid(), nobody_uid);
+  ASSERT_EQ(geteuid(), getuid());
+
+  {
+    auto dropper = DropPrivileges::get();
+    EXPECT_TRUE(dropper->dropTo("nobody"));
+    EXPECT_EQ(geteuid(), nobody_uid);
+  }
+
+  EXPECT_NE(geteuid(), nobody_uid);
+}
+}

--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -63,6 +63,15 @@ QueryData genUsers(QueryContext& context) {
         }
       }
     }
+  } else if (context.constraints["username"].exists(EQUALS)) {
+    auto usernames = context.constraints["username"].getAll(EQUALS);
+    for (const auto& username : usernames) {
+      WriteLock lock(pwdEnumerationMutex);
+      pwd = getpwnam(username.c_str());
+      if (pwd != nullptr) {
+        genUser(pwd, results);
+      }
+    }
   } else {
     WriteLock lock(pwdEnumerationMutex);
     pwd = getpwent();


### PR DESCRIPTION
1. Introduce a new `dropTo` call that allows tables to drop the processes effective privileges to a `username`.
2. Allow `users` on Linux to optimize based on the `username` column.
3. For APT/DEB/RPM tables, drop privileges to `nobody` before accessing any database content. 