### PR TITLE
[Fix #2862] Fix plist NSString raw pointer string conversion

### DIFF
--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -45,9 +45,14 @@ static Status filterArray(id plist, const std::string& root, pt::ptree& tree);
 
 static inline std::string getValue(id value) {
   if ([value isKindOfClass:[NSString class]]) {
-    return [value UTF8String];
+    if ([value UTF8String] != nullptr) {
+      return [value UTF8String];
+    }
   } else if ([value isKindOfClass:[NSNumber class]]) {
-    return [[value stringValue] UTF8String];
+    if ([value stringValue] != nullptr &&
+        [[value stringValue] UTF8String] != nullptr) {
+      return [[value stringValue] UTF8String];
+    }
   } else if ([value isKindOfClass:[NSData class]]) {
     NSString* dataString = [value base64EncodedStringWithOptions:0];
     return [dataString UTF8String];

--- a/osquery/tables/system/darwin/packages.cpp
+++ b/osquery/tables/system/darwin/packages.cpp
@@ -286,7 +286,10 @@ void genPackageReceipt(const std::string& path, QueryData& results) {
       r[kPkgReceiptKeys.at(row.at("key"))] = row.at("value");
     }
   }
-  results.push_back(std::move(r));
+
+  if (!r["package_id"].empty()) {
+    results.push_back(std::move(r));
+  }
 }
 
 QueryData genPackageReceipts(QueryContext& context) {


### PR DESCRIPTION
`NSString` and `NSNumber` may return empty raw pointers. This fix checks the internal raw pointer (`[value UTF8String]`) before attempting a `std::string` conversion.