### PR TITLE
Fix regression in Requests/TLS APIs related to verb detection

### DIFF
--- a/osquery/distributed/plugins/tls.cpp
+++ b/osquery/distributed/plugins/tls.cpp
@@ -70,14 +70,10 @@ Status TLSDistributedPlugin::setUp() {
 }
 
 Status TLSDistributedPlugin::getQueries(std::string& json) {
-  if (FLAGS_tls_node_api) {
-    pt::ptree params;
-    params.put("verb", "POST");
-    return TLSRequestHelper::go<JSONSerializer>(
-        read_uri_, params, json, FLAGS_distributed_tls_max_attempts);
-  }
+  pt::ptree params;
+  params.put("_verb", "POST");
   return TLSRequestHelper::go<JSONSerializer>(
-      read_uri_, json, FLAGS_distributed_tls_max_attempts);
+      read_uri_, params, json, FLAGS_distributed_tls_max_attempts);
 }
 
 Status TLSDistributedPlugin::writeResults(const std::string& json) {
@@ -85,9 +81,6 @@ Status TLSDistributedPlugin::writeResults(const std::string& json) {
   try {
     std::stringstream ss(json);
     pt::read_json(ss, params);
-    if (FLAGS_tls_node_api) {
-      params.put("verb", "POST");
-    }
   } catch (const pt::ptree_error& e) {
     return Status(1, "Error parsing JSON: " + std::string(e.what()));
   }

--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -122,6 +122,9 @@ Status TLSLogForwarder::send(std::vector<std::string>& log_data,
   // The response body is ignored (status is set appropriately by
   // TLSRequestHelper::go())
   std::string response;
+  if (FLAGS_logger_tls_compress) {
+    params.put("_compress", true);
+  }
   return TLSRequestHelper::go<JSONSerializer>(uri_, params, response);
 }
 }

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -198,8 +198,8 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
 
   // Allow request calls to override the default HTTP POST verb.
   HTTPVerb verb = HTTP_POST;
-  if (options_.count("verb") > 0) {
-    verb = (HTTPVerb)options_.get<int>("verb", HTTP_POST);
+  if (options_.count("_verb") > 0) {
+    verb = (HTTPVerb)options_.get<int>("_verb", HTTP_POST);
   }
 
   VLOG(1) << "TLS/HTTPS " << ((verb == HTTP_POST) ? "POST" : "PUT")


### PR DESCRIPTION
The `Request` API uses a "waterfall" calling pattern resulting in all logic handled in a method responsible for `POST`ing content to an endpoint. A recent change to the logger `tls` plugin migrated transport calls to the `Request` API but did not handle this under-the-hood logic error (as well as a lack of compression support within the `Request` API).

This change introduces `_verb` as a potential parameter and `_get` to force a GET request via the waterfall calling. Requesting compression is the responsibility of the caller via a new `_compress` parameter. 