### PR TITLE
[Fix #2764] Attempt to build all packages on every Linux OS

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -10,66 +10,42 @@ if(APPLE)
     DEPENDS daemon shell
   )
 elseif(LINUX)
-  if(DEBIAN_BASED)
-    # Set basic catch-alls for debian-based systems.
-    set(PACKAGE_TYPE "deb")
-    set(PACKAGE_ITERATION "1.debian")
-    set(PACKAGE_DEPENDENCIES
-      "libc6 (>=2.13)"
-      "zlib1g"
-    )
-
-    if(OSQUERY_BUILD_DISTRO STREQUAL "precise")
-      set(PACKAGE_ITERATION "1.ubuntu12")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "wheezy")
-      set(PACKAGE_ITERATION "1.debian7")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "trusty")
-      set(PACKAGE_ITERATION "1.ubuntu14")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "jessie")
-      set(PACKAGE_ITERATION "1.debian8")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "xenial")
-      set(PACKAGE_ITERATION "1.ubuntu16")
-    endif()
-  elseif(REDHAT_BASED)
-    set(PACKAGE_TYPE "rpm")
-    set(PACKAGE_ITERATION "1.el")
-    set(PACKAGE_DEPENDENCIES
-      "glibc >= 2.12"
-      "zlib"
-    )
-    if(OSQUERY_BUILD_DISTRO STREQUAL "centos6")
-      set(PACKAGE_ITERATION "1.el6")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel6")
-      set(PACKAGE_ITERATION "1.rhel6")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "scientific6")
-      set(PACKAGE_ITERATION "1.el6")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "oracle6")
-      set(PACKAGE_ITERATION "1.oel6")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "centos7")
-      set(PACKAGE_ITERATION "1.el7")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "rhel7")
-      set(PACKAGE_ITERATION "1.rhel7")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "scientific7")
-      set(PACKAGE_ITERATION "1.el7")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "oracle7")
-      set(PACKAGE_ITERATION "1.oel7")
-    elseif(OSQUERY_BUILD_DISTRO STREQUAL "amazon2015.03")
-      set(PACKAGE_ITERATION "1.amazon2015")
-    endif()
-  endif()
-  JOIN("${PACKAGE_DEPENDENCIES}" ", " PACKAGE_DEPENDENCIES)
-
   add_custom_target(
     packages
-    COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-      -t ${PACKAGE_TYPE} -i "${PACKAGE_ITERATION}"
-      -d "${PACKAGE_DEPENDENCIES}"
-    COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/codegen/genapi.py" "${CMAKE_SOURCE_DIR}"
-      "--output" "--directory" "${CMAKE_BINARY_DIR}"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     COMMENT "Building linux packages (no custom config)" VERBATIM
     DEPENDS daemon shell
   )
+
+  find_program(FPM_EXECUTABLE "fpm" ENV PATH)
+  find_program(RPMBUILD_EXECUTABLE "rpmbuild" ENV PATH)
+
+  if(FPM_EXECUTABLE)
+    add_custom_command(TARGET packages PRE_BUILD
+      COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+        -t "deb" -i "1.14"
+    )
+    add_custom_command(TARGET packages PRE_BUILD
+      COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+        -t "deb" -i "1.16" -s
+    )
+
+    if(RPMBUILD_EXECUTABLE)
+      add_custom_command(TARGET packages PRE_BUILD
+        COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+          -t "rpm" -i "1.el6"
+      )
+      add_custom_command(TARGET packages PRE_BUILD
+        COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+          -t "rpm" -i "1.el7" -s
+      )
+    else()
+      WARNING_LOG("Skipping RPM/CentOS packages: Cannot find rpmbuild")
+    endif()
+  else()
+    WARNING_LOG("Cannot find fpm executable in path")
+  endif()
+
 endif()
 
 if(NOT DEFINED KERNEL_BINARY)

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -13,11 +13,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
 BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build/linux"}
 
-export PATH="$PATH:/usr/local/bin"
+export PATH="/usr/local/osquery/bin:/usr/local/bin:$PATH"
 source "$SOURCE_DIR/tools/lib.sh"
 
 PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`
-PACKAGE_ARCH=`uname -m`
+PACKAGE_ARCH="x86_64"
 PACKAGE_ITERATION=""
 PACKAGE_TYPE=""
 DESCRIPTION="osquery is an operating system instrumentation toolchain."
@@ -46,6 +46,7 @@ OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"
 OSQUERY_LOG_DIR="/var/log/osquery/"
 OSQUERY_VAR_DIR="/var/osquery"
 OSQUERY_ETC_DIR="/etc/osquery"
+USE_SYSTEMD=0
 
 WORKING_DIR=/tmp/osquery_packaging
 INSTALL_PREFIX=$WORKING_DIR/prefix
@@ -53,7 +54,10 @@ DEBUG_PREFIX=$WORKING_DIR/debug
 
 function usage() {
   fatal "Usage: $0 -t deb|rpm -i REVISION -d DEPENDENCY_LIST
-
+    [-u|--preuninst] /path/to/pre-uninstall
+    [-p|--postinst] /path/to/post-install
+    [-c|--config] /path/to/embedded.config
+    [-s|--systemd]
   This will generate an Linux package with:
   (1) An example config /usr/share/osquery/osquery.example.conf
   (2) An init.d script /etc/init.d/osqueryd
@@ -78,6 +82,8 @@ function parse_args() {
       -i | --iteration )      shift
                               PACKAGE_ITERATION=$1
                               ;;
+      -s | --systemd )        USE_SYSTEMD=1
+                              ;;
       -d | --dependencies )   shift
                               PACKAGE_DEPENDENCIES="${@}"
                               ;;
@@ -97,7 +103,7 @@ function check_parsed_args() {
 function get_pkg_suffix() {
   if [[ $PACKAGE_TYPE == "deb" ]]; then
     # stay compliant with Debian package naming convention
-    echo "_${PACKAGE_VERSION}_$(dpkg --print-architecture).${PACKAGE_TYPE}"
+    echo "_${PACKAGE_VERSION}_${PACKAGE_ITERATION}.amd64.${PACKAGE_TYPE}"
   else
     V=`echo ${PACKAGE_VERSION}|tr '-' '_'`
     echo "-${V}-${PACKAGE_ITERATION}.${PACKAGE_ARCH}.${PACKAGE_TYPE}"
@@ -111,7 +117,7 @@ function main() {
   platform OS
   distro $OS DISTRO
 
-  OUTPUT_PKG_PATH="$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"
+  OUTPUT_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"`
 
   rm -rf $WORKING_DIR
   rm -f $OUTPUT_PKG_PATH
@@ -145,12 +151,14 @@ function main() {
     cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/tls-server-certs.pem
   fi
 
-  if [[ $DISTRO = "xenial" ]]; then
+  if [[ $PACKAGE_TYPE = "deb" && $USE_SYSTEMD = "1" ]]; then
     #Change config path to Ubuntu/Xenial default
     SYSTEMD_SYSCONFIG_DST=$SYSTEMD_SYSCONFIG_DST_DEBIAN
   fi
 
-  if [[ $DISTRO = "centos7" || $DISTRO = "rhel7" || $DISTRO = "xenial" ]]; then
+  PKG_INIT_LOG="for upstart"
+  if [[ $USE_SYSTEMD = "1" ]]; then
+    PKG_INIT_LOG="for systemd"
     # Install the systemd service and sysconfig
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SERVICE_DST`
     mkdir -p `dirname $INSTALL_PREFIX$SYSTEMD_SYSCONFIG_DST`
@@ -161,12 +169,12 @@ function main() {
     cp $INITD_SRC $INSTALL_PREFIX$INITD_DST
   fi
 
-  if [[ $DISTRO = "xenial" ]]; then
+  if [[ $PACKAGE_TYPE = "deb" && $USE_SYSTEMD = "1" ]]; then
     #Change config path in service unit
     sed -i 's/sysconfig/default/g' $INSTALL_PREFIX$SYSTEMD_SERVICE_DST
   fi
 
-  log "creating package"
+  log "creating $PACKAGE_TYPE package ($PKG_INIT_LOG)"
   IFS=',' read -a deps <<< "$PACKAGE_DEPENDENCIES"
   PACKAGE_DEPENDENCIES=
   for element in "${deps[@]}"
@@ -202,6 +210,7 @@ function main() {
     -n $PACKAGE_NAME -v $PACKAGE_VERSION \
     --iteration $PACKAGE_ITERATION \
     -a $PACKAGE_ARCH               \
+    --log error                    \
     $PREUNINST_CMD                 \
     $POSTINST_CMD                  \
     $PACKAGE_DEPENDENCIES          \
@@ -212,8 +221,7 @@ function main() {
 
   # Generate debug packages for Linux or CentOS
   BUILD_DEBUG_PKG=false
-  if [[ $OS = "ubuntu" || $OS = "debian" ]]; then
-    BUILD_DEBUG_PKG=true
+  if [[ $PACKAGE_TYPE = "deb" ]]; then
     PACKAGE_DEBUG_NAME="$PACKAGE_NAME-dbg"
     PACKAGE_DEBUG_DEPENDENCIES="osquery (= $PACKAGE_VERSION-$PACKAGE_ITERATION)"
 
@@ -222,14 +230,13 @@ function main() {
     mkdir -p $BINARY_DEBUG_DIR
     cp "$BUILD_DIR/osquery/osqueryi" $BINARY_DEBUG_DIR
     cp "$BUILD_DIR/osquery/osqueryd" $BINARY_DEBUG_DIR
-  elif [[ $OS = "rhel" || $OS = "centos" || $OS = "fedora" ]]; then
-    BUILD_DEBUG_PKG=true
+  elif [[ $PACKAGE_TYPE = "rpm" ]]; then
     PACKAGE_DEBUG_NAME="$PACKAGE_NAME-debuginfo"
     PACKAGE_DEBUG_DEPENDENCIES="osquery = $PACKAGE_VERSION"
 
     # Create Build-ID links for executables and Dwarfs.
-    BUILD_ID_SHELL=`eu-readelf -n "$BUILD_DIR/osquery/osqueryi" | grep "Build ID" | awk '{print $3}'`
-    BUILD_ID_DAEMON=`eu-readelf -n "$BUILD_DIR/osquery/osqueryd" | grep "Build ID" | awk '{print $3}'`
+    BUILD_ID_SHELL=`readelf -n "$BUILD_DIR/osquery/osqueryi" | grep "Build ID" | awk '{print $3}'`
+    BUILD_ID_DAEMON=`readelf -n "$BUILD_DIR/osquery/osqueryd" | grep "Build ID" | awk '{print $3}'`
     BUILDLINK_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/.build-id/64
     if [[ ! "$BUILD_ID_SHELL" = "" ]]; then
       mkdir -p $BUILDLINK_DEBUG_DIR
@@ -257,15 +264,16 @@ function main() {
   fi
 
   PACKAGE_DEBUG_DEPENDENCIES=`echo "$PACKAGE_DEBUG_DEPENDENCIES"|tr '-' '_'`
-  OUTPUT_DEBUG_PKG_PATH="$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"
-  if [[ $BUILD_DEBUG_PKG ]]; then
+  OUTPUT_DEBUG_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"`
+  if [[ ! -z "$DEBUG" ]]; then
     rm -f $OUTPUT_DEBUG_PKG_PATH
-    CMD="$FPM -s dir -t $PACKAGE_TYPE \
+    CMD="$FPM -s dir -t $PACKAGE_TYPE            \
       -n $PACKAGE_DEBUG_NAME -v $PACKAGE_VERSION \
-      --iteration $PACKAGE_ITERATION \
-      -a $PACKAGE_ARCH \
-      -d \"$PACKAGE_DEBUG_DEPENDENCIES\" \
-      -p $OUTPUT_DEBUG_PKG_PATH \
+      --iteration $PACKAGE_ITERATION             \
+      -a $PACKAGE_ARCH                           \
+      --log error                                \
+      -d \"$PACKAGE_DEBUG_DEPENDENCIES\"         \
+      -p $OUTPUT_DEBUG_PKG_PATH                  \
       $EPILOG \"$DEBUG_PREFIX/=/\""
     eval "$CMD"
     log "debug created at $OUTPUT_DEBUG_PKG_PATH"


### PR DESCRIPTION
With the last several months of changes to the build system, every Linux binary can be transposed onto any other (as long as they are using a 2011+ `glibc` and running on `x86_64` hardware). Thus there is no need to isolate package building to the current-running-OS.

This commit changes `make packages` to build 4 packages:
* A DEB for upstart/initd hosts
* A DEB for systemd hosts
* A RPM for upstart/initd hosts
* A RPM for systemd hosts

We name the upstart package iterations: `14` and `el6` respectively for the last OS in the family to use upstart. The systemd packages are `16` and `el7` respectively.