### PR TITLE
Fix missing columns in wmi_event_filters table

### DIFF
--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -36,6 +36,7 @@ QueryData genWmiFilters(QueryContext& context) {
       Row r;
 
       result.GetString("Name", r["name"]);
+      result.GetString("Query", r["query"]);
       result.GetString("QueryLanguage", r["query_language"]);
       result.GetString("__CLASS", r["class"]);
       result.GetString("__RELPATH", r["relative_path"]);

--- a/specs/windows/wmi_event_filters.table
+++ b/specs/windows/wmi_event_filters.table
@@ -3,6 +3,7 @@ description("Lists WMI event filters")
 schema([
     Column("name", TEXT, "Unique identifier of an event filter."),
     Column("query", TEXT, "Windows Management Instrumentation Query Language (WQL) event query that specifies the set of events for consumer notification, and the specific conditions for notification."),
+    Column("query_language", TEXT, "Query language that the query is written in."),
     Column("class", TEXT, "The name of the class."),
     Column("relative_path", TEXT, "Relative path to the class or instance."),
 ])


### PR DESCRIPTION
The "query" column was missing from the cpp file and the the "query_language" column was missing from the table spec. This fixes both issues.