### PR TITLE
Fix crash in FIM processing

### DIFF
--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -212,8 +212,14 @@ INotifyEventContextRef INotifyEventPublisher::createEventContextFrom(
   // Get the pathname the watch fired on.
   {
     WriteLock lock(path_mutex_);
-    ec->path = descriptor_paths_.at(event->wd);
+    if (descriptor_paths_.find(event->wd) == descriptor_paths_.end()) {
+      // return a blank event context if we can't find the paths for the event
+      return ec;
+    } else {
+      ec->path = descriptor_paths_.at(event->wd);
+    }
   }
+
   if (event->len > 1) {
     ec->path += event->name;
   }


### PR DESCRIPTION
This fixes a crash in the file event processing path. It is possible that by the time a kernel file event is dequeued and the code hits createEventContextFrom() in inotify.cpp, the path from the descriptor_path_ map has been purged (say, by a remote config update from a TLS backend). This causes the code to crash when it dereferences the descriptor_path_ map in INotifyEventPublisher::createEventContextFrom.

The fix is to check for the existence of the descriptor_path_ after acquiring the path_mutex_. If not found the particular kernel event is effectively discarded.

