### PR TITLE
[Fix #2674] Add SQLite prepare lock to shell_exec

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -174,9 +174,15 @@ inline bool isPlatform(PlatformType a, const PlatformType& t = kPlatformType) {
   return (static_cast<int>(t) & static_cast<int>(a)) != 0;
 }
 
-/// Helper alias for defining mutexes throughout the codebase.
+/// Helper alias for defining mutexes.
 using Mutex = std::mutex;
 
 /// Helper alias for write locking a mutex.
 using WriteLock = std::lock_guard<Mutex>;
+
+/// Helper alias for defining recursive mutexes.
+using RecursiveMutex = std::recursive_mutex;
+
+/// Helper alias for write locking a recursive mutex.
+using RecursiveLock = std::lock_guard<std::recursive_mutex>;
 }

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -78,9 +78,6 @@ const std::string kFailedQueries = "failed_queries";
 Mutex config_hash_mutex_;
 Mutex config_valid_mutex_;
 
-using RecursiveMutex = std::recursive_mutex;
-using RecursiveLock = std::lock_guard<std::recursive_mutex>;
-
 /// Several config methods require enumeration via predicate lambdas.
 RecursiveMutex config_schedule_mutex_;
 RecursiveMutex config_files_mutex_;

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -20,6 +20,16 @@
 namespace osquery {
 
 /**
+ * @brief A protection around concurrent table attach requests.
+ *
+ * Table attaching is not concurrent. Attaching is the only unprotected SQLite
+ * operation from osquery's usage perspective. The extensions API allows for
+ * concurrent access of non-thread-safe database resources for attaching table
+ * schema and filter routing instructions.
+ */
+extern RecursiveMutex kAttachMutex;
+
+/**
  * @brief osquery cursor object.
  *
  * Only used in the SQLite virtual table module methods.
@@ -70,6 +80,16 @@ Status attachFunctionInternal(
     const std::string &name,
     std::function<
         void(sqlite3_context *context, int argc, sqlite3_value **argv)> func);
+
+/**
+ * A generated foreign amalgamation file includes schema for all tables.
+ *
+ * When the build system generates TablePlugin%s from the .table spec files, it
+ * reads the foreign-platform tables and generates an associated schema plugin.
+ * These plugins are amalgamated into 'foreign_amalgamation' and do not call
+ * their filter generation functions.
+ */
+void registerForeignTables();
 
 /// Attach all table plugins to an in-memory SQLite database.
 void attachVirtualTables(const SQLiteDBInstanceRef &instance);


### PR DESCRIPTION
#2674 demonstrates a leak and race between the shell's `shell_exec` and extension's use of the `Registry`. Internals may assume a valid SQLite DB handle for running internal queries. If there is no resource contention the handle used by the shell is the same as internal queries. Unfortunately the shell makes use of the handle directly and MUST lock access.