### PR TITLE
[Fix #2912] Close initial Python thrift connections

### DIFF
--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -55,7 +55,7 @@ class AdditionalFeatureTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Introspect into the daemon's query packs.
         client = test_base.EXClient(daemon.options["extensions_socket"])
-        test_base.expectTrue(client.open)
+        test_base.expectTrue(client.try_open)
         self.assertTrue(client.open())
         em = client.getEM()
 

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -385,6 +385,13 @@ class EXClient(object):
         if self.transport:
             self.transport.close()
 
+    def try_open(self, timeout=0.1, interval=0.01):
+        '''Try to open, on success, close the UNIX domain socket.'''
+        did_open = self.open(timeout, interval)
+        if did_open:
+            self.close()
+        return did_open
+
     def open(self, timeout=0.1, interval=0.01):
         '''Attempt to open the UNIX domain socket.'''
         delay = 0

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -555,7 +555,7 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
 
         # The sets of example tests will use the extensions APIs.
         self.client = EXClient(self.daemon.options["extensions_socket"])
-        expectTrue(self.client.open)
+        expectTrue(self.client.try_open)
         self.assertTrue(self.client.open())
         self.em = self.client.getEM()
 

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -22,9 +22,9 @@ import time
 import threading
 import unittest
 
-
 # osquery-specific testing utils
 import test_base
+import utils
 
 EXTENSION_TIMEOUT = 10
 
@@ -212,7 +212,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client
         client = test_base.EXClient(extension.options["extensions_socket"])
-        test_base.expectTrue(client.open)
+        test_base.expectTrue(client.try_open)
         self.assertTrue(client.open(timeout=EXTENSION_TIMEOUT))
         em = client.getEM()
 
@@ -249,8 +249,9 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
     @test_base.flaky
     def test_6_extensions_directory_autoload(self):
-        loader = test_base.Autoloader(
-            [test_base.ARGS.build + "/osquery/"])
+        utils.copy_file(test_base.ARGS.build + "/osquery/example_extension.ext",
+            test_base.CONFIG_DIR)
+        loader = test_base.Autoloader([test_base.CONFIG_DIR])
         daemon = self._run_daemon({
             "disable_watchdog": True,
             "extensions_timeout": EXTENSION_TIMEOUT,
@@ -332,7 +333,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
 
         # Get a python-based thrift client to the manager and extension.
         client = test_base.EXClient(extension.options["extensions_socket"])
-        test_base.expectTrue(client.open)
+        test_base.expectTrue(client.try_open)
         self.assertTrue(client.open(timeout=EXTENSION_TIMEOUT))
         em = client.getEM()
 
@@ -342,7 +343,7 @@ class ExtensionTests(test_base.ProcessGenerator, unittest.TestCase):
         ex_uuid = result.keys()[0]
         client2 = test_base.EXClient(extension.options["extensions_socket"],
             uuid=ex_uuid)
-        test_base.expectTrue(client2.open)
+        test_base.expectTrue(client2.try_open)
         self.assertTrue(client2.open(timeout=EXTENSION_TIMEOUT))
         ex = client2.getEX()
 

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -62,6 +62,10 @@ def reset_dir(p):
         pass
 
 
+def copy_file(f, d):
+    shutil.copy(f, d)
+
+
 def platform():
     platform = sys.platform
     if platform.find("linux") == 0:


### PR DESCRIPTION
The 0.10.0 Thrift Python module (auto-installed through pip updates) requires transport connections to be `.close`d before their `.open` will return success. In our tests we use an expect/assert model to apply timeouts and intervals for checking transport statuses; first expect with timeouts, then asset without. The initial expect, when true, blocks subsequent checks.