### PR TITLE
Add a TLS config plugin test that runs the scheduler

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -331,6 +331,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(SchedulerTests, test_config_results_purge);
   FRIEND_TEST(EventsTests, test_event_subscriber_configure);
   FRIEND_TEST(TLSConfigTests, test_retrieve_config);
+  FRIEND_TEST(TLSConfigTests, test_runner_and_scheduler);
 };
 
 /**

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -26,7 +26,7 @@ from urlparse import parse_qs
 
 EXAMPLE_CONFIG = {
     "schedule": {
-        "tls_proc": {"query": "select * from processes", "interval": 0},
+        "tls_proc": {"query": "select * from processes", "interval": 1},
     },
     "node_invalid": False,
 }


### PR DESCRIPTION
This adds a test to run the config updater (from the TLS plugin as an example) alongside the scheduler runner. If there is a critical section here, this and TSAN will find it.