### PR TITLE
build: Install VS build tools on build hosts

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -305,9 +305,13 @@ function Main {
   $out = Install-ChocoPackage 'python2' '2.7.11'
   $out = Install-PipPackage
   $out = Update-GitSubmodule
-  $deploymentFile = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, 'vsdeploy.xml'))
-  $chocoParams = @("--execution-timeout", "7200", "-packageParameters", "--AdminFile ${deploymentFile}")
-  $out = Install-ChocoPackage 'visualstudio2015community' '' ${chocoParams}
+  if (Test-Path env:OSQUERY_BUILD_HOST) {
+    $out = Install-ChocoPackage 'visualcppbuildtools'
+  } else {
+    $deploymentFile = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, 'vsdeploy.xml'))
+    $chocoParams = @("--execution-timeout", "7200", "-packageParameters", "--AdminFile ${deploymentFile}")
+    $out = Install-ChocoPackage 'visualstudio2015community' '' ${chocoParams}
+  }
   if(Test-RebootPending -eq $true) {
     Write-Host "*** Windows requires a reboot to complete installing Visual Studio. Please reboot your system and re-run this provisioning script. ***" -foregroundcolor yellow
     Exit 0


### PR DESCRIPTION
This looks for a special environment variable set on our build hosts: `OSQUERY_BUILD_HOST`. If this is found (with any value) the provisioning script will install the minimal build-tools from Visual Studio to save time.