### PR TITLE
[Fix #2120] Request daemon shutdown when logger_path becomes invalid

### DIFF
--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -127,8 +127,11 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
 
   status = logQueryLogItem(item);
   if (!status.ok()) {
-    LOG(ERROR) << "Error logging the results of query: " << name << ": "
-               << status.toString();
+    // If log directory is not available, then the daemon shouldn't continue.
+    std::string error = "Error logging the results of query: " + name + ": " +
+                        status.toString();
+    LOG(ERROR) << error;
+    Initializer::requestShutdown(EXIT_CATASTROPHIC, error);
   }
 }
 


### PR DESCRIPTION
This implementation doesn't distinguish between different causes for the log path becoming invalid (e.g. directory removed vs log file assigned elevated permissions), which might be a worthwhile improvement(?) in the future.