### PR TITLE
Do not calculate hash to avoid generating additional access events

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -95,6 +95,8 @@ File accesses on Linux using inotify may induce unexpected and unwanted performa
 
 To enable access monitoring for the above set of directories in 'homes' and the single 'etc'.
 
+**WARNING:** The hashes of files will not be calculated to avoid generating additional access events.
+
 ### Process File Accesses on OS X
 
 It is possible to monitor for file accesses by process using the osquery OS X kernel module. File accesses induce a LOT of stress on the system and are more or less useless giving the context from userland monitoring systems (aka, not having the process that caused the modification).

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -97,11 +97,8 @@ Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     decorateFileEvent(
         ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
   } else {
-    // The access event on Linux would generate additional events if stated.
-    for (const auto& column : kCommonFileColumns) {
-      r[column] = "0";
-    }
-    r["hashed"] = "0";
+    // The access event on Linux would generate additional events if hashed.
+    decorateFileEvent(ec->path, false, r);
   }
 
   // A callback is somewhat useless unless it changes the EventSubscriber


### PR DESCRIPTION
If `file_accesses` is set in a config file, `osquery` doesn't collect stat-information of files.

```
$ cat /etc/osquery/osquery.conf
{
  "schedule": {
    "file_events": {
      "query": "select * from file_events;",
      "removed": false,
      "interval": 3
    }
  },
  "file_paths": {
    "tmp": [
      "/tmp/%%"
    ]
  },
  "file_accesses": ["tmp"]
}

$ sudo service osqueryd start
$ echo test >> /tmp/testfile
$ tail -n 3 /var/log/osquery/osqueryd.results.log
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 08:04:54 2016 UTC","unixTime":"1478765094","columns":{"action":"OPENED","atime":"0","category":"tmp","ctime":"0","gid":"0","hashed":"0","inode":"0","md5":"","mode":"0","mtime":"0","sha1":"","sha256":"","size":"0","target_path":"\/tmp\/testfile","time":"1478765093","transaction_id":"0","uid":"0"},"action":"added"}
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 08:04:54 2016 UTC","unixTime":"1478765094","columns":{"action":"UPDATED","atime":"0","category":"tmp","ctime":"0","gid":"0","hashed":"0","inode":"0","md5":"","mode":"0","mtime":"0","sha1":"","sha256":"","size":"0","target_path":"\/tmp\/testfile","time":"1478765093","transaction_id":"0","uid":"0"},"action":"added"}
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 08:04:54 2016 UTC","unixTime":"1478765094","columns":{"action":"UPDATED","atime":"0","category":"tmp","ctime":"0","gid":"0","hashed":"0","inode":"0","md5":"","mode":"0","mtime":"0","sha1":"","sha256":"","size":"0","target_path":"\/tmp\/testfile","time":"1478765093","transaction_id":"0","uid":"0"},"action":"added"}
```

As above, atime, ctime and inode(etc.) are 0.
These values are set in the following place.
https://github.com/facebook/osquery/blob/77ceca46935dae717048eb1abc35c4a6ea34e44f/osquery/tables/events/linux/file_events.cpp#L100-L106

To resolve the double `ATTRIBUTES_MODIFIED` issue, do not stat inotify access subscriptions. ( #1814 )

I want to know `ctime` and `mtime` of the `ACCESSED` event, but all events are set to 0.

I think that it doesn't matter to collect the attributes of file (atime, etc).
Calculating hashes would generate additional events.
Then, I pass `decorateFileEvent` function to `hash=false`.
When `file_accesses` is set, I can get stat-information, excluding hashes.
```
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 11:03:39 2016 UTC","unixTime":"1478775819","columns":{"action":"OPENED","atime":"1478775765","category":"tmp","ctime":"1478775765","gid":"500","hashed":"0","inode":"292988","md5":"","mode":"0664","mtime":"1478775765","sha1":"","sha256":"","size":"45","target_path":"\/tmp\/testfile","time":"1478775819","transaction_id":"0","uid":"500"},"action":"added"}
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 11:03:39 2016 UTC","unixTime":"1478775819","columns":{"action":"ACCESSED","atime":"1478775765","category":"tmp","ctime":"1478775765","gid":"500","hashed":"0","inode":"292988","md5":"","mode":"0664","mtime":"1478775765","sha1":"","sha256":"","size":"45","target_path":"\/tmp\/testfile","time":"1478775819","transaction_id":"0","uid":"500"},"action":"added"}
{"name":"file_events","hostIdentifier":"vagrant-centos65.vagrantup.com","calendarTime":"Thu Nov 10 11:03:42 2016 UTC","unixTime":"1478775822","columns":{"action":"UPDATED","atime":"","category":"tmp","ctime":"","gid":"","hashed":"0","inode":"","md5":"","mode":"","mtime":"","sha1":"","sha256":"","size":"","target_path":"\/tmp\/.testfile.swp","time":"1478775820","transaction_id":"0","uid":""},"action":"added"}
```
