### PR TITLE
Add --extension to osqueryi for quick autoloading

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,14 +1,13 @@
-osquery is an operating system instrumentation framework for OS X, Linux, and FreeBSD.
-The tools make low-level operating system analytics and monitoring both performant and intuitive.
+osquery is an operating system instrumentation framework for Windows, OS X (macOS), Linux, and FreeBSD. The tools make low-level operating system analytics and monitoring both performant and intuitive.
 
 osquery exposes an operating system as a high-performance relational database. This allows you to write SQL queries to explore operating system data. With osquery, SQL tables represent abstract concepts such as running processes, loaded kernel modules, open network connections, browser plugins, hardware events or file hashes.
 
 ## Getting Started
 
-If you're interested in **installing osquery** check out the install guide for [OS X](installation/install-osx.md), [Linux](installation/install-linux.md), and [FreeBSD](installation/install-freebsd.md).
+If you're interested in **installing osquery** check out the install guide for [Windows](installation/install-windows.md), [OS X](installation/install-osx.md), [Linux](installation/install-linux.md), and [FreeBSD](installation/install-freebsd.md).
 
-If you're interested in **deploying osquery** to provide your organization with deeper insight into your Linux, FreeBSD, and OS X hosts check out the [using osqueryd guide](introduction/using-osqueryd.md).
-If you're interested in **performing ad-hoc queries**, check out [using osqueryi](introduction/using-osqueryi.md).
+If you're interested in **deploying osquery** to provide your organization with deeper insight into your Linux, FreeBSD, OS X, and Windows hosts check out the [using osqueryd guide](introduction/using-osqueryd.md).
+If you're interested in **performing ad-hoc queries** and exploring tables, check out [using osqueryi](introduction/using-osqueryi.md).
 
 If you're interested in **extending one of the existing osquery tools** or improving core libraries, read the developer documentation pages. You should start with "[building the code](development/building.md)" and "[contributing code](development/contributing-code.md)".
 
@@ -16,6 +15,6 @@ If you're interested in **integrating osquery** into your own tool, check out th
 
 ## Getting help
 
-If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/facebook/osquery/issues). Keep in touch with osquery developers and users in **#osquery** on **freenode**.
+If any part of osquery is not working as expected, please create a [GitHub Issue](https://github.com/facebook/osquery/issues). Keep in touch with osquery developers and users in our Slack [https://osquery-slack.herokuapp.com/](https://osquery-slack.herokuapp.com/).
 
-If you have long-form questions, please email [osquery@googlegroups.com](mailto:osquery@googlegroups.com).
+If you have long-form questions, please email [osquery@fb.com](mailto:osquery@fb.com).

--- a/docs/wiki/introduction/overview.md
+++ b/docs/wiki/introduction/overview.md
@@ -2,7 +2,7 @@ The high-performance and low-footprint distributed host monitoring daemon, **osq
 
 The interactive query console, **osqueryi**, gives you a SQL interface to try out new queries and explore your operating system. With the power of a complete SQL language and dozens of useful tables built-in, **osqueryi** is an invaluable tool when performing incident response, diagnosing a systems operations problem, troubleshooting a performance issue, etc.
 
-osquery is cross platform. Even though osquery takes advantage of very low-level operating system APIs, you can build and use osquery on Mac OS X, Ubuntu, CentOS and other popular enterprise Linux distributions. This has the distinct advantage of allowing you to be able to use one platform for monitoring complex operating system state across your entire infrastructure. Monitor your corporate Mac OS X clients the same way you monitor your production Linux servers.
+osquery is cross platform. Even though osquery takes advantage of very low-level operating system APIs, you can build and use osquery on Windows, Mac OS X, Ubuntu, CentOS and other popular enterprise Linux distributions. This has the distinct advantage of allowing you to be able to use one platform for monitoring complex operating system state across your entire infrastructure. Monitor your corporate Windows or Mac OS X clients the same way you monitor your production Linux servers.
 
 To make deploying osquery in your infrastructure as easy as possible, osquery comes with native packages for all supported operating systems. There is extensive tooling and documentation around creating packages so packaging and deploying your custom osquery tools can be just as easy too.
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -84,6 +84,8 @@ CLI_FLAG(string,
          "Optional path to a list of autoloaded registry modules")
 #endif
 
+SHELL_FLAG(string, extension, "", "Path to a single extension to autoload");
+
 /**
  * @brief Alias the extensions_socket (used by core) to a simple 'socket'.
  *
@@ -383,6 +385,12 @@ static bool isFileSafe(std::string& path, ExtenableTypes type) {
 
 Status loadExtensions(const std::string& loadfile) {
   std::string autoload_paths;
+  if (!FLAGS_extension.empty()) {
+    // This is a shell-only development flag for quickly loading/using a single
+    // extension. It bypasses the safety check.
+    Watcher::addExtensionPath(FLAGS_extension);
+  }
+
   if (readFile(loadfile, autoload_paths).ok()) {
     for (auto& path : osquery::split(autoload_paths, "\n")) {
       if (isFileSafe(path, EXTENSION)) {


### PR DESCRIPTION
This adds a new shell-only flag `--extension` that "autoloads" a single extension. This is helpful for testing/developing extensions.