### PR TITLE
Allow POSIX to gracefully stop workers

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -105,6 +105,7 @@ enum {
 /// For Windows, SIGILL and SIGTERM are not generated signals. To supplant the
 /// SIGUSR1 use-case on POSIX, we use SIGILL.
 #define SIGUSR1 SIGILL
+#define SIGUSR2 SIGILL
 
 #endif
 
@@ -142,7 +143,7 @@ void signalHandler(int num) {
         // Reload configuration.
       }
     } else if (num == SIGTERM || num == SIGINT || num == SIGABRT ||
-               num == SIGUSR1) {
+               num == SIGUSR1 || num == SIGUSR2) {
 #ifndef WIN32
       // Time to stop, set an upper bound time constraint on how long threads
       // have to terminate (join). Publishers may be in 20ms or similar sleeps.
@@ -350,6 +351,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
 
   std::signal(SIGABRT, signalHandler);
   std::signal(SIGUSR1, signalHandler);
+  std::signal(SIGUSR2, signalHandler);
 
   // If the caller is checking configuration, disable the watchdog/worker.
   if (FLAGS_config_check) {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -105,7 +105,6 @@ enum {
 /// For Windows, SIGILL and SIGTERM are not generated signals. To supplant the
 /// SIGUSR1 use-case on POSIX, we use SIGILL.
 #define SIGUSR1 SIGILL
-#define SIGUSR2 SIGILL
 
 #endif
 
@@ -143,7 +142,7 @@ void signalHandler(int num) {
         // Reload configuration.
       }
     } else if (num == SIGTERM || num == SIGINT || num == SIGABRT ||
-               num == SIGUSR1 || num == SIGUSR2) {
+               num == SIGUSR1) {
 #ifndef WIN32
       // Time to stop, set an upper bound time constraint on how long threads
       // have to terminate (join). Publishers may be in 20ms or similar sleeps.
@@ -351,7 +350,6 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
 
   std::signal(SIGABRT, signalHandler);
   std::signal(SIGUSR1, signalHandler);
-  std::signal(SIGUSR2, signalHandler);
 
   // If the caller is checking configuration, disable the watchdog/worker.
   if (FLAGS_config_check) {

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -55,7 +55,7 @@ bool PlatformProcess::killGracefully() const {
     return false;
   }
 
-  int status = ::kill(nativeHandle(), SIGUSR2);
+  int status = ::kill(nativeHandle(), SIGINT);
   return (status == 0);
 }
 

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -46,7 +46,16 @@ bool PlatformProcess::kill() const {
     return false;
   }
 
-  int status = ::kill(id_, SIGKILL);
+  int status = ::kill(nativeHandle(), SIGKILL);
+  return (status == 0);
+}
+
+bool PlatformProcess::killGracefully() const {
+  if (!isValid()) {
+    return false;
+  }
+
+  int status = ::kill(nativeHandle(), SIGUSR2);
   return (status == 0);
 }
 

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -113,6 +113,11 @@ class PlatformProcess : private boost::noncopyable {
   bool kill() const;
 
   /**
+   * @brief Attempt to kill a process gracefully, usually a child process.
+   */
+  bool killGracefully() const;
+
+  /**
    * @brief Wait or cleanup a process, usually a child process.
    *
    * This will wait for a process to cleanup. Use this after requesting a

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -265,12 +265,16 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
 }
 
 void WatcherRunner::stopChild(const PlatformProcess& child) const {
-  child.kill();
+  child.killGracefully();
 
   // Clean up the defunct (zombie) process.
   if (!child.cleanup()) {
-    Initializer::requestShutdown(EXIT_CATASTROPHIC,
-                                 "Watcher cannot stop worker process");
+    // The child did not exit, force kill and attempt to cleanup again.
+    child.kill();
+    if (!child.cleanup()) {
+      Initializer::requestShutdown(EXIT_CATASTROPHIC,
+                                   "Watcher cannot stop worker process");
+    }
   }
 }
 

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -79,7 +79,11 @@ bool PlatformProcess::kill() const {
     return false;
   }
 
-  return (::TerminateProcess(id_, 0) != FALSE);
+  return (::TerminateProcess(nativeHandle(), 0) != FALSE);
+}
+
+bool PlatformProcess::killGracefully() const {
+  return kill();
 }
 
 ProcessState PlatformProcess::checkStatus(int& status) const {


### PR DESCRIPTION
This adds a new method to the `PlatformProcess` API: `killGracefully` that should be implemented on each platform to ask an osquery worker process to stop. On POSIX this uses `SIGUSR2`, the worker process should catch this signal and shutdown cleanly. 