### PR TITLE
Fix TLS logger plugin handling of re-enrollment

### DIFF
--- a/osquery/distributed/plugins/tls.cpp
+++ b/osquery/distributed/plugins/tls.cpp
@@ -24,7 +24,6 @@
 #include <osquery/registry.h>
 
 #include "osquery/core/json.h"
-#include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"
 #include "osquery/remote/utility.h"
 

--- a/osquery/logger/plugins/tests/tls_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/tls_logger_tests.cpp
@@ -29,7 +29,7 @@ class TLSLoggerTests : public testing::Test {
 };
 
 TEST_F(TLSLoggerTests, test_database) {
-  auto forwarder = std::make_shared<TLSLogForwarder>("fake_key");
+  auto forwarder = std::make_shared<TLSLogForwarder>();
   std::string expected = "{\"new_json\": true}";
   forwarder->logString(expected);
   StatusLogLine status;
@@ -57,7 +57,7 @@ TEST_F(TLSLoggerTests, test_send) {
   TLSServerRunner::start();
   TLSServerRunner::setClientConfig();
 
-  auto forwarder = std::make_shared<TLSLogForwarder>("fake_key");
+  auto forwarder = std::make_shared<TLSLogForwarder>();
   for (size_t i = 0; i < 20; i++) {
     std::string expected = "{\"more_json\": true}";
     forwarder->logString(expected);

--- a/osquery/logger/plugins/tls.h
+++ b/osquery/logger/plugins/tls.h
@@ -26,14 +26,11 @@ namespace osquery {
  */
 class TLSLogForwarder : public BufferedLogForwarder {
  public:
-  explicit TLSLogForwarder(const std::string& node_key);
+  explicit TLSLogForwarder();
 
  protected:
   Status send(std::vector<std::string>& log_data,
               const std::string& log_type) override;
-
-  /// Receive an enrollment/node key from the backing store cache.
-  std::string node_key_;
 
   /// Endpoint URI
   std::string uri_;


### PR DESCRIPTION
Two bugs in the TLS logger re-enrollment handling are fixed by this commit:

1. A fixed node key is used, so a new node key acquired through re-enrollment
is ignored.
2. The body is not checked for node_invalid, so no re-enrollment is triggered
when necessary.

Each of these bugs is fixed by the following:

1. Call `getNodeKey("tls")` instead of using a fixed stored node key.

2. Use TLSRequestHelper::go which already includes handling for node_invalid
(this makes these TLS calls consistent with other TLS methods).