### PR TITLE
Fix for sending only failed data to kinesis on full or partial failed uploads

### DIFF
--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -95,7 +95,7 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
     Aws::Kinesis::Model::PutRecordsResult result = outcome.GetResult();
     VLOG(1) << "Successfully sent "
             << result.GetRecords().size() - result.GetFailedRecordCount()
-            << " of " << result.GetRecords().size() << " logs to Kinesis.";
+            << " of " << result.GetRecords().size() << " logs to Kinesis";
     if (result.GetFailedRecordCount() != 0) {
       std::vector<std::string> resend;
       std::string error_msg = "";
@@ -110,7 +110,7 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       // exit if all uploads fail right off the bat
       // exit if we have tried too many times
       // note, this will go back to the default logger batch retry code
-      if (retry_count < 1 ||
+      if (retry_count == 0 ||
           int(log_data.size()) == result.GetFailedRecordCount()) {
         LOG(ERROR) << "Kinesis write for " << result.GetFailedRecordCount()
                    << " of " << result.GetRecords().size()

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -68,7 +68,7 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
   size_t retry_count = 100;
   size_t retry_delay = 3000;
   size_t original_data_size = log_data.size();
-  // exit if we have sent all the data
+  // exit if we sent all the data
   while (log_data.size() > 0) {
     if (FLAGS_aws_kinesis_random_partition_key) {
       boost::uuids::uuid uuid = boost::uuids::random_generator()();

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -111,7 +111,8 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       // exit if all uploads fail right off the bat
       // note, this will go back to the default logger batch retry code
       if (retry_count == 0 ||
-          static_cast<int>(original_data_size) == result.GetFailedRecordCount()) {
+          static_cast<int>(original_data_size) ==
+              result.GetFailedRecordCount()) {
         LOG(ERROR) << "Kinesis write for " << result.GetFailedRecordCount()
                    << " of " << result.GetRecords().size()
                    << " records failed with error " << error_msg;

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -111,7 +111,7 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       // exit if we have tried too many times
       // note, this will go back to the default logger batch retry code
       if (retry_count == 0 ||
-          int(log_data.size()) == result.GetFailedRecordCount()) {
+          static_cast<int>(log_data.size()) == result.GetFailedRecordCount()) {
         LOG(ERROR) << "Kinesis write for " << result.GetFailedRecordCount()
                    << " of " << result.GetRecords().size()
                    << " records failed with error " << error_msg;

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -65,8 +65,8 @@ Status KinesisLoggerPlugin::logString(const std::string& s) {
 
 Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
                                  const std::string& log_type) {
-  int retry_count = 100;
-  int retry_delay = 3000;
+  size_t retry_count = 100;
+  size_t retry_delay = 3000;
   std::vector<std::string> batch = log_data;
   // exit if we have sent all the data
   while (batch.size() > 0) {

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -25,7 +25,6 @@
 namespace osquery {
 
 DECLARE_uint64(aws_kinesis_period);
-DECLARE_uint64(aws_kinesis_failed_upload_retry_count);
 
 class KinesisLogForwarder : public BufferedLogForwarder {
  private:
@@ -48,7 +47,6 @@ class KinesisLogForwarder : public BufferedLogForwarder {
   std::shared_ptr<Aws::Kinesis::KinesisClient> client_{nullptr};
 
   FRIEND_TEST(KinesisTests, test_send);
-  int retry_count = FLAGS_aws_kinesis_failed_upload_retry_count;
 };
 
 class KinesisLoggerPlugin : public LoggerPlugin {

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -25,6 +25,7 @@
 namespace osquery {
 
 DECLARE_uint64(aws_kinesis_period);
+DECLARE_uint64(aws_kinesis_failed_upload_retry_count);
 
 class KinesisLogForwarder : public BufferedLogForwarder {
  private:
@@ -47,6 +48,7 @@ class KinesisLogForwarder : public BufferedLogForwarder {
   std::shared_ptr<Aws::Kinesis::KinesisClient> client_{nullptr};
 
   FRIEND_TEST(KinesisTests, test_send);
+  int retry_count = FLAGS_aws_kinesis_failed_upload_retry_count;
 };
 
 class KinesisLoggerPlugin : public LoggerPlugin {

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -70,7 +70,7 @@ TEST_F(KinesisTests, test_send) {
   entry.SetErrorMessage("Foo error");
   outcome.GetResult().SetFailedRecordCount(1);
   outcome.GetResult().AddRecords(entry);
-
+  forwarder.retry_count=0;
   EXPECT_CALL(*client,
               PutRecords(Property(
                   &Aws::Kinesis::Model::PutRecordsRequest::GetRecords,

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -68,9 +68,9 @@ TEST_F(KinesisTests, test_send) {
   outcome.GetResult().AddRecords(entry);
   entry.SetErrorCode("foo");
   entry.SetErrorMessage("Foo error");
-  outcome.GetResult().SetFailedRecordCount(1);
+  outcome.GetResult().SetFailedRecordCount(2);
   outcome.GetResult().AddRecords(entry);
-  forwarder.retry_count = 0;
+
   EXPECT_CALL(*client,
               PutRecords(Property(
                   &Aws::Kinesis::Model::PutRecordsRequest::GetRecords,

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -70,7 +70,7 @@ TEST_F(KinesisTests, test_send) {
   entry.SetErrorMessage("Foo error");
   outcome.GetResult().SetFailedRecordCount(1);
   outcome.GetResult().AddRecords(entry);
-  forwarder.retry_count=0;
+  forwarder.retry_count = 0;
   EXPECT_CALL(*client,
               PutRecords(Property(
                   &Aws::Kinesis::Model::PutRecordsRequest::GetRecords,


### PR DESCRIPTION
@zwass could I get your opinion/assistance on this PR?  In short, there is an issue in the kinesis logger plugin where duplicate data gets sent to kinesis if there is an upload which partially fails.  

It may not seem too dire, but I have seen single endpoints send over 100k dup events over a 24h time period from just ~3k source events.  This typically happens in environments where kinesis is under heavy load and rate limit errors pop up.

With the current code path, when you receive errors like the following, osquery will resend all data (even the ones that successfully uploaded) until all data in the batch is successfully uploaded.

```
E1101 15:20:31.287334 4284416 aws_kinesis.cpp:111] Kinesis write for 5 of 140 records failed with error Rate exceeded for shard....REDACTED...
```

So in the above example, osquery tried to send 140 records.  135 of them were successfully inserted into kinesis but 5 failed. Osquery will resend all 140 records over and over again until all 140 are successfully upload.  When kinesis is under heavy load and rate limits are the cause of the failure, the next uploads will typically fail as well.  This can cause a large amount of dup data. 

Im not a huge fan of my PR, but I wanted to get something submitted sooner than later so we can agree on a proper fix.  It should also help you get an idea of the issue.

Do you think we should:

1. clean up this PR and go with it?
2. drop the flags and come up with sane defaults?
3. just delete the successful events from the log_data arg (possibly the best solution)
4. do something completely different?