### PR TITLE
Add --extensions_require feature

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -73,6 +73,18 @@ Status getExtensions(const std::string& manager_path,
 Status pingExtension(const std::string& path);
 
 /**
+ * @brief Perform an action while waiting for an the extension timeout.
+ *
+ * We define a 'global' extension timeout using CLI flags.
+ * There are several locations where code may act assuming an extension has
+ * loaded or broadcasted a registry.
+ *
+ * @param predicate return true or set stop to end the timeout loop.
+ * @return the last status from the predicate.
+ */
+Status applyExtensionDelay(std::function<Status(bool& stop)> predicate);
+
+/**
  * @brief Request the extensions API to autoload any appropriate extensions.
  *
  * Extensions may be 'autoloaded' using the `extensions_autoload` command line

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -189,14 +189,14 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-DECLARE_string(distributed_plugin);
-DECLARE_bool(disable_distributed);
 DECLARE_string(config_plugin);
 DECLARE_bool(config_check);
 DECLARE_bool(config_dump);
-DECLARE_bool(disable_database);
 DECLARE_bool(database_dump);
 DECLARE_string(database_path);
+DECLARE_string(distributed_plugin);
+DECLARE_bool(disable_distributed);
+DECLARE_bool(disable_database);
 DECLARE_bool(disable_events);
 
 #if !defined(__APPLE__) && !defined(WIN32)
@@ -506,35 +506,25 @@ bool Initializer::isWorker() {
 
 void Initializer::initActivePlugin(const std::string& type,
                                    const std::string& name) const {
-  // Use a delay, meaning the amount of milliseconds waited for extensions.
-  size_t delay = 0;
-  // The timeout is the maximum milliseconds in seconds to wait for extensions.
-  size_t timeout = atoi(FLAGS_extensions_timeout.c_str()) * 1000;
-  if (timeout < kExtensionInitializeLatency * 10) {
-    timeout = kExtensionInitializeLatency * 10;
-  }
-
-  // Attempt to set the request plugin as active.
-  Status status;
-  do {
-    status = Registry::setActive(type, name);
-    if (status.ok()) {
-      // The plugin was found, and is not active.
-      return;
+  auto status = applyExtensionDelay(([type, name](bool& stop) {
+    auto rs = Registry::setActive(type, name);
+    if (rs.ok()) {
+      // The plugin was found, and is now active.
+      return rs;
     }
 
     if (!Watcher::hasManagedExtensions()) {
-      // The plugin was found locally, and is not active, problem.
-      break;
+      // The plugin must be local, and is not active, problem.
+      stop = true;
     }
-    // The plugin is not local and is not active, wait and retry.
-    delay += kExtensionInitializeLatency;
-    sleepFor(kExtensionInitializeLatency);
-  } while (delay < timeout);
+    return rs;
+  }));
 
-  LOG(ERROR) << "Cannot activate " << name << " " << type
-             << " plugin: " << status.getMessage();
-  requestShutdown(EXIT_CATASTROPHIC);
+  if (!status.ok()) {
+    LOG(ERROR) << "Cannot activate " << name << " " << type
+               << " plugin: " << status.getMessage();
+    requestShutdown(EXIT_CATASTROPHIC);
+  }
 }
 
 void Initializer::start() const {


### PR DESCRIPTION
This introduces a new feature `--extensions_require` that allows a `flagfile` to set a comma-separated set of extension names. osquery will apply the existing `--extensions_timeout` while waiting for the set of extensions to be registered.

The shell or daemon will emit a warning message if a required extension is not found within the timeout.

This is helpful for `osqueryi` when the tool does not need to depend on active config or logger plugins. Before, when using one of the query-and-exit workflows, extensions were useless.