### PR TITLE
OS X: bypass ASL tests on 10.12

### DIFF
--- a/osquery/tables/system/darwin/tests/asl_tests.cpp
+++ b/osquery/tables/system/darwin/tests/asl_tests.cpp
@@ -168,6 +168,12 @@ TEST_F(AslTests, test_convert_like_regex) {
 }
 
 TEST_F(AslTests, test_actual_query) {
+  auto version = SQL::selectAllFrom("os_version");
+  if (version[0]["minor"] == "12") {
+    // MacOS Sierra does not support ASL.
+    return;
+  }
+
   // An integration test, this test writes to ASL, and then verifies that we
   // can query for the written log
   std::string time_str = std::to_string(std::time(nullptr));


### PR DESCRIPTION
ASL is deprecated on OS X 10.12. The APIs are tested and pass but the actual query does not work. This inspects the `minor` version of the OS, if it matches `12` (macOS Sierra) the test is bypassed.