### PR TITLE
Add launchd name for OSX_Keydnap

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -289,7 +289,7 @@
       "value": "Artifact used by this malware"
     },
     "OSX_Keydnap": {
-      "query": "select * from launchd where name = 'com.apple.iCloud.sync.daemon';",
+      "query": "select * from launchd where name IN ('com.apple.iCloud.sync.daemon', 'com.geticloud.icloud.photo');",
       "interval": "86400",
       "description": "(http://www.welivesecurity.com/2016/07/06/new-osxkeydnap-malware-hungry-credentials)",
       "value": "Artifact used by this malware"


### PR DESCRIPTION
I went through the compilation of OSX malware for 2016 (https://objective-see.com/blog/blog_0x16.html) and reviewed the `osx-attacks.conf` pack, to make sure we have them all covered.