### PR TITLE
Fix UDEV publisher unit tests LSAN bug

### DIFF
--- a/osquery/events/linux/audit.cpp
+++ b/osquery/events/linux/audit.cpp
@@ -169,6 +169,7 @@ void AuditEventPublisher::tearDown() {
   }
 
   audit_close(handle_);
+  handle_ = 0;
 }
 
 inline void handleAuditConfigChange(const struct audit_reply& reply) {

--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -159,7 +159,10 @@ class AuditEventPublisher
   Status run() override;
 
  public:
-  AuditEventPublisher() : EventPublisher(){};
+  AuditEventPublisher() : EventPublisher() {}
+  virtual ~AuditEventPublisher() {
+    tearDown();
+  }
 
  private:
   /// Maintain a list of audit rule data for displaying or deleting.

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -108,7 +108,9 @@ void INotifyEventPublisher::configure() {
 }
 
 void INotifyEventPublisher::tearDown() {
-  ::close(inotify_handle_);
+  if (inotify_handle_ > -1) {
+    ::close(inotify_handle_);
+  }
   inotify_handle_ = -1;
 }
 

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -118,6 +118,10 @@ class INotifyEventPublisher
   DECLARE_PUBLISHER("inotify");
 
  public:
+  virtual ~INotifyEventPublisher() {
+    tearDown();
+  }
+
   /// Create an `inotify` handle descriptor.
   Status setUp() override;
 
@@ -139,7 +143,9 @@ class INotifyEventPublisher
       struct inotify_event* event) const;
 
   /// Check if the application-global `inotify` handle is alive.
-  bool isHandleOpen() const { return inotify_handle_ > 0; }
+  bool isHandleOpen() const {
+    return inotify_handle_ > 0;
+  }
 
   /// Check all added Subscription%s for a path.
   bool isPathMonitored(const std::string& path) const;
@@ -177,10 +183,14 @@ class INotifyEventPublisher
                   const INotifyEventContextRef& ec) const override;
 
   /// Get the INotify file descriptor.
-  int getHandle() const { return inotify_handle_; }
+  int getHandle() const {
+    return inotify_handle_;
+  }
 
   /// Get the number of actual INotify active descriptors.
-  size_t numDescriptors() const { return descriptors_.size(); }
+  size_t numDescriptors() const {
+    return descriptors_.size();
+  }
 
   /// If we overflow, try and restart the monitor
   Status restartMonitoring();

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -43,8 +43,6 @@ Status UdevEventPublisher::setUp() {
   return Status(0, "OK");
 }
 
-void UdevEventPublisher::configure() {}
-
 void UdevEventPublisher::tearDown() {
   WriteLock lock(mutex_);
   if (monitor_ != nullptr) {

--- a/osquery/events/linux/udev.h
+++ b/osquery/events/linux/udev.h
@@ -79,15 +79,15 @@ class UdevEventPublisher
   DECLARE_PUBLISHER("udev");
 
  public:
-  Status setUp() override;
+  virtual ~UdevEventPublisher() {
+    tearDown();
+  }
 
-  void configure() override;
+  Status setUp() override;
 
   void tearDown() override;
 
   Status run() override;
-
-  UdevEventPublisher() : EventPublisher(){};
 
   /**
    * @brief Return a string representation of a udev property.

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -20,8 +20,12 @@ namespace osquery {
 
 class EventsTests : public ::testing::Test {
  public:
-  void SetUp() override { Registry::registry("config_parser")->setUp(); }
-  void TearDown() override { EventFactory::end(true); }
+  void SetUp() override {
+    Registry::registry("config_parser")->setUp();
+  }
+  void TearDown() override {
+    EventFactory::end(true);
+  }
 };
 
 // The most basic event publisher uses useless Subscription/Event.
@@ -186,10 +190,14 @@ class TestEventPublisher
     smallest_ever_ = smallest_subscription;
   }
 
-  void tearDown() override { smallest_ever_ += 1; }
+  void tearDown() override {
+    smallest_ever_ += 1;
+  }
 
   // Custom methods do not make sense, but for testing it exists.
-  int getTestValue() { return smallest_ever_; }
+  int getTestValue() {
+    return smallest_ever_;
+  }
 
  public:
   bool configure_run{false};
@@ -271,9 +279,13 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
   bool shouldFireBethHathTolled{false};
   size_t timesConfigured{0};
 
-  FakeEventSubscriber() { setName("FakeSubscriber"); }
+  FakeEventSubscriber() {
+    setName("FakeSubscriber");
+  }
 
-  void configure() override { timesConfigured++; }
+  void configure() override {
+    timesConfigured++;
+  }
 
   Status Callback(const ECRef& ec, const SCRef& sc) {
     // We don't care about the subscription or the event contexts.
@@ -399,7 +411,9 @@ TEST_F(EventsTests, test_fire_event) {
 
 class SubFakeEventSubscriber : public FakeEventSubscriber {
  public:
-  SubFakeEventSubscriber() { setName("SubFakeSubscriber"); }
+  SubFakeEventSubscriber() {
+    setName("SubFakeSubscriber");
+  }
 
  private:
   FRIEND_TEST(EventsTests, test_subscriber_names);
@@ -435,6 +449,6 @@ TEST_F(EventsTests, test_event_toggle_subscribers) {
 
   // Registering a disabled subscriber will put it into a paused state.
   EventFactory::registerEventSubscriber(sub);
-  EXPECT_EQ(sub->state(), SUBSCRIBER_PAUSED);
+  EXPECT_EQ(sub->state(), EventState::EVENT_PAUSED);
 }
 }

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -70,7 +70,7 @@ QueryData genOsqueryEvents(QueryContext& context) {
       r["events"] = INTEGER(subref->numEvents());
 
       // Subscribers are always active, even if their publisher is not.
-      r["active"] = (subref->state() == SUBSCRIBER_RUNNING) ? "1" : "0";
+      r["active"] = (subref->state() == EventState::EVENT_RUNNING) ? "1" : "0";
     } else {
       r["subscriptions"] = "0";
       r["events"] = "0";


### PR DESCRIPTION
The UDEV tests for Linux call `osquery::attachEvents` several times. This causes event publishers to call their `::setUp` methods without a `::tearDown`, violating the events state guarantees. This will definitely lead to leaks.