### PR TITLE
[Fix #2678] Run postinstall for OpenSSL to install certs.pem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ FORMAT_COMMAND := python tools/formatting/git-clang-format.py \
 	"--commit" "master" "-f" "--style=file"
 
 ANALYSIS := ${SOURCE_DIR}/tools/analysis
-DEFINES := CTEST_OUTPUT_ON_FAILURE=1 ${PATH_SET} \
+DEFINES := CTEST_OUTPUT_ON_FAILURE=1 \
 	LSAN_OPTIONS="detect_container_overflow=0 \
 	suppressions=${ANALYSIS}/lsan.supp" \
 	ASAN_OPTIONS="suppressions=${ANALYSIS}/asan.supp" \
@@ -183,6 +183,7 @@ sync: .setup
 
 test:
 	@cd build/$(BUILD_DIR) && $(DEFINES) $(CTEST)
+
 %::
 	@cd build/$(BUILD_DIR) && $(CMAKE) && \
 		$(DEFINES) $(MAKE) --no-print-directory $@

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -187,7 +187,9 @@ function platform_linux_main() {
   # Build a bottle for perl and openssl.
   # OpenSSL is needed for the final build.
   # local_brew_tool perl -vd --without-test
+  brew_clean curl
   local_brew_tool openssl
+  local_brew_postinstall openssl
   local_brew_link openssl
 
   # LLVM dependencies.
@@ -248,7 +250,8 @@ function platform_darwin_main() {
   brew_tool makedepend
   brew_tool clang-format
 
-  local_brew_dependency openssl --without-test
+  local_brew_dependency openssl
+  local_brew_postinstall openssl
   local_brew_link openssl
 
   brew_tool pkg-config

--- a/tools/provision/formula/curl.rb
+++ b/tools/provision/formula/curl.rb
@@ -5,11 +5,12 @@ class Curl < AbstractOsqueryFormula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.48.0.tar.bz2"
   sha256 "864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "24a87b472bd056b78a3f37a793fa57e618d05333f3b6c94827a0fb03a34861e1" => :x86_64_linux
+    sha256 "e10eb6e0dba4312da745f538a2832c27637a69f55731cfa21c95bef122fb6099" => :x86_64_linux
   end
 
   keg_only :provided_by_osx

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -7,14 +7,14 @@ class Openssl < AbstractOsqueryFormula
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2i.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2i.tar.gz"
   sha256 "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "34c4d438179121bc38bffde80a9ad1e1213135df9492dbbd1bbc10097d4d29a7" => :sierra
+    sha256 "3a593fed8efd77bf6ae3b9e5b16f7c0072b2f249dff9222344e6a6191f0c76cb" => :sierra
     sha256 "fd11d0d4e127128b81810e1aff2dd7a2e4e81b916fa23cedb6955ddc73dacdb6" => :el_capitan
-    sha256 "e24d6d9361661fe76cb0dfdb75c706d0621ebe8e1438111e912d782c819bf935" => :x86_64_linux
+    sha256 "11cc84110960f765d1ee91a14425c6f4b09734272cd6f14a09f85ff428fe183a" => :x86_64_linux
   end
 
   resource "cacert" do
@@ -127,9 +127,10 @@ class Openssl < AbstractOsqueryFormula
   end
 
   def post_install
+    ENV.delete "LIBRARY_PATH"
     unless OS.mac?
       # Optional: Download and install cacert.pem from curl.haxx.se
-      # (etc/"openssl").install resource("cacert").files("cacert-2016-04-20.pem" => "cert.pem")
+      (etc/"openssl").install resource("cacert").files("cacert-2016-04-20.pem" => "cert.pem")
       return
     end
 

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -174,6 +174,11 @@ function brew_internal() {
   export HOMEBREW_OPTIMIZATION_LEVEL=-Os
   if [[ ! -z "$OSQUERY_BUILD_BOTTLES" && ! "$TYPE" = "upstream" ]]; then
     $BREW bottle --skip-relocation "${FORMULA}"
+  elif [[ "$TYPE" = "clean" ]]; then
+    if [[ ! "${INSTALLED}" = "${STABLE}" ]]; then
+      log "brew cleaning older version of $TOOL: ${STABLE}"
+      $BREW remove --force "${FORMULA}"
+    fi
   elif [[ "${INSTALLED}" = "NAN" || "${INSTALLED}" = "None" ]]; then
     log "brew package $TOOL installing new version: ${STABLE}"
     $BREW install $ARGS "${FORMULA}"
@@ -205,6 +210,11 @@ function local_brew_unlink() {
 
 function local_brew_uninstall() {
   brew_internal "uninstall" $@
+}
+
+function brew_clean() {
+  # Remove older versions if installed.
+  brew_internal "clean" $@
 }
 
 function brew_tool() {


### PR DESCRIPTION
This tries to handle all potential setups:
* Someone has OpenSSL installed without `certs.pem`: uninstall `curl`, reinstall `openssl` with `certs.pem`, reinstall `curl`.
* Someone with neither will install `openssl` then `curl`.
