### PR TITLE
Add a flag for prepending @cee: to json-logged messages to syslog

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -315,6 +315,10 @@ Maximum returned row value size.
 
 Set the syslog facility (number) 0-23 for the results log. When using the **syslog** logger plugin the default facility is 19 at the `LOG_INFO` level, which does not log to `/var/log/system`.
 
+`--logger_syslog_prepend_cee`
+
+Prepend a `@cee:` cookie to JSON-formatted messages sent to the **syslog** logger plugin. Several syslog parsers use this cookie to indicate that the message payload is parseable JSON. The default value is false.
+
 ## Distributed query service flags
 
 `--distributed_plugin=tls`

--- a/osquery/logger/plugins/syslog.cpp
+++ b/osquery/logger/plugins/syslog.cpp
@@ -20,6 +20,11 @@ FLAG(int32,
      LOG_LOCAL3 >> 3,
      "Syslog facility for status and results logs (0-23, default 19)");
 
+FLAG(bool,
+     logger_syslog_prepend_cee,
+     false,
+     "Prepend @cee: tag to logged JSON messages");
+
 class SyslogLoggerPlugin : public LoggerPlugin {
  public:
   bool usesLogStatus() override { return true; }
@@ -34,7 +39,11 @@ class SyslogLoggerPlugin : public LoggerPlugin {
 REGISTER(SyslogLoggerPlugin, "logger", "syslog");
 
 Status SyslogLoggerPlugin::logString(const std::string& s) {
-  syslog(LOG_INFO, "%s", s.c_str());
+  if (FLAGS_logger_syslog_prepend_cee) {
+    syslog(LOG_INFO, "@cee:%s", s.c_str());
+  } else {
+    syslog(LOG_INFO, "%s", s.c_str());
+  }
   return Status(0, "OK");
 }
 


### PR DESCRIPTION
Several syslog parsers (e.g. rsyslog, syslog-ng) rely on the existence of a `@cee:` cookie prepended to the log message payload to indicate that the remainder of the message is a parseable JSON message. This PR is to add support for prepending the cookie by the flag `logger_syslog_prepend_cee`.