### PR TITLE
[Fix #2744] Increase amount of logged messages

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -202,7 +202,7 @@ void restoreScheduleBlacklist(std::map<std::string, size_t>& blacklist) {
   getDatabaseValue(kPersistentSettings, kFailedQueries, content);
   auto blacklist_pairs = osquery::split(content, ":");
   if (blacklist_pairs.size() == 0 || blacklist_pairs.size() % 2 != 0) {
-    // Nothing in the blacklist, or malformed data.
+    VLOG(1) << "Failed to restore blacklist (no entries/malformed data)";
     return;
   }
 
@@ -265,7 +265,7 @@ void Config::addPack(const std::string& name,
             source + FLAGS_pack_delimiter + pack_name, pack_tree, true);
       }
     } catch (const std::exception& e) {
-      LOG(WARNING) << "Error adding pack: " << pack_name << ": " << e.what();
+      LOG(WARNING) << "Error adding pack " << pack_name << ": " << e.what();
     }
   });
 
@@ -380,6 +380,7 @@ Status Config::load() {
   valid_ = false;
   auto config_plugin = RegistryFactory::get().getActive("config");
   if (!RegistryFactory::get().exists("config", config_plugin)) {
+    LOG(WARNING) << "Missing config plugin: " << config_plugin;
     return Status(1, "Missing config plugin " + config_plugin);
   }
 
@@ -424,8 +425,9 @@ Status Config::updateSource(const std::string& source,
     std::stringstream json_stream;
     json_stream << clone;
     pt::read_json(json_stream, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    return Status(1, "Error parsing the config JSON");
+  } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Error parsing the config JSON: " << e.what();
+    return Status(1, e.what());
   }
 
   // extract the "schedule" key and store it as the main pack
@@ -443,7 +445,8 @@ Status Config::updateSource(const std::string& source,
     for (const std::pair<std::string, pt::ptree>& query : scheduled_queries) {
       auto query_name = query.second.get<std::string>("name", "");
       if (query_name.empty()) {
-        return Status(1, "Error getting name from legacy scheduled query");
+        LOG(WARNING) << "Error getting name from legacy scheduled query";
+        return Status(1, "Failed to get query name");
       }
       queries.add_child(query_name, query.second);
     }
@@ -481,6 +484,7 @@ Status Config::genPack(const std::string& name,
   Registry::call("config", request, response);
 
   if (response.size() == 0 || response[0].count(name) == 0) {
+    LOG(WARNING) << "Invalid plugin response";
     return Status(1, "Invalid plugin response");
   }
 
@@ -494,6 +498,7 @@ Status Config::genPack(const std::string& name,
     addPack(name, source, pack_tree);
   } catch (const pt::json_parser::json_parser_error& /* e */) {
     LOG(WARNING) << "Error parsing the pack JSON: " << name;
+    return Status(1, "Failed to parse pack");
   }
   return Status(0);
 }
@@ -623,6 +628,7 @@ void Config::purge() {
       last_executed = boost::lexical_cast<size_t>(content);
     } catch (const boost::bad_lexical_cast& /* e */) {
       // Erase the timestamp as is it potentially corrupt.
+      VLOG(1) << "Potentially corrupted timestamp erased: " << saved_query;
       deleteDatabaseValue(kPersistentSettings, "timestamp." + saved_query);
       continue;
     }
@@ -651,7 +657,8 @@ void Config::reset() {
     std::shared_ptr<ConfigParserPlugin> parser = nullptr;
     try {
       parser = std::dynamic_pointer_cast<ConfigParserPlugin>(plugin.second);
-    } catch (const std::bad_cast& /* e */) {
+    } catch (const std::bad_cast& e) {
+      VLOG(1) << "Error retrieving pointer: " << e.what();
       continue;
     }
     if (parser == nullptr || parser.get() == nullptr) {
@@ -743,7 +750,8 @@ void Config::hashSource(const std::string& source, const std::string& content) {
 
 Status Config::genHash(std::string& hash) {
   if (!valid_) {
-    return Status(1, "Current config is not valid");
+    LOG(WARNING) << "Current config is not valid";
+    return Status(1, "Invalid config");
   }
 
   WriteLock lock(config_hash_mutex_);
@@ -787,13 +795,15 @@ void Config::files(
 Status ConfigPlugin::genPack(const std::string& name,
                              const std::string& value,
                              std::string& pack) {
+  VLOG(1) << "Not implemented";
   return Status(1, "Not implemented");
 }
 
 Status ConfigPlugin::call(const PluginRequest& request,
                           PluginResponse& response) {
   if (request.count("action") == 0) {
-    return Status(1, "Config plugins require an action in PluginRequest");
+    LOG(WARNING) << "Config plugins require an action in PluginRequest";
+    return Status(1, "Config plugins missing action");
   }
 
   if (request.at("action") == "genConfig") {
@@ -803,7 +813,8 @@ Status ConfigPlugin::call(const PluginRequest& request,
     return stat;
   } else if (request.at("action") == "genPack") {
     if (request.count("name") == 0 || request.count("value") == 0) {
-      return Status(1, "Missing name or value");
+      LOG(WARNING) << "Missing request name or value";
+      return Status(1, "Missing name/value");
     }
     std::string pack;
     auto stat = genPack(request.at("name"), request.at("value"), pack);
@@ -811,11 +822,13 @@ Status ConfigPlugin::call(const PluginRequest& request,
     return stat;
   } else if (request.at("action") == "update") {
     if (request.count("source") == 0 || request.count("data") == 0) {
-      return Status(1, "Missing source or data");
+      LOG(WARNING) << "Missing request source or data";
+      return Status(1, "Missing source/data");
     }
     return Config::getInstance().update(
         {{request.at("source"), request.at("data")}});
   }
+  LOG(ERROR) << "Config plugin action unknown: " << request.at("action");
   return Status(1, "Config plugin action unknown: " + request.at("action"));
 }
 

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -71,6 +71,8 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     for (const auto& path : category.second) {
       auto pattern = path.second.get_value<std::string>("");
       if (pattern.empty()) {
+        VLOG(1) << "Empty pattern from path " << path.first
+                << " in config source: " << source;
         continue;
       }
       replaceGlobWildcards(pattern);

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -44,6 +44,8 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
   for (const auto& option : options) {
     std::string value = options.get<std::string>(option.first, "");
     if (value.empty()) {
+      VLOG(1) << "Empty option value from " << option.first
+              << " in config source: " << source;
       continue;
     }
 

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -46,7 +46,8 @@ Status FilesystemConfigPlugin::genConfig(
   boost::system::error_code ec;
   if (!fs::is_regular_file(FLAGS_config_path, ec) ||
       ec.value() != errc::success) {
-    return Status(1, "config file does not exist: " + FLAGS_config_path);
+    LOG(WARNING) << "Config file does not exist: " << FLAGS_config_path;
+    return Status(1, FLAGS_config_path);
   }
 
   std::vector<std::string> conf_files;
@@ -101,7 +102,8 @@ Status FilesystemConfigPlugin::genPack(const std::string& name,
     pt::write_json(output, multi_pack, false);
     pack = output.str();
     if (pack.empty()) {
-      return Status(1, "Multi-pack content empty");
+      LOG(WARNING) << "Multi-pack content empty for value " << value;
+      return Status(1, value);
     }
 
     return Status(0);
@@ -109,7 +111,8 @@ Status FilesystemConfigPlugin::genPack(const std::string& name,
 
   boost::system::error_code ec;
   if (!fs::is_regular_file(value, ec) || ec.value() != errc::success) {
-    return Status(1, value + " is not a valid path");
+    LOG(WARNING) << "Invalid path for requested pack: " << value;
+    return Status(1, value);
   }
 
   return readFile(value, pack);

--- a/osquery/config/plugins/tls.cpp
+++ b/osquery/config/plugins/tls.cpp
@@ -70,7 +70,8 @@ Status TLSConfigPlugin::setUp() {
     auto node_key = getNodeKey("tls");
     if (node_key.size() == 0) {
       // Could not generate a node key, continue logging to stderr.
-      return Status(1, "No node key, TLS config failed.");
+      LOG(WARNING) << "Error generating node key, TLS config failed";
+      return Status(1);
     }
   }
 
@@ -144,6 +145,7 @@ void TLSConfigRefreshRunner::start() {
     // Since the pause occurs before the logic, we need to check for an
     // interruption request.
     if (interrupted()) {
+      VLOG(1) << "TLS Config refresh was interrupted by request";
       return;
     }
 

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -17,6 +17,8 @@
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/uuid/sha1.hpp>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/conversions.h"
 
 namespace bai = boost::archive::iterators;
@@ -46,6 +48,7 @@ std::string base64Decode(const std::string& encoded) {
   }
 
   if (size == 0) {
+    VLOG(1) << "Nothing to decode, empty input string";
     return "";
   }
 
@@ -60,6 +63,7 @@ std::string base64Encode(const std::string& unencoded) {
   std::stringstream os;
 
   if (unencoded.size() == 0) {
+    VLOG(1) << "Nothing to encode, empty input string";
     return std::string();
   }
 

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <osquery/flags.h>
+#include <osquery/logger.h>
 
 namespace boost {
 template <>
@@ -44,7 +45,8 @@ int Flag::createAlias(const std::string& alias, const FlagDetail& flag) {
 Status Flag::getDefaultValue(const std::string& name, std::string& value) {
   flags::CommandLineFlagInfo info;
   if (!flags::GetCommandLineFlagInfo(name.c_str(), &info)) {
-    return Status(1, "Flags name not found.");
+    LOG(WARNING) << "Flags name not found: " << name;
+    return Status(1, "Flags name not found: " + name);
   }
 
   value = info.default_value;
@@ -95,7 +97,8 @@ Status Flag::updateValue(const std::string& name, const std::string& value) {
     flags::SetCommandLineOption(real_name.c_str(), value.c_str());
     return Status(0, "OK");
   }
-  return Status(1, "Flag not found");
+  LOG(WARNING) << "Flag not found: " << name;
+  return Status(1, "Flag not found: " + name);
 }
 
 std::map<std::string, FlagInfo> Flag::flags() {
@@ -105,7 +108,7 @@ std::map<std::string, FlagInfo> Flag::flags() {
   std::map<std::string, FlagInfo> flags;
   for (const auto& flag : info) {
     if (instance().flags_.count(flag.name) == 0) {
-      // This flag info was not defined within osquery.
+      VLOG(1) << "Flag not defined within osquery: " << flag.name;
       continue;
     }
 
@@ -161,7 +164,8 @@ void Flag::printFlags(bool shell, bool external, bool cli) {
         continue;
       }
     } else {
-      // This flag was not defined as an osquery flag or flag alias.
+      VLOG(1) << "Flag or flag alias not defined within osquery: "
+              << flag.second->name;
       continue;
     }
 

--- a/osquery/core/posix/utils.cpp
+++ b/osquery/core/posix/utils.cpp
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/utils.h"
 
 namespace osquery {
@@ -29,10 +31,12 @@ std::string platformStrerr(int errnum) {
 
 Status platformStrncpy(char* dst, size_t nelms, const char* src, size_t count) {
   if (dst == nullptr || src == nullptr || nelms == 0) {
+    LOG(WARNING) << "Failed to strncpy: invalid arguments";
     return Status(1, "Failed to strncpy: invalid arguments");
   }
 
   if (count > nelms) {
+    LOG(WARNING) << "Failed to strncpy: dst too small";
     return Status(1, "Failed to strncpy: dst too small");
   }
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -228,8 +228,9 @@ Status checkStalePid(const std::string& content) {
   int pid;
   try {
     pid = boost::lexical_cast<int>(content);
-  } catch (const boost::bad_lexical_cast& /* e */) {
-    return Status(0, "Could not parse pid from existing pidfile");
+  } catch (const boost::bad_lexical_cast& e) {
+    LOG(WARNING) << "Could not parse pid from existing pidifle: " << e.what();
+    return Status(0, e.what());
   }
 
   PlatformProcess target(pid);
@@ -274,6 +275,7 @@ Status createPidFile() {
     std::string content;
     auto read_status = readFile(pidfile_path, content, true);
     if (!read_status.ok()) {
+      LOG(WARNING) << "Could not read pidfile: " << read_status.toString();
       return Status(1, "Could not read pidfile: " + read_status.toString());
     }
 
@@ -287,7 +289,6 @@ Status createPidFile() {
   try {
     boost::filesystem::remove(pidfile_path);
   } catch (const boost::filesystem::filesystem_error& /* e */) {
-    // Unable to remove old pidfile.
     LOG(WARNING) << "Unable to remove the osqueryd pidfile";
   }
 

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -15,6 +15,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/process.h"
 
 namespace osquery {
@@ -129,8 +131,10 @@ std::shared_ptr<PlatformProcess> PlatformProcess::getLauncherProcess() {
     handle = reinterpret_cast<HANDLE>(static_cast<std::uintptr_t>(
         std::stoull(*launcher_handle, nullptr, 16)));
   } catch (std::invalid_argument e) {
+    LOG(WARNING) << "Error retrieving handle: " << e.what();
     return std::make_shared<PlatformProcess>();
   } catch (std::out_of_range e) {
+    LOG(WARNING) << "Error retrieving handle: " << e.what();
     return std::make_shared<PlatformProcess>();
   }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -69,6 +69,7 @@ Status serializeRow(const Row& r, pt::ptree& tree) {
       tree.put<std::string>(i.first, i.second);
     }
   } catch (const std::exception& e) {
+    LOG(WARNING) << "Error serializing row: " << e.what();
     return Status(1, e.what());
   }
   return Status(0, "OK");
@@ -96,7 +97,7 @@ Status serializeRowJSON(const Row& r, std::string& json) {
   try {
     pt::write_json(output, tree, false);
   } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
+    LOG(WARNING) << "Error serializing row as JSON: " << e.what();
     return Status(1, e.what());
   }
   json = output.str();
@@ -119,6 +120,7 @@ Status deserializeRowJSON(const std::string& json, Row& r) {
     input << json;
     pt::read_json(input, tree);
   } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Error deserializing row from JSON: " << e.what();
     return Status(1, e.what());
   }
   return deserializeRow(tree, r);
@@ -161,7 +163,7 @@ Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
   try {
     pt::write_json(output, tree, false);
   } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
+    LOG(WARNING) << "Error serializing query data as JSON: " << e.what();
     return Status(1, e.what());
   }
   json = output.str();
@@ -187,6 +189,7 @@ Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
     input << json;
     pt::read_json(input, tree);
   } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Error deserializing query data from JSON: " << e.what();
     return Status(1, e.what());
   }
   return deserializeQueryData(tree, qd);
@@ -241,7 +244,7 @@ Status serializeDiffResultsJSON(const DiffResults& d, std::string& json) {
   try {
     pt::write_json(output, tree, false);
   } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
+    LOG(WARNING) << "Error serializing diff results as JSON: " << e.what();
     return Status(1, e.what());
   }
   json = output.str();
@@ -339,7 +342,7 @@ Status serializeQueryLogItemJSON(const QueryLogItem& i, std::string& json) {
   try {
     pt::write_json(output, tree, false);
   } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
+    LOG(WARNING) << "Error serializing query log item as JSON: " << e.what();
     return Status(1, e.what());
   }
   json = output.str();
@@ -373,6 +376,8 @@ Status deserializeQueryLogItemJSON(const std::string& json,
     input << json;
     pt::read_json(input, tree);
   } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Error deserializing query log item from JSON: "
+                 << e.what();
     return Status(1, e.what());
   }
   return deserializeQueryLogItem(tree, item);
@@ -427,6 +432,7 @@ Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& i,
     try {
       pt::write_json(output, event.second, false);
     } catch (const pt::json_parser::json_parser_error& e) {
+      LOG(WARNING) << "Error serializing query log item as JSON: " << e.what();
       return Status(1, e.what());
     }
     items.push_back(output.str());

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -286,8 +286,8 @@ rocksdb::ColumnFamilyHandle* RocksDBDatabasePlugin::getHandleForColumnFamily(
         return handles_[i];
       }
     }
-  } catch (const std::exception& /* e */) {
-    // pass through and return nullptr
+  } catch (const std::exception& e) {
+    VLOG(1) << "Failed to retrieve handles: " << e.what();
   }
   return nullptr;
 }

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -63,7 +63,7 @@ void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
   try {
     point_.pause(milli);
   } catch (const RunnerInterruptError&) {
-    // The pause request was canceled.
+    VLOG(1) << "The pause request was cancelled";
   }
 }
 

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -108,7 +108,8 @@ Status Distributed::serializeResults(std::string& json) {
   try {
     pt::write_json(ss, results, false);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error writing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error serializing JSON: " << e.what();
+    return Status(1, e.what());
   }
   json = ss.str();
 
@@ -145,7 +146,8 @@ Status Distributed::flushCompleted() {
 
   auto distributed_plugin = RegistryFactory::get().getActive("distributed");
   if (!RegistryFactory::get().exists("distributed", distributed_plugin)) {
-    return Status(1, "Missing distributed plugin " + distributed_plugin);
+    LOG(WARNING) << "Missing distributed plugin: " << distributed_plugin;
+    return Status(1, "Missing distributed plugin: " + distributed_plugin);
   }
 
   std::string results;
@@ -176,6 +178,7 @@ Status Distributed::acceptWork(const std::string& work) {
     for (const auto& node : queries) {
       auto query = queries.get<std::string>(node.first, "");
       if (query.empty() || node.first.empty()) {
+        LOG(WARNING) << "Distributed query does not have complete attributes";
         return Status(1, "Distributed query does not have complete attributes");
       }
       setDatabaseValue(kQueries, kDistributedQueryPrefix + node.first, query);
@@ -197,7 +200,8 @@ Status Distributed::acceptWork(const std::string& work) {
     }
 
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error parsing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error parsing JSON: " << e.what();
+    return Status(1, e.what());
   }
 
   return Status(0, "OK");
@@ -236,7 +240,8 @@ Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
   try {
     pt::write_json(ss, tree, false);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error serializing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error serializing query request as JSON: " << e.what();
+    return Status(1, e.what());
   }
   json = ss.str();
 
@@ -257,7 +262,8 @@ Status deserializeDistributedQueryRequestJSON(const std::string& json,
   try {
     pt::read_json(ss, tree);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error serializing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error deserializing query request from JSON: " << e.what();
+    return Status(1, e.what());
   }
   return deserializeDistributedQueryRequest(tree, r);
 }
@@ -294,7 +300,8 @@ Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
   try {
     pt::write_json(ss, tree, false);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error serializing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error serializing query result as JSON: " << e.what();
+    return Status(1, e.what());
   }
   json = ss.str();
 
@@ -329,7 +336,8 @@ Status deserializeDistributedQueryResultJSON(const std::string& json,
     std::stringstream ss(json);
     pt::read_json(ss, tree);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error serializing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error deserializing query result from JSON: " << e.what();
+    return Status(1, e.what());
   }
   return deserializeDistributedQueryResult(tree, r);
 }

--- a/osquery/distributed/plugins/tls.cpp
+++ b/osquery/distributed/plugins/tls.cpp
@@ -82,7 +82,8 @@ Status TLSDistributedPlugin::writeResults(const std::string& json) {
     std::stringstream ss(json);
     pt::read_json(ss, params);
   } catch (const pt::ptree_error& e) {
-    return Status(1, "Error parsing JSON: " + std::string(e.what()));
+    LOG(WARNING) << "Error parsing JSON: " << e.what();
+    return Status(1, e.what());
   }
 
   // The response is ignored.

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -661,8 +661,9 @@ Status EventFactory::registerEventPublisher(const PluginRef& pub) {
   try {
     auto base_pub = std::dynamic_pointer_cast<EventPublisherPlugin>(pub);
     specialized_pub = std::static_pointer_cast<BaseEventPublisher>(base_pub);
-  } catch (const std::bad_cast& /* e */) {
-    return Status(1, "Incorrect plugin");
+  } catch (const std::bad_cast& e) {
+    LOG(WARNING) << "Error converting plugin to event publisher: " << e.what();
+    return Status(1, e.what());
   }
 
   if (specialized_pub == nullptr || specialized_pub.get() == nullptr) {
@@ -707,8 +708,9 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
   try {
     auto base_sub = std::dynamic_pointer_cast<EventSubscriberPlugin>(sub);
     specialized_sub = std::static_pointer_cast<BaseEventSubscriber>(base_sub);
-  } catch (const std::bad_cast& /* e */) {
-    return Status(1, "Incorrect plugin");
+  } catch (const std::bad_cast& e) {
+    LOG(WARNING) << "Error converting plugin to event publisher: " << e.what();
+    return Status(1, e.what());
   }
 
   if (specialized_sub == nullptr || specialized_sub.get() == nullptr) {
@@ -799,7 +801,8 @@ size_t EventFactory::numSubscriptions(EventPublisherID& type_id) {
   EventPublisherRef publisher;
   try {
     publisher = EventFactory::getInstance().getEventPublisher(type_id);
-  } catch (std::out_of_range& /* e */) {
+  } catch (std::out_of_range& e) {
+    VLOG(1) << "Failed to get event publisher reference: " << e.what();
     return 0;
   }
   return publisher->numSubscriptions();

--- a/osquery/events/kernel.cpp
+++ b/osquery/events/kernel.cpp
@@ -51,11 +51,13 @@ Status KernelEventPublisher::setUp() {
     queue_ = new CQueue(kKernelDevice, kKernelQueueSize);
   } catch (const CQueueException &e) {
     queue_ = nullptr;
+    LOG(WARNING) << "Error initializing kernel structures: " << e.what();
     return Status(1, e.what());
   }
 
   if (queue_ == nullptr) {
-    return Status(1, "Could not allocate CQueue object");
+    LOG(WARNING) << "Error allocating kernel structures";
+    return Status(1, "Error allocating kernel structures");
   }
 
   return Status(0, "OK");

--- a/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
+++ b/osquery/events/kernel/benchmarks/kernel_communication_benchmarks.cpp
@@ -15,6 +15,7 @@
 #include <benchmark/benchmark.h>
 
 #include <osquery/dispatcher.h>
+#include <osquery/logger.h>
 
 #include "osquery/events/kernel.h"
 
@@ -27,7 +28,7 @@ static inline void producerThread(benchmark::State &state) {
   try {
     queue = std::unique_ptr<CQueue>(new CQueue(kKernelDevice, 8 * (1 << 20)));
   } catch (const CQueueException &e) {
-    // The device interface cannot be found or cannot be opened.
+    VLOG(1) << "Device interface cannot be found or opened: " << e.what();
   }
 
   osquery_event_t event;

--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -19,6 +19,7 @@
 #include <boost/algorithm/hex.hpp>
 
 #include <osquery/events.h>
+#include <osquery/logger.h>
 
 namespace osquery {
 
@@ -154,6 +155,7 @@ inline std::string decodeAuditValue(const std::string& s) {
   try {
     return boost::algorithm::unhex(s);
   } catch (const boost::algorithm::hex_decode_error& e) {
+    VLOG(1) << "Failed to decode audit value: " << e.what();
     return s;
   }
 }

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -130,8 +130,9 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
         auto client = EXManagerClient(path);
         client.get()->ping(status);
         return Status(0, "OK");
-      } catch (const std::exception& /* e */) {
+      } catch (const std::exception& e) {
         // Path might exist without a connected extension or extension manager.
+        VLOG(1) << "Error retrieving connected extension: " << e.what();
       }
     }
     // Only check active once if this check does not allow a timeout.
@@ -190,7 +191,8 @@ void ExtensionWatcher::watch() {
       auto client = EXManagerClient(path_);
       // Ping the extension manager until it goes down.
       client.get()->ping(status);
-    } catch (const std::exception& /* e */) {
+    } catch (const std::exception& e) {
+      VLOG(1) << "Error retrieving extension manager: " << e.what();
       core_sane = false;
     }
   } else {
@@ -234,7 +236,8 @@ void ExtensionManagerWatcher::watch() {
         auto client = EXClient(path);
         // Ping the extension until it goes down.
         client.get()->ping(status);
-      } catch (const std::exception& /* e */) {
+      } catch (const std::exception& e) {
+        VLOG(1) << "Error retrieving extension: " << e.what();
         failures_[uuid] += 1;
         continue;
       }
@@ -487,7 +490,8 @@ Status startExtension(const std::string& manager_path,
     // logger and config.
     client.get()->options(options);
   } catch (const std::exception& e) {
-    return Status(1, "Extension register failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to register extension: " << e.what();
+    return Status(1, e.what());
   }
 
   // Now that the UUID is known, try to clean up stale socket paths.
@@ -529,7 +533,8 @@ Status queryExternal(const std::string& manager_path,
     auto client = EXManagerClient(manager_path);
     client.get()->query(response, query);
   } catch (const std::exception& e) {
-    return Status(1, "Extension call failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to call extension: " << e.what();
+    return Status(1, e.what());
   }
 
   for (const auto& row : response.response) {
@@ -557,7 +562,8 @@ Status getQueryColumnsExternal(const std::string& manager_path,
     auto client = EXManagerClient(manager_path);
     client.get()->getQueryColumns(response, query);
   } catch (const std::exception& e) {
-    return Status(1, "Extension call failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to call extension: " << e.what();
+    return Status(1, e.what());
   }
 
   // Translate response map: {string: string} to a vector: pair(name, type).
@@ -592,7 +598,8 @@ Status pingExtension(const std::string& path) {
     auto client = EXClient(path);
     client.get()->ping(ext_status);
   } catch (const std::exception& e) {
-    return Status(1, "Extension call failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to call extension: " << e.what();
+    return Status(1, e.what());
   }
 
   return Status(ext_status.code, ext_status.message);
@@ -618,7 +625,8 @@ Status getExtensions(const std::string& manager_path,
     auto client = EXManagerClient(manager_path);
     client.get()->extensions(ext_list);
   } catch (const std::exception& e) {
-    return Status(1, "Extension call failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to call extension: " << e.what();
+    return Status(1, e.what());
   }
 
   // Add the extension manager to the list called (core).
@@ -663,7 +671,8 @@ Status callExtension(const std::string& extension_path,
     auto client = EXClient(extension_path);
     client.get()->call(ext_response, registry, item, request);
   } catch (const std::exception& e) {
-    return Status(1, "Extension call failed: " + std::string(e.what()));
+    LOG(WARNING) << "Failed to call extension: " << e.what();
+    return Status(1, e.what());
   }
 
   // Convert from Thrift-internal list type to PluginResponse type.

--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -202,7 +202,8 @@ Status parsePlist(const fs::path& path, pt::ptree& tree) {
     @try {
       // Parse the plist data into a core foundation dictionary-literal.
       status = filterPlist(plist_data, tree);
-    } @catch (NSException* exception) {
+    } @catch (NSException* e) {
+      LOG(WARNING) << "Plist data is corrupted";
       status = Status(1, "Plist data is corrupted");
     }
     [stream close];

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -495,8 +495,9 @@ Status parseJSONContent(const std::string& content, pt::ptree& tree) {
     std::stringstream json_stream;
     json_stream << content;
     pt::read_json(json_stream, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    return Status(1, "Could not parse JSON from file");
+  } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Failed to parse JSON from file: " << e.what();
+    return Status(1, e.what());
   }
   return Status(0, "OK");
 }

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -54,7 +54,9 @@ Status procDescriptors(const std::string& process,
       }
     }
   } catch (boost::filesystem::filesystem_error& e) {
-    return Status(1, "Cannot access descriptors for " + process);
+    LOG(WARNING) << "Cannot access descriptors for " << process << ": "
+                 << e.what();
+    return Status(1, e.what());
   }
 
   return Status(0, "OK");

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -288,7 +288,8 @@ static void deserializeIntermediateLog(const PluginRequest& request,
     std::stringstream input;
     input << request.at("log");
     pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
+  } catch (const pt::json_parser::json_parser_error& e) {
+    LOG(WARNING) << "Error deserializing log: " << e.what();
     return;
   }
 

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -272,7 +272,8 @@ Status getAWSRegionFromProfile(std::string& region) {
         GetProfileDirectory();
     pt::ini_parser::read_ini(profile_dir + "/config", tree);
   } catch (const pt::ini_parser::ini_parser_error& e) {
-    return Status(1, std::string("Error reading profile file: ") + e.what());
+    LOG(ERROR) << "Error reading profile file: " << e.what();
+    return Status(1, e.what());
   }
 
   // Profile names are prefixed with "profile ", except for "default".

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -17,6 +17,7 @@
 #include <osquery/database.h>
 #include <osquery/enroll.h>
 #include <osquery/flags.h>
+#include <osquery/logger.h>
 #include <osquery/registry.h>
 #include <osquery/system.h>
 
@@ -207,7 +208,7 @@ Status BufferedLogForwarder::logStatus(const std::vector<StatusLogLine>& log,
       pt::write_json(json_output, buffer, false);
       json = json_output.str();
     } catch (const pt::json_parser::json_parser_error& e) {
-      // The log could not be represented as JSON.
+      LOG(WARNING) << "Error converting to JSON: " << e.what();
       return Status(1, e.what());
     }
 

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -104,6 +104,8 @@ Status FilesystemLoggerPlugin::logStringToFile(const std::string& s,
                            FLAGS_logger_mode,
                            true);
   } catch (const std::exception& e) {
+    LOG(WARNING) << "Error writing to file " << log_path_.string() << "/"
+                 << filename << ": " << e.what();
     return Status(1, e.what());
   }
   return status;

--- a/osquery/logger/plugins/tls.cpp
+++ b/osquery/logger/plugins/tls.cpp
@@ -110,8 +110,9 @@ Status TLSLogForwarder::send(std::vector<std::string>& log_data,
                 input << item;
                 std::string().swap(item);
                 pt::read_json(input, child);
-              } catch (const pt::json_parser::json_parser_error& /* e */) {
+              } catch (const pt::json_parser::json_parser_error& e) {
                 // The log line entered was not valid JSON, skip it.
+                LOG(WARNING) << "Error reading JSON: " << e.what();
                 return;
               }
               children.push_back(std::make_pair("", std::move(child)));

--- a/osquery/main/lib.cpp
+++ b/osquery/main/lib.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <osquery/core.h>
+#include <osquery/logger.h>
 
 #include "osquery/core/conversions.h"
 
@@ -57,7 +58,8 @@ bool versionAtLeast(const std::string& v, const std::string& sdk) {
       } else if (std::stoi(chunk) > std::stoi(required_version[index])) {
         return true;
       }
-    } catch (const std::invalid_argument& /* e */) {
+    } catch (const std::invalid_argument& e) {
+      VLOG(1) << "Failed to parse version number: " << e.what();
       if (chunk.compare(required_version[index]) < 0) {
         return false;
       }

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -643,8 +643,8 @@ void Plugin::setResponse(const std::string& key,
   std::ostringstream output;
   try {
     boost::property_tree::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    // The plugin response could not be serialized.
+  } catch (const pt::json_parser::json_parser_error& e) {
+    VLOG(1) << "Error serializing plugin response: " << e.what();
   }
   response.push_back({{key, output.str()}});
 }

--- a/osquery/remote/serializers/json.cpp
+++ b/osquery/remote/serializers/json.cpp
@@ -21,7 +21,8 @@ Status JSONSerializer::serialize(const pt::ptree& params,
   try {
     pt::write_json(output, params, false);
   } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, std::string("JSON serialize error: ") + e.what());
+    LOG(WARNING) << "Error serializing JSON: " << e.what();
+    return Status(1, e.what());
   }
   serialized = output.str();
   return Status(0, "OK");
@@ -41,7 +42,8 @@ Status JSONSerializer::deserialize(const std::string& serialized,
     input << serialized;
     pt::read_json(input, params);
   } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, std::string("JSON deserialize error: ") + e.what());
+    LOG(WARNING) << "Error deserializing JSON: " << e.what();
+    return Status(1, e.what());
   }
   return Status(0, "OK");
 }

--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -133,8 +133,7 @@ TEST_F(TLSTransportsTests, test_call_verify_peer) {
     // error or request-connection problem.
     EXPECT_EQ(status.getCode(), 2);
     if (!nameError(status)) {
-      EXPECT_EQ(status.getMessage(),
-                "Request error: certificate verify failed");
+      EXPECT_EQ(status.getMessage(), "certificate verify failed");
     }
   }
 }

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -177,8 +177,8 @@ Status TLSTransport::sendRequest() {
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
   } catch (const std::exception& e) {
-    return Status((tlsFailure(e.what())) ? 2 : 1,
-                  std::string("Request error: ") + e.what());
+    LOG(WARNING) << "Request error: " << e.what();
+    return Status((tlsFailure(e.what())) ? 2 : 1, e.what());
   }
   return response_status_;
 }
@@ -222,8 +222,8 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
   } catch (const std::exception& e) {
-    return Status((tlsFailure(e.what())) ? 2 : 1,
-                  std::string("Request error: ") + e.what());
+    LOG(WARNING) << "Request error: " << e.what();
+    return Status((tlsFailure(e.what())) ? 2 : 1, e.what());
   }
   return response_status_;
 }

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -99,6 +99,7 @@ void parseSockAddr(const std::string& saddr, AuditFields& r) {
     try {
       r["socket"] = boost::algorithm::unhex(saddr.substr(begin, end - begin));
     } catch (const boost::algorithm::hex_decode_error& e) {
+      VLOG(1) << "Failed to decode address: " << e.what();
       r["socket"] = "unknown";
     }
   } else {

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -156,7 +156,8 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
   try {
     yaraParser = std::dynamic_pointer_cast<YARAConfigParserPlugin>(parser);
   } catch (const std::bad_cast& e) {
-    return Status(1, "Error casting yara config parser plugin");
+    LOG(WARNING) << "Error casting yara config parser plugin: " << e.what();
+    return Status(1, e.what());
   }
   if (yaraParser == nullptr || yaraParser.get() == nullptr) {
     return Status(1, "Yara parser unknown.");

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -38,14 +38,15 @@ Status getVerifyFlags(SecCSFlags& flags) {
   if (sFlags == 0) {
     auto qd = SQL::selectAllFrom("os_version");
     if (qd.size() != 1) {
-      return Status(-1, "Couldn't determine OS X version");
+      return Status(-1, "Error determining macOS version");
     }
 
     int minorVersion;
     try {
       minorVersion = lexical_cast<int>(qd.front().at("minor"));
     } catch (const bad_lexical_cast& e) {
-      return Status(-1, "Couldn't determine OS X version");
+      LOG(WARNING) << "Error determining macOS version: " << e.what();
+      return Status(-1, e.what());
     }
 
     sFlags = kSecCSStrictValidate | kSecCSCheckAllArchitectures;
@@ -55,7 +56,7 @@ Status getVerifyFlags(SecCSFlags& flags) {
   }
 
   flags = sFlags;
-  return Status(0, "ok");
+  return Status(0, "OK");
 }
 
 // Generate a signature for a single file.

--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -17,6 +17,7 @@
 #include <boost/format.hpp>
 #include <boost/noncopyable.hpp>
 
+#include <osquery/logger.h>
 #include <osquery/tables.h>
 
 namespace osquery {
@@ -402,6 +403,7 @@ float getConvertedValue(const std::string &smcType, const std::string &smcVal) {
   try {
     val = boost::algorithm::unhex(smcVal);
   } catch (const boost::algorithm::hex_decode_error &e) {
+    LOG(WARNING) << "Error converting hex string to decimal: " << e.what();
     return -1.0;
   }
 
@@ -672,6 +674,7 @@ std::string getFanName(const std::string &smcVal) {
   try {
     val = boost::algorithm::unhex(smcVal.substr(8, 24));
   } catch (const boost::algorithm::hex_decode_error &e) {
+    LOG(WARNING) << "Error converting from hex string: " << e.what();
     return "";
   }
 

--- a/osquery/tables/system/darwin/startup_items.cpp
+++ b/osquery/tables/system/darwin/startup_items.cpp
@@ -130,6 +130,7 @@ void genLoginItems(const fs::path& homedir, QueryData& results) {
         results.push_back(r);
       }
     } catch (const pt::ptree_error& e) {
+      VLOG(2) << "Failed to retrieve plist entry: " << e.what();
       continue;
     }
   }

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -155,7 +155,8 @@ void genProcessMap(const std::string& pid, QueryData& results) {
         r["start"] = "0x" + addresses[0];
         r["end"] = "0x" + addresses[1];
       } else {
-        // Problem with the address format.
+        VLOG(1) << "Faulty address format: " << fields[0] << "(PID: " << pid
+                << ")";
         continue;
       }
     }
@@ -164,9 +165,10 @@ void genProcessMap(const std::string& pid, QueryData& results) {
     try {
       auto offset = std::stoll(fields[2], nullptr, 16);
       r["offset"] = (offset != 0) ? BIGINT(offset) : r["start"];
-
     } catch (const std::exception& e) {
       // Value was out of range or could not be interpreted as a hex long long.
+      VLOG(1) << "Error converting value to hex long long: " << fields[2]
+              << "(PID: " << pid << ")";
       r["offset"] = "-1";
     }
     r["device"] = fields[3];
@@ -240,6 +242,8 @@ SimpleProcStat::SimpleProcStat(const std::string& pid) {
       this->start_time = TEXT(AS_LITERAL(BIGINT_LITERAL, details.at(19)) / 100);
     } catch (const boost::bad_lexical_cast& e) {
       this->start_time = "-1";
+      VLOG(1) << "Failed to set stat start time. Stat state: " << this->state
+              << " (PID: " << pid << ")";
     }
   }
 

--- a/osquery/tables/system/posix/suid_bin.cpp
+++ b/osquery/tables/system/posix/suid_bin.cpp
@@ -113,6 +113,7 @@ void genSuidBinsFromPath(const std::string& path, QueryData& results) {
       try {
         ++it;
       } catch (fs::filesystem_error& e) {
+        LOG(WARNING) << "Cannot enumerate files in directory: " << subpath;
         break;
       }
     }

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -151,7 +151,8 @@ QueryData genFile(QueryContext& context) {
       for (; begin != end; ++begin) {
         genFileInfo(begin->path(), directory_string, "", results);
       }
-    } catch (const fs::filesystem_error& /* e */) {
+    } catch (const fs::filesystem_error& e) {
+      VLOG(1) << "Failed to generate info for file: " << e.what();
       continue;
     }
   }


### PR DESCRIPTION
Here's my attempt at increasing the amount of logging throughout the code base. Notes on convention:

- Messages are logged immediately after the thrown error, with the error itself (i.e. "e.what()") included with the return Status as applicable
- In cases where the error causes program termination, LOG(ERROR) is used (this one's obvious)
- In cases where the error causes the function to return early, LOG(WARNING) is used
- In cases where the error doesn't cause the function to return early, but alters its behavior noticeably, VLOG(1) is used
- In cases similar to the above, but where the condition could happen multiple times in quick succession (e.g. try/catch nested inside a loop), VLOG(2) is used

Notably absent from the above scheme is the use of LOG(FATAL), LOG(INFO), and higher levels of VLOG(...)

If there are any recommendations for better use of the various google-glog macros, I'd be happy to discuss them :)