### PR TITLE
Update dependency build flows on Linux and OS X

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -6,9 +6,10 @@
 
 # osquery-specific helper macros
 macro(LOG_PLATFORM NAME)
-  set(LINK "https://github.com/facebook/osquery/issues/2169")
-  LOG("Welcome to the redesigned v1.8.0 osquery build system!")
-  LOG("For migration and details please see: ${ESC}[1m${LINK}${ESC}[m")
+  set(LINK "http://osquery.readthedocs.io/en/stable/development/building/")
+  LOG("Welcome to osquery's build-- thank you for your patience! :)")
+  LOG("For a brief tutorial see: ${ESC}[1m${LINK}${ESC}[m")
+  LOG("If at first you dont succeed, perhaps: make distclean; make depsclean")
   LOG("Building for platform ${ESC}[36;1m${NAME} (${OSQUERY_BUILD_PLATFORM}, ${OSQUERY_BUILD_DISTRO})${ESC}[m")
   LOG("Building osquery version ${ESC}[36;1m ${OSQUERY_BUILD_VERSION} sdk ${OSQUERY_BUILD_SDK_VERSION}${ESC}[m")
 endmacro(LOG_PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ ifneq ($(OSQUERY_DEPS),)
 else
 	DEPS_DIR = /usr/local/osquery
 endif
+
 PATH_SET := PATH="$(DEPS_DIR)/bin:/usr/local/bin:$(PATH)"
 CMAKE := $(PATH_SET) CXXFLAGS="-L$(DEPS_DIR)/lib" cmake ../../
 CTEST := $(PATH_SET) ctest ../../
@@ -44,6 +45,11 @@ DEFINES := CTEST_OUTPUT_ON_FAILURE=1 \
 .PHONY: docs build
 
 all: .setup
+ifeq ($(wildcard $(DEPS_DIR)/.*),)
+	@echo "-- Warning! Cannot find dependencies install directory: $(DEPS_DIR)"
+	@echo "-- Have you run: make deps?"
+	@false
+endif
 	@cd build/$(BUILD_DIR) && $(CMAKE) && \
 		$(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)
 

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -21,7 +21,7 @@ import subprocess
 
 ORACLE_RELEASE = "/etc/oracle-release"
 SYSTEM_RELEASE = "/etc/system-release"
-LSB_RELEASE        = "/etc/lsb-release"
+LSB_RELEASE    = "/etc/lsb-release"
 DEBIAN_VERSION = "/etc/debian_version"
 
 def _platform():

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -144,9 +144,9 @@ function platform_darwin_main() {
   brew_dependency osquery/osquery-local/linenoise-ng
 
   # POSIX-shared locally-managed tools.
-  brew_tool osquery/osquery-local/zzuf
-  brew_tool osquery/osquery-local/cppcheck
-  brew_tool osquery/osquery-local/ccache
+  brew_dependency osquery/osquery-local/zzuf
+  brew_dependency osquery/osquery-local/cppcheck
+  brew_dependency osquery/osquery-local/ccache
 }
 
 function main() {

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -86,10 +86,12 @@ function platform_linux_main() {
   # LLVM/Clang.
   brew_tool osquery/osquery-local/llvm
 
+  # Util-Linux provides libuuid.
+  brew_dependency osquery/osquery-local/util-linux
+
   platform_posix_main
 
   # General Linux dependencies and custom formulas for table implementations.
-  brew_dependency osquery/osquery-local/util-linux
   brew_dependency osquery/osquery-local/libgpg-error
   brew_dependency osquery/osquery-local/libdevmapper
   brew_dependency osquery/osquery-local/libaptpkg

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -85,7 +85,6 @@ function platform_linux_main() {
 
   # LLVM/Clang.
   brew_tool osquery/osquery-local/llvm
-  set_deps_compilers clang
 
   platform_posix_main
 

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -87,7 +87,7 @@ function platform_linux_main() {
   brew_tool osquery/osquery-local/llvm
   set_deps_compilers clang
 
-  brew_dependency osquery/osquery-local/lz4
+  platform_posix_main
 
   # General Linux dependencies and custom formulas for table implementations.
   brew_dependency osquery/osquery-local/util-linux
@@ -102,7 +102,6 @@ function platform_linux_main() {
   brew_dependency osquery/osquery-local/libdpkg
   brew_dependency osquery/osquery-local/librpm
 
-  platform_posix_main
 }
 
 function platform_darwin_main() {
@@ -121,28 +120,27 @@ function platform_darwin_main() {
   brew_tool osquery/osquery-local/python
   brew_tool osquery/osquery-local/cmake --without-docs
 
-  brew_dependency osquery/osquery-local/lz4
-
   platform_posix_main
 }
 
  function platform_posix_main() {
   # List of LLVM-compiled dependencies.
-  brew_dependency osquery/osquery-local/linenoise-ng
+  brew_dependency osquery/osquery-local/lz4
+  brew_dependency osquery/osquery-local/libmagic
+  brew_dependency osquery/osquery-local/pcre
   brew_dependency osquery/osquery-local/boost
   brew_dependency osquery/osquery-local/asio
   brew_dependency osquery/osquery-local/cpp-netlib
   brew_dependency osquery/osquery-local/google-benchmark
-  brew_dependency osquery/osquery-local/pcre
   brew_dependency osquery/osquery-local/snappy
   brew_dependency osquery/osquery-local/sleuthkit
-  brew_dependency osquery/osquery-local/libmagic
   brew_dependency osquery/osquery-local/thrift
   brew_dependency osquery/osquery-local/rocksdb
   brew_dependency osquery/osquery-local/gflags
   brew_dependency osquery/osquery-local/aws-sdk-cpp
   brew_dependency osquery/osquery-local/yara
   brew_dependency osquery/osquery-local/glog
+  brew_dependency osquery/osquery-local/linenoise-ng
 
   # POSIX-shared locally-managed tools.
   brew_tool osquery/osquery-local/zzuf

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -67,6 +67,7 @@ function platform_linux_main() {
   brew_tool m4
   brew_tool autoconf
   brew_tool automake
+  brew_tool libxml2
 
   # OpenSSL is needed for the final build.
   brew_clean osquery/osquery-local/curl
@@ -84,6 +85,9 @@ function platform_linux_main() {
 
   # LLVM/Clang.
   brew_tool osquery/osquery-local/llvm
+  set_deps_compilers clang
+
+  brew_dependency osquery/osquery-local/lz4
 
   # General Linux dependencies and custom formulas for table implementations.
   brew_dependency osquery/osquery-local/util-linux
@@ -117,6 +121,8 @@ function platform_darwin_main() {
   brew_tool osquery/osquery-local/python
   brew_tool osquery/osquery-local/cmake --without-docs
 
+  brew_dependency osquery/osquery-local/lz4
+
   platform_posix_main
 }
 
@@ -128,7 +134,6 @@ function platform_darwin_main() {
   brew_dependency osquery/osquery-local/cpp-netlib
   brew_dependency osquery/osquery-local/google-benchmark
   brew_dependency osquery/osquery-local/pcre
-  brew_dependency osquery/osquery-local/lz4
   brew_dependency osquery/osquery-local/snappy
   brew_dependency osquery/osquery-local/sleuthkit
   brew_dependency osquery/osquery-local/libmagic

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -27,14 +27,132 @@ LINUXBREW_DUPES="83cad3d474e6d245cd543521061bba976529e5df"
 source "$SCRIPT_DIR/lib.sh"
 source "$SCRIPT_DIR/provision/lib.sh"
 
+function platform_linux_main() {
+  brew_uninstall bison
+
+  # GCC 5x bootstrapping.
+  brew_tool patchelf
+  brew_tool zlib
+  brew_tool binutils
+  brew_tool linux-headers
+  brew_tool gmp
+  brew_tool mpfr
+  brew_tool libmpc
+  brew_tool isl
+  brew_tool pkg-config
+
+  # Build a bottle of a modern glibc.
+  brew_tool osquery/osquery-local/glibc
+
+  # Build a bottle for a legacy glibc.
+  brew_tool osquery/osquery-local/glibc-legacy
+
+  # GCC 5x.
+  brew_tool osquery/osquery-local/gcc
+
+  # Need LZMA for final builds.
+  brew_tool osquery/osquery-local/zlib-legacy
+  brew_tool osquery/osquery-local/xz
+
+  brew_tool osquery/osquery-local/ncurses
+  brew_tool osquery/osquery-local/bzip2
+  brew_tool osquery/osquery-local/readline
+
+  brew_tool unzip
+  brew_tool sqlite
+  brew_tool makedepend
+  brew_tool libidn
+  brew_tool libedit
+  brew_tool libtool
+  brew_tool m4
+  brew_tool autoconf
+  brew_tool automake
+
+  # OpenSSL is needed for the final build.
+  brew_clean osquery/osquery-local/curl
+  brew_tool osquery/osquery-local/openssl
+
+  # Curl and Python are needed for LLVM mostly.
+  brew_tool osquery/osquery-local/curl
+  brew_tool osquery/osquery-local/python
+  brew_tool osquery/osquery-local/cmake --without-docs
+
+  # Linux library secondary dependencies.
+  brew_tool osquery/osquery-local/berkeley-db
+  brew_tool osquery/osquery-local/popt
+  brew_tool osquery/osquery-local/beecrypt
+
+  # LLVM/Clang.
+  brew_tool osquery/osquery-local/llvm
+
+  # General Linux dependencies and custom formulas for table implementations.
+  brew_dependency osquery/osquery-local/util-linux
+  brew_dependency osquery/osquery-local/libgpg-error
+  brew_dependency osquery/osquery-local/libdevmapper
+  brew_dependency osquery/osquery-local/libaptpkg
+  brew_dependency osquery/osquery-local/libiptables
+  brew_dependency osquery/osquery-local/libgcrypt
+  brew_dependency osquery/osquery-local/libcryptsetup
+  brew_dependency osquery/osquery-local/libudev
+  brew_dependency osquery/osquery-local/libaudit
+  brew_dependency osquery/osquery-local/libdpkg
+  brew_dependency osquery/osquery-local/librpm
+
+  platform_posix_main
+}
+
+function platform_darwin_main() {
+  brew_tool xz
+  brew_tool readline
+  brew_tool sqlite
+  brew_tool makedepend
+  brew_tool clang-format
+  brew_tool pkg-config
+  brew_tool bison
+  brew_tool autoconf
+  brew_tool automake
+  brew_tool libtool
+
+  brew_dependency osquery/osquery-local/openssl
+  brew_tool osquery/osquery-local/python
+  brew_tool osquery/osquery-local/cmake --without-docs
+
+  platform_posix_main
+}
+
+ function platform_posix_main() {
+  # List of LLVM-compiled dependencies.
+  brew_dependency osquery/osquery-local/linenoise-ng
+  brew_dependency osquery/osquery-local/boost
+  brew_dependency osquery/osquery-local/asio
+  brew_dependency osquery/osquery-local/cpp-netlib
+  brew_dependency osquery/osquery-local/google-benchmark
+  brew_dependency osquery/osquery-local/pcre
+  brew_dependency osquery/osquery-local/lz4
+  brew_dependency osquery/osquery-local/snappy
+  brew_dependency osquery/osquery-local/sleuthkit
+  brew_dependency osquery/osquery-local/libmagic
+  brew_dependency osquery/osquery-local/thrift
+  brew_dependency osquery/osquery-local/rocksdb
+  brew_dependency osquery/osquery-local/gflags
+  brew_dependency osquery/osquery-local/aws-sdk-cpp
+  brew_dependency osquery/osquery-local/yara
+  brew_dependency osquery/osquery-local/glog
+
+  # POSIX-shared locally-managed tools.
+  brew_tool osquery/osquery-local/zzuf
+  brew_tool osquery/osquery-local/cppcheck
+  brew_tool osquery/osquery-local/ccache
+}
+
 function main() {
   platform OS
   distro $OS DISTRO
   threads THREADS
 
   if ! hash sudo 2>/dev/null; then
-   echo "Please install sudo in this machine"
-   exit 0
+    echo "Please install sudo in this machine"
+    exit 1
   fi
 
   # Setup the osquery dependency directory.
@@ -101,7 +219,7 @@ function main() {
     brew_bottle "$2"
     return
   elif [[ "$1" = "install" ]]; then
-    local_brew_dependency "$2"
+    brew_dependency "$2"
     return
   fi
 
@@ -135,161 +253,6 @@ function main() {
 
   log "running auxiliary initialization"
   initialize $OS
-}
-
-function platform_linux_main() {
-  # GCC 5x bootstrapping.
-  brew_tool patchelf
-  brew_tool zlib
-  brew_tool binutils
-  brew_tool linux-headers
-
-  # Build a bottle of a modern glibc.
-  local_brew_tool glibc
-  local_brew_postinstall glibc
-
-  # Build a bottle for a legacy glibc.
-  local_brew_tool glibc-legacy
-  local_brew_unlink glibc-legacy
-  local_brew_link glibc-legacy
-  local_brew_postinstall glibc-legacy
-
-  # Additional GCC 5x bootstrapping.
-  brew_tool gmp
-  brew_tool mpfr
-  brew_tool libmpc
-  brew_tool isl
-
-  # GCC 5x.
-  local_brew_tool gcc
-  # Remove gcc-postinstall when GCC is next updated.
-  local_brew_postinstall gcc
-  set_deps_compilers gcc
-
-  # Need LZMA for final builds.
-  local_brew_tool zlib-legacy
-  local_brew_tool xz
-
-  # GCC-compiled (C) dependencies.
-  brew_tool pkg-config
-
-  # Build a bottle for ncurses
-  local_brew_tool ncurses
-
-  # Need BZIP/Readline for final build.
-  local_brew_tool bzip2
-  brew_tool unzip
-  local_brew_tool readline
-  brew_tool sqlite
-  brew_tool makedepend
-  brew_tool libidn
-
-  # Build a bottle for perl and openssl.
-  # OpenSSL is needed for the final build.
-  # local_brew_tool perl -vd --without-test
-  brew_clean curl
-  local_brew_tool openssl
-  local_brew_postinstall openssl
-  local_brew_link openssl
-
-  # LLVM dependencies.
-  brew_tool libxml2
-  brew_tool libedit
-  brew_tool libtool
-  brew_tool m4
-  brew_tool bison
-
-  # More LLVM dependencies.
-  brew_tool autoconf
-  brew_tool automake
-
-  # Curl and Python are needed for LLVM mostly.
-  local_brew_tool curl
-  local_brew_tool python
-  local_brew_postinstall python
-  local_brew_tool cmake --without-docs
-
-  # Linux library secondary dependencies.
-  local_brew_tool berkeley-db
-  local_brew_tool popt
-  local_brew_tool beecrypt
-
-  # LLVM/Clang.
-  local_brew_tool llvm
-  set_deps_compilers clang
-
-  # General Linux dependencies.
-  local_brew_dependency util-linux
-
-  platform_posix_main
-
-  local_brew_tool zzuf
-  local_brew_tool cppcheck
-  local_brew_tool ccache
-
-  # Linux specific custom formulas.
-  local_brew_dependency libgpg-error
-  local_brew_dependency libdevmapper
-  local_brew_dependency libaptpkg
-  local_brew_dependency libiptables
-  local_brew_dependency libgcrypt
-  local_brew_dependency libcryptsetup
-  local_brew_dependency libudev
-  local_brew_dependency libaudit
-  local_brew_dependency libdpkg
-  local_brew_dependency librpm
-
-  # Restore the compilers to GCC for the remainder of provisioning.
-  set_deps_compilers gcc
-}
-
-function platform_darwin_main() {
-  brew_tool xz
-  brew_tool readline
-  brew_tool sqlite
-  brew_tool makedepend
-  brew_tool clang-format
-
-  local_brew_dependency openssl
-  local_brew_postinstall openssl
-  local_brew_link openssl
-
-  brew_tool pkg-config
-  brew_tool autoconf
-  brew_tool automake
-  brew_tool libtool
-  brew_tool bison
-  brew_link bison
-
-  local_brew_tool python
-  local_brew_postinstall python
-  local_brew_tool cmake --without-docs
-
-  platform_posix_main
-
-  local_brew_tool zzuf
-  local_brew_tool cppcheck
-  local_brew_tool ccache
-}
-
-function platform_posix_main() {
-  # List of LLVM-compiled dependencies.
-  local_brew_dependency linenoise-ng
-  local_brew_dependency boost
-  local_brew_dependency asio
-  local_brew_dependency cpp-netlib
-  local_brew_dependency google-benchmark
-  local_brew_dependency pcre
-  local_brew_dependency lz4
-  local_brew_dependency snappy
-  local_brew_dependency sleuthkit
-  local_brew_dependency libmagic
-  local_brew_dependency thrift
-  local_brew_dependency rocksdb
-  local_brew_dependency gflags
-  local_brew_dependency aws-sdk-cpp
-  local_brew_dependency yara
-  local_brew_dependency glog
 }
 
 check $1 "$2"

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -17,5 +17,6 @@ function distro_main() {
   package xz
   package ruby
   package bzip2
+  package bison
+  package flex
 }
-

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -21,6 +21,8 @@ function distro_main() {
   package gcc-c++
   package bzip2
   package gettext-devel
+  package bison
+  package flex
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -17,4 +17,6 @@ function distro_main() {
   package g++
   package ruby
   package curl
+  package bison
+  package flex
 }

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -20,6 +20,8 @@ function distro_main() {
   package gcc
   package bzip2
   package gettext-devel
+  package bison
+  package flex
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -79,6 +79,7 @@ class AbstractOsqueryFormula < Formula
     # Reset compile flags for safety, we want to control them explicitly.
     reset "CFLAGS"
     reset "CXXFLAGS"
+    reset "CPPFLAGS"
 
     # Reset the following since the logic within the 'std' environment does not
     # known about our legacy runtime 'glibc' formula name.
@@ -119,11 +120,14 @@ class AbstractOsqueryFormula < Formula
       append "LDFLAGS", "-Wl,-rpath,#{default_prefix}/lib"
 
       # Adding this one line to help gcc too.
-      append "LDFLAGS", "-L#{default_prefix}/lib"
-      # We want the legacy path to be the last thing prepended.
-      prepend "LDFLAGS", "-L#{legacy_prefix}/lib"
+      if !["openssl"].include?(self.name)
+        append "LDFLAGS", "-L#{default_prefix}/lib"
+        # We want the legacy path to be the last thing prepended.
+        prepend "LDFLAGS", "-L#{legacy_prefix}/lib"
+      end
 
       prepend_path "LIBRARY_PATH", default_prefix/"lib"
+      # prepend_path "LIBRARY_PATH", Formula["osquery/osquery-local/glibc"].lib
       prepend_path "LIBRARY_PATH", legacy_prefix/"lib"
 
       # This is already set to the PREFIX
@@ -141,6 +145,8 @@ class AbstractOsqueryFormula < Formula
     # Everyone receives:
     append "CFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
     append "CXXFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
+
+    prepend_path "PKG_CONFIG_PATH", legacy_prefix/"lib/pkgconfig"
 
     self.audit
     reset "DEBUG"
@@ -160,5 +166,6 @@ class AbstractOsqueryFormula < Formula
     puts ":: LD_LIBRARY_PATH : " + ENV["LD_LIBRARY_PATH"].to_s
     puts ":: LIBRARY_PATH    : " + ENV["LIBRARY_PATH"].to_s
     puts ":: LD_RUN_PATH     : " + ENV["LD_RUN_PATH"].to_s
+    puts ":: PKG_CONFIG_PATH : " + ENV["PKG_CONFIG_PATH"].to_s
   end
 end

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -137,7 +137,7 @@ class AbstractOsqueryFormula < Formula
       prepend_path "CPATH", default_prefix/"include"
 
       if [ENV["CC"]].include?("#{default_prefix}/bin/clang")
-        append "LDFLAGS", "-lrt -lpthread"
+        append "LDFLAGS", "-lrt -lpthread -ldl"
       end
     end
 

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -134,7 +134,6 @@ class AbstractOsqueryFormula < Formula
       end
 
       prepend_path "LIBRARY_PATH", default_prefix/"lib"
-      # prepend_path "LIBRARY_PATH", Formula["osquery/osquery-local/glibc"].lib
       prepend_path "LIBRARY_PATH", legacy_prefix/"lib"
 
       # This is already set to the PREFIX

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -42,6 +42,13 @@ class AbstractOsqueryFormula < Formula
     end
   end
 
+  def osquery_cmake_args
+    std_cmake_args + [
+      "-DCMAKE_LIBRARY_PATH=#{ENV["LIBRARY_PATH"]}",
+      "-DCMAKE_INCLUDE_PATH=#{legacy_prefix}/include:#{default_prefix}/include",
+    ]
+  end
+
   def reset(name)
     ENV.delete name
   end

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -135,6 +135,10 @@ class AbstractOsqueryFormula < Formula
 
       # Set the search path for header files.
       prepend_path "CPATH", default_prefix/"include"
+
+      if [ENV["CC"]].include?("#{default_prefix}/bin/clang")
+        append "LDFLAGS", "-lrt -lpthread"
+      end
     end
 
     if !OS.linux?

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -21,7 +21,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
 
     inreplace "CMakeLists.txt", "${CMAKE_CXX_FLAGS_RELEASE} -s", "${CMAKE_CXX_FLAGS_RELEASE}"
 
-    args = std_cmake_args
+    args = osquery_cmake_args
     args << "-DSTATIC_LINKING=1"
     args << "-DNO_HTTP_CLIENT=1"
     args << "-DMINIMIZE_SIZE=ON"

--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -52,6 +52,7 @@ class Cmake < AbstractOsqueryFormula
     end
 
     ENV.append "CXXFLAGS", "-L#{legacy_prefix}/lib"
+    ENV.append "CXXFLAGS", "-L#{default_prefix}/lib"
 
     system "./bootstrap", *args
     system "make"

--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -53,6 +53,7 @@ class Cmake < AbstractOsqueryFormula
 
     ENV.append "CXXFLAGS", "-L#{legacy_prefix}/lib"
     ENV.append "CXXFLAGS", "-L#{default_prefix}/lib"
+    ENV.append "CXXFLAGS", "-lrt -lpthread"
 
     system "./bootstrap", *args
     system "make"

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -29,7 +29,7 @@ class CppNetlib < AbstractOsqueryFormula
     ]
 
     # NB: Do not build examples or tests as they require submodules.
-    args += std_cmake_args
+    args += osquery_cmake_args
     system "cmake", *args
     system "make"
     system "make", "install"

--- a/tools/provision/formula/cppcheck.rb
+++ b/tools/provision/formula/cppcheck.rb
@@ -26,7 +26,7 @@ class Cppcheck < AbstractOsqueryFormula
     args << "-DHAVE_RULES=ON" if build.with? "rules"
 
     mkdir "build" do
-      args += std_cmake_args
+      args += osquery_cmake_args
       system "cmake", "..", *args
       system "make"
       system "make", "install"

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -108,8 +108,8 @@ class Gcc < AbstractOsqueryFormula
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{default_prefix}/lib/gcc/#{version_suffix}"
     inreplace "libitm/method-serial.cc", "assert (ok);", "(void) ok;"
 
-    ENV.delete "LDFLAGS"
-    ENV.delete "LD_LIBRARY_PATH"
+    # ENV.delete "LDFLAGS"
+    # ENV.delete "LD_LIBRARY_PATH"
     # ENV.delete "LIBRARY_PATH"
 
     # osquery: speed up the build by skipping the bootstrap.

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -63,10 +63,6 @@ class Gcc < AbstractOsqueryFormula
       "--with-build-time-tools=#{binutils}",
     ]
 
-    # Set the search path for glibc libraries and objects.
-    # CentOS 7 doesn't like: #{Formula["glibc-legacy"].lib}:
-    # ENV["LIBRARY_PATH"] = "#{Formula["osquery/osquery-local/glibc"].lib}:#{Formula["cctools"].lib}"
-
     args += [
       "--prefix=#{prefix}",
       "--enable-languages=#{languages.join(",")}",
@@ -110,7 +106,6 @@ class Gcc < AbstractOsqueryFormula
 
     ENV.delete "LDFLAGS"
     ENV.delete "LD_LIBRARY_PATH"
-    # ENV.delete "LIBRARY_PATH"
 
     # osquery: speed up the build by skipping the bootstrap.
     args << "--disable-bootstrap"

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -197,7 +197,7 @@ class Gcc < AbstractOsqueryFormula
       + -isystem #{legacy_prefix}/include -isystem #{default_prefix}/include
 
       *link_libgcc:
-      #{glibc.installed? ? "-nostdlib -L#{libgcc}" : "+"} -L#{legacy_prefix}/lib -L#{default_prefix}/lib
+      #{glibc.installed? ? "-nostdlib -L#{libgcc}" : "+"} -L#{legacy_prefix}/lib -L#{default_prefix}/lib -lrt -lpthread
 
       *link:
       + --dynamic-linker #{legacy_prefix}/lib/ld-linux-x86-64.so.2 -rpath #{default_prefix}/lib

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -108,8 +108,8 @@ class Gcc < AbstractOsqueryFormula
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{default_prefix}/lib/gcc/#{version_suffix}"
     inreplace "libitm/method-serial.cc", "assert (ok);", "(void) ok;"
 
-    # ENV.delete "LDFLAGS"
-    # ENV.delete "LD_LIBRARY_PATH"
+    ENV.delete "LDFLAGS"
+    ENV.delete "LD_LIBRARY_PATH"
     # ENV.delete "LIBRARY_PATH"
 
     # osquery: speed up the build by skipping the bootstrap.

--- a/tools/provision/formula/gflags.rb
+++ b/tools/provision/formula/gflags.rb
@@ -19,7 +19,7 @@ class Gflags < AbstractOsqueryFormula
   def install
     ENV.cxx11
 
-    args = std_cmake_args
+    args = osquery_cmake_args
     args << "-DBUILD_SHARED_LIBS=OFF"
 
     mkdir "buildroot" do

--- a/tools/provision/formula/glibc-legacy.rb
+++ b/tools/provision/formula/glibc-legacy.rb
@@ -23,6 +23,8 @@ class GlibcLegacy < AbstractOsqueryFormula
   # Linux kernel headers 2.6.19 or later are required
   depends_on "linux-headers" => [:build, :recommended]
 
+  # This package is provided for legacy headers and linking to maintain ABI
+  # compatibility for the deploy-targets.
   set_legacy
 
   def install
@@ -82,7 +84,7 @@ diff -Nur glibc-2.12.2/configure glibc-2.12.2-patched/configure
 +    3.4* | 4.[0-9]* | 5.[0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
- 
+
 @@ -5252,7 +5252,7 @@
    ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
    case $ac_prog_version in
@@ -91,35 +93,35 @@ diff -Nur glibc-2.12.2/configure glibc-2.12.2-patched/configure
 +    3.79* | 3.[89]* | 4.[0-9]* )
         ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
      *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
- 
+
 diff -Nur glibc-2.12.2/math/bits/mathcalls.h glibc-2.12.2-patched/math/bits/mathcalls.h
 --- glibc-2.12.2/math/bits/mathcalls.h  2010-12-13 02:47:26.000000000 -0800
 +++ glibc-2.12.2-patched/math/bits/mathcalls.h  2016-07-17 14:51:30.329424398 -0700
 @@ -197,9 +197,11 @@
  _Mdouble_END_NAMESPACE
- 
+
  #ifdef __USE_MISC
 +# if !defined __cplusplus || __cplusplus < 201103L /* Conflicts with C++11.  */
  /* Return 0 if VALUE is finite or NaN, +1 if it
     is +Infinity, -1 if it is -Infinity.  */
  __MATHDECL_1 (int,isinf,, (_Mdouble_ __value)) __attribute__ ((__const__));
 +#endif
- 
+
  /* Return nonzero if VALUE is finite and not NaN.  */
  __MATHDECL_1 (int,finite,, (_Mdouble_ __value)) __attribute__ ((__const__));
 @@ -226,13 +228,14 @@
  __END_NAMESPACE_C99
  #endif
- 
+
 -
  /* Return nonzero if VALUE is not a number.  */
  __MATHDECL_1 (int,__isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
- 
+
  #if defined __USE_MISC || defined __USE_XOPEN
 +# if !defined __cplusplus || __cplusplus < 201103L /* Conflicts with C++11.  */
  /* Return nonzero if VALUE is not a number.  */
  __MATHDECL_1 (int,isnan,, (_Mdouble_ __value)) __attribute__ ((__const__));
 +#endif
- 
+
  /* Bessel functions.  */
  __MATHCALL (j0,, (_Mdouble_));

--- a/tools/provision/formula/google-benchmark.rb
+++ b/tools/provision/formula/google-benchmark.rb
@@ -23,7 +23,7 @@ class GoogleBenchmark < AbstractOsqueryFormula
     ENV.cxx11
     ENV.append_to_cflags "-Wno-zero-length-array"
 
-    system "cmake", *std_cmake_args
+    system "cmake", *osquery_cmake_args
     system "make"
     system "make", "install"
   end

--- a/tools/provision/formula/libmagic.rb
+++ b/tools/provision/formula/libmagic.rb
@@ -3,9 +3,8 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libmagic < AbstractOsqueryFormula
   desc "Implementation of the file(1) command"
   homepage "https://www.darwinsys.com/file/"
-  url "ftp://ftp.astron.com/pub/file/file-5.25.tar.gz"
-  mirror "https://fossies.org/linux/misc/file-5.25.tar.gz"
-  sha256 "3735381563f69fb4239470b8c51b876a80425348b8285a7cded8b61d6b890eca"
+  url "https://fossies.org/linux/misc/file-5.29.tar.gz"
+  sha256 "ea661277cd39bf8f063d3a83ee875432cc3680494169f952787e002bdd3884c0"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -21,9 +20,6 @@ class Libmagic < AbstractOsqueryFormula
 
   def install
     ENV.universal_binary if build.universal?
-
-    # Clean up "src/magic.h" as per http://bugs.gw.com/view.php?id=330
-    rm "src/magic.h"
 
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/tools/provision/formula/linenoise-ng.rb
+++ b/tools/provision/formula/linenoise-ng.rb
@@ -17,7 +17,7 @@ class LinenoiseNg < AbstractOsqueryFormula
   def install
     mkdir "build"
     cd "build" do
-      args = std_cmake_args
+      args = osquery_cmake_args
       args += [
         "-DCMAKE_CXX_FLAGS=-mno-avx -fPIC"
       ]

--- a/tools/provision/formula/llvm.rb
+++ b/tools/provision/formula/llvm.rb
@@ -92,8 +92,8 @@ class Llvm < AbstractOsqueryFormula
   fails_with :llvm
 
   def install
-    # Added to gcc's specs.
-    # ENV.append "LDFLAGS", "-lrt -lpthread"
+    # Added to gcc's specs, but also needed here.
+    ENV.append "LDFLAGS", "-lrt -lpthread"
 
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang

--- a/tools/provision/formula/llvm.rb
+++ b/tools/provision/formula/llvm.rb
@@ -92,6 +92,9 @@ class Llvm < AbstractOsqueryFormula
   fails_with :llvm
 
   def install
+    # Added to gcc's specs.
+    # ENV.append "LDFLAGS", "-lrt -lpthread"
+
     # Apple's libstdc++ is too old to build LLVM
     ENV.libcxx if ENV.compiler == :clang
 

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -50,11 +50,11 @@ class Openssl < AbstractOsqueryFormula
       "enable-cms",
     ]
     if OS.linux?
-      args << [
+      args += [
         ENV.cppflags,
         ENV.cflags,
         ENV.ldflags,
-      ].join(" ")
+      ]
     end
     return args
   end

--- a/tools/provision/formula/pcre.rb
+++ b/tools/provision/formula/pcre.rb
@@ -50,7 +50,7 @@ class Pcre < AbstractOsqueryFormula
                           "--enable-jit"
     system "make"
     ENV.deparallelize
-    system "make", "test" if build.with? "check"
+    # system "make", "test" if build.with? "check"
     system "make", "install"
   end
 

--- a/tools/provision/formula/pcre.rb
+++ b/tools/provision/formula/pcre.rb
@@ -50,7 +50,6 @@ class Pcre < AbstractOsqueryFormula
                           "--enable-jit"
     system "make"
     ENV.deparallelize
-    # system "make", "test" if build.with? "check"
     system "make", "install"
   end
 

--- a/tools/provision/formula/thrift.rb
+++ b/tools/provision/formula/thrift.rb
@@ -48,6 +48,7 @@ class Thrift < AbstractOsqueryFormula
       "--with-openssl=#{HOMEBREW_PREFIX}"
     ]
 
+    ENV.prepend_path "PATH", Formula["bison"].bin
     system "./bootstrap.sh" unless build.stable?
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",

--- a/tools/provision/formula/zlib-legacy.rb
+++ b/tools/provision/formula/zlib-legacy.rb
@@ -5,6 +5,7 @@ class ZlibLegacy < AbstractOsqueryFormula
   homepage "http://www.zlib.net/"
   url "https://github.com/madler/zlib/archive/v1.2.3.tar.gz"
   sha256 "2134178c123ea8252fd6afc9b794d9a2df480ccd030cc5db720a41883676fc2e"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -12,11 +13,13 @@ class ZlibLegacy < AbstractOsqueryFormula
     sha256 "caa265822ed35d1e0b2a702aa959d4044a00be3e22ad6e99d685d85bd36d2be6" => :x86_64_linux
   end
 
-  keg_only :provided_by_osx
-
   option :universal
 
   patch :DATA
+
+  # This package is provided for legacy headers and linking to maintain ABI
+  # compatibility for the deploy-targets.
+  set_legacy
 
   # http://zlib.net/zlib_how.html
   resource "test_artifact" do
@@ -25,13 +28,29 @@ class ZlibLegacy < AbstractOsqueryFormula
     sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
   end
 
-  set_legacy
-
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--prefix=#{prefix}", "--shared"
     system "make"
     system "make", "install"
+
+    mkdir_p "#{legacy_prefix}/lib/pkgconfig"
+    config = Pathname.new("#{prefix}/lib/pkgconfig/zlib.pc")
+    config.write <<-EOS.undent
+      prefix=#{prefix}
+      exec_prefix=\$\{prefix\}
+      libdir=\$\{exec_prefix\}/lib
+      sharedlibdir=\$\{libdir\}
+      includedir=\$\{prefix\}/include
+
+      Name: zlib
+      Description: zlib compression library
+      Version: #{version}
+
+      Requires:
+      Libs: -L\$\{libdir\} -L\$\{sharedlibdir\} -lz
+      Cflags: -I\$\{includedir\}
+    EOS
   end
 
   test do
@@ -52,7 +71,7 @@ index d7ffdc3..d7ca2c8 100755
 +++ b/configure
 @@ -19,6 +19,7 @@
  # an error.
- 
+
  LIBS=libz.a
 +LDSHAREDFLAGS="$LDFLAGS"
  LDFLAGS="-L. ${LIBS}"
@@ -63,6 +82,6 @@ index d7ffdc3..d7ca2c8 100755
  SHAREDLIBV=${SHAREDLIBV-"libz$shared_ext.$VER"}
  SHAREDLIBM=${SHAREDLIBM-"libz$shared_ext.$VER1"}
 +LDSHARED="$LDSHARED $LDSHAREDFLAGS"
- 
+
  if test $shared -eq 1; then
    echo Checking for shared library support...

--- a/tools/provision/formula/zzuf.rb
+++ b/tools/provision/formula/zzuf.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Zzuf < AbstractOsqueryFormula
   desc "Transparent application input fuzzer"
   homepage "http://caca.zoy.org/wiki/zzuf"
-  url "https://github.com/theopolis/zzuf/archive/v0.15-osx-r1.tar.gz"
-  sha256 "78c2250829b205c94643afa31bf8155bac629c9c8676d9a37670c62c16f4f03b"
-  version "0.15-osx-r1"
+  url "https://github.com/theopolis/zzuf/archive/v0.15-osx-r2.tar.gz"
+  sha256 "9f59bac21aef5408bbdaab0b2732ca5848dbd3e74297b66c34245bdbc04db86e"
+  version "0.15-osx-r2"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -202,7 +202,9 @@ function brew_tool() {
 
 function brew_dependency() {
   # Essentially uses clang instead of GCC.
+  set_deps_compilers clang
   brew_internal "dependency" $@
+  set_deps_compilers gcc
 }
 
 function brew_link() {

--- a/tools/provision/manjaro.sh
+++ b/tools/provision/manjaro.sh
@@ -17,4 +17,6 @@ function distro_main() {
   package xz
   package ruby
   package bzip2
+  package bison
+  package flex
 }

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -20,6 +20,8 @@ function distro_main() {
   package gcc
   package bzip2
   package gettext-devel
+  package bison
+  package flex
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -21,6 +21,8 @@ function distro_main() {
   package gcc-c++
   package bzip2
   package gettext-devel
+  package bison
+  package flex
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -20,6 +20,8 @@ function distro_main() {
   package gcc
   package bzip2
   package gettext-devel
+  package bison
+  package flex
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -17,4 +17,6 @@ function distro_main() {
   package g++
   package ruby
   package curl
+  package bison
+  package flex
 }


### PR DESCRIPTION
After a few months of introducing a new "type" of technical debt into the new `brew`-based dependency manager (`./tools/provision.sh`), it is time to pay up!

1. Change some of the `CMake` welcome messaging to point to Readthedocs, versus the old build problem statement Github issue.
2. Add a gut-check for new builders who eagerly run `make`. The check should ask them to run `make deps` first.
3. The provision removes a managed `bison` install. This is due to `bison` having been compiled with a static `m4` location. If we edit bison's data directory we may cause the application to fault. We now ask the system to provide a `bison` and `flex`.
4. The `zlib-legacy` package now includes a `.pc` file and local formulas will prefer the legacy-library directory for configurations.
5. The provision arguments now use the "fully qualified" brew package names. These include the organization, tap name, and formula name to differentiate from the upstream-managed formulas.

The most fragile change is a reordering of installs. While this works with bottle installs, it may not work for source builds.