### PR TITLE
[windows] add virtual table for patches

### DIFF
--- a/osquery/tables/system/windows/patches.cpp
+++ b/osquery/tables/system/windows/patches.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/sql.h>
+#include <osquery/system.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genInstalledPatches(QueryContext& context) {
+  QueryData results;
+
+  WmiRequest wmiSystemReq("select * from Win32_QuickFixEngineering");
+  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+
+  if (wmiResults.size() != 0) {
+    Row r;
+
+    for (const auto& item : wmiResults) {
+      item.GetString("CSName", r["csname"]);
+      item.GetString("HotFixID", r["hotfix_id"]);
+      item.GetString("Caption", r["caption"]);
+      item.GetString("Description", r["description"]);
+      item.GetString("FixComments", r["fix_comments"]);
+      item.GetString("InstalledBy", r["installed_by"]);
+      item.GetString("InstallDate", r["install_date"]);
+      item.GetString("InstalledOn", r["installed_on"]);
+
+      results.push_back(r);
+    }
+  }
+
+  return results;
+}
+}
+}

--- a/specs/windows/patches.table
+++ b/specs/windows/patches.table
@@ -1,0 +1,16 @@
+table_name("patches")
+description("Lists all the patches applied. Note: This does not include patches applied via MSI or downloaded from Windows Update (e.g. Service Packs).")
+schema([
+  Column("csname", TEXT, "The name of the host the patch is installed on."),
+  Column("hotfix_id", TEXT, "The KB ID of the patch."),
+  Column("caption", TEXT, "Short description of the patch."),
+  Column("description", TEXT, "Fuller description of the patch."),
+  Column("fix_comments", TEXT, "Additional comments about the patch."),
+  Column("installed_by", TEXT, "The system context in which the patch as installed."),
+  Column("install_date", TEXT, "Indicates when the patch was installed. Lack of a value does not indicate that the patch was not installed."),
+  Column("installed_on", TEXT, "The date when the patch was installed."),
+])
+implementation("system/windows/patches@genInstalledPatches")
+examples([
+  "select * from patches",
+])


### PR DESCRIPTION
Ahoy friends! I will have a future need to have some reporting around what patches might be installed on a given windows computer. This thing you guys built just happens to have a nice way to do that, so I selfishly added this instead of filing an issue that @PoppySeedPlehzr may or may not have time to work on in the future 😆 

Kudos for making it easy, the docs were fairly easy to follow along although I find myself having to rebuild everything every time (though that is probably because I am OCD on arranging the schema 😉 )

Also not super sure how to test, but I made it pass the compiler, linker, tests, and got this lovely output on my computer:
```
PS C:\> C:\Users\svmastersamurai\github\osquery\build\windows10\osquery\Release\osqueryi.exe
Using a virtual database. Need help, type '.help'
osquery> .tables
...
  => patches
...
osquery> select hotfix_id,description,installed_on from patches;
+-----------+-----------------+--------------+
| hotfix_id | description     | installed_on |
+-----------+-----------------+--------------+
| KB3176936 | Update          | 8/29/2016    |
| KB3199986 | Update          | 11/10/2016   |
| KB3202790 | Security Update | 11/10/2016   |
| KB3200970 | Security Update | 11/10/2016   |
+-----------+-----------------+--------------+
```