### PR TITLE
Refactor test/ctest and suppressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,6 @@ elseif(DEFINED ENV{SANITIZE})
       -fsanitize=leak
     )
   endif()
-
-  set(ENV{ASAN_OPTIONS} "detect_container_overflow=0")
-  set(ENV{TSAN_OPTIONS} "suppressions=${CMAKE_SOURCE_DIR}/tools/analysis/tsan.supp")
 else()
   set(DEBUG FALSE)
   if(WINDOWS)

--- a/tools/analysis/lsan.supp
+++ b/tools/analysis/lsan.supp
@@ -1,0 +1,1 @@
+leak:apache::thrift::transport::TServerSocket::listen


### PR DESCRIPTION
The LLVM sanitize framework environment variables are cleared from `cmake` to `ctest`. To enable suppression and options during `make test` we need to break out the `test` target and set the variables for the `ctest` call.