### PR TITLE
deps: Bottle updates for OS X: augeas, libxml2

### DIFF
--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -11,6 +11,7 @@ class Augeas < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "a090cf5f9ecfa57f858433cc6ad46cd9d64430844c1fafd380848179887fb486" => :sierra
     sha256 "8ef71ee4d9bb8c976150af61e811ff31e065ffb9f6c28cc4b8b8cd7145e9cd2c" => :x86_64_linux
   end
 

--- a/tools/provision/formula/libxml2.rb
+++ b/tools/provision/formula/libxml2.rb
@@ -11,6 +11,7 @@ class Libxml2 < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
+    sha256 "ad126db38749740bb13423e32d716f70208729d1b4d32f4285ad078b65ed70cf" => :sierra
     sha256 "92cbb6676f6788431da1b915781c4e44e3194fb286818e04dcfa428aa8879620" => :x86_64_linux
   end
 


### PR DESCRIPTION
This adds hashes for `augeas` and `libxml2` for OS X 10.12.