### PR TITLE
Fix Deadlock in rocksdb log callback

### DIFF
--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -299,6 +299,31 @@ Status logQueryLogItem(const QueryLogItem& item, const std::string& receiver);
 Status logSnapshotQuery(const QueryLogItem& item);
 
 /**
+ * @brief Helper class to disable logger forwarding
+ *
+ * Sometimes, it is useful to turn off log forwarding and force status logs to
+ * be buffered. One example is with handling of rocksdb status logs; if those
+ * status logs are forwarded, it can cause a deadlock inside rocksdb, if the
+ * logger plugin tries to call back into rocksdb.
+ *
+ * Creating an object of this class allows one to halt log forwarding and
+ * leave the log sink in a locked/non-forwarding state. Any log requests in this
+ * * state are guaranteed to be buffered. Callback loops can thus be avoided.
+ *
+ * The logger forwarding state is restored and unlocked as soon as the object
+ * of this class goes out of scope.
+ */
+class LoggerForwardingDisabler {
+ public:
+  LoggerForwardingDisabler();
+  ~LoggerForwardingDisabler();
+
+ private:
+  /// Value of the
+  bool forward_state_;
+};
+
+/**
  * @brief Sink a set of buffered status logs.
  *
  * When the osquery daemon uses a watcher/worker set, the watcher's status logs

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include <sys/resource.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -85,5 +86,9 @@ bool isUserAdmin() {
 
 int platformGetPid() {
   return (int)getpid();
+}
+
+int platformGetTid() {
+  return (int)syscall(SYS_gettid);
 }
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -275,4 +275,12 @@ void setToBackgroundPriority();
 * and on posix platforms returns getpid()
 */
 int platformGetPid();
+
+/**
+* @brief Returns the current thread id
+*
+* On Windows, returns the value of GetCurrentThreadId
+* and on posix platforms returns gettid()
+*/
+int platformGetTid();
 }

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -187,4 +187,8 @@ bool isUserAdmin() {
 int platformGetPid() {
   return (int)GetCurrentProcessId();
 }
+
+int platformGetTid() {
+  return (int)GetCurrentThreadId();
+}
 }

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -130,6 +130,11 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 
   // There is a spurious warning on first open.
   if (log_line.find("Error when reading") == std::string::npos) {
+    // Rocksdb calls are non-reentrant. Since this callback is made in the
+    // context of a rocksdb api call, turn log forwarding off to prevent the
+    // logger from trying to make a call back into rocksdb and causing a
+    // deadlock
+    LoggerForwardingDisabler forwarding_disabler;
     LOG(INFO) << "RocksDB: " << log_line;
   }
 }


### PR DESCRIPTION
This fix resolves a deadlock condition as follows:

Thread calls a put operation in rocksdb
rocksdb acquires a mutex, mu_, in its write path.
rocksdb decides to flush, which has a LOG call in its path.
The LOG call calls GlogRocksDBLogger::Logv, which calls Google Log
Google Log decides to flush, which ends up making a call back to rocksdb put

The thread deadlocks on itself, since rocksdb's mutex is a fast (ie., non-recursive) mutex.

The recommended "thread safe" way for google logging is to use RAW_LOG_XXX method, which is what this PR does.

Unfortunately, the side effect of this is that rocksdb logs will not be sent to a TLS backend or to a File Logger. They will merely show up on stderr.