### PR TITLE
[Fix #2681] Use subscriber setUp result to enable/disable

### DIFF
--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -684,8 +684,13 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
     }
   }
 
-  // Let the module initialize any Subscriptions.
-  auto status = Status(0, "OK");
+  // Allow subscribers a configure-time setup to determine if they should run.
+  auto status = specialized_sub->setUp();
+  if (!status) {
+    specialized_sub->disabled = true;
+  }
+
+  // Let the subscriber initialize any Subscriptions.
   if (!FLAGS_disable_events && !specialized_sub->disabled) {
     specialized_sub->expireCheck(true);
     status = specialized_sub->init();

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -39,7 +39,10 @@ class SocketEventSubscriber : public EventSubscriber<AuditEventPublisher> {
  public:
   /// This subscriber depends on a configuration boolean.
   Status setUp() override {
-    return Status((FLAGS_audit_allow_sockets) ? 0 : 1);
+    if (!FLAGS_audit_allow_sockets) {
+      return Status(1, "Subscriber disabled via configuration");
+    }
+    return Status(0);
   }
 
   /// The process event subscriber declares an audit event type subscription.


### PR DESCRIPTION
It is important to run subscriber `setUp` methods and use the result to potentially disable subscribers.

When a subscriber is disabled, the `init` method to add subscriptions will not be called. This fixes an oversight with the Linux `audit` publisher. Currently enabling audit will always enable `bind` and `connect` auditing, along with process auditing.