### PR TITLE
deps: Linux: apt-pkg 1.3.1

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -85,6 +85,8 @@ if(NOT WINDOWS)
   ADD_OSQUERY_LINK_ADDITIONAL("ssl")
   ADD_OSQUERY_LINK_ADDITIONAL("yara")
   ADD_OSQUERY_LINK_ADDITIONAL("crypto")
+  ADD_OSQUERY_LINK_ADDITIONAL("libpthread")
+
   ADD_OSQUERY_LINK_CORE("crypto")
 
   # Linenoise will be used when compiling osqueryi.
@@ -331,15 +333,15 @@ if(NOT DEFINED ENV{SKIP_TESTS})
   # osquery benchmarks.
   if(NOT DEFINED ENV{SKIP_BENCHMARKS} AND NOT ${OSQUERY_BUILD_SDK_ONLY})
     add_executable(osquery_benchmarks main/benchmarks.cpp ${OSQUERY_BENCHMARKS})
+    target_link_libraries(osquery_benchmarks benchmark libosquery_testing pthread)
     ADD_DEFAULT_LINKS(osquery_benchmarks TRUE)
-    target_link_libraries(osquery_benchmarks benchmark libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_benchmarks "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")
     set(BENCHMARK_TARGET "$<TARGET_FILE:osquery_benchmarks>")
 
     # osquery kernel benchmarks.
     add_executable(osquery_kernel_benchmarks main/benchmarks.cpp ${OSQUERY_KERNEL_BENCHMARKS})
+    target_link_libraries(osquery_kernel_benchmarks benchmark libosquery_testing pthread)
     ADD_DEFAULT_LINKS(osquery_kernel_benchmarks TRUE)
-    target_link_libraries(osquery_kernel_benchmarks benchmark libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_kernel_benchmarks "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS} -DKERNEL_TEST=1")
 
     # make benchmark

--- a/tools/provision/formula/libaptpkg.rb
+++ b/tools/provision/formula/libaptpkg.rb
@@ -3,7 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libaptpkg < AbstractOsqueryFormula
   desc "The low-level bindings for apt-pkg"
   homepage "https://apt.alioth.debian.org/python-apt-doc/library/apt_pkg.html"
-  url "https://osquery-packages.s3.amazonaws.com/deps/apt-1.2.6.tar.gz"
+  url "https://github.com/Debian/apt/archive/1.3.1.tar.gz"
+  sha256 "a91a5e96417aad33f236234730b2a0bed3a028d6fc01c57d060b7d92746bf65a"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -11,20 +13,94 @@ class Libaptpkg < AbstractOsqueryFormula
     sha256 "d69b612d10e545121c36dfa9181130420a516a8d6001a5228c8810a2d76309cc" => :x86_64_linux
   end
 
+  patch :DATA
+
   def install
-    args = []
-    args << "STATICLIBS=1"
+    args = osquery_cmake_args
+    args << "-DWITH_DOC=NO"
+    args << "-DUSE_NLS=NO"
 
-    inreplace "configure", "dpkg-architecture -qDEB_HOST_ARCH", "echo 'amd64'"
+    system "cmake", *args
+    system "make"
 
-    system "make", "clean"
-    system "./configure", "--prefix=#{prefix}"
-    system "make", "library", *args
-
-    # apt-pkg does not include an install target.
     mkdir_p "#{prefix}/lib"
-    system "cp", "bin/libapt-pkg.a", "#{prefix}/lib/"
+    system "cp", "apt-pkg/libapt-pkg.a", "#{prefix}/lib/"
     mkdir_p "#{prefix}/include/apt-pkg"
     system "cp include/apt-pkg/*.h #{prefix}/include/apt-pkg/"
   end
 end
+
+__END__
+diff --git a/CMake/Documentation.cmake b/CMake/Documentation.cmake
+index f3bbfdc..f37b82c 100644
+--- a/CMake/Documentation.cmake
++++ b/CMake/Documentation.cmake
+@@ -24,6 +24,7 @@
+ # SOFTWARE.
+ 
+ 
++if(WITH_DOC)
+ find_path(DOCBOOK_XSL manpages/docbook.xsl
+          # Debian
+          /usr/share/xml/docbook/stylesheet/docbook-xsl
+@@ -43,6 +44,7 @@ find_path(DOCBOOK_XSL manpages/docbook.xsl
+ if(NOT DOCBOOK_XSL)
+     message(FATAL_ERROR "Could not find docbook xsl")
+ endif()
++endif()
+ 
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docbook-text-style.xsl.cmake.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/docbook-text-style.xsl)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 19d8728..47a527f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,17 +197,17 @@ configure_file(CMake/config.h.in ${PROJECT_BINARY_DIR}/include/config.h)
+ configure_file(CMake/apti18n.h.in ${PROJECT_BINARY_DIR}/include/apti18n.h)
+ 
+ # Add our subdirectories
+-add_subdirectory(vendor)
++#add_subdirectory(vendor)
+ add_subdirectory(apt-pkg)
+-add_subdirectory(apt-private)
+-add_subdirectory(apt-inst)
+-add_subdirectory(cmdline)
+-add_subdirectory(completions)
+-add_subdirectory(doc)
+-add_subdirectory(dselect)
+-add_subdirectory(ftparchive)
+-add_subdirectory(methods)
+-add_subdirectory(test)
++#add_subdirectory(apt-private)
++#add_subdirectory(apt-inst)
++#add_subdirectory(cmdline)
++#add_subdirectory(completions)
++#add_subdirectory(doc)
++#add_subdirectory(dselect)
++#add_subdirectory(ftparchive)
++#add_subdirectory(methods)
++#add_subdirectory(test)
+ 
+ if (USE_NLS)
+ add_subdirectory(po)
+diff --git a/apt-pkg/CMakeLists.txt b/apt-pkg/CMakeLists.txt
+index 1b493c8..dad5c8c 100644
+--- a/apt-pkg/CMakeLists.txt
++++ b/apt-pkg/CMakeLists.txt
+@@ -21,7 +21,7 @@ file(GLOB_RECURSE library "*.cc")
+ file(GLOB_RECURSE headers "*.h")
+ 
+ # Create a library using the C++ files
+-add_library(apt-pkg SHARED ${library})
++add_library(apt-pkg STATIC ${library})
+ add_dependencies(apt-pkg apt-pkg-versionscript)
+ # Link the library and set the SONAME
+ target_include_directories(apt-pkg
+@@ -46,7 +46,7 @@ set_target_properties(apt-pkg PROPERTIES SOVERSION ${MAJOR})
+ add_version_script(apt-pkg)
+ 
+ # Install the library and the header files
+-install(TARGETS apt-pkg LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS apt-pkg ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/apt-pkg)
+ flatify(${PROJECT_BINARY_DIR}/include/apt-pkg/ "${headers}")


### PR DESCRIPTION
This updates `libaptpkg` to version 1.3.1. This is a significant change for the dependency as the build system moves from autotools to `cmake`. There are non-trivial changes required to (1) build without the documentation tools and (2) build a static library of just `apt-pkg`. 