### PR TITLE
Change logging level in certain cases

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -111,7 +111,7 @@ std::string getHostname() {
 }
 
 std::string generateNewUUID() {
-  LOG(INFO) << "Cannot retrieve platform UUID: generating an ephemeral UUID";
+  VLOG(1) << "Cannot retrieve platform UUID: generating an ephemeral UUID";
   boost::uuids::uuid uuid = boost::uuids::random_generator()();
   return boost::uuids::to_string(uuid);
 }
@@ -259,8 +259,7 @@ Status checkStalePid(const std::string& content) {
 
     return Status(1, "osqueryd (" + content + ") is already running");
   } else {
-    VLOG(1) << "Found stale process for osqueryd (" << content
-            << ") removing pidfile";
+    VLOG(1) << "Found stale process for osqueryd (" << content << ")";
   }
 
   return Status(0, "OK");

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -199,7 +199,7 @@ Status RocksDBDatabasePlugin::setUp() {
   }
 
   if (!DatabasePlugin::kCheckingDB) {
-    LOG(INFO) << "Opening RocksDB handle: " << path_;
+    VLOG(1) << "Opening RocksDB handle: " << path_;
   }
 
   // Tests may trash calls to setUp, make sure subsequent calls do not leak.

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -66,14 +66,14 @@ SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
 
 inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // Execute the scheduled query and create a named query object.
-  LOG(INFO) << "Executing scheduled query: " << name << ": " << query.query;
+  LOG(INFO) << "Executing scheduled query " << name << ": " << query.query;
   runDecorators(DECORATE_ALWAYS);
 
   auto sql =
       (FLAGS_enable_monitor) ? monitor(name, query) : SQLInternal(query.query);
 
   if (!sql.ok()) {
-    LOG(ERROR) << "Error executing scheduled query: " << name << ": "
+    LOG(ERROR) << "Error executing scheduled query " << name << ": "
                << sql.getMessageString();
     return;
   }

--- a/osquery/events/darwin/kernel_util.cpp
+++ b/osquery/events/darwin/kernel_util.cpp
@@ -89,7 +89,7 @@ void loadKernelExtension() {
       CFArrayCreate(nullptr, (const void**)urls, 1, &kCFTypeArrayCallBacks);
   if (KextManagerLoadKextWithIdentifier(kKernelBundleId, directoryArray) !=
       kOSReturnSuccess) {
-    LOG(INFO) << "Could not autoload kernel extension";
+    VLOG(1) << "Could not autoload kernel extension";
   } else {
     VLOG(1) << "Autoloaded osquery kernel extension";
   }

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -906,8 +906,8 @@ void attachEvents() {
   for (const auto& subscriber : subscribers) {
     auto status = EventFactory::registerEventSubscriber(subscriber.second);
     if (!status.ok()) {
-      LOG(INFO) << "Error registering subscriber: " << subscriber.first << ": "
-                << status.getMessage();
+      VLOG(1) << "Error registering subscriber: " << subscriber.first << ": "
+              << status.getMessage();
     }
   }
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -199,7 +199,7 @@ void ExtensionWatcher::watch() {
   }
 
   if (!core_sane) {
-    LOG(INFO) << "Extension watcher ending: osquery core has gone away";
+    VLOG(1) << "Extension watcher ending: osquery core has gone away";
     exitFatal(0);
   }
 


### PR DESCRIPTION
Follow-up to PR #2823

Change the logging level used in a number of locations in the code base, to better capture priority of each message.

Primary changes are cases of LOG(INFO) to VLOG(1), with a few occurrences of LOG(INFO) to LOG(WARNING).