### PR TITLE
Fix deterministic and package build tests on OS X

### DIFF
--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -230,8 +230,8 @@ function main() {
   log "package created at $OUTPUT_PKG_PATH"
 
   # We optionally create an RPM equivalent.
-  FPM=$(which fpm)
-  RPMBUILD=$(which rpmbuild)
+  FPM=$(which fpm || true)
+  RPMBUILD=$(which rpmbuild || true)
   if [[ ! "$FPM" = "" && ! "$RPMBUILD" = "" ]]; then
     log "creating RPM equivalent"
 

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -123,7 +123,11 @@ function build_target() {
 
 function check_deterministic() {
   # Expect the project to have been built.
-  DAEMON=build/$DISTRO/osquery/osqueryd
+  ALIAS=$DISTRO
+  if [[ "$OS" = "darwin" ]]; then
+    ALIAS=darwin
+  fi
+  DAEMON=build/$ALIAS/osquery/osqueryd
   strip $DAEMON
   RUN1=$(shasum -a 256 $DAEMON)
 


### PR DESCRIPTION
This fixes the aync tests in Jenkins that build `packages` and detect deterministic build failures.