### PR TITLE
[Fix #2656] Refactor events_optimize to act per-query

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -29,6 +29,9 @@ class Pack;
 class Schedule;
 class ConfigParserPlugin;
 
+/// The name of the executing query within the single-threaded schedule.
+extern const std::string kExecutingQuery;
+
 /**
  * @brief The programmatic representation of osquery's configuration
  *

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -24,7 +24,7 @@
 
 namespace osquery {
 
-FLAG(bool, enable_monitor, false, "Enable the schedule monitor");
+FLAG(bool, enable_monitor, true, "Enable the schedule monitor");
 
 FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit")
 

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -60,6 +60,49 @@ static inline EventTime timeFromRecord(const std::string& record) {
   return afinite;
 }
 
+static inline void getOptimizeData(EventTime& o_time,
+                                   size_t& o_eid,
+                                   const std::string& publisher) {
+  // Read the optimization time for the current executing query.
+  std::string query_name;
+  getDatabaseValue(kPersistentSettings, kExecutingQuery, query_name);
+  if (query_name.empty()) {
+    // Fallback when daemons disable query monitoring.
+    query_name = publisher;
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kEvents, "optimize." + query_name, content);
+    long long optimize_time = 0;
+    safeStrtoll(content, 10, optimize_time);
+    o_time = static_cast<EventTime>(optimize_time);
+  }
+
+  {
+    std::string content;
+    getDatabaseValue(kEvents, "optimize_eid." + query_name, content);
+    long long optimize_eid = 0;
+    safeStrtoll(content, 10, optimize_eid);
+    o_eid = static_cast<size_t>(optimize_eid);
+  }
+}
+
+static inline void setOptimizeData(EventTime time,
+                                   size_t eid,
+                                   const std::string& publisher) {
+  // Store the optimization time and eid.
+  std::string query_name;
+  getDatabaseValue(kPersistentSettings, kExecutingQuery, query_name);
+  if (query_name.empty()) {
+    // Fallback when daemons disable query monitoring.
+    query_name = publisher;
+  }
+
+  setDatabaseValue(kEvents, "optimize." + query_name, std::to_string(time));
+  setDatabaseValue(kEvents, "optimize_eid." + query_name, std::to_string(eid));
+}
+
 QueryData EventSubscriberPlugin::genTable(QueryContext& context) {
   // Stop is an unsigned (-1), our end of time equivalent.
   EventTime start = 0, stop = 0;
@@ -83,13 +126,9 @@ QueryData EventSubscriberPlugin::genTable(QueryContext& context) {
   } else if (kToolType == ToolType::DAEMON && FLAGS_events_optimize) {
     // If the daemon is querying a subscriber without a 'time' constraint and
     // allows optimization, only emit events since the last query.
+    getOptimizeData(optimize_time_, optimize_eid_, dbNamespace());
     start = optimize_time_;
     optimize_time_ = getUnixTime() - 1;
-
-    // Store the optimize time such that it can be restored if the daemon is
-    // restarted.
-    auto index_key = "optimize." + dbNamespace();
-    setDatabaseValue(kEvents, index_key, std::to_string(optimize_time_));
   }
   return get(start, stop);
 }
@@ -421,8 +460,6 @@ QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
     unsigned long int eidr = 0;
     if (safeStrtoul(records.back().first, 10, eidr)) {
       optimize_eid_ = static_cast<size_t>(eidr);
-      auto index_key = "optimize_id." + dbNamespace();
-      setDatabaseValue(kEvents, index_key, records.back().first);
     }
   }
 
@@ -446,6 +483,10 @@ QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
     // Set the expire time to NOW - "configured lifetime".
     // Index retrieval will apply the constraints checking and auto-expire.
     expire_time_ = getUnixTime() - getEventsExpiry();
+  }
+
+  if (FLAGS_events_optimize) {
+    setOptimizeData(optimize_time_, optimize_eid_, dbNamespace());
   }
 
   return results;
@@ -701,24 +742,6 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
 
   auto& ef = EventFactory::getInstance();
   ef.event_subs_[name] = specialized_sub;
-
-  // Restore optimize times for a daemon.
-  if (kToolType == ToolType::DAEMON && FLAGS_events_optimize) {
-    auto index_key = "optimize." + specialized_sub->dbNamespace();
-    std::string content;
-    if (getDatabaseValue(kEvents, index_key, content)) {
-      long long optimize_time = 0;
-      safeStrtoll(content, 10, optimize_time);
-      specialized_sub->optimize_time_ = static_cast<EventTime>(optimize_time);
-    }
-
-    index_key = "optimize_id." + specialized_sub->dbNamespace();
-    if (getDatabaseValue(kEvents, index_key, content)) {
-      long long optimize_id = 0;
-      safeStrtoll(content, 10, optimize_id);
-      specialized_sub->optimize_eid_ = static_cast<size_t>(optimize_id);
-    }
-  }
 
   // Set state of subscriber.
   if (!status.ok()) {

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -13,6 +13,7 @@
 
 #include <gtest/gtest.h>
 
+#include <osquery/config.h>
 #include <osquery/core.h>
 #include <osquery/database.h>
 #include <osquery/events.h>
@@ -262,6 +263,9 @@ TEST_F(EventsDatabaseTests, test_optimize) {
   kToolType = ToolType::DAEMON;
   FLAGS_events_optimize = true;
 
+  // Must also define an executing query.
+  setDatabaseValue(kPersistentSettings, kExecutingQuery, "events_db_test");
+
   QueryContext context;
   auto t = getUnixTime();
   auto results = sub->genTable(context);
@@ -282,8 +286,7 @@ TEST_F(EventsDatabaseTests, test_optimize) {
   // The optimize time should have been written to the database.
   // It should be the same as the current (relative) optimize time.
   std::string content;
-  getDatabaseValue(
-      "events", "optimize.DBFakePublisher.DBFakeSubscriber", content);
+  getDatabaseValue("events", "optimize.events_db_test", content);
   EXPECT_EQ(std::to_string(sub->optimize_time_), content);
 
   // Restore the tool type.


### PR DESCRIPTION
The `--events_optimize` flag was never intended to support multiple scheduled queries acting on the same events-based subscriber (the virtual table). This change allows optimization to occur on the query-level, not the subscriber.
