### PR TITLE
[Fix #2726] Update OpenSSL to 1.0.2j and use linker versions

### DIFF
--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -5,6 +5,7 @@ class Cmake < AbstractOsqueryFormula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.6/cmake-3.6.1.tar.gz"
   sha256 "28ee98ec40427d41a45673847db7a905b59ce9243bb866eaf59dce0f58aaef11"
+  revision 1
 
   head "https://cmake.org/cmake.git"
 

--- a/tools/provision/formula/curl.rb
+++ b/tools/provision/formula/curl.rb
@@ -5,7 +5,7 @@ class Curl < AbstractOsqueryFormula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.48.0.tar.bz2"
   sha256 "864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/curl.rb
+++ b/tools/provision/formula/curl.rb
@@ -5,7 +5,7 @@ class Curl < AbstractOsqueryFormula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.48.0.tar.bz2"
   sha256 "864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753"
-  revision 2
+  revision 4
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -100,7 +100,10 @@ class Curl < AbstractOsqueryFormula
     end
     args << "--disable-ldap" if build.without? "openldap"
 
+    ENV["PKG_CONFIG"] = "pkg-config --static"
+    ENV.append "LDFLAGS", "-static"
     system "./configure", *args
+    system "make", "curl_LDFLAGS=-all-static"
     system "make", "install"
   end
 

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -7,7 +7,7 @@ class Openssl < AbstractOsqueryFormula
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2j.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2j.tar.gz"
   sha256 "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -20,8 +20,8 @@ class Openssl < AbstractOsqueryFormula
   resource "cacert" do
     # Update post_install when you update this resource.
     # homepage "http://curl.haxx.se/docs/caextract.html"
-    url "https://curl.haxx.se/ca/cacert-2016-04-20.pem"
-    sha256 "2c6d4960579b0d4fd46c6cbf135545116e76f2dbb7490e24cf330f2565770362"
+    url "https://curl.haxx.se/ca/cacert-2016-11-02.pem"
+    sha256 "cc7c9e2d259e20b72634371b146faec98df150d18dd9da9ad6ef0b2deac2a9d3"
   end
 
   option "without-test", "Skip build-time tests (not recommended)"
@@ -33,11 +33,11 @@ class Openssl < AbstractOsqueryFormula
   depends_on :perl => ["5.0", :build] unless OS.mac?
 
   def arch_args
-    return { :i386  => %w[linux-generic32], :x86_64 => %w[linux-x86_64] } if OS.linux?
-    {
-      :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
-      :i386   => %w[darwin-i386-cc],
-    }
+    if OS.linux?
+      %w[linux-x86_64]
+    else
+      %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128]
+    end
   end
 
   def configure_args
@@ -48,7 +48,6 @@ class Openssl < AbstractOsqueryFormula
       "no-ssl3",
       "no-asm",
       "zlib-dynamic",
-      "shared",
       "enable-cms",
     ]
     if OS.linux?
@@ -56,7 +55,6 @@ class Openssl < AbstractOsqueryFormula
         ENV.cppflags,
         ENV.cflags,
         ENV.ldflags,
-        "-Wl,--version-script=#{prefix}/openssl.ld",
       ].join(" ")
     end
     return args
@@ -71,80 +69,12 @@ class Openssl < AbstractOsqueryFormula
               'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
               'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);' if OS.mac?
 
-    archs = [Hardware::CPU.arch_64_bit]
-
-    dirs = []
-
-    version_script = prefix/"openssl.ld"
-    version_script.write <<-EOS.undent
-      OPENSSL_1.0.1d {
-        global:
-          *;
-      };
-      OPENSSL_1.0.1 {
-        global:
-          *;
-      };
-      OPENSSL_1.0.0 {
-        global:
-          *;
-      };
-    EOS
-
-    archs.each do |arch|
-      if build.universal?
-        dir = "build-#{arch}"
-        dirs << dir
-        mkdir dir
-        mkdir "#{dir}/engines"
-        system "make", "clean"
-      end
-
-      ENV.deparallelize
-      system "perl", "./Configure", *(configure_args + arch_args[arch])
-      system "make", "depend"
-      system "make"
-      system "make", "test" if build.with?("test")
-
-      if build.universal?
-        cp "include/openssl/opensslconf.h", dir
-        cp Dir["*.?.?.?.dylib", "*.a", "apps/openssl"], dir
-        cp Dir["engines/**/*.dylib"], "#{dir}/engines"
-      end
-    end
-
+    ENV.deparallelize
+    system "perl", "./Configure", *(configure_args + arch_args)
+    system "make", "depend"
+    system "make"
+    system "make", "test" if build.with?("test")
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
-
-    if build.universal?
-      %w[libcrypto libssl].each do |libname|
-        system "lipo", "-create", "#{dirs.first}/#{libname}.1.0.0.dylib",
-                                  "#{dirs.last}/#{libname}.1.0.0.dylib",
-                       "-output", "#{lib}/#{libname}.1.0.0.dylib"
-        system "lipo", "-create", "#{dirs.first}/#{libname}.a",
-                                  "#{dirs.last}/#{libname}.a",
-                       "-output", "#{lib}/#{libname}.a"
-      end
-
-      Dir.glob("#{dirs.first}/engines/*.dylib") do |engine|
-        libname = File.basename(engine)
-        system "lipo", "-create", "#{dirs.first}/engines/#{libname}",
-                                  "#{dirs.last}/engines/#{libname}",
-                       "-output", "#{lib}/engines/#{libname}"
-      end
-
-      system "lipo", "-create", "#{dirs.first}/openssl",
-                                "#{dirs.last}/openssl",
-                     "-output", "#{bin}/openssl"
-
-      confs = archs.map do |arch|
-        <<-EOS.undent
-          #ifdef __#{arch}__
-          #{(buildpath/"build-#{arch}/opensslconf.h").read}
-          #endif
-          EOS
-      end
-      (include/"openssl/opensslconf.h").atomic_write confs.join("\n")
-    end
   end
 
   def openssldir
@@ -153,33 +83,7 @@ class Openssl < AbstractOsqueryFormula
 
   def post_install
     ENV.delete "LIBRARY_PATH"
-    unless OS.mac?
-      # Optional: Download and install cacert.pem from curl.haxx.se
-      (etc/"openssl").install resource("cacert").files("cacert-2016-04-20.pem" => "cert.pem")
-      return
-    end
-
-    keychains = %w[
-      /Library/Keychains/System.keychain
-      /System/Library/Keychains/SystemRootCertificates.keychain
-    ]
-
-    certs_list = `security find-certificate -a -p #{keychains.join(" ")}`
-    certs = certs_list.scan(
-      /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
-    )
-
-    valid_certs = certs.select do |cert|
-      IO.popen("#{bin}/openssl x509 -inform pem -checkend 0 -noout", "w") do |openssl_io|
-        openssl_io.write(cert)
-        openssl_io.close_write
-      end
-
-      $?.success?
-    end
-
-    openssldir.mkpath
-    (openssldir/"cert.pem").atomic_write(valid_certs.join("\n"))
+    (etc/"openssl").install resource("cacert").files("cacert-2016-11-02.pem" => "cert.pem")
   end
 
   def caveats; <<-EOS.undent

--- a/tools/provision/formula/python.rb
+++ b/tools/provision/formula/python.rb
@@ -6,6 +6,7 @@ class Python < AbstractOsqueryFormula
   url "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz"
   sha256 "d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978"
   head "https://hg.python.org/cpython", :using => :hg, :branch => "2.7"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"


### PR DESCRIPTION
1. We bump the version of `curl` to force a rebuild and uninstall-before-reinstall-of-`openssl`. ;)
2. We bump the version of `openssl` from `1.0.2i` to `1.0.2j`.
3. We add a `version-script` to the linker to include the `1.0.0` ABI symbols (needed by the system `curl` on Ubuntu during the intermediate downloads before installing our local `curl`).