### PR TITLE
Improvements to platformChmod for closer POSIX behavior on Windows

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -204,7 +204,7 @@ class PlatformFile {
    *       of this function ensures that writes are explicitly denied for the
    *       file AND the file's parent directory.
    */
-  Status isImmutable() const;
+  Status hasSafePermissions() const;
 
   bool getFileTimes(PlatformTime& times);
 

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -202,9 +202,9 @@ class PlatformFile {
    * @brief Determines how immutable the file is to external modifications.
    * @note Currently, this is only implemented on Windows. The Windows version
    *       of this function ensures that writes are explicitly denied for the
-   *       file and the file's parent directory.
+   *       file AND the file's parent directory.
    */
-  Status isNonWritable() const;
+  Status isImmutable() const;
 
   bool getFileTimes(PlatformTime& times);
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -443,7 +443,7 @@ bool safePermissions(const std::string& dir,
     result = fd.isExecutable();
 
     // Otherwise, require matching or root file ownership.
-    if (executable && (result.getCode() > 0 || !fd.isNonWritable().ok())) {
+    if (executable && (result.getCode() > 0 || !fd.isImmutable().ok())) {
       // Require executable, implies by the owner.
       return false;
     }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -443,7 +443,7 @@ bool safePermissions(const std::string& dir,
     result = fd.isExecutable();
 
     // Otherwise, require matching or root file ownership.
-    if (executable && (result.getCode() > 0 || !fd.isImmutable().ok())) {
+    if (executable && (result.getCode() > 0 || !fd.hasSafePermissions().ok())) {
       // Require executable, implies by the owner.
       return false;
     }

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -156,7 +156,7 @@ Status PlatformFile::isExecutable() const {
   return Status(1, "Not executable");
 }
 
-Status PlatformFile::isNonWritable() const {
+Status PlatformFile::isImmutable() const {
   struct stat file;
   if (::fstat(handle_, &file) < 0) {
     return Status(-1, "fstat error");

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -156,7 +156,7 @@ Status PlatformFile::isExecutable() const {
   return Status(1, "Not executable");
 }
 
-Status PlatformFile::isImmutable() const {
+Status PlatformFile::hasSafePermissions() const {
   struct stat file;
   if (::fstat(handle_, &file) < 0) {
     return Status(-1, "fstat error");

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -492,8 +492,8 @@ TEST_F(FileOpsTests, test_safe_permissions) {
     EXPECT_TRUE(fd.hasSafePermissions().ok());
   }
 
-  EXPECT_TRUE(platformChmod(temp_file, all_access));
   EXPECT_TRUE(platformChmod(root_dir, all_access));
+  EXPECT_TRUE(platformChmod(temp_file, all_access));
 
   fs::remove_all(root_dir);
 }

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -425,7 +425,7 @@ TEST_F(FileOpsTests, test_immutable) {
   PlatformFile fd(temp_file, PF_CREATE_NEW | PF_WRITE);
   EXPECT_TRUE(fd.isValid());
 
-  EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH));
+  EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IWGRP | S_IROTH | S_IWOTH));
   EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IROTH));
 
   auto status = fd.isImmutable();
@@ -433,14 +433,14 @@ TEST_F(FileOpsTests, test_immutable) {
   EXPECT_EQ(1, status.getCode());
 
   EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IROTH));
-  EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH));
+  EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWGRP | S_IROTH | S_IWOTH));
 
   status = fd.isImmutable();
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(1, status.getCode());
 
   EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IROTH));
-  EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWUSR | S_IROTH));
+  EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWGRP | S_IROTH));
 
   status = fd.isImmutable();
   EXPECT_FALSE(status.ok());

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -432,7 +432,7 @@ TEST_F(FileOpsTests, test_immutable) {
         platformChmod(temp_file, S_IRUSR | S_IWGRP | S_IROTH | S_IWOTH));
     EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IROTH));
 
-    auto status = fd.isImmutable();
+    auto status = fd.hasSafePermissions();
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
@@ -440,24 +440,24 @@ TEST_F(FileOpsTests, test_immutable) {
     EXPECT_TRUE(platformChmod(root_dir,
                               S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
 
-    status = fd.isImmutable();
+    status = fd.hasSafePermissions();
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
     EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH));
 
-    status = fd.isImmutable();
+    status = fd.hasSafePermissions();
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
     EXPECT_TRUE(platformChmod(temp_file, 0));
     EXPECT_TRUE(platformChmod(root_dir, 0));
-    EXPECT_TRUE(fd.isImmutable().ok());
+    EXPECT_TRUE(fd.hasSafePermissions().ok());
 
     EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IROTH));
-    EXPECT_TRUE(fd.isImmutable().ok());
+    EXPECT_TRUE(fd.hasSafePermissions().ok());
   }
 
   EXPECT_TRUE(platformChmod(

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -416,6 +416,8 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
   }
 }
 
+#ifdef WIN32
+// Windows-specific test for file "immutability"
 TEST_F(FileOpsTests, test_immutable) {
   const auto root_dir = (fs::temp_directory_path() / "immutable-test").string();
   const auto temp_file = root_dir + "/test";
@@ -465,6 +467,7 @@ TEST_F(FileOpsTests, test_immutable) {
 
   fs::remove_all(root_dir);
 }
+#endif
 
 TEST_F(FileOpsTests, test_glob) {
   {

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -416,11 +416,11 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
   }
 }
 
-#ifdef WIN32
-// Windows-specific test for file "immutability"
-TEST_F(FileOpsTests, test_immutable) {
+TEST_F(FileOpsTests, test_safe_permissions) {
   const auto root_dir = (fs::temp_directory_path() / "immutable-test").string();
   const auto temp_file = root_dir + "/test";
+  const int all_access = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP |
+                         S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;
 
   fs::create_directories(root_dir);
 
@@ -436,38 +436,67 @@ TEST_F(FileOpsTests, test_immutable) {
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
+    if (isPlatform(PlatformType::TYPE_POSIX)) {
+      // On POSIX, chmod on a file requires +x on the parent directory
+      EXPECT_TRUE(platformChmod(root_dir, all_access));
+    }
+
     EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(platformChmod(root_dir,
                               S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
 
     status = fd.hasSafePermissions();
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(1, status.getCode());
+
+    if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+      EXPECT_FALSE(status.ok());
+      EXPECT_EQ(1, status.getCode());
+    } else {
+      // On POSIX, we only check to see if temp_file has S_IWOTH
+      EXPECT_TRUE(status.ok());
+    }
+
+    if (isPlatform(PlatformType::TYPE_POSIX)) {
+      // On POSIX, chmod on a file requires +x on the parent directory
+      EXPECT_TRUE(platformChmod(root_dir, all_access));
+    }
 
     EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH));
 
     status = fd.hasSafePermissions();
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(1, status.getCode());
+
+    if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+      EXPECT_FALSE(status.ok());
+      EXPECT_EQ(1, status.getCode());
+    } else {
+      // On POSIX, we only check to see if temp_file has S_IWOTH
+      EXPECT_TRUE(status.ok());
+    }
+
+    if (isPlatform(PlatformType::TYPE_POSIX)) {
+      // On POSIX, chmod on a file requires +x on the parent directory
+      EXPECT_TRUE(platformChmod(root_dir, all_access));
+    }
 
     EXPECT_TRUE(platformChmod(temp_file, 0));
     EXPECT_TRUE(platformChmod(root_dir, 0));
     EXPECT_TRUE(fd.hasSafePermissions().ok());
+
+    if (isPlatform(PlatformType::TYPE_POSIX)) {
+      // On POSIX, chmod on a file requires +x on the parent directory
+      EXPECT_TRUE(platformChmod(root_dir, all_access));
+    }
 
     EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(fd.hasSafePermissions().ok());
   }
 
-  EXPECT_TRUE(platformChmod(
-      temp_file, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
-  EXPECT_TRUE(platformChmod(
-      root_dir, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+  EXPECT_TRUE(platformChmod(temp_file, all_access));
+  EXPECT_TRUE(platformChmod(root_dir, all_access));
 
   fs::remove_all(root_dir);
 }
-#endif
 
 TEST_F(FileOpsTests, test_glob) {
   {

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -417,7 +417,8 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
 }
 
 TEST_F(FileOpsTests, test_safe_permissions) {
-  const auto root_dir = (fs::temp_directory_path() / "immutable-test").string();
+  const auto root_dir =
+      (fs::temp_directory_path() / "safe-perms-test").string();
   const auto temp_file = root_dir + "/test";
   const int all_access = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP |
                          S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -428,21 +428,22 @@ TEST_F(FileOpsTests, test_immutable) {
 
     EXPECT_TRUE(
         platformChmod(temp_file, S_IRUSR | S_IWGRP | S_IROTH | S_IWOTH));
-    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IROTH));
+    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IROTH));
 
     auto status = fd.isImmutable();
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
-    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IROTH));
-    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWGRP | S_IROTH | S_IWOTH));
+    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
+    EXPECT_TRUE(platformChmod(root_dir,
+                              S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
 
     status = fd.isImmutable();
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(1, status.getCode());
 
-    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IROTH));
-    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWGRP | S_IROTH));
+    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
+    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IWGRP | S_IROTH));
 
     status = fd.isImmutable();
     EXPECT_FALSE(status.ok());
@@ -452,13 +453,15 @@ TEST_F(FileOpsTests, test_immutable) {
     EXPECT_TRUE(platformChmod(root_dir, 0));
     EXPECT_TRUE(fd.isImmutable().ok());
 
-    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IROTH));
-    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IROTH));
+    EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IRGRP | S_IROTH));
+    EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IRGRP | S_IROTH));
     EXPECT_TRUE(fd.isImmutable().ok());
   }
 
-  EXPECT_TRUE(platformChmod(temp_file, S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH));
-  EXPECT_TRUE(platformChmod(root_dir, S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH));
+  EXPECT_TRUE(platformChmod(
+      temp_file, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
+  EXPECT_TRUE(platformChmod(
+      root_dir, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH));
 
   fs::remove_all(root_dir);
 }

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -685,7 +685,7 @@ static Status isWriteDenied(PACL acl) {
   return Status(1, "No deny ACE for write");
 }
 
-Status PlatformFile::isImmutable() const {
+Status PlatformFile::hasSafePermissions() const {
   PACL file_dacl = nullptr;
   PSECURITY_DESCRIPTOR file_sd = nullptr;
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -705,8 +705,7 @@ Status PlatformFile::hasSafePermissions() const {
   std::vector<char> path_buf;
   path_buf.assign(MAX_PATH + 1, '\0');
 
-  // Derive the parent directory and insure it is also immutable
-
+  // Derive the parent directory and insure it also has safe permissions
   if (::GetFinalPathNameByHandleA(
           handle_, path_buf.data(), MAX_PATH, FILE_NAME_NORMALIZED) == 0) {
     return Status(-1, "GetFinalPathNameByHandleA failed");


### PR DESCRIPTION
 * Renamed `isNonWritable` to `isImmutable` to avoid confusion. `isImmutable` checks to see if the current file is impervious to changes with a check of its parent directory as well.
 * Improvements on `platformChmod` to mimic POSIX behavior better
   * Owner now always have the ability to delete the file and modify the file's DACL
   * All users can at the minimum, read the file's DACL so `isExecutable` and `isImmutable` won't error out complaining about being unable to read the file's DACL
 * `isImmutable` now works on files with the DACL modified by `platformChmod`
 * Added new `platformChmod`, `isImmutable`, and `isExecutable` tests