### PR TITLE
[Fix #2704] Various distributed code cleanups

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -113,7 +113,8 @@ The read request sends the enrollment **node_key** for identification. The distr
 {
   "queries": {
     "id1": "select * from osquery_info;",
-    "id2": "select * from osquery_schedule;"
+    "id2": "select * from osquery_schedule;",
+    "id3": "select * from does_not_exist;"
   },
   "node_invalid": false // Optional, return true to indicate re-enrollment.
 }
@@ -131,10 +132,19 @@ The read request sends the enrollment **node_key** for identification. The distr
     "id2": [
       {"column1": "value1", "column2": "value2"},
       {"column1": "value1", "column2": "value2"}
-    ]
+    ],
+    "id3": []
+  },
+  "statuses": {
+    "id1": 0,
+    "id2": 0,
+    "id3": 2,
   }
 }
 ```
+
+In version 2.1.2 the distributed write API added the top-level `statuses` key.
+These error codes correspond to SQLite error codes. Consider non-0 values to indicate query execution failures.
 
 **Distributed write** response POST body:
 ```json

--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -26,13 +26,6 @@ namespace osquery {
 struct DistributedQueryRequest {
  public:
   explicit DistributedQueryRequest() {}
-  explicit DistributedQueryRequest(const std::string& q, const std::string& i)
-      : query(q), id(i) {}
-
-  /// equals operator
-  bool operator==(const DistributedQueryRequest& comp) const {
-    return (comp.query == query) && (comp.id == id);
-  }
 
   std::string query;
   std::string id;
@@ -87,18 +80,15 @@ Status deserializeDistributedQueryRequestJSON(const std::string& json,
  */
 struct DistributedQueryResult {
  public:
-  explicit DistributedQueryResult() {}
-  explicit DistributedQueryResult(const DistributedQueryRequest& req,
-                                  const QueryData& res)
-      : request(req), results(res) {}
-
-  /// equals operator
-  bool operator==(const DistributedQueryResult& comp) const {
-    return (comp.request == request) && (comp.results == results);
-  }
+  DistributedQueryResult() {}
+  DistributedQueryResult(const DistributedQueryRequest& req,
+                         const QueryData& res,
+                         const Status& s)
+      : request(req), results(res), status(s) {}
 
   DistributedQueryRequest request;
   QueryData results;
+  Status status;
 };
 
 /**

--- a/osquery/dispatcher/distributed.cpp
+++ b/osquery/dispatcher/distributed.cpp
@@ -35,6 +35,7 @@ void DistributedRunner::start() {
     if (dist.getPendingQueryCount() > 0) {
       dist.runQueries();
     }
+
     std::string str_acu = "0";
     Status database = getDatabaseValue(
         kPersistentSettings, "distributed_accelerate_checkins_expire", str_acu);

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -33,9 +33,7 @@ FLAG(bool,
      true,
      "Disable distributed queries (default true)");
 
-Mutex distributed_queries_mutex_;
-Mutex distributed_results_mutex_;
-const std::string kDistributedQueryPrefix = "distributed.";
+const std::string kDistributedQueryPrefix{"distributed."};
 
 Status DistributedPlugin::call(const PluginRequest& request,
                                PluginResponse& response) {
@@ -80,33 +78,31 @@ Status Distributed::pullUpdates() {
 }
 
 size_t Distributed::getPendingQueryCount() {
-  std::vector<std::string> distributed_queries;
-  scanDatabaseKeys(kQueries, distributed_queries, kDistributedQueryPrefix);
-  return distributed_queries.size();
+  std::vector<std::string> queries;
+  scanDatabaseKeys(kQueries, queries, kDistributedQueryPrefix);
+  return queries.size();
 }
 
 size_t Distributed::getCompletedCount() {
-  WriteLock lock(distributed_results_mutex_);
   return results_.size();
 }
 
 Status Distributed::serializeResults(std::string& json) {
-  pt::ptree tree;
-
-  {
-    WriteLock lock(distributed_results_mutex_);
-    for (const auto& result : results_) {
-      pt::ptree qd;
-      auto s = serializeQueryData(result.results, qd);
-      if (!s.ok()) {
-        return s;
-      }
-      tree.add_child(result.request.id, qd);
+  pt::ptree queries;
+  pt::ptree statuses;
+  for (const auto& result : results_) {
+    pt::ptree qd;
+    auto s = serializeQueryData(result.results, qd);
+    if (!s.ok()) {
+      return s;
     }
-  }
+    queries.add_child(result.request.id, qd);
+    statuses.put(result.request.id, result.status.getCode());
+    }
 
   pt::ptree results;
-  results.add_child("queries", tree);
+  results.add_child("queries", queries);
+  results.add_child("statuses", statuses);
 
   std::stringstream ss;
   try {
@@ -120,24 +116,22 @@ Status Distributed::serializeResults(std::string& json) {
 }
 
 void Distributed::addResult(const DistributedQueryResult& result) {
-  WriteLock wlock_results(distributed_results_mutex_);
   results_.push_back(result);
 }
 
 Status Distributed::runQueries() {
   while (getPendingQueryCount() > 0) {
-    auto query = popRequest();
-    LOG(INFO) << "Executing distributed query: " << query.id << ": "
-              << query.query;
+    auto request = popRequest();
+    LOG(INFO) << "Executing distributed query: " << request.id << ": "
+              << request.query;
 
-    auto sql = SQL(query.query);
+    auto sql = SQL(request.query);
     if (!sql.getStatus().ok()) {
-      LOG(ERROR) << "Error executing distributed query: " << query.id << ": "
+      LOG(ERROR) << "Error executing distributed query: " << request.id << ": "
                  << sql.getMessageString();
-      continue;
     }
 
-    DistributedQueryResult result(std::move(query), std::move(sql.rows()));
+    DistributedQueryResult result(request, sql.rows(), sql.getStatus());
     addResult(result);
   }
   return flushCompleted();
@@ -183,6 +177,7 @@ Status Distributed::acceptWork(const std::string& work) {
       }
       setDatabaseValue(kQueries, kDistributedQueryPrefix + node.first, query);
     }
+
     if (tree.count("accelerate") > 0) {
       auto new_time = tree.get<std::string>("accelerate", "");
       unsigned long duration;
@@ -206,14 +201,16 @@ Status Distributed::acceptWork(const std::string& work) {
 }
 
 DistributedQueryRequest Distributed::popRequest() {
-  WriteLock wlock_queries(distributed_queries_mutex_);
-  std::vector<std::string> distributed_queries;
-  scanDatabaseKeys(kQueries, distributed_queries, kDistributedQueryPrefix);
+  // Read all pending queries.
+  std::vector<std::string> queries;
+  scanDatabaseKeys(kQueries, queries, kDistributedQueryPrefix);
+
+  // Set the last-most-recent query as the request, and delete it.
   DistributedQueryRequest request;
-  request.id =
-      distributed_queries.front().substr(kDistributedQueryPrefix.size());
-  getDatabaseValue(kQueries, distributed_queries.front(), request.query);
-  deleteDatabaseValue(kQueries, distributed_queries.front());
+  const auto& next = queries.front();
+  request.id = next.substr(kDistributedQueryPrefix.size());
+  getDatabaseValue(kQueries, next, request.query);
+  deleteDatabaseValue(kQueries, next);
   return request;
 }
 
@@ -231,6 +228,7 @@ Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
   if (!s.ok()) {
     return s;
   }
+
   std::stringstream ss;
   try {
     pt::write_json(ss, tree, false);
@@ -288,6 +286,7 @@ Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
   if (!s.ok()) {
     return s;
   }
+
   std::stringstream ss;
   try {
     pt::write_json(ss, tree, false);
@@ -322,9 +321,9 @@ Status deserializeDistributedQueryResult(const pt::ptree& tree,
 
 Status deserializeDistributedQueryResultJSON(const std::string& json,
                                              DistributedQueryResult& r) {
-  std::stringstream ss(json);
   pt::ptree tree;
   try {
+    std::stringstream ss(json);
     pt::read_json(ss, tree);
   } catch (const pt::ptree_error& e) {
     return Status(1, "Error serializing JSON: " + std::string(e.what()));


### PR DESCRIPTION
1. Some cleanups (visual/programmatic) to the Distributed code.
2. Appending a `statuses` top-level key to the distributed write API.

Failed distributed queries will now include an empty result set in their response. Additionally, a new key, `statuses` will include a key/value pair for each distributed query ID as the key. The value will be the SQLite response code from the query execution. Failed executions will include non-0 statuses.