### PR TITLE
mkdocs: Clean wiki during distclean and define extra_css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ strip: .setup
 	cd build/$(BUILD_DIR) && find ./osquery -executable -type f | xargs strip
 
 distclean:
-	rm -rf .sources build/$(BUILD_DIR) build/debug_$(BUILD_DIR) build/docs
+	rm -rf .sources build/$(BUILD_DIR) build/debug_$(BUILD_DIR) build/docs build/wiki
 ifeq ($(PLATFORM),Linux)
 	rm -rf build/linux build/debug_linux
 endif

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ theme: readthedocs
 
 docs_dir: docs/wiki
 site_dir: build/wiki
+extra_css:
+- theme/osquery.css
+
 pages:
 - Introduction:
   - Welcome to osquery: index.md


### PR DESCRIPTION
Strict-mode `mkdocs` requires us to list any additional CSS files staged in our `docs_dir`.