### PR TITLE
Remove /maxcpucount from Windows build script

### DIFF
--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -6,7 +6,7 @@ cd .\build\windows10
 cmake ..\.. -G "Visual Studio 14 2015 Win64"
 
 for %%t in (shell,daemon,osquery_tests,osquery_additional_tests,osquery_tables_tests) do (
-  cmake --build . --target %%t --config Release -- /maxcpucount /verbosity:minimal
+  cmake --build . --target %%t --config Release -- /verbosity:minimal
   if errorlevel 1 goto end
 )
 


### PR DESCRIPTION
The `/maxcpucount` causes Windows 2012R2 to run out of heap space. The MSBuild utility, when using `/MP` will spawn count(CPU) * 2 compiler processes.

Error encountered: `fatal error C1060: compiler is out of heap space`
Reference: https://msdn.microsoft.com/en-us/library/bb385193.aspx
Similar issue: https://github.com/appveyor/ci/issues/742
