### PR TITLE
[Fix #2702] Use libxar for safari_extensions parsing

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE)
   ADD_OSQUERY_LINK_ADDITIONAL("-framework DiskArbitration")
 
   ADD_OSQUERY_LINK_ADDITIONAL("libresolv.dylib")
-  ADD_OSQUERY_LINK_ADDITIONAL("libarchive.dylib")
+  ADD_OSQUERY_LINK_ADDITIONAL("libxar.dylib")
   ADD_OSQUERY_LINK_ADDITIONAL("magic")
   ADD_OSQUERY_LINK_ADDITIONAL("tsk")
 elseif(FREEBSD)


### PR DESCRIPTION
After lots of trials and tribulations, it seems `libarchive` cannot parse all of the Safari-supported XAR types. Moving our extraction and parsing to `libxar` works.

Tested that this does not leak. There are less-than-awesome APIs that do not allow us as much control over the content allocation, but it's no big deal in practice. 