### PR TITLE
Rename augeas path column to node

### DIFF
--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -7,19 +7,21 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+
 #include <gtest/gtest.h>
 
 #include <osquery/sql.h>
 
 namespace osquery {
 namespace tables {
+
 class AugeasTests : public testing::Test {};
 
 TEST_F(AugeasTests, select_hosts_by_path_expression) {
-  auto results = SQL("select * from augeas where path='/files/etc/hosts'");
+  auto results = SQL("select * from augeas where path = '/etc/hosts' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
-  ASSERT_EQ(results.rows()[0].at("path"), "/files/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("filename"), "/etc/hosts");
+  ASSERT_EQ(results.rows()[0].at("node"), "/files/etc/hosts");
+  ASSERT_EQ(results.rows()[0].at("path"), "/etc/hosts");
   ASSERT_EQ(results.rows()[0].at("label"), "hosts");
   ASSERT_TRUE(results.rows()[0].at("value").empty())
       << "Value is not empty. Got " << results.rows()[0].at("value")
@@ -27,11 +29,11 @@ TEST_F(AugeasTests, select_hosts_by_path_expression) {
 }
 
 TEST_F(AugeasTests, select_etc_by_path_expression) {
-  auto results = SQL("select * from augeas where path='/files/etc'");
+  auto results = SQL("select * from augeas where path = '/etc' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
-  ASSERT_EQ(results.rows()[0].at("path"), "/files/etc");
+  ASSERT_EQ(results.rows()[0].at("node"), "/files/etc");
   ASSERT_EQ(results.rows()[0].at("label"), "etc");
-  ASSERT_TRUE(results.rows()[0].at("filename").empty())
+  ASSERT_FALSE(results.rows()[0].at("path").empty())
       << "Filename is not empty. Got " << results.rows()[0].at("filename")
       << "instead";
   ASSERT_TRUE(results.rows()[0].at("value").empty())
@@ -41,41 +43,19 @@ TEST_F(AugeasTests, select_etc_by_path_expression) {
 
 TEST_F(AugeasTests, select_by_path_expression_with_or) {
   auto results =
-      SQL("select * from augeas where path='/files/etc/hosts' or "
-          "path='/files/etc/resolv.conf' order by path");
+      SQL("select * from augeas where path = '/etc/hosts' or "
+          "path = '/etc/resolv.conf' group by path order by path");
+
   ASSERT_EQ(results.rows().size(), 2U);
-
-  ASSERT_EQ(results.rows()[0].at("path"), "/files/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("filename"), "/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("label"), "hosts");
-  ASSERT_TRUE(results.rows()[0].at("value").empty())
-      << "Value is not empty. Got " << results.rows()[0].at("value")
-      << "instead";
-
-  ASSERT_EQ(results.rows()[1].at("path"), "/files/etc/resolv.conf");
-  ASSERT_EQ(results.rows()[1].at("filename"), "/etc/resolv.conf");
-  ASSERT_EQ(results.rows()[1].at("label"), "resolv.conf");
-  ASSERT_TRUE(results.rows()[1].at("value").empty())
-      << "Value is not empty. Got " << results.rows()[1].at("value")
-      << "instead";
+  ASSERT_EQ(results.rows()[0].at("path"), "/etc/hosts");
+  ASSERT_EQ(results.rows()[1].at("path"), "/etc/resolv.conf");
 }
 
-TEST_F(AugeasTests, select_hosts_by_filename) {
-  auto results = SQL("select * from augeas where filename='/etc/hosts'");
+TEST_F(AugeasTests, select_hosts_by_node) {
+  auto results = SQL("select * from augeas where node = '/files/etc/hosts'");
   ASSERT_GE(results.rows().size(), 1U);
-  ASSERT_EQ(results.rows()[0].at("path"), "/files/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("filename"), "/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("label"), "hosts");
-  ASSERT_TRUE(results.rows()[0].at("value").empty())
-      << "Value is not empty. Got " << results.rows()[0].at("value")
-      << "instead";
-}
-
-TEST_F(AugeasTests, select_hosts_by_label) {
-  auto results = SQL("select * from augeas where label='hosts'");
-  ASSERT_GE(results.rows().size(), 1U);
-  ASSERT_EQ(results.rows()[0].at("path"), "/files/etc/hosts");
-  ASSERT_EQ(results.rows()[0].at("filename"), "/etc/hosts");
+  ASSERT_EQ(results.rows()[0].at("node"), "/files/etc/hosts");
+  ASSERT_EQ(results.rows()[0].at("path"), "/etc/hosts");
   ASSERT_EQ(results.rows()[0].at("label"), "hosts");
   ASSERT_TRUE(results.rows()[0].at("value").empty())
       << "Value is not empty. Got " << results.rows()[0].at("value")

--- a/specs/posix/augeas.table
+++ b/specs/posix/augeas.table
@@ -1,9 +1,12 @@
-table_name("augeas")
+table_name("augeas", aliases=["configurations"])
 description("Configuration files parsed by augeas.")
 schema([
-    Column("path", TEXT, "The path of the configuration item"),
+    Column("node", TEXT, "The node path of the configuration item"),
     Column("value", TEXT, "The value of the configuration item"),
     Column("label", TEXT, "The label of the configuration item"),
-    Column("filename", TEXT, "The path to the configuration file")
+    Column("path", TEXT, "The path to the configuration file")
 ])
 implementation("other/augeas@genAugeas")
+examples([
+  "select * from augeas where path = '/etc/hosts'",
+])


### PR DESCRIPTION
This renames the existing `augeas` table's `path` column to `node` and `filename` to `path`. This allows the table specification to mimic others such that `path` refers to a filesystem's path.

This diction is not "completely" perfect, but does a decent job: http://augeas.net/docs/api.html

We also allow the queryer to include `node =` and `path =` expressions in the predicate to better optimization the matching.

```
osquery> select count(1) from augeas;
+----------+
| count(1) |
+----------+
| 46131    |
+----------+
Run Time: real 2.434 user 2.408000 sys 0.024000
osquery> select count(1) from augeas where path = '/etc/hosts';
+----------+
| count(1) |
+----------+
| 27       |
+----------+
Run Time: real 0.830 user 0.820000 sys 0.008000
osquery> select count(1) from augeas where node = '/files/etc/hosts';
+----------+
| count(1) |
+----------+
| 1        |
+----------+
Run Time: real 0.821 user 0.804000 sys 0.020000
osquery> select count(1) from augeas where node LIKE '/files/etc/hosts%';
+----------+
| count(1) |
+----------+
| 47       |
+----------+
Run Time: real 2.435 user 2.420000 sys 0.008000
```

There is still work to be done to better optimize this table.