### PR TITLE
Remove pattern column from OceanLotus

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -3,7 +3,13 @@
   "version": "1.4.5",
   "queries": {
     "WireLurker": {
-      "query" : "select * from launchd where name = 'com.apple.machook_damon.plist' or name = 'com.apple.globalupdate.plist' or name = 'com.apple.appstore.plughelper.plist' or name = 'com.apple.MailServiceAgentHelper.plist' or name = 'com.apple.systemkeychain-helper.plist' or name = 'com.apple.periodic-dd-mm-yy.plist';",
+      "query" : "select * from launchd where
+        name = 'com.apple.machook_damon.plist' OR
+        name = 'com.apple.globalupdate.plist' OR
+        name = 'com.apple.appstore.plughelper.plist' OR
+        name = 'com.apple.MailServiceAgentHelper.plist' OR
+        name = 'com.apple.systemkeychain-helper.plist' OR
+        name = 'com.apple.periodic-dd-mm-yy.plist';",
       "interval" : "86400",
       "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
       "value" : "Artifact used by this malware"
@@ -141,7 +147,13 @@
       "value" : "Artifact used by this malware"
     },
     "Vsearch": {
-      "query" : "select * from launchd where name = 'com.vsearch.agent.plist' or name = 'com.vsearch.daemon.plist' or name = 'com.vsearch.helper.plist' or name = 'Jack.plist' or program_arguments = '/etc/run_upd.sh' or program_arguments like '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
+      "query" : "select * from launchd where
+        name = 'com.vsearch.agent.plist' OR
+        name = 'com.vsearch.daemon.plist' OR
+        name = 'com.vsearch.helper.plist' OR
+        name = 'Jack.plist' OR
+        program_arguments = '/etc/run_upd.sh' OR
+        program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
       "interval" : "86400",
       "description" : "(http://www.thesafemac.com/arg-downlite/)",
       "value" : "Artifact used by this malware"
@@ -159,7 +171,16 @@
       "value" : "Artifact used by this malware"
     },
     "Genieo": {
-      "query" : "select * from launchd where name = 'com.genieo.completer.download.plist' or name = 'com.genieo.completer.update.plist' or name = 'com.genieo.completer.ltvbit.plist' or name = 'com.installer.completer.download.plist' or name = 'com.installer.completer.update.plist' or name = 'com.installer.completer.ltvbit.plist' or name = 'com.genieoinnovation.macextension.plist' or name = 'com.genieoinnovation.macextension.client.plist' or name = 'com.genieo.engine.plist';",
+      "query" : "select * from launchd where
+        name = 'com.genieo.completer.download.plist' OR
+        name = 'com.genieo.completer.update.plist' OR
+        name = 'com.genieo.completer.ltvbit.plist' OR
+        name = 'com.installer.completer.download.plist' OR
+        name = 'com.installer.completer.update.plist' OR
+        name = 'com.installer.completer.ltvbit.plist' OR
+        name = 'com.genieoinnovation.macextension.plist' OR
+        name = 'com.genieoinnovation.macextension.client.plist' OR
+        name = 'com.genieo.engine.plist';",
       "interval" : "86400",
       "description" : "(http://www.thesafemac.com/arg-genieo/)",
       "value" : "Artifact used by this malware"
@@ -183,7 +204,11 @@
       "value" : "Artifact used by this malware"
     },
     "HackingTeam_Mac_RAT3": {
-      "query" : "select * from launchd where label = 'com.ht.RCSMac' or name = 'com.apple.loginStoreagent.plist' or name = 'com.apple.mdworker.plist' or name = 'com.apple.UIServerLogin.plist';",
+      "query" : "select * from launchd where
+        label = 'com.ht.RCSMac' OR
+        name = 'com.apple.loginStoreagent.plist' OR
+        name = 'com.apple.mdworker.plist' OR
+        name = 'com.apple.UIServerLogin.plist';",
       "interval" : "86400",
       "description" : "Detect RAT used by Hacking Team",
       "value" : "Artifact used by this malware"
@@ -208,7 +233,9 @@
       "value": "Artifact used by this malware"
     },
     "Keranger_2": {
-      "query": "select * from file where path like '/Users/%/Library/.kernel_%' union select * from file where path like '/Users/%/Library/kernel_service';",
+      "query": "select * from file where
+        path LIKE '/Users/%/Library/.kernel_%' OR
+        path LIKE '/Users/%/Library/kernel_service';",
       "interval": "86400",
       "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
       "value": "Artifact used by this malware"
@@ -274,7 +301,14 @@
       "value": "Artifact used by this malware"
     },
     "OSX_Backdoor_Mokes": {
-      "query": "select * from file where path like '/Users/%/Library/App Store/storeuserd' or path like '/Users/%/Library/com.apple.spotlight/SpotlightHelper' or path like '/Users/%/Library/Dock/com.apple.dock.cache' or path like '/Users/%/Library/Dropbox/DropboxCache' or path like '/Users/%/Library/Skype/SkypeHelper' or path like '/Users/%/Library/Google/Chrome/nacld' or path like '/Users/%/Library/Firefox/Profiles/profiled';",
+      "query": "select * from file where
+        path LIKE '/Users/%/Library/App Store/storeuserd' OR
+        path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR
+        path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR
+        path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR
+        path LIKE '/Users/%/Library/Skype/SkypeHelper' OR
+        path LIKE '/Users/%/Library/Google/Chrome/nacld' OR
+        path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
       "interval": "86400",
       "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
       "value": "Artifact used by this malware"
@@ -292,73 +326,17 @@
       "value" : "Artifact used by this malware"
     },
     "OceanLotus_dropped_file_1": {
-      "query" : "select * from file where pattern = '/Users/%/Library/Logs/.Logs/corevideosd';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_2": {
-      "query" : "select * from file where path = '/Library/Logs/.Logs/corevideosd';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_3": {
-      "query" : "select * from file where pattern = '/Users/%/Library/.SystemPreferences/.prev/.ver.txt';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_4": {
-      "query" : "select * from file where path = '/Library/.SystemPreferences/.prev/.ver.txt';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_5": {
-      "query" : "select * from file where pattern = '/Users/%/Library/Parallels/.cfg';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_6": {
-      "query" : "select * from file where path = '/Library/Parallels/.cfg';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_7": {
-      "query" : "select * from file where pattern = '/Users/%/Library/Preferences/.fDTYuRs';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_8": {
-      "query" : "select * from file where pattern = '/Users/%/Library/Hash/.Hashtag/.hash';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_9": {
-      "query" : "select * from file where path = '/Library/Hash/.Hashtag/.hash';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_10": {
-      "query" : "select * from file where pattern = '/Users/%/Library/Hash/.hash';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_11": {
-      "query" : "select * from file where path = '/Library/Hash/.hash';",
-      "interval" : "86400",
-      "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
-      "value" : "Artifact used by this malware"
-    },
-    "OceanLotus_dropped_file_12": {
-      "query" : "select * from file where path = '/tmp/crunzip.temp.%';",
+      "query" : "select * from file, (
+        select '/Library/Logs/.Logs/corevideosd' ioc union
+        select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union
+        select '/Library/Parallels/.cfg' ioc union
+        select '/Library/Preferences/.fDTYuRs' ioc union
+        select '/Library/Hash/.Hashtag/.hash' ioc union
+        select '/Library/Hash/.hash' ioc
+      ) iocs where
+        file.path LIKE '/Users/%/' || ioc OR
+        file.path = iocs.ioc OR
+        file.path LIKE '/tmp/crunzip.temp.%';",
       "interval" : "86400",
       "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
       "value" : "Artifact used by this malware"


### PR DESCRIPTION
Our lazy-build release checks found errors in the packs: https://jenkins.osquery.io/job/osqueryMasterPosixPackages/13/TargetSystem=vm-osx12/console

The `file` table's `pattern` column was removed in version `1.7.1`. This cleans up the erroring queries and flattens the OceanLotus queries into 1.