### PR TITLE
Allow configuration JSON to include escaped newlines

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -3,12 +3,12 @@
   "version": "1.4.5",
   "queries": {
     "WireLurker": {
-      "query" : "select * from launchd where
-        name = 'com.apple.machook_damon.plist' OR
-        name = 'com.apple.globalupdate.plist' OR
-        name = 'com.apple.appstore.plughelper.plist' OR
-        name = 'com.apple.MailServiceAgentHelper.plist' OR
-        name = 'com.apple.systemkeychain-helper.plist' OR
+      "query" : "select * from launchd where \
+        name = 'com.apple.machook_damon.plist' OR \
+        name = 'com.apple.globalupdate.plist' OR \
+        name = 'com.apple.appstore.plughelper.plist' OR \
+        name = 'com.apple.MailServiceAgentHelper.plist' OR \
+        name = 'com.apple.systemkeychain-helper.plist' OR \
         name = 'com.apple.periodic-dd-mm-yy.plist';",
       "interval" : "86400",
       "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
@@ -147,12 +147,12 @@
       "value" : "Artifact used by this malware"
     },
     "Vsearch": {
-      "query" : "select * from launchd where
-        name = 'com.vsearch.agent.plist' OR
-        name = 'com.vsearch.daemon.plist' OR
-        name = 'com.vsearch.helper.plist' OR
-        name = 'Jack.plist' OR
-        program_arguments = '/etc/run_upd.sh' OR
+      "query" : "select * from launchd where \
+        name = 'com.vsearch.agent.plist' OR \
+        name = 'com.vsearch.daemon.plist' OR \
+        name = 'com.vsearch.helper.plist' OR \
+        name = 'Jack.plist' OR \
+        program_arguments = '/etc/run_upd.sh' OR \
         program_arguments LIKE '/Library/Application Support/%/Agent/agent.app/Contents/MacOS/agent%';",
       "interval" : "86400",
       "description" : "(http://www.thesafemac.com/arg-downlite/)",
@@ -171,15 +171,15 @@
       "value" : "Artifact used by this malware"
     },
     "Genieo": {
-      "query" : "select * from launchd where
-        name = 'com.genieo.completer.download.plist' OR
-        name = 'com.genieo.completer.update.plist' OR
-        name = 'com.genieo.completer.ltvbit.plist' OR
-        name = 'com.installer.completer.download.plist' OR
-        name = 'com.installer.completer.update.plist' OR
-        name = 'com.installer.completer.ltvbit.plist' OR
-        name = 'com.genieoinnovation.macextension.plist' OR
-        name = 'com.genieoinnovation.macextension.client.plist' OR
+      "query" : "select * from launchd where \
+        name = 'com.genieo.completer.download.plist' OR \
+        name = 'com.genieo.completer.update.plist' OR \
+        name = 'com.genieo.completer.ltvbit.plist' OR \
+        name = 'com.installer.completer.download.plist' OR \
+        name = 'com.installer.completer.update.plist' OR \
+        name = 'com.installer.completer.ltvbit.plist' OR \
+        name = 'com.genieoinnovation.macextension.plist' OR \
+        name = 'com.genieoinnovation.macextension.client.plist' OR \
         name = 'com.genieo.engine.plist';",
       "interval" : "86400",
       "description" : "(http://www.thesafemac.com/arg-genieo/)",
@@ -204,10 +204,10 @@
       "value" : "Artifact used by this malware"
     },
     "HackingTeam_Mac_RAT3": {
-      "query" : "select * from launchd where
-        label = 'com.ht.RCSMac' OR
-        name = 'com.apple.loginStoreagent.plist' OR
-        name = 'com.apple.mdworker.plist' OR
+      "query" : "select * from launchd where \
+        label = 'com.ht.RCSMac' OR \
+        name = 'com.apple.loginStoreagent.plist' OR \
+        name = 'com.apple.mdworker.plist' OR \
         name = 'com.apple.UIServerLogin.plist';",
       "interval" : "86400",
       "description" : "Detect RAT used by Hacking Team",
@@ -233,8 +233,8 @@
       "value": "Artifact used by this malware"
     },
     "Keranger_2": {
-      "query": "select * from file where
-        path LIKE '/Users/%/Library/.kernel_%' OR
+      "query": "select * from file where \
+        path LIKE '/Users/%/Library/.kernel_%' OR \
         path LIKE '/Users/%/Library/kernel_service';",
       "interval": "86400",
       "description": "http://researchcenter.paloaltonetworks.com/2016/03/new-os-x-ransomware-keranger-infected-transmission-bittorrent-client-installer/",
@@ -301,13 +301,13 @@
       "value": "Artifact used by this malware"
     },
     "OSX_Backdoor_Mokes": {
-      "query": "select * from file where
-        path LIKE '/Users/%/Library/App Store/storeuserd' OR
-        path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR
-        path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR
-        path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR
-        path LIKE '/Users/%/Library/Skype/SkypeHelper' OR
-        path LIKE '/Users/%/Library/Google/Chrome/nacld' OR
+      "query": "select * from file where \
+        path LIKE '/Users/%/Library/App Store/storeuserd' OR \
+        path LIKE '/Users/%/Library/com.apple.spotlight/SpotlightHelper' OR \
+        path LIKE '/Users/%/Library/Dock/com.apple.dock.cache' OR \
+        path LIKE '/Users/%/Library/Dropbox/DropboxCache' OR \
+        path LIKE '/Users/%/Library/Skype/SkypeHelper' OR \
+        path LIKE '/Users/%/Library/Google/Chrome/nacld' OR \
         path LIKE '/Users/%/Library/Firefox/Profiles/profiled';",
       "interval": "86400",
       "description": "(https://securelist.com/blog/research/75990/the-missing-piece-sophisticated-os-x-backdoor-discovered/)",
@@ -326,16 +326,16 @@
       "value" : "Artifact used by this malware"
     },
     "OceanLotus_dropped_file_1": {
-      "query" : "select * from file, (
-        select '/Library/Logs/.Logs/corevideosd' ioc union
-        select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union
-        select '/Library/Parallels/.cfg' ioc union
-        select '/Library/Preferences/.fDTYuRs' ioc union
-        select '/Library/Hash/.Hashtag/.hash' ioc union
-        select '/Library/Hash/.hash' ioc
-      ) iocs where
-        file.path LIKE '/Users/%/' || ioc OR
-        file.path = iocs.ioc OR
+      "query" : "select * from file, ( \
+        select '/Library/Logs/.Logs/corevideosd' ioc union \
+        select '/Library/.SystemPreferences/.prev/.ver.txt' ioc union \
+        select '/Library/Parallels/.cfg' ioc union \
+        select '/Library/Preferences/.fDTYuRs' ioc union \
+        select '/Library/Hash/.Hashtag/.hash' ioc union \
+        select '/Library/Hash/.hash' ioc \
+      ) iocs where \
+        file.path LIKE '/Users/%/' || ioc OR \
+        file.path = iocs.ioc OR \
         file.path LIKE '/tmp/crunzip.temp.%';",
       "interval" : "86400",
       "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 import json
 import os
 import subprocess
+import string
 import unittest
 
 # osquery-specific testing utils
@@ -37,7 +38,9 @@ class ReleaseTests(test_base.QueryTester):
         for root, dirs, files in os.walk(PACKS_DIR):
             for name in files:
                 with open(os.path.join(PACKS_DIR, name), 'r') as fh:
-                    packs[name] = json.loads(fh.read())
+                    content = fh.read()
+                    content = string.replace(content, "\\\n", "")
+                    packs[name] = json.loads(content)
         for name, pack in packs.items():
             if "queries" not in pack:
                 continue


### PR DESCRIPTION
To support "pretty" JSON in configuration and pack data, we support using `\\\\n` within the JSON content. Although JSON does not support this, we will replace the escape sequence when reading the content before applying parsers.