### PR TITLE
C++ conformance fixes (MSVC /permissive-)

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -242,7 +242,7 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
   }
 
   hr = services_->ExecQuery(
-      L"WQL", (BSTR)wql.c_str(), WBEM_FLAG_FORWARD_ONLY, nullptr, &enum_);
+      (BSTR)L"WQL", (BSTR)wql.c_str(), WBEM_FLAG_FORWARD_ONLY, nullptr, &enum_);
   if (hr != S_OK) {
     enum_ = nullptr;
     return;

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -160,7 +160,7 @@ class WmiResultItem {
 */
 class WmiRequest {
  public:
-  explicit WmiRequest(const std::string& query, BSTR nspace = L"ROOT\\CIMV2");
+  explicit WmiRequest(const std::string& query, BSTR nspace = (BSTR)L"ROOT\\CIMV2");
   WmiRequest(WmiRequest&& src);
   ~WmiRequest();
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -160,7 +160,8 @@ class WmiResultItem {
 */
 class WmiRequest {
  public:
-  explicit WmiRequest(const std::string& query, BSTR nspace = (BSTR)L"ROOT\\CIMV2");
+  explicit WmiRequest(const std::string& query,
+                      BSTR nspace = (BSTR)L"ROOT\\CIMV2");
   WmiRequest(WmiRequest&& src);
   ~WmiRequest();
 

--- a/osquery/tables/networking/windows/win_sockets.h
+++ b/osquery/tables/networking/windows/win_sockets.h
@@ -47,8 +47,7 @@ class WinSockets : private boost::noncopyable {
   MIB_UDP6TABLE_OWNER_PID* udp6Table_ = nullptr;
 
   /// Helper function to allocate a table based off of family and protocol
-  void* allocateSocketTable(unsigned long protocol,
-                            unsigned long family);
+  void* allocateSocketTable(unsigned long protocol, unsigned long family);
 };
 }
 }

--- a/osquery/tables/networking/windows/win_sockets.h
+++ b/osquery/tables/networking/windows/win_sockets.h
@@ -47,8 +47,8 @@ class WinSockets : private boost::noncopyable {
   MIB_UDP6TABLE_OWNER_PID* udp6Table_ = nullptr;
 
   /// Helper function to allocate a table based off of family and protocol
-  void* WinSockets::allocateSocketTable(unsigned long protocol,
-                                        unsigned long family);
+  void* allocateSocketTable(unsigned long protocol,
+                            unsigned long family);
 };
 }
 }

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -29,7 +29,7 @@ QueryData genWmiCliConsumers(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM CommandLineEventConsumer";
 
-  WmiRequest request(ss.str(), L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
   if (request.getStatus().ok()) {
     std::vector<WmiResultItem>& results = request.results();
     for (const auto& result : results) {

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -29,7 +29,7 @@ QueryData genWmiFilters(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM __EventFilter";
 
-  WmiRequest request(ss.str(), L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
   if (request.getStatus().ok()) {
     std::vector<WmiResultItem>& results = request.results();
     for (const auto& result : results) {

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -29,7 +29,7 @@ QueryData genFilterConsumer(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
-  WmiRequest request(ss.str(), L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
   if (request.getStatus().ok()) {
     std::vector<WmiResultItem>& results = request.results();
     for (const auto& result : results) {

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -29,7 +29,7 @@ QueryData genScriptConsumers(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
-  WmiRequest request(ss.str(), L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
   if (request.getStatus().ok()) {
     std::vector<WmiResultItem>& results = request.results();
     for (const auto& result : results) {


### PR DESCRIPTION
We (the MSVC compiler team) use the OSQuery project as part of our
"Real world code" tests.  I noticed a few places in your windows
specific code where your build would fail if you used the
/permissive- switch because of language conformance issues.
for more information on /permissive- see our blogpost:
https://blogs.msdn.microsoft.com/vcblog/2016/11/16/permissive-switch/
I have not added/modified any tests because this does not change
behavior.

There are two types of language conformance issues fixed in this:

1) Strict string conversion (this is also covered by the /Zc:strictStrings flag)
The 'const' is not implicitly dropped by string literals, which means the following is not allowed:

    //BSTR is a wchar_t*
    BSTR str = L"const string literal"; //error: cannot convert a 'const wchar_t*' to a 'wchar_t*'

I preserved your current behavior by adding a cast to BSTR.  A better fix
would probably be to use SysAllocString (see the documentation for BSTR on MSDN).
I did not make that change because of my limited testing capabilities.

2)Fully qualified inline declarations members inside class

    struct A {
        void A::f() { } // Error: illegal qualified name in member declaration, remove redundant 'A::' to fix
    };