### PR TITLE
Move Mutex to shared_timed_mutex and add ReadLock

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -12,7 +12,7 @@
 
 #include <csignal>
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -175,10 +175,13 @@ inline bool isPlatform(PlatformType a, const PlatformType& t = kPlatformType) {
 }
 
 /// Helper alias for defining mutexes.
-using Mutex = std::mutex;
+using Mutex = std::shared_timed_mutex;
 
 /// Helper alias for write locking a mutex.
-using WriteLock = std::lock_guard<Mutex>;
+using WriteLock = std::unique_lock<Mutex>;
+
+/// Helper alias for read locking a mutex.
+using ReadLock = std::shared_lock<Mutex>;
 
 /// Helper alias for defining recursive mutexes.
 using RecursiveMutex = std::recursive_mutex;

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -36,7 +36,9 @@ class RunnerInterruptPoint : private boost::noncopyable {
   void cancel();
 
   /// Pause until the requested millisecond delay has elapsed or a cancel.
-  void pause(size_t milli) { pause(std::chrono::milliseconds(milli)); }
+  void pause(size_t milli) {
+    pause(std::chrono::milliseconds(milli));
+  }
 
   /// Pause until the requested millisecond delay has elapsed or a cancel.
   void pause(std::chrono::milliseconds milli);
@@ -69,7 +71,9 @@ class InterruptableRunnable {
   virtual void stop() = 0;
 
   /// Put the runnable into an interruptible sleep.
-  virtual void pause() { pauseMilli(std::chrono::milliseconds(100)); }
+  virtual void pause() {
+    pauseMilli(std::chrono::milliseconds(100));
+  }
 
   /// Put the runnable into an interruptible sleep.
   virtual void pauseMilli(size_t milli) {
@@ -81,7 +85,9 @@ class InterruptableRunnable {
 
  private:
   /// Testing only, the interruptible will bypass initial interruption check.
-  void mustRun() { bypass_check_ = true; }
+  void mustRun() {
+    bypass_check_ = true;
+  }
 
  private:
   /**
@@ -91,7 +97,7 @@ class InterruptableRunnable {
    * Interruption means resources have been stopped.
    * Non-interruption means no attempt to affect resources has been started.
    */
-  std::mutex stopping_;
+  Mutex stopping_;
 
   /// If a service includes a run loop it should check for interrupted.
   std::atomic<bool> interrupted_{false};
@@ -134,7 +140,9 @@ class InternalRunnable : private boost::noncopyable,
    * #hasRun makes a much better guess at the state of the thread.
    * If it has run then stop must be called.
    */
-  bool hasRun() { return run_; }
+  bool hasRun() {
+    return run_;
+  }
 
  protected:
   /// Require the runnable thread define an entrypoint.
@@ -182,7 +190,9 @@ class Dispatcher : private boost::noncopyable {
   static void stopServices();
 
   /// Return number of services.
-  size_t serviceCount() { return services_.size(); }
+  size_t serviceCount() {
+    return services_.size();
+  }
 
  private:
   /**
@@ -200,7 +210,9 @@ class Dispatcher : private boost::noncopyable {
 
  private:
   /// For testing only, reset the stopping status for unittests.
-  void resetStopping() { stopping_ = false; }
+  void resetStopping() {
+    stopping_ = false;
+  }
 
  private:
   /// The set of shared osquery service threads.

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -362,10 +362,10 @@ class EventPublisherPlugin : public Plugin,
   std::atomic<bool> started_{false};
 
   /// A lock for incrementing the next EventContextID.
-  std::mutex ec_id_lock_;
+  Mutex ec_id_lock_;
 
   /// A lock for subscription manipulation.
-  std::mutex subscription_lock_;
+  Mutex subscription_lock_;
 
   /// A helper count of event publisher runloop iterations.
   std::atomic<size_t> restart_count_{0};
@@ -643,10 +643,10 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   size_t optimize_eid_{0};
 
   /// Lock used when incrementing the EventID database index.
-  std::mutex event_id_lock_;
+  Mutex event_id_lock_;
 
   /// Lock used when recording an EventID and time into search bins.
-  std::mutex event_record_lock_;
+  Mutex event_record_lock_;
 
  private:
   friend class EventFactory;

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -108,7 +108,7 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
   rocksdb::Options options_;
 
   /// Deconstruction mutex.
-  std::mutex close_mutex_;
+  Mutex close_mutex_;
 };
 
 /// Backing-storage provider for osquery internal/core.
@@ -231,7 +231,7 @@ Status RocksDBDatabasePlugin::setUp() {
 }
 
 void RocksDBDatabasePlugin::close() {
-  std::unique_lock<std::mutex> lock(close_mutex_);
+  WriteLock lock(close_mutex_);
   for (auto handle : handles_) {
     delete handle;
   }

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -25,9 +25,12 @@ namespace osquery {
 DECLARE_string(database_path);
 
 const std::map<std::string, std::string> kDBSettings = {
-    {"synchronous", "OFF"},      {"count_changes", "OFF"},
-    {"default_temp_store", "2"}, {"auto_vacuum", "FULL"},
-    {"journal_mode", "OFF"},     {"cache_size", "1000"},
+    {"synchronous", "OFF"},
+    {"count_changes", "OFF"},
+    {"default_temp_store", "2"},
+    {"auto_vacuum", "FULL"},
+    {"journal_mode", "OFF"},
+    {"cache_size", "1000"},
     {"page_count", "1000"},
 };
 
@@ -57,10 +60,14 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
   Status setUp() override;
 
   /// Database workflow: close and cleanup.
-  void tearDown() override { close(); }
+  void tearDown() override {
+    close();
+  }
 
   /// Need to tear down open resources,
-  virtual ~SQLiteDatabasePlugin() { close(); }
+  virtual ~SQLiteDatabasePlugin() {
+    close();
+  }
 
  private:
   void close();
@@ -70,7 +77,7 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
   sqlite3* db_{nullptr};
 
   /// Deconstruction mutex.
-  std::mutex close_mutex_;
+  Mutex close_mutex_;
 };
 
 /// Backing-storage provider for osquery internal/core.
@@ -144,7 +151,7 @@ Status SQLiteDatabasePlugin::setUp() {
 }
 
 void SQLiteDatabasePlugin::close() {
-  std::unique_lock<std::mutex> lock(close_mutex_);
+  WriteLock lock(close_mutex_);
   if (db_ != nullptr) {
     sqlite3_close(db_);
     db_ = nullptr;

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -24,7 +24,7 @@ FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
 
 /// Cancel the pause request.
 void RunnerInterruptPoint::cancel() {
-  WriteLock lock(mutex_);
+  std::unique_lock<std::mutex> lock(mutex_);
   stop_ = true;
   condition_.notify_all();
 }

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -228,7 +228,7 @@ ExtensionRunnerCore::~ExtensionRunnerCore() {
 
 void ExtensionRunnerCore::stop() {
   {
-    std::unique_lock<std::mutex> lock(service_start_);
+    WriteLock lock(service_start_);
     service_stopping_ = true;
     if (transport_ != nullptr) {
       // This is an opportunity to interrupt the transport listens.
@@ -252,7 +252,7 @@ inline void removeStalePaths(const std::string& manager) {
 
 void ExtensionRunnerCore::startServer(TProcessorRef processor) {
   {
-    std::unique_lock<std::mutex> lock(service_start_);
+    WriteLock lock(service_start_);
     // A request to stop the service may occur before the thread starts.
     if (service_stopping_) {
       return;
@@ -294,7 +294,7 @@ void ExtensionRunner::start() {
 
 ExtensionManagerRunner::~ExtensionManagerRunner() {
   // Only attempt to remove stale paths if the server was started.
-  std::unique_lock<std::mutex> lock(service_start_);
+  WriteLock lock(service_start_);
   if (server_ != nullptr) {
     removeStalePaths(path_);
   }

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -305,7 +305,7 @@ class ExtensionRunnerCore : public InternalRunnable {
   TThreadedServerRef server_{nullptr};
 
   /// Protect the service start and stop, this mutex protects server creation.
-  std::mutex service_start_;
+  Mutex service_start_;
 
   /// Record a dispatcher's request to stop the service.
   bool service_stopping_{false};

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -184,7 +184,7 @@ void SQLiteSQLPlugin::detach(const std::string& name) {
   detachTableInternal(name, dbc->db());
 }
 
-SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, std::mutex& mtx)
+SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, Mutex& mtx)
     : db_(db), lock_(mtx, std::try_to_lock) {
   if (lock_.owns_lock()) {
     primary_ = true;
@@ -282,7 +282,7 @@ SQLiteDBInstanceRef SQLiteDBManager::getUnique() {
 
 SQLiteDBInstanceRef SQLiteDBManager::getConnection(bool primary) {
   auto& self = instance();
-  std::unique_lock<std::mutex> lock(self.create_mutex_);
+  WriteLock lock(self.create_mutex_);
 
   if (self.db_ == nullptr) {
     // Create primary SQLite DB instance.

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -43,7 +43,7 @@ class SQLiteDBInstance : private boost::noncopyable {
   SQLiteDBInstance() {
     init();
   }
-  SQLiteDBInstance(sqlite3*& db, std::mutex& mtx);
+  SQLiteDBInstance(sqlite3*& db, Mutex& mtx);
   ~SQLiteDBInstance();
 
   /// Check if the instance is the osquery primary.
@@ -88,7 +88,7 @@ class SQLiteDBInstance : private boost::noncopyable {
   sqlite3* db_{nullptr};
 
   /// An attempted unique lock on the manager's primary database access mutex.
-  std::unique_lock<std::mutex> lock_;
+  WriteLock lock_;
 
   /// Vector of tables that need their constraints cleared after execution.
   std::map<std::string, VirtualTableContent*> affected_tables_;
@@ -169,10 +169,10 @@ class SQLiteDBManager : private boost::noncopyable {
   SQLiteDBInstanceRef connection_{nullptr};
 
   /// Mutex and lock around sqlite3 access.
-  std::mutex mutex_;
+  Mutex mutex_;
 
   /// A write mutex for initializing the primary database.
-  std::mutex create_mutex_;
+  Mutex create_mutex_;
 
   /// Member variable to hold set of disabled tables.
   std::unordered_set<std::string> disabled_tables_;

--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -8,8 +8,8 @@
  *
  */
 
-#include <set>
 #include <mutex>
+#include <set>
 
 #include <grp.h>
 
@@ -19,21 +19,21 @@
 namespace osquery {
 namespace tables {
 
-std::mutex grpEnumerationMutex;
+Mutex grpEnumerationMutex;
 
-QueryData genGroups(QueryContext &context) {
-  std::lock_guard<std::mutex> lock(grpEnumerationMutex);
+QueryData genGroups(QueryContext& context) {
   QueryData results;
-  struct group *grp = nullptr;
+  struct group* grp = nullptr;
   std::set<long> groups_in;
 
+  WriteLock lock(grpEnumerationMutex);
   setgrent();
   while ((grp = getgrent()) != nullptr) {
     if (std::find(groups_in.begin(), groups_in.end(), grp->gr_gid) ==
         groups_in.end()) {
       Row r;
       r["gid"] = INTEGER(grp->gr_gid);
-      r["gid_signed"] = INTEGER((int32_t) grp->gr_gid);
+      r["gid_signed"] = INTEGER((int32_t)grp->gr_gid);
       r["groupname"] = TEXT(grp->gr_name);
       results.push_back(r);
       groups_in.insert(grp->gr_gid);

--- a/osquery/tables/system/linux/user_groups.cpp
+++ b/osquery/tables/system/linux/user_groups.cpp
@@ -8,21 +8,21 @@
  *
  */
 
-#include "osquery/core/conversions.h"
 #include "osquery/tables/system/user_groups.h"
+#include "osquery/core/conversions.h"
 
 namespace osquery {
 namespace tables {
 
-extern std::mutex pwdEnumerationMutex;
+extern Mutex pwdEnumerationMutex;
 
-QueryData genUserGroups(QueryContext &context) {
+QueryData genUserGroups(QueryContext& context) {
   QueryData results;
-  struct passwd *pwd = nullptr;
+  struct passwd* pwd = nullptr;
 
   if (context.constraints["uid"].exists(EQUALS)) {
     std::set<std::string> uids = context.constraints["uid"].getAll(EQUALS);
-    for (const auto &uid : uids) {
+    for (const auto& uid : uids) {
       long auid{0};
       if (safeStrtol(uid, 10, auid) && (pwd = getpwuid(auid)) != nullptr) {
         user_t<uid_t, gid_t> user;
@@ -33,7 +33,7 @@ QueryData genUserGroups(QueryContext &context) {
       }
     }
   } else {
-    std::lock_guard<std::mutex> lock(pwdEnumerationMutex);
+    WriteLock lock(pwdEnumerationMutex);
     std::set<gid_t> users_in;
     while ((pwd = getpwent()) != nullptr) {
       if (std::find(users_in.begin(), users_in.end(), pwd->pw_uid) ==

--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -20,7 +20,7 @@
 namespace osquery {
 namespace tables {
 
-std::mutex pwdEnumerationMutex;
+Mutex pwdEnumerationMutex;
 
 void genUser(const struct passwd* pwd, QueryData& results) {
   Row r;


### PR DESCRIPTION
This moves almost all use cases of `std::mutex` to `std::shared_timed_mutex` under the alias of `Mutex` for simplicity. We then add a unique/exclusive write lock as `std::unique_lock`, the companion `ReadLock` is a `std::shared_lock`.

This is run under `SANITIZE_THREAD=1 make sanitize; make test` on Linux.