### PR TITLE
Fix deadlock in decorator execution

### DIFF
--- a/osquery/config/parsers/decorators.cpp
+++ b/osquery/config/parsers/decorators.cpp
@@ -194,6 +194,7 @@ void DecoratorsConfigParserPlugin::updateDecorations(
 inline void addDecoration(const std::string& source,
                           const std::string& name,
                           const std::string& value) {
+  WriteLock lock(DecoratorsConfigParserPlugin::kDecorationsMutex);
   DecoratorsConfigParserPlugin::kDecorations[source][name] = value;
 }
 
@@ -237,7 +238,6 @@ void runDecorators(DecorationPoint point,
 
   // Abstract the use of the decorator parser API.
   auto dp = std::dynamic_pointer_cast<DecoratorsConfigParserPlugin>(parser);
-  WriteLock lock(DecoratorsConfigParserPlugin::kDecorationsMutex);
   if (point == DECORATE_LOAD) {
     for (const auto& target_source : dp->load_) {
       if (source.empty() || target_source.first == source) {
@@ -268,7 +268,7 @@ void getDecorations(std::map<std::string, std::string>& results) {
     return;
   }
 
-  WriteLock lock(DecoratorsConfigParserPlugin::kDecorationsMutex);
+  ReadLock lock(DecoratorsConfigParserPlugin::kDecorationsMutex);
   // Copy the decorations into the log_item.
   for (const auto& source : DecoratorsConfigParserPlugin::kDecorations) {
     for (const auto& decoration : source.second) {


### PR DESCRIPTION
Decoration population/execution will execute queries and store results in the decorator config parser plugin. Status logs may be generated while executing queries, these will query the current decorator content (at that point, the previously-existing results). The current implementation includes a dead lock.

1. Run decorators (write lock)
2. Query
3. Run tables
4. Log
5. Get decorators (write lock)

The new implementation avoids a dead lock

1. Run decorators
2. Query
3. Run tables
4. Log
5. Get old decorators (write lock)
6. (release lock)
7. Store new decorators (write lock)

The new implementation further improves the logic by changing the *Get decorators* step to use a read lock.

This should fix: #2910, it may also fix @morrigan's issue from #1277 