### PR TITLE
Lucid package build fixes

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -117,8 +117,7 @@ function main() {
   platform OS
   distro $OS DISTRO
 
-  touch "$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"
-  OUTPUT_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"`
+  OUTPUT_PKG_PATH=`realpath "$BUILD_DIR"`/$PACKAGE_NAME$(get_pkg_suffix)
 
   rm -rf $WORKING_DIR
   rm -f $OUTPUT_PKG_PATH
@@ -261,8 +260,7 @@ function main() {
   fi
 
   PACKAGE_DEBUG_DEPENDENCIES=`echo "$PACKAGE_DEBUG_DEPENDENCIES"|tr '-' '_'`
-  touch "$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"
-  OUTPUT_DEBUG_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"`
+  OUTPUT_DEBUG_PKG_PATH=`realpath "$BUILD_DIR"`/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)
   if [[ ! -z "$DEBUG" ]]; then
     rm -f $OUTPUT_DEBUG_PKG_PATH
     CMD="$FPM -s dir -t $PACKAGE_TYPE            \

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -117,6 +117,7 @@ function main() {
   platform OS
   distro $OS DISTRO
 
+  touch "$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"
   OUTPUT_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_NAME$(get_pkg_suffix)"`
 
   rm -rf $WORKING_DIR
@@ -264,6 +265,7 @@ function main() {
   fi
 
   PACKAGE_DEBUG_DEPENDENCIES=`echo "$PACKAGE_DEBUG_DEPENDENCIES"|tr '-' '_'`
+  touch "$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"
   OUTPUT_DEBUG_PKG_PATH=`realpath "$BUILD_DIR/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)"`
   if [[ ! -z "$DEBUG" ]]; then
     rm -f $OUTPUT_DEBUG_PKG_PATH

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -184,12 +184,8 @@ function main() {
     PACKAGE_DEPENDENCIES="$PACKAGE_DEPENDENCIES -d \"$element\""
   done
 
-  platform OS
-  distro $OS DISTRO
-  FPM="fpm"
-  if [[ $DISTRO == "lucid" ]]; then
-    FPM="/var/lib/gems/1.8/bin/fpm"
-  fi
+  # Let callers provide their own fpm if desired
+  FPM=${FPM:="fpm"}
 
   POSTINST_CMD=""
   if [[ $OSQUERY_POSTINSTALL != "" ]] && [[ -f $OSQUERY_POSTINSTALL ]]; then


### PR DESCRIPTION
This PR contains a few minor bugfixes to the packaging script that I encountered while trying to get the osquery package to build on lucid. For reference, here is the [dockerfile](https://github.com/danielpops/osquery-lucid-build/blob/master/Dockerfile) I've been using to build on top of the ubuntu/lucid base image.

For the FPM thing, I originally was having difficulties getting FPM `gem install`ed with the apt-get installed version of ruby, so I decided to build the latest and greatest ruby from source. But then I observed the following failure when trying to build:

```
[+] creating deb package (for upstart)
/osquery/osquery/tools/deployment/make_linux_package.sh: line 220: /var/lib/gems/1.8/bin/fpm: No such file or directory
```

For the realpath thing, I'm actually not sure how it could work as-is for anyone, since realpath fails if the file doesn't actually exist:
```
Building linux packages (no custom config)
/osquery/osquery/tools/deployment/../../build/linux/osquery_2.1.2-45-g93ce41b_1.14.amd64.deb: No such file or directory
```

And as a sanity test:

```
danielpops@danielpops-dev:~/scratch/osquery $ realpath ./foo.txt
./foo.txt: No such file or directory
danielpops@danielpops-dev:~/scratch/osquery $ echo $?
1
danielpops@danielpops-dev:~/scratch/osquery $ touch ./foo.txt
danielpops@danielpops-dev:~/scratch/osquery $ realpath ./foo.txt
/home/danielpops/scratch/osquery/foo.txt
danielpops@danielpops-dev:~/scratch/osquery $ echo $?
0
```