### PR TITLE
Restore the /maxcpucount switch for MSBuild

### DIFF
--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -6,7 +6,7 @@ cd .\build\windows10
 cmake ..\.. -G "Visual Studio 14 2015 Win64"
 
 for %%t in (shell,daemon,osquery_tests,osquery_additional_tests,osquery_tables_tests) do (
-  cmake --build . --target %%t --config Release -- /verbosity:minimal
+  cmake --build . --target %%t --config Release -- /verbosity:minimal /maxcpucount
   if errorlevel 1 goto end
 )
 


### PR DESCRIPTION
Previously, the `/maxcpucount` switch caused Heap exhaustion errors on the AWS Windows 2012R2 hosts. We should triage this more carefully and experiment with different machine types and `MSBuild` options.