### PR TITLE
Allow watchdog watcher to wait for child exits

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -95,9 +95,6 @@ enum {
   " - https://osquery.readthedocs.org/en/latest/introduction/using-osqueryd/"  \
   "\n\n";
 
-/// Seconds to alarm and quit for non-responsive event loops.
-#define SIGNAL_ALARM_TIMEOUT 4
-
 /// For Windows, SIGILL and SIGTERM
 #ifdef WIN32
 
@@ -110,6 +107,10 @@ enum {
 #define SIGUSR1 SIGILL
 
 #endif
+
+namespace osquery {
+CLI_FLAG(uint64, alarm_timeout, 4, "Seconds to wait for a graceful shutdown");
+}
 
 namespace {
 extern "C" {
@@ -145,7 +146,7 @@ void signalHandler(int num) {
 #ifndef WIN32
       // Time to stop, set an upper bound time constraint on how long threads
       // have to terminate (join). Publishers may be in 20ms or similar sleeps.
-      alarm(SIGNAL_ALARM_TIMEOUT);
+      alarm(osquery::FLAGS_alarm_timeout);
 #endif
 
       // Restore the default signal handler.
@@ -344,6 +345,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
   std::signal(SIGINT, signalHandler);
   std::signal(SIGHUP, signalHandler);
   std::signal(SIGALRM, signalHandler);
+  std::signal(SIGCHLD, SIG_IGN);
 #endif
 
   std::signal(SIGABRT, signalHandler);

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-#include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/system.h>
 
@@ -25,8 +24,6 @@
 extern char** environ;
 
 namespace osquery {
-
-DECLARE_uint64(alarm_timeout);
 
 PlatformProcess::PlatformProcess(PlatformPidType id) : id_(id) {}
 
@@ -51,26 +48,6 @@ bool PlatformProcess::kill() const {
 
   int status = ::kill(id_, SIGKILL);
   return (status == 0);
-}
-
-bool PlatformProcess::cleanup() const {
-  if (!isValid()) {
-    return false;
-  }
-
-  size_t delay = 0;
-  size_t timeout = (FLAGS_alarm_timeout + 1) * 1000;
-  while (delay < timeout) {
-    int status = 0;
-    if (checkStatus(status) == PROCESS_EXITED) {
-      return true;
-    }
-
-    sleepFor(200);
-    delay += 200;
-  }
-  // The requested process did not exit.
-  return false;
 }
 
 ProcessState PlatformProcess::checkStatus(int& status) const {

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -21,9 +21,13 @@
 
 #include <boost/optional.hpp>
 
+#include <osquery/flags.h>
+
 #include "osquery/core/process.h"
 
 namespace osquery {
+
+DECLARE_uint64(alarm_timeout);
 
 int platformGetUid() {
   return ::getuid();
@@ -69,10 +73,6 @@ std::string platformModuleGetError() {
 
 bool platformModuleClose(ModuleHandle module) {
   return (::dlclose(module) == 0);
-}
-
-void cleanupDefunctProcesses() {
-  ::waitpid(-1, nullptr, WNOHANG);
 }
 
 void setToBackgroundPriority() {

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -112,6 +112,16 @@ class PlatformProcess : private boost::noncopyable {
   /// Hard terminates the process
   bool kill() const;
 
+  /**
+   * @brief Wait or cleanup a process, usually a child process.
+   *
+   * This will wait for a process to cleanup. Use this after requesting a
+   * graceful shutdown.
+   *
+   * @return true if the process was cleaned, otherwise false.
+   */
+  bool cleanup() const;
+
   /// Returns whether the PlatformProcess object is valid
   bool isValid() const {
     return (id_ != kInvalidPid);
@@ -252,9 +262,6 @@ bool platformModuleClose(ModuleHandle module);
  * Note, this only works on worker processes.
  */
 bool isLauncherProcessDead(PlatformProcess& launcher);
-
-/// Waits for defunct processes to terminate.
-void cleanupDefunctProcesses();
 
 /// Sets the current process to run with background scheduling priority.
 void setToBackgroundPriority();

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -268,7 +268,10 @@ void WatcherRunner::stopChild(const PlatformProcess& child) const {
   child.kill();
 
   // Clean up the defunct (zombie) process.
-  cleanupDefunctProcesses();
+  if (!child.cleanup()) {
+    Initializer::requestShutdown(EXIT_CATASTROPHIC,
+                                 "Watcher cannot stop worker process");
+  }
 }
 
 PerformanceChange getChange(const Row& r, PerformanceState& state) {

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -190,8 +190,6 @@ bool platformModuleClose(ModuleHandle module) {
   return (::FreeLibrary(static_cast<HMODULE>(module)) != 0);
 }
 
-void cleanupDefunctProcesses() {}
-
 void setToBackgroundPriority() {}
 
 // Helper function to determine if thread is running with admin privilege.


### PR DESCRIPTION
Assuming a child worker will exit within `--alarm_timeout` seconds, we at-most wait another second for the process to stop after a watcher signals. 