### PR TITLE
Uptime implementation on Windows

### DIFF
--- a/osquery/tables/system/uptime.cpp
+++ b/osquery/tables/system/uptime.cpp
@@ -16,6 +16,8 @@
 #include <sys/sysctl.h>
 #elif defined(__linux__)
 #include <sys/sysinfo.h>
+#elif defined(WIN32)
+#include <windows.h>
 #endif
 
 namespace osquery {
@@ -43,6 +45,8 @@ long getUptime() {
   }
 
   return sys_info.uptime;
+#elif defined(WIN32)
+  return (long)GetTickCount64() / 1000;
 #endif
 
   return -1;


### PR DESCRIPTION
On my laptop:

```
C:\Users\marpaia\git\osquery [uptime ≡]> .\build\windows10\osquery\Release\osqueryi.exe
Using a virtual database. Need help, type '.help'
osquery> select * from uptime;
+------+-------+---------+---------+---------------+
| days | hours | minutes | seconds | total_seconds |
+------+-------+---------+---------+---------------+
| 0    | 8     | 29      | 51      | 30591         |
+------+-------+---------+---------+---------------+
osquery>
```

close #2905 