### PR TITLE
Require an extension socket with extensions_require

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -754,7 +754,7 @@ Status startExtensionManager(const std::string& manager_path) {
         if (getExtensions(extensions).ok()) {
           for (const auto& existing : extensions) {
             if (existing.second.name == extension) {
-              return Status(0);
+              return pingExtension(getExtensionSocket(existing.first));
             }
           }
         }


### PR DESCRIPTION
There is a logic race when using `--extensions_require`. Currently the flag requires an extension's registry be broadcasted to the core, it does not require the extension's socket to be available for API access. If using:
```
osqueryi --extensions_require example -A example
```
The result is unpredictable without blocking until a valid `::ping` is returned.