### PR TITLE
Explicitly set chocolatey source

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -140,7 +140,7 @@ function Install-ChocoPackage {
   $isInstalled = Test-ChocoPackageInstalled $packageName $packageVersion
   if (-not $isInstalled) {
     Write-Host " => Did not find. Installing $packageName $packageVersion" -foregroundcolor Cyan
-    $args = @("install", "-y", "-r", "${packageName}")
+    $args = @("install", "-s", "https://chocolatey.org/api/v2/", "-y", "-r", "${packageName}")
     if ($packageVersion -ne '') {
       $args += @("--version", "${packageVersion}")
     }


### PR DESCRIPTION
We utilize a different chocolatey source internally, but we pull from chocolatey for numerous packages. This commit makes sure that we're explicit about which source we're pulling packages from.