### PR TITLE
[Fix #2396] New table: sudoers

### DIFF
--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <locale>
+#include <vector>
+
+#include <boost/algorithm/string/trim.hpp>
+
+#include <osquery/filesystem.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+const std::string kSudoFile = "/etc/sudoers";
+
+QueryData genSudoers(QueryContext& context) {
+  QueryData results;
+
+  if (!isReadable(kSudoFile).ok()) {
+    return results;
+  }
+
+  std::string contents;
+  if (!forensicReadFile(kSudoFile, contents).ok()) {
+    return results;
+  }
+
+  auto lines = split(contents, "\n");
+  std::vector<std::string> valid_lines;
+
+  for (auto& line : lines) {
+    boost::trim(line);
+
+    // Only add lines that are not comments or blank.
+    if (line.size() > 0 && line.at(0) != '#') {
+      valid_lines.push_back(line);
+    }
+  }
+
+  for (const auto& line : valid_lines) {
+    Row r;
+    auto cols = split(line);
+    r["header"] = cols.at(0);
+
+    cols.erase(cols.begin());
+    r["rule_details"] = join(cols, " ");
+
+    results.push_back(r);
+  }
+
+  return results;
+}
+}
+}

--- a/specs/posix/sudoers.table
+++ b/specs/posix/sudoers.table
@@ -1,0 +1,7 @@
+table_name("sudoers")
+description("Rules for running commands as other users via sudo.")
+schema([
+    Column("header", TEXT, "Symbol for given rule"),
+    Column("rule_details", TEXT, "Rule definition")
+])
+implementation("sudoers@genSudoers")


### PR DESCRIPTION
I've done some profiling of this on my machine, and the statistics seem fine across the board. Please test on your machines as well.

Also, as per the original issue, there may be more useful things we can do with the different rule types/sections/etc, as opposed to the current implementation of two simple columns. Discussion of possible alternative implementations would be appreciated.
