### PR TITLE
Fix Linux processes table threads column

### DIFF
--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -229,7 +229,7 @@ static inline SimpleProcStat getProcStat(const std::string& pid) {
     stat.user_time = details.at(11);
     stat.system_time = details.at(12);
     stat.nice = details.at(16);
-    stat.threads = details.at(20);
+    stat.threads = details.at(17);
     try {
       stat.start_time = TEXT(AS_LITERAL(BIGINT_LITERAL, details.at(19)) / 100);
     } catch (const boost::bad_lexical_cast& e) {


### PR DESCRIPTION
This was reporting the offset from the documented `/proc/N/stat` field, we walk 3 items before splitting the `stat` details.