### PR TITLE
[Fix #2641] Update OS X build and add Sierra hashes

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -19,9 +19,9 @@ LINUXBREW_REPO="https://github.com/Linuxbrew/brew"
 
 # Set the SHA1 commit hashes for the pinned homebrew Taps.
 # Pinning allows determinism for bottle availability, expect to update often.
-HOMEBREW_CORE="14eaa685169edf4283e1dadd5818646f67d09f30"
+HOMEBREW_CORE="0e6f293450cf9b54e324e92ea0b0475fd4e0d929"
 LINUXBREW_CORE="600e1460c79b9cf6945e87cb5374b9202db1f6a9"
-HOMEBREW_DUPES="36b6b7cd76a482319611eeb71e51f3134018a21c"
+HOMEBREW_DUPES="00df450f28f23aa1013564889d11440ab80b36a5"
 LINUXBREW_DUPES="83cad3d474e6d245cd543521061bba976529e5df"
 
 source "$SCRIPT_DIR/lib.sh"
@@ -206,9 +206,6 @@ function platform_linux_main() {
   local_brew_tool python
   local_brew_postinstall python
   local_brew_tool cmake --without-docs
-  local_brew_tool zzuf
-  local_brew_tool cppcheck
-  local_brew_tool ccache
 
   # Linux library secondary dependencies.
   local_brew_tool berkeley-db
@@ -223,6 +220,10 @@ function platform_linux_main() {
   local_brew_dependency util-linux
 
   platform_posix_main
+
+  local_brew_tool zzuf
+  local_brew_tool cppcheck
+  local_brew_tool ccache
 
   # Linux specific custom formulas.
   local_brew_dependency libgpg-error
@@ -254,18 +255,18 @@ function platform_darwin_main() {
   brew_tool autoconf
   brew_tool automake
   brew_tool libtool
-  brew_tool m4
   brew_tool bison
   brew_link bison
 
   local_brew_tool python
   local_brew_postinstall python
   local_brew_tool cmake --without-docs
+
+  platform_posix_main
+
   local_brew_tool zzuf
   local_brew_tool cppcheck
   local_brew_tool ccache
-
-  platform_posix_main
 }
 
 function platform_posix_main() {

--- a/tools/provision/formula/asio.rb
+++ b/tools/provision/formula/asio.rb
@@ -11,6 +11,7 @@ class Asio < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "65551c74dfd7eb3cb553fb2adb678cb500f9f70556353750891188c83c33f6db" => :sierra
     sha256 "9131610c48a4c1e956c93e9afa4bc8776c7f86ac41be913cfad17048484dd155" => :el_capitan
     sha256 "e3f0a2e933ec5dd787510f38215c33e92254b9cde1196d34348740618a3720d7" => :x86_64_linux
   end

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -9,6 +9,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "0b9d7b11f5c6e7cf7de5b20c5cc19bb2e4f844df4afa00a535d648b99ef3a747" => :sierra
     sha256 "4a46a467ea1a8e1bd4c10b42dfe30055f6d3eb0bddee4f64c108a7ca780915ce" => :el_capitan
     sha256 "99c11985fc79446a442055eae1c1eecdf14d33434f40df91bd99f97c0b7dadce" => :x86_64_linux
   end

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -24,6 +24,7 @@ class Boost < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "b133a4ea9b79073a66ef11722dd94ea12f07c64c51ec0216dce193af73f438e9" => :sierra
     sha256 "5d531037e8fc6760c3cd1522703dc816c1fa2ae22a4695bb9698dc359ffc16c7" => :el_capitan
     sha256 "638c0f9dbd32c9c40459d8a377dcd63406347eccdefccaf8bca344c16f5566b4" => :x86_64_linux
   end

--- a/tools/provision/formula/ccache.rb
+++ b/tools/provision/formula/ccache.rb
@@ -9,6 +9,7 @@ class Ccache < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "7252af8fa4fe3b76281a4c330a737d583c5074fcb44119b5edc83332774b62e2" => :sierra
     sha256 "de5a5e43ceb9b925a94fe0b5788fdca0ae58ae12eb48819a765cd3ad6c9a65f7" => :el_capitan
     sha256 "7e2f7acbedf1466376a4cbe6ca90e0cc1ce1d3cebbd31bd0cd10447ffd333bb1" => :x86_64_linux
   end

--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -11,6 +11,7 @@ class Cmake < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "5adefeb50d8db10a5d0c937ea0cd26c63434d53701820034c3bc0ad16f1fb747" => :sierra
     sha256 "c2dd35936fd86bf1a17173e874dc8a1eb0bcc3a540b445473c7eaea0d62e7fac" => :el_capitan
     sha256 "d69f263f4c793cf077b7892eaeb795adb40435a923b570883ad50b4eba4a4eef" => :x86_64_linux
   end
@@ -50,7 +51,7 @@ class Cmake < AbstractOsqueryFormula
       args << "--sphinx-man" << "--sphinx-build=#{Formula["sphinx-doc"].opt_bin}/sphinx-build"
     end
 
-    ENV.append "CXXFLAGS", "-L#{legacy.lib}"
+    ENV.append "CXXFLAGS", "-L#{legacy_prefix}/lib"
 
     system "./bootstrap", *args
     system "make"

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -10,6 +10,7 @@ class CppNetlib < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "6847b96010d47388abd54587b2142b9fca3bec1e8172eb9ebf8f6742b2103a37" => :sierra
     sha256 "63381c4bcf64028c92aaaf51df8637b1d3ab5ffd3a3c30736c04361c2e08af6a" => :el_capitan
     sha256 "e906fa8d5347a923fffe6443a8ec1346a6e798ed7bf6071b5a002958d25eca3a" => :x86_64_linux
   end

--- a/tools/provision/formula/cppcheck.rb
+++ b/tools/provision/formula/cppcheck.rb
@@ -11,6 +11,7 @@ class Cppcheck < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "9d05ec931b6b3e449cce066d6205205057875760396eccff8441534cd58c1b43" => :sierra
     sha256 "9499986e0e2859a8d6356a406cdff0b88a2c8c0eac3b2d3c936a7dbcbf567454" => :el_capitan
     sha256 "0001d1022bea7c04a34301ddc0d65e84045056db187df2b992306d2e62595543" => :x86_64_linux
   end

--- a/tools/provision/formula/gflags.rb
+++ b/tools/provision/formula/gflags.rb
@@ -9,6 +9,7 @@ class Gflags < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "478baa80b373c27fd573b68b9f0e1bfb9fc5376997ce1aafd750bbb06d9056b1" => :sierra
     sha256 "1770ef053f031ceb8987cb2bdd7f99e784752aba5a7a5948998dacb144d9908b" => :el_capitan
     sha256 "bdc41e050721865cc5b2b72152a4229e2f83bbb7cb4f03c3d636c43cbc0aba73" => :x86_64_linux
   end

--- a/tools/provision/formula/glog.rb
+++ b/tools/provision/formula/glog.rb
@@ -9,6 +9,7 @@ class Glog < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "d3c906bfb34f14ef461c48f00778fde144f83a9b9215d7b3c47cea7f4bf941a9" => :sierra
     sha256 "d268354a25c56e1e5c653cb0ce0f5d4ed00213484fa969eea1fab03d765814c9" => :el_capitan
     sha256 "f432478f58c504eaa69caf1c37461d478086e57b2d396c2d8c83e687425255c3" => :x86_64_linux
   end

--- a/tools/provision/formula/google-benchmark.rb
+++ b/tools/provision/formula/google-benchmark.rb
@@ -10,6 +10,7 @@ class GoogleBenchmark < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "b69e21940600808f50327171dd226fe8649c42ebadfaa222951c759c1366e23b" => :sierra
     sha256 "980e2adab86440ba9c3edea31cf082b1b5f7cd3a08df1f2491c4ebc1d2b7f5c9" => :el_capitan
     sha256 "11e90b22673d2ba5417557a73ed8eaf9b0688f698d16645b907a84d9ee0f0e52" => :x86_64_linux
   end

--- a/tools/provision/formula/libmagic.rb
+++ b/tools/provision/formula/libmagic.rb
@@ -10,6 +10,7 @@ class Libmagic < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "906e03a38f95e1d5fad4bd540a64bbcdcc7235993cf760b005d15446b16e7be0" => :sierra
     sha256 "bd197ddf2bc1ec309c354a0a5182e0e8620ec9b8c1fda97d34ad19b1748fc5e9" => :el_capitan
     sha256 "1fab0b41cfae9411e0bf622ede55977ecd71cc9336725f4fa64282adf0281998" => :x86_64_linux
   end

--- a/tools/provision/formula/linenoise-ng.rb
+++ b/tools/provision/formula/linenoise-ng.rb
@@ -7,6 +7,12 @@ class LinenoiseNg < AbstractOsqueryFormula
   sha256 "c317f3ec92dcb4244cb62f6fb3b7a0a5a53729a85842225fcfce0d4a429a0dfa"
   revision 2
 
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "94ad589501fb7d118dfab673b8e45d268d726175243b2a205ad5eca446c9352e" => :sierra
+  end
+
   def install
     mkdir "build"
     cd "build" do

--- a/tools/provision/formula/lz4.rb
+++ b/tools/provision/formula/lz4.rb
@@ -11,6 +11,7 @@ class Lz4 < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "893b7bd9c8e2c6bc7b3f7f6e8833cbf26a027ee750ad7970ed0b932272a05c45" => :sierra
     sha256 "3e76610faa04e0ba81a8b58de3421be77f7e226db6d78bab88eac0df82a947bf" => :el_capitan
     sha256 "684e6c315fa4a4ada277771559f5504c57363d5192c9252bffc6085dee9e04ec" => :x86_64_linux
   end

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -12,6 +12,7 @@ class Openssl < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "34c4d438179121bc38bffde80a9ad1e1213135df9492dbbd1bbc10097d4d29a7" => :sierra
     sha256 "fd11d0d4e127128b81810e1aff2dd7a2e4e81b916fa23cedb6955ddc73dacdb6" => :el_capitan
     sha256 "e24d6d9361661fe76cb0dfdb75c706d0621ebe8e1438111e912d782c819bf935" => :x86_64_linux
   end

--- a/tools/provision/formula/pcre.rb
+++ b/tools/provision/formula/pcre.rb
@@ -10,6 +10,7 @@ class Pcre < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "b08e622fd735f2a3701f92e529aa9ab1a10de8261c6edc8ef66a7f5b15d81ba5" => :sierra
     sha256 "d53bd23be25af381a8a5e645d90f4a83e4e5acf3111abd4e482160621cff6349" => :el_capitan
     sha256 "3d2507879303c57941fa19972dc9eed980318751725908a5f8db1ba1104ea3d6" => :x86_64_linux
   end

--- a/tools/provision/formula/python.rb
+++ b/tools/provision/formula/python.rb
@@ -10,6 +10,7 @@ class Python < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "7a65be973f72ecbfdb56c7e0a703a199bf5c14f8cacb9aac37684d99871a2741" => :sierra
     sha256 "96d0ef61fc9c1045696b1171952119b30c67dc5c45ad0ec458f78aa3ee0424da" => :el_capitan
     sha256 "d1b62a9115e0449f6136e5dafe9d9d138a473f384dd346a09bd9172b04a26c34" => :x86_64_linux
   end

--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -9,6 +9,7 @@ class Rocksdb < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "036ca6d31d132a1c71a703e83df4b6b0148585405a2a6bdbf2efa2cbaec778a4" => :sierra
     sha256 "a9111aa79915afe327106bfd824185e5f85230b46c2972b8b2d8500131ab8c6c" => :el_capitan
     sha256 "1ca1a32b3709b6c4a0890a929d0a3aa327ddc364ecc1d2dc076a85114272c9db" => :x86_64_linux
   end

--- a/tools/provision/formula/sleuthkit.rb
+++ b/tools/provision/formula/sleuthkit.rb
@@ -10,6 +10,7 @@ class Sleuthkit < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "bc7fe404554c5fb2c28eccb7b8e820420c48464030fd25b3d3c6bddb00208977" => :sierra
     sha256 "280f5ef4460942a04e7eb89ed3bb761fb28d35dcd656f7633864bcbdfc8a0be0" => :el_capitan
     sha256 "68daa7ee6ee634b9e16a385a4fe5dbeb719287e15885b76949916a1a24668d35" => :x86_64_linux
   end

--- a/tools/provision/formula/snappy.rb
+++ b/tools/provision/formula/snappy.rb
@@ -9,6 +9,7 @@ class Snappy < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "dc1023c5e85eda474df62e735d68c97656efa92974b28531737c5cddba511316" => :sierra
     sha256 "bfb084be2ab8d6d302504b306be9dcc753be9543aecbc0f695b6908b32efb2ee" => :el_capitan
     sha256 "d376883230a45dc1cc7f58fdaa5e5b06b913b0b7dd38d1ab55513bcbff795c1b" => :x86_64_linux
   end

--- a/tools/provision/formula/thrift.rb
+++ b/tools/provision/formula/thrift.rb
@@ -10,6 +10,7 @@ class Thrift < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "7c4a1aa18ee2473aebcf78093b59168fa0663b639c895c3a6795c69739c20305" => :sierra
     sha256 "d1117be1bd961e63402db5bd824a1ad848b54ee28a06338b17bd9235643dfd0b" => :el_capitan
     sha256 "da5294848c117ee640ad5a287b00d9af4e013264235d2579453e5ce35b1795d5" => :x86_64_linux
   end

--- a/tools/provision/formula/yara.rb
+++ b/tools/provision/formula/yara.rb
@@ -8,6 +8,7 @@ class Yara < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "d321f236fbdda9a08772d6fbdef20365b5332a437b584f709f0f8be894b34af1" => :sierra
     sha256 "e9fe2b5ec31076d218d22e7190a9b010d0de8dd12330785395e8d5deeea85ea7" => :el_capitan
     sha256 "12428e1c14b244f812bb6577b993c306ff56d62e966acd0152a2b805724f9bd9" => :x86_64_linux
   end

--- a/tools/provision/formula/zzuf.rb
+++ b/tools/provision/formula/zzuf.rb
@@ -10,6 +10,7 @@ class Zzuf < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "0811de4fdac7e4188c61fea1318c759fffe334011c342f0f370f0942844054c1" => :sierra
     sha256 "37ef864273fa364fd08e26b5173c12e70ab9d6d42b988b4b2f36a8835c156d42" => :el_capitan
     sha256 "6e2de1bed215d2c945b6283cb07a642124a954061086b3ea93eefdedacb8a7a1" => :x86_64_linux
   end

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -27,7 +27,7 @@ function setup_brew() {
     git clone $BREW_REPO "$DEPS"
   else
     log "checking for updates to brew"
-    #git pull
+    git pull
   fi
 
   # Create a local cache directory
@@ -55,12 +55,12 @@ function setup_brew() {
   # Grab full clone to perform a pin
   log "installing homebrew core"
   $BREW tap homebrew/core --full
-  (cd $TAPS/homebrew/homebrew-core && git reset --hard $CORE_COMMIT)
+  (cd $TAPS/homebrew/homebrew-core && git pull && git reset --hard $CORE_COMMIT)
 
   # Need dupes for upzip.
   log "installing homebrew dupes"
   $BREW tap homebrew/dupes --full
-  (cd $TAPS/homebrew/homebrew-dupes && git reset --hard $DUPES_COMMIT)
+  (cd $TAPS/homebrew/homebrew-dupes && git pull && git reset --hard $DUPES_COMMIT)
 
   # Create a 'legacy' mirror.
   if [[ -L "$DEPS/legacy" ]]; then


### PR DESCRIPTION
This updates the commit hashes for `Homebrew` core and dupes to support building on OS X 10.12. That allows binary (bottle) installs for some of our tools. The local builds for library dependencies have been uploaded to S3.