### PR TITLE
[#2736] Add memory and utilization limit override flags

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -76,6 +76,16 @@ Disable userland watchdog process. **osqueryd** uses a watchdog process to monit
 Performance limit level (0=loose, 1=normal, 2=restrictive, 3=debug). The default watchdog process uses a "level" to configure performance limits.
 The higher the level the more strict the limits become. The "debug" level disables the performance limits completely.
 
+The watchdog "profiles" can be overridden for Memory and CPU Utilization.
+
+`--watchdog_memory_limit=0`
+
+If this value is non-0 the watchdog level (`--watchdog_level`) for maximum memory is overridden. Use this if you would like to allow the `osqueryd` process to allocate more than 100M, but somewhere less than 1G.
+
+`--watchdog_utilization_limit=0`
+
+If this value is non-0 the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 90% of a thread for more than 6 seconds of wall time.
+
 `--utc=true`
 
 Attempt to convert all UNIX calendar times to UTC.

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -196,10 +196,14 @@ class FakeWatcherRunner : public WatcherRunner {
   *
   * Internal calls to getProcessRow will return this structure.
   */
-  void setProcessRow(QueryData qd) { qd_ = std::move(qd); }
+  void setProcessRow(QueryData qd) {
+    qd_ = std::move(qd);
+  }
 
   /// The tests do not have access to the processes table.
-  QueryData getProcessRow(pid_t pid) const override { return qd_; }
+  QueryData getProcessRow(pid_t pid) const override {
+    return qd_;
+  }
 
  private:
   QueryData qd_;
@@ -232,7 +236,7 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
   EXPECT_EQ(100U, state.initial_footprint);
 
   // The measurement of latency applies an interval value normalization.
-  auto iv = std::max(getWorkerLimit(INTERVAL), (size_t)1);
+  auto iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), (size_t)1);
   EXPECT_EQ(100U / iv, state.user_time);
   EXPECT_EQ(0U, state.sustained_latency);
 

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -42,7 +42,7 @@ class WatcherRunner;
  * here, and organized into levels. Such that a caller may enforce rigor or
  * relax the performance expectations of a osquery daemon.
  */
-enum WatchdogLimitType {
+enum class WatchdogLimitType {
   MEMORY_LIMIT,
   UTILIZATION_LIMIT,
   RESPAWN_LIMIT,
@@ -109,13 +109,19 @@ class Watcher : private boost::noncopyable {
                                      size_t respawn_time);
 
   /// Lock access to extensions.
-  static void lock() { instance().lock_.lock(); }
+  static void lock() {
+    instance().lock_.lock();
+  }
 
   /// Unlock access to extensions.
-  static void unlock() { instance().lock_.unlock(); }
+  static void unlock() {
+    instance().lock_.unlock();
+  }
 
   /// Accessor for autoloadable extension paths.
-  static const ExtensionMap& extensions() { return instance().extensions_; }
+  static const ExtensionMap& extensions() {
+    return instance().extensions_;
+  }
 
   /// Lookup extension path from pid.
   static std::string getExtensionPath(const PlatformProcess& child);
@@ -131,7 +137,9 @@ class Watcher : private boost::noncopyable {
   static PerformanceState& getState(const std::string& extension);
 
   /// Accessor for the worker process.
-  static PlatformProcess& getWorker() { return *instance().worker_; }
+  static PlatformProcess& getWorker() {
+    return *instance().worker_;
+  }
 
   /// Setter for worker process.
   static void setWorker(const std::shared_ptr<PlatformProcess>& child) {
@@ -146,13 +154,19 @@ class Watcher : private boost::noncopyable {
   static void reset(const PlatformProcess& child);
 
   /// Count the number of worker restarts.
-  static size_t workerRestartCount() { return instance().worker_restarts_; }
+  static size_t workerRestartCount() {
+    return instance().worker_restarts_;
+  }
 
   /// Become responsible for the worker's fate, but do not guarantee its safety.
-  static void bindFates() { instance().restart_worker_ = false; }
+  static void bindFates() {
+    instance().restart_worker_ = false;
+  }
 
   /// Check if the worker and watcher's fates are bound.
-  static bool fatesBound() { return !instance().restart_worker_; }
+  static bool fatesBound() {
+    return !instance().restart_worker_;
+  }
 
   /**
    * @brief Return the state of autoloadable extensions.
@@ -164,7 +178,9 @@ class Watcher : private boost::noncopyable {
   static bool hasManagedExtensions();
 
   /// Check the status of the last worker.
-  static int getWorkerStatus() { return instance().worker_status_; }
+  static int getWorkerStatus() {
+    return instance().worker_status_;
+  }
 
  private:
   /// Do not request the lock until extensions are used.
@@ -179,7 +195,9 @@ class Watcher : private boost::noncopyable {
 
  private:
   /// Inform the watcher that the worker restarted without cause.
-  static void workerRestarted() { instance().worker_restarts_++; }
+  static void workerRestarted() {
+    instance().worker_restarts_++;
+  }
 
  private:
   /// Performance state for the worker process.
@@ -228,10 +246,14 @@ class Watcher : private boost::noncopyable {
 class WatcherLocker {
  public:
   /// Construct and gain watcher lock.
-  WatcherLocker() { Watcher::lock(); }
+  WatcherLocker() {
+    Watcher::lock();
+  }
 
   /// Destruct and release watcher lock.
-  ~WatcherLocker() { Watcher::unlock(); }
+  ~WatcherLocker() {
+    Watcher::unlock();
+  }
 };
 
 /**
@@ -287,7 +309,9 @@ class WatcherRunner : public InternalRunnable {
 
  private:
   /// For testing only, ask the WatcherRunner to run a start loop once.
-  void runOnce() { run_once_ = true; }
+  void runOnce() {
+    run_once_ = true;
+  }
 
  private:
   /// Keep the invocation daemon's argc to iterate through argv.


### PR DESCRIPTION
This introduces `--watchdog_memory_limit` and `--watchdog_utilization_limit`, see the updates to the wiki (included) for a few more details.