### PR TITLE
[Fix #2579] Remove database_in_memory flag

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -519,9 +519,6 @@ class DatabasePlugin : public Plugin {
   /// The database was opened in a ReadOnly mode.
   bool read_only_{false};
 
-  /// True if the database was started in an in-memory mode.
-  bool in_memory_{false};
-
   /// Original requested path on disk.
   std::string path_;
 };

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -32,12 +32,6 @@ CLI_FLAG(string,
          "If using a disk-based backing store, specify a path");
 FLAG_ALIAS(std::string, db_path, database_path);
 
-CLI_FLAG(bool,
-         database_in_memory,
-         false,
-         "Keep osquery backing-store in memory");
-FLAG_ALIAS(bool, use_in_memory_database, database_in_memory);
-
 FLAG(bool, disable_database, false, "Disable the persistent RocksDB storage");
 DECLARE_bool(decorations_top_level);
 

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -14,7 +14,6 @@
 namespace osquery {
 
 DECLARE_string(database_path);
-DECLARE_bool(database_in_memory);
 
 class EphemeralDatabasePlugin : public DatabasePlugin {
   using DBType = std::map<std::string, std::map<std::string, std::string> >;

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -27,7 +27,6 @@
 namespace osquery {
 
 DECLARE_string(database_path);
-DECLARE_bool(database_in_memory);
 
 class GlogRocksDBLogger : public rocksdb::Logger {
  public:
@@ -179,9 +178,6 @@ Status RocksDBDatabasePlugin::setUp() {
   // Consume the current settings.
   // A configuration update may change them, but that does not affect state.
   path_ = fs::path(FLAGS_database_path).make_preferred().string();
-  if (FLAGS_database_in_memory) {
-    LOG(INFO) << "RocksDB ignoring request for an in-memory database";
-  }
 
   if (pathExists(path_).ok() && !isReadable(path_).ok()) {
     return Status(1, "Cannot read RocksDB path: " + path_);


### PR DESCRIPTION
This `--database_in_memory` is an old flag that was never used.