### PR TITLE
[Fix #2652] Shorten long lines

### DIFF
--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -150,7 +150,8 @@ void FilesystemLoggerPlugin::init(const std::string& name,
   auto basename = (log_path_ / name).string();
 
   google::SetLogDestination(google::GLOG_INFO, (basename + ".INFO.").c_str());
-  google::SetLogDestination(google::GLOG_WARNING, (basename + ".WARNING.").c_str());
+  google::SetLogDestination(google::GLOG_WARNING,
+                            (basename + ".WARNING.").c_str());
   google::SetLogDestination(google::GLOG_ERROR, (basename + ".ERROR.").c_str());
 
   // Store settings for logging to stderr.

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -34,7 +34,8 @@ const std::string kVersion = STR(OSQUERY_BUILD_VERSION);
 #endif
 const std::string kSDKVersion = OSQUERY_SDK_VERSION;
 const std::string kSDKPlatform = OSQUERY_PLATFORM;
-const PlatformType kPlatformType = static_cast<PlatformType>(OSQUERY_PLATFORM_MASK);
+const PlatformType kPlatformType =
+    static_cast<PlatformType>(OSQUERY_PLATFORM_MASK);
 
 bool versionAtLeast(const std::string& v, const std::string& sdk) {
   if (v == "0.0.0" || sdk == "0.0.0") {

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -23,10 +23,16 @@
 #ifdef WIN32
 #pragma warning(push, 3)
 
-/// Suppressing warning C4005: 'ASIO_ERROR_CATEGORY_NOEXCEPT': macro redefinition
+/*
+ * Suppressing warning C4005: 
+ * 'ASIO_ERROR_CATEGORY_NOEXCEPT': macro redefinition
+ */
 #pragma warning(disable: 4005)
 
-/// Suppressing warning C4244: 'argument': conversion from '__int64' to 'long', possible loss of data
+/*
+ * Suppressing warning C4244: 
+ * 'argument': conversion from '__int64' to 'long', possible loss of data
+ */
 #pragma warning(disable: 4244)
 #else
 #pragma clang diagnostic push


### PR DESCRIPTION
Used clang-format to shorten lines greater than 80 characters wide.

Exceptional case occured for "tls.h", in which the offending lines were
located in between the "clang-format (off/on)" comments.