### PR TITLE
Add optional default flagfile /etc/osquery/osquery.flags.default

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -33,6 +33,7 @@ Include line-delimited switches to be interpreted and used as CLI-flags:
 --watchlog_level=2
 ```
 
+If no `--flagfile` is provided, osquery will try to find and use a "default" flagfile at `/etc/osquery/osquery.flags.default`. Both the shell and daemon will discover and use the defaults.
 
 ### Configuration control flags
 


### PR DESCRIPTION
This optional "default" `flagfile` is used in the shell and daemon ONLY if the file exists. This is helpful when using a default set of extensions/additional tables. The default `flagfile` can set `--extensions_require` after having autoloaded from `/etc/osquery/extensions.autoload`.