### PR TITLE
Allow tools/build.sh to SKIP_TESTS

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -25,6 +25,7 @@ source $SCRIPT_DIR/lib.sh
 # $ export RUN_TARGET=target
 
 # Run the build function and the tests
-build true
+if [[ -z "$SKIP_TESTS" ]]; then RUN_TESTS=true; else RUN_TESTS=false; fi
+build $RUN_TESTS
 
 exit 0


### PR DESCRIPTION
To allow new jobs like `make fuzz` we want to build the `shell` target only.

We can achieve that with the CI build host entry point: `./tools/build.sh` if we allow it to skip building and running tests. The facility for building a single target exists using `RUN_TARGET`, but not skipping/running the tests. Other parts of the build system use `SKIP_TESTS`. This adds similar functionality.