### PR TITLE
add drop fields to interface details for linux/osx

### DIFF
--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -88,7 +88,8 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["obytes"] = BIGINT_FROM_UINT32(ifd->tx_bytes);
     r["ierrors"] = BIGINT_FROM_UINT32(ifd->rx_errors);
     r["oerrors"] = BIGINT_FROM_UINT32(ifd->tx_errors);
-
+    r["idrops"] = BIGINT_FROM_UINT32(ifd->rx_dropped);
+    r["odrops"] = BIGINT_FROM_UINT32(ifd->tx_dropped);
     // Get Linux physical properties for the AF_PACKET entry.
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd >= 0) {
@@ -123,6 +124,8 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["obytes"] = BIGINT_FROM_UINT32(ifd->ifi_obytes);
     r["ierrors"] = BIGINT_FROM_UINT32(ifd->ifi_ierrors);
     r["oerrors"] = BIGINT_FROM_UINT32(ifd->ifi_oerrors);
+    r["idrops"] = BIGINT_FROM_UINT32(ifd->ifi_iqdrops);
+    r["odrops"] = INTEGER(0);
     r["last_change"] = BIGINT_FROM_UINT32(ifd->ifi_lastchange.tv_sec);
 #endif
   }

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -12,6 +12,8 @@ schema([
     Column("obytes", BIGINT, "Output bytes"),
     Column("ierrors", BIGINT, "Input errors"),
     Column("oerrors", BIGINT, "Output errors"),
+    Column("idrops", BIGINT, "Input drops"),
+    Column("odrops", BIGINT, "Output drops"),
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
     Column("description", TEXT, "Short description of the object—a one-line string."),
     Column("manufacturer", TEXT, "Name of the network adapter's manufacturer."),


### PR DESCRIPTION
We want to track drop packets.. 

osx doesn't have tx drops.. anyone knows why? 