### PR TITLE
Allow TableOptions::Additional to influence cost

### DIFF
--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -343,7 +343,7 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
       if (options & ColumnOptions::REQUIRED) {
         index_used = true;
         required_satisfied = true;
-      } else if (options & ColumnOptions::INDEX) {
+      } else if (options & (ColumnOptions::INDEX | ColumnOptions::ADDITIONAL)) {
         index_used = true;
       }
 


### PR DESCRIPTION
Some columns include the `ColumnOptions::ADDITIONAL` option, indicating a predicate will alter the results and possibly return additional content. The best index cost calculation should bias towards a lower cost when these columns are included.

The OS X `preferences` table should also use `LIKE` for `path` constraints operators.