### PR TITLE
Removed stream name checking for aws kinesis and firehose setup

### DIFF
--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -118,12 +118,6 @@ Status FirehoseLogForwarder::setUp() {
   // Make sure we can connect to designated stream
   Aws::Firehose::Model::DescribeDeliveryStreamRequest r;
   r.SetDeliveryStreamName(FLAGS_aws_firehose_stream);
-
-  auto outcome = client_->DescribeDeliveryStream(r);
-  if (!outcome.IsSuccess()) {
-    return Status(
-        1, "Could not find Firehose stream: " + FLAGS_aws_firehose_stream);
-  }
   VLOG(1) << "Firehose logging initialized with stream: "
           << FLAGS_aws_firehose_stream;
   return Status(0);

--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -13,8 +13,6 @@
 #include <boost/algorithm/string/join.hpp>
 
 #include <aws/core/utils/Outcome.h>
-#include <aws/firehose/model/DescribeDeliveryStreamRequest.h>
-#include <aws/firehose/model/DescribeDeliveryStreamResult.h>
 #include <aws/firehose/model/PutRecordBatchRequest.h>
 #include <aws/firehose/model/PutRecordBatchResponseEntry.h>
 #include <aws/firehose/model/PutRecordBatchResult.h>
@@ -116,8 +114,6 @@ Status FirehoseLogForwarder::setUp() {
   }
 
   // Make sure we can connect to designated stream
-  Aws::Firehose::Model::DescribeDeliveryStreamRequest r;
-  r.SetDeliveryStreamName(FLAGS_aws_firehose_stream);
   VLOG(1) << "Firehose logging initialized with stream: "
           << FLAGS_aws_firehose_stream;
   return Status(0);

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -153,11 +153,6 @@ Status KinesisLogForwarder::setUp() {
   // Make sure we can connect to designated stream
   Aws::Kinesis::Model::DescribeStreamRequest r;
   r.SetStreamName(FLAGS_aws_kinesis_stream);
-  auto outcome = client_->DescribeStream(r);
-  if (!outcome.IsSuccess()) {
-    return Status(1,
-                  "Could not find Kinesis stream: " + FLAGS_aws_kinesis_stream);
-  }
   VLOG(1) << "Kinesis logging initialized with stream: "
           << FLAGS_aws_kinesis_stream;
   return Status(0);

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -13,8 +13,6 @@
 #include <boost/algorithm/string/join.hpp>
 
 #include <aws/core/utils/Outcome.h>
-#include <aws/kinesis/model/DescribeStreamRequest.h>
-#include <aws/kinesis/model/DescribeStreamResult.h>
 #include <aws/kinesis/model/PutRecordsRequest.h>
 #include <aws/kinesis/model/PutRecordsRequestEntry.h>
 #include <aws/kinesis/model/PutRecordsResult.h>
@@ -150,9 +148,6 @@ Status KinesisLogForwarder::setUp() {
     return Status(1, "Stream name must be specified with --aws_kinesis_stream");
   }
 
-  // Make sure we can connect to designated stream
-  Aws::Kinesis::Model::DescribeStreamRequest r;
-  r.SetStreamName(FLAGS_aws_kinesis_stream);
   VLOG(1) << "Kinesis logging initialized with stream: "
           << FLAGS_aws_kinesis_stream;
   return Status(0);


### PR DESCRIPTION
Based on the recommendation of other osquery aws users, we feel it is best to remove the aws kinesis and firehose stream name checking.  The current method we use (describe stream) and the past method (list streams) have pretty nasty rate limits of around 5-10 RPS.  This can cause dos of osquery agents if you are doing a large rollout that is not staggered.

Docs for the rate limits can be found here:
http://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html

I have tested this check removal and all seems fine.  There is however some work that may need done on the logging for partial failed uploads as the info it logs may not be accurate.  Ill check that code path at a later time as it will be a bit more work.

Ultimately, this change seems safe and I have not seen any adverse side effects.

@zwass what do you think?