### PR TITLE
Manage queue configuration for Linux audit

### DIFF
--- a/osquery/events/linux/tests/audit_tests.cpp
+++ b/osquery/events/linux/tests/audit_tests.cpp
@@ -25,11 +25,13 @@ extern bool handleAuditReply(const struct audit_reply& reply,
                              AuditEventContextRef& ec);
 
 /// Internal audit subscriber (socket events) testable methods.
-extern void parseSockAddr(const std::string& saddr, Row& r, bool local);
+extern void parseSockAddr(const std::string& saddr, Row& r);
 
 class AuditTests : public testing::Test {
  protected:
-  void SetUp() override { Row().swap(row_); }
+  void SetUp() override {
+    Row().swap(row_);
+  }
 
  protected:
   Row row_;
@@ -155,33 +157,27 @@ TEST_F(AuditTests, test_audit_assembler) {
 TEST_F(AuditTests, test_parse_sock_addr) {
   Row r;
   std::string msg = "02001F907F0000010000000000000000";
-  parseSockAddr(msg, r, true);
-  ASSERT_FALSE(r["local_address"].empty());
-  EXPECT_EQ(r["local_address"], "127.0.0.1");
+  parseSockAddr(msg, r);
+  ASSERT_FALSE(r["remote_address"].empty());
+  EXPECT_EQ(r["remote_address"], "127.0.0.1");
   EXPECT_EQ(r["family"], "2");
-  EXPECT_EQ(r["local_port"], "8080");
-
-  Row r2;
-  parseSockAddr(msg, r2, false);
-  ASSERT_FALSE(r2["remote_address"].empty());
-  EXPECT_EQ(r2["remote_address"], "127.0.0.1");
-  EXPECT_EQ(r2["remote_port"], "8080");
+  EXPECT_EQ(r["remote_port"], "8080");
 
   Row r3;
   std::string msg2 = "0A001F9100000000FE80000000000000022522FFFEB03684000000";
-  parseSockAddr(msg2, r3, false);
+  parseSockAddr(msg2, r3);
   ASSERT_FALSE(r3["remote_address"].empty());
   EXPECT_EQ(r3["remote_address"], "fe80:0000:0000:0000:0225:22ff:feb0:3684");
   EXPECT_EQ(r3["remote_port"], "8081");
 
   Row r4;
   std::string msg3 = "01002F746D702F6F7371756572792E656D0000";
-  parseSockAddr(msg3, r4, true);
+  parseSockAddr(msg3, r4);
   ASSERT_FALSE(r4["socket"].empty());
   EXPECT_EQ(r4["socket"], "/tmp/osquery.em");
 
   msg3 = "0100002F746D702F6F7371756572792E656D";
-  parseSockAddr(msg3, r4, true);
+  parseSockAddr(msg3, r4);
   EXPECT_EQ(r4["socket"], "/tmp/osquery.em");
 }
 }

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include <boost/algorithm/hex.hpp>
-
 #include <osquery/config.h>
 #include <osquery/logger.h>
 #include <osquery/sql.h>
@@ -26,59 +24,8 @@ namespace tables {
 extern long getUptime();
 }
 
-class ProcessEventSubscriber : public EventSubscriber<AuditEventPublisher> {
- public:
-  /// The process event subscriber declares an audit event type subscription.
-  Status init() override;
-
-  /// Kernel events matching the event type will fire.
-  Status Callback(const ECRef& ec, const SCRef& sc);
-
- private:
-  /// The next expected process event state.
-  AuditProcessEventState state_{STATE_SYSCALL};
-
-  /// Along with the state, track the building row.
-  Row row_;
-};
-
-inline std::string decodeAuditValue(const std::string& s) {
-  if (s.size() > 1 && s[0] == '"') {
-    return s.substr(1, s.size() - 2);
-  }
-  try {
-    return boost::algorithm::unhex(s);
-  } catch (const boost::algorithm::hex_decode_error& e) {
-    return s;
-  }
-}
-
-Status validAuditState(int type, AuditProcessEventState& state) {
-  // Define some acceptable transitions outside of the default state.
-  bool acceptable = (type == STATE_PATH && state == STATE_EXECVE);
-  acceptable |= (type == STATE_PATH && state == STATE_CWD);
-  if (type != state && !acceptable) {
-    // This is an out-of-order event, drop it.
-    return Status(1, "Out of order");
-  }
-
-  // Update the next expected state.
+bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   if (type == AUDIT_SYSCALL) {
-    state = STATE_EXECVE;
-  } else if (type == AUDIT_EXECVE) {
-    state = STATE_CWD;
-  } else if (type == AUDIT_CWD) {
-    state = STATE_PATH;
-  } else {
-    state = STATE_SYSCALL;
-  }
-
-  return Status(0, "OK");
-}
-
-inline void updateAuditRow(const AuditEventContextRef& ec, Row& r) {
-  const auto& fields = ec->fields;
-  if (ec->type == AUDIT_SYSCALL) {
     r["pid"] = (fields.count("pid")) ? fields.at("pid") : "0";
     r["parent"] = fields.count("ppid") ? fields.at("ppid") : "0";
     r["uid"] = fields.count("uid") ? fields.at("uid") : "0";
@@ -87,9 +34,18 @@ inline void updateAuditRow(const AuditEventContextRef& ec, Row& r) {
     r["egid"] = fields.count("egid") ? fields.at("euid") : "0";
     r["path"] = (fields.count("exe")) ? decodeAuditValue(fields.at("exe")) : "";
 
+    auto qd = SQL::selectAllFrom("file", "path", EQUALS, r.at("path"));
+    if (qd.size() == 1) {
+      r["ctime"] = qd.front().at("ctime");
+      r["atime"] = qd.front().at("atime");
+      r["mtime"] = qd.front().at("mtime");
+      r["btime"] = "0";
+    }
+
     // This should get overwritten during the EXECVE state.
     r["cmdline"] = (fields.count("comm")) ? fields.at("comm") : "";
-    // Do not record a cmdline size. If the final state is reached and no 'argc'
+    // Do not record a cmdline size. If the final state is reached and no
+    // 'argc'
     // has been filled in then the EXECVE state was not used.
     r["cmdline_size"] = "";
 
@@ -99,7 +55,7 @@ inline void updateAuditRow(const AuditEventContextRef& ec, Row& r) {
     r["env"] = "";
   }
 
-  if (ec->type == AUDIT_EXECVE) {
+  if (type == AUDIT_EXECVE) {
     // Reset the temporary storage from the SYSCALL state.
     r["cmdline"] = "";
     for (const auto& arg : fields) {
@@ -115,31 +71,40 @@ inline void updateAuditRow(const AuditEventContextRef& ec, Row& r) {
     }
 
     // There may be a better way to calculate actual size from audit.
-    // Then an overflow could be calculated/determined based on actual/expected.
+    // Then an overflow could be calculated/determined based on
+    // actual/expected.
     r["cmdline_size"] = std::to_string(r.at("cmdline").size());
-  }
-
-  if (ec->type == AUDIT_PATH) {
-    r["mode"] = (fields.count("mode")) ? fields.at("mode") : "";
-    r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";
-    r["owner_gid"] = fields.count("ogid") ? fields.at("ogid") : "0";
-
-    auto qd = SQL::selectAllFrom("file", "path", EQUALS, r.at("path"));
-    if (qd.size() == 1) {
-      r["ctime"] = qd.front().at("ctime");
-      r["atime"] = qd.front().at("atime");
-      r["mtime"] = qd.front().at("mtime");
-      r["btime"] = "0";
-    }
 
     // Uptime is helpful for execution-based events.
     r["uptime"] = std::to_string(tables::getUptime());
   }
+
+  if (type == AUDIT_PATH) {
+    r["mode"] = (fields.count("mode")) ? fields.at("mode") : "";
+    r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";
+    r["owner_gid"] = fields.count("ogid") ? fields.at("ogid") : "0";
+  }
+  return true;
 }
+
+class ProcessEventSubscriber : public EventSubscriber<AuditEventPublisher> {
+ public:
+  /// The process event subscriber declares an audit event type subscription.
+  Status init() override;
+
+  /// Kernel events matching the event type will fire.
+  Status Callback(const ECRef& ec, const SCRef& sc);
+
+ private:
+  AuditAssembler asm_;
+};
 
 REGISTER(ProcessEventSubscriber, "event_subscriber", "process_events");
 
 Status ProcessEventSubscriber::init() {
+  asm_.start(
+      10, {AUDIT_SYSCALL, AUDIT_EXECVE, AUDIT_PATH, AUDIT_CWD}, &ProcessUpdate);
+
   auto sc = createSubscriptionContext();
 
   // Monitor for execve syscalls.
@@ -160,28 +125,16 @@ Status ProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return Status(0, "OK");
   }
 
-  if (!validAuditState(ec->type, state_).ok()) {
-    state_ = STATE_SYSCALL;
-    Row().swap(row_);
+  if (ec->type == AUDIT_PATH && ec->fields.count("item") &&
+      ec->fields.at("item") != "0") {
     return Status(0, "OK");
   }
 
-  // Fill in row fields based on the event state.
-  updateAuditRow(ec, row_);
-
-  // Only add the event if finished (aka a PATH event was emitted).
-  if (state_ == STATE_SYSCALL) {
-    // If the EXECVE state was not used, decode the cmdline value.
-    if (row_.at("cmdline_size").size() == 0) {
-      // This allows at most 1 decode call per potentially-encoded item.
-      row_["cmdline"] = decodeAuditValue(row_.at("cmdline"));
-      row_["cmdline_size"] = "1";
-    }
-
-    add(row_);
-    Row().swap(row_);
+  auto fields = asm_.add(ec->auid, ec->type, ec->fields);
+  if (fields.is_initialized()) {
+    add(*fields);
   }
 
   return Status(0, "OK");
 }
-} // namespace osquery
+}

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -103,7 +103,7 @@ REGISTER(ProcessEventSubscriber, "event_subscriber", "process_events");
 
 Status ProcessEventSubscriber::init() {
   asm_.start(
-      10, {AUDIT_SYSCALL, AUDIT_EXECVE, AUDIT_PATH, AUDIT_CWD}, &ProcessUpdate);
+      20, {AUDIT_SYSCALL, AUDIT_EXECVE, AUDIT_PATH, AUDIT_CWD}, &ProcessUpdate);
 
   auto sc = createSubscriptionContext();
 


### PR DESCRIPTION
This adds 3 controls for Linux audit:
- The `backlog_wait_time`, the Hz to pause each enqueue within the kernel.
- The `blacklog_limit`, the size of the queue.
- The failure action.

When osquery terminates safely the default settings for audit are restored.