### PR TITLE
Adding cppcheck analysis script

### DIFF
--- a/tools/analysis/analyze.bat
+++ b/tools/analysis/analyze.bat
@@ -1,0 +1,3 @@
+@echo off
+"C:\Program Files\Cppcheck\cppcheck.exe" --quiet -i .\third-party\ -i .\build\ .
+"C:\Program Files\Cppcheck\cppcheck.exe" --quiet --project=.\build\windows10\OSQUERY.sln

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -263,8 +263,8 @@ function Update-GitSubmodule {
 }
 
 function Main {
-  if ($PSVersionTable.PSVersion.Major -lt 3.0 ) {
-    Write-Output "This installer requires Powershell 3.0 or Greater."
+  if ($PSVersionTable.PSVersion.Major -lt 5.0 ) {
+    Write-Output "This installer requires Powershell 5.0 or Greater."
     Exit -1
   }
 
@@ -276,6 +276,7 @@ function Main {
   }
   Write-Host "[+] Success!" -foregroundcolor Green
   Install-Chocolatey
+  Install-ChocoPackage 'cppcheck'
   Install-ChocoPackage '7zip.commandline'
   Install-ChocoPackage 'cmake.portable' '3.6.1'
   Install-ChocoPackage 'python2' '2.7.11'


### PR DESCRIPTION
This PR adds in a cppcheck that will be run against new PRs for Windows going forward. Alongside this new static analysis script, I'm fixing a few issues it found including a leaking resource handle in the deamon's `installService` code.

Currently our static analysis will only fail on errors found, as opposed to warnings and style issues.

Lastly, I'm bumping up our Powershell gate to be 5.0 and greater, as currently our provisioning script fails on Powershell 3.0 due to our use of newer cmdlets. I'm currently working on making our provisioning 3.0 friendly, but this will come later.