### PR TITLE
[Fix #2630] Remove 'definition' TablePlugin action

### DIFF
--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -125,10 +125,6 @@ Status TablePlugin::call(const PluginRequest& request,
     // The "columns" action returns a PluginRequest filled with column
     // information such as name and type.
     response = routeInfo();
-  } else if (request.at("action") == "definition") {
-    response.push_back({
-        {"definition", columnDefinition()},
-    });
   } else {
     return Status(1, "Unknown table plugin action: " + request.at("action"));
   }

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1082,13 +1082,15 @@ inline void meta_schema(int nArg, char** azArg) {
       continue;
     }
 
-    osquery::PluginRequest request = {{"action", "definition"}};
     osquery::PluginResponse response;
-    osquery::Registry::call("table", table_name, request, response);
-    fprintf(stdout,
-            "CREATE TABLE %s%s;\n",
-            table_name.c_str(),
-            response[0].at("definition").c_str());
+    auto status = osquery::Registry::call(
+        "table", table_name, {{"action", "columns"}}, response);
+    if (status.ok()) {
+      fprintf(stdout,
+              "CREATE TABLE %s%s;\n",
+              table_name.c_str(),
+              osquery::columnDefinition(response, true).c_str());
+    }
   }
 }
 


### PR DESCRIPTION
The `definition` action is fairly legacy. Move to the new `columns` action that handles a few additional error cases such as missing column "options".