### PR TITLE
Improve RocksDB thread usage and write stalls

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -146,6 +146,8 @@ Status RocksDBDatabasePlugin::setUp() {
 
   if (!initialized_) {
     initialized_ = true;
+    options_.OptimizeForSmallDb();
+
     // Set meta-data (mostly) handling options.
     options_.create_if_missing = true;
     options_.create_missing_column_families = true;
@@ -160,10 +162,11 @@ Status RocksDBDatabasePlugin::setUp() {
     options_.compaction_style = rocksdb::kCompactionStyleLevel;
     options_.arena_block_size = (4 * 1024);
     options_.write_buffer_size = (4 * 1024) * 100; // 100 blocks.
-    options_.max_write_buffer_number = 3;
+    options_.max_write_buffer_number = 4;
     options_.min_write_buffer_number_to_merge = 1;
-    options_.max_background_compactions = 2;
-    options_.max_background_flushes = 2;
+    // Before adding the OptimizeForSmallDB API call we used:
+    //   options_.max_background_compactions = 2;
+    //   options_.max_background_flushes = 2;
 
     // Create an environment to replace the default logger.
     if (logger_ == nullptr) {


### PR DESCRIPTION
This improves RocksDB's write times and overall exceptional impact on the system when using the `system_stress` and Audit benchmarks.

Average impact with `N=10` (before):
```
resident_size = 24404000
   total_size = 783816000
    user_time = 1077
  system_time = 406
```

Average impact with `N=10` (after):
```
resident_size = 30244000
   total_size = 581640000
    user_time = 743
  system_time = 235
```

Compared to using internal structures that bypass RocksDB:
```
resident_size = 27908000
   total_size = 499476000
    user_time = 647
  system_time = 70
```

A subsequent read stress using several `group by` predicates uses high RSS. This is the same with RocksDB and using internal ephemeral structures (`--disable_database`) and is most likely related to the SQLite balloning issue we've created.