### PR TITLE
add XcodeGhost dropped files

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -340,6 +340,20 @@
       "interval" : "86400",
       "description" : "OceanLotus dropped file (https://www.alienvault.com/blogs/labs-research/oceanlotus-for-os-x-an-application-bundle-pretending-to-be-an-adobe-flash-update)",
       "value" : "Artifact used by this malware"
+    },
+    "XcodeGhost": {
+      "query" : "select * from ( \
+        select apps.bundle_short_version as xcode_version, \
+          apps.path as xcode_path, \
+          file.path, \
+          file.type as file_type \
+        from apps, file \
+        where apps.bundle_name='Xcode' and \
+          file.path like (apps.path || '/Contents/Developer/Platforms/%/Developer/SDKs/Library/%%') \
+      ) join hash using (path) where file_type = 'regular';"
+      "interval" : "86400",
+      "description" : "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
+      "value" : "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Add xcode ghost iocs from:

http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/