### PR TITLE
Add a new host_identifier option

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -274,6 +274,13 @@ std::string getHostname();
 Status getHostUUID(std::string& ident);
 
 /**
+ * @brief Getter for a more random generated uuid.
+ *
+ * @return ok on success and ident is set to the host's uuid, otherwise failure.
+ */
+Status getGeneratedUUID(std::string& ident);
+
+/**
  * @brief generate a uuid to uniquely identify this machine
  *
  * @return uuid string to identify this machine

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -211,6 +211,13 @@ QueryData genOsqueryInfo(QueryContext& context) {
   QueryData results;
 
   Row r;
+
+  static std::string uuid;
+  if (uuid.size() == 0) {
+    getGeneratedUUID(uuid);
+  }
+  r["uuid"] = uuid;
+
   r["pid"] = INTEGER(PlatformProcess::getCurrentProcess()->pid());
   r["version"] = kVersion;
 

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -1,6 +1,7 @@
 table_name("osquery_info")
 description("Top level information about the running version of osquery.")
 schema([
+    Column("uuid", TEXT, "Universally unique osqueryd instance ID"),
     Column("pid", INTEGER, "Process (or thread/handle) ID"),
     Column("version", TEXT, "osquery toolkit version"),
     Column("config_hash", TEXT, "Hash of the working configuration state"),


### PR DESCRIPTION
This PR does three basic things:

- Updates the number of `host_identifier` options to 3:
  - `uuid`: a universally unique identifier that is likely to be unique among all osquery instances
  - `hardware_id`: a identifier that it likely to be the same on instances of osquery running on the same hardware.
  - `hostname`: just the hostname of the computer. this is the default.
- Revert the functionality of `uuid` to that as it was before #2522 
- Add a `uuid` column to `osquery_info` which includes the osquery instance unique uuid (the `uuid` column of `system_info` will still return the hardware id).