### PR TITLE
Remove warning message during build

### DIFF
--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -107,11 +107,11 @@ class ExtensionsTest : public testing::Test {
     return extensions;
   }
 
-  bool socketExistsLocal(const std::string& socket_path) {
+  bool socketExistsLocal(const std::string& check_path) {
     // Wait until the runnable/thread created the socket.
     int delay = 0;
     while (delay < kTimeout) {
-      if (osquery::socketExists(socket_path).ok()) {
+      if (osquery::socketExists(check_path).ok()) {
         return true;
       }
       sleepFor(kDelay);


### PR DESCRIPTION
Change argument name for function in order to remove warning about its declaration shadowing a member variable.