### PR TITLE
Sanity check Linux memory_map offsets

### DIFF
--- a/osquery/tables/system/linux/memory_map.cpp
+++ b/osquery/tables/system/linux/memory_map.cpp
@@ -33,6 +33,9 @@ QueryData genMemoryMap(QueryContext& context) {
   for (const auto& line : regions) {
     auto b1 = line.find_first_of("-");
     auto b2 = line.find_first_of(" : ");
+    if (b1 == std::string::npos || b2 == std::string::npos) {
+      continue;
+    }
 
     Row r;
     r["start"] = "0x" + line.substr(0, b1);


### PR DESCRIPTION
This is the result of 1 round of `make fuzz`, the seed uses a basic PRNG, this just popped up. There's no existing risk as the input to `memory_map` is from `/proc`. But squashing this is good form and prevents future early-exits from `make fuzz`.