### PR TITLE
Introduce scheduler reload feature

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -589,6 +589,9 @@ Status scanDatabaseKeys(const std::string& domain,
                         const std::string& prefix,
                         size_t max = 0);
 
+/// Allow callers to reload or reset the database plugin.
+void resetDatabase();
+
 /// Allow callers to scan each column family and print each value.
 void dumpDatabase();
 }

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -20,6 +20,8 @@
 
 #include <glog/logging.h>
 
+#include <boost/noncopyable.hpp>
+
 #include <osquery/database.h>
 #include <osquery/flags.h>
 #include <osquery/registry.h>
@@ -330,7 +332,7 @@ Status logSnapshotQuery(const QueryLogItem& item);
  * The logger forwarding state is restored and unlocked as soon as the object
  * of this class goes out of scope.
  */
-class LoggerForwardingDisabler {
+class LoggerForwardingDisabler : private boost::noncopyable {
  public:
   LoggerForwardingDisabler();
   ~LoggerForwardingDisabler();

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -35,7 +35,7 @@ int platformGetUid() {
 
 bool isLauncherProcessDead(PlatformProcess& launcher) {
   if (!launcher.isValid()) {
-    return false;
+    return true;
   }
 
   return (::getppid() != launcher.nativeHandle());

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -634,7 +634,6 @@ void resetDatabase() {
     LOG(WARNING) << "Unable to reset database plugin: "
                  << Registry::get().getActive("database");
   }
-  printf("done\n");
 }
 
 void dumpDatabase() {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -505,6 +505,8 @@ Status DatabasePlugin::call(const PluginRequest& request,
       response.push_back({{"k", k}});
     }
     return status;
+  } else if (request.at("action") == "reset") {
+    return this->reset();
   }
 
   return Status(1, "Unknown database plugin action");
@@ -601,6 +603,14 @@ Status scanDatabaseKeys(const std::string& domain,
   } else {
     auto plugin = getDatabasePlugin();
     return plugin->scan(domain, keys, prefix, max);
+  }
+}
+
+void resetDatabase() {
+  PluginRequest request = {{"action", "reset"}};
+  if (!Registry::call("database", request)) {
+    LOG(WARNING) << "Unable to reset database plugin: "
+                 << Registry::get().getActive("database");
   }
 }
 

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -130,10 +130,10 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 
   // There is a spurious warning on first open.
   if (log_line.find("Error when reading") == std::string::npos) {
-    // Rocksdb calls are non-reentrant. Since this callback is made in the
-    // context of a rocksdb api call, turn log forwarding off to prevent the
-    // logger from trying to make a call back into rocksdb and causing a
-    // deadlock
+    // RocksDB calls are non-reentrant. Since this callback is made in the
+    // context of a RocksDB API call, turn log forwarding off to prevent the
+    // logger from trying to make a call back into RocksDB and causing a
+    // deadlock.
     LoggerForwardingDisabler forwarding_disabler;
     LOG(INFO) << "RocksDB: " << log_line;
   }
@@ -141,7 +141,7 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 
 Status RocksDBDatabasePlugin::setUp() {
   if (!kDBHandleOptionAllowOpen) {
-    LOG(WARNING) << RLOG(1629) << "Not allowed to create DBHandle instance";
+    LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
   if (!initialized_) {

--- a/osquery/database/plugins/tests/rocksdb_tests.cpp
+++ b/osquery/database/plugins/tests/rocksdb_tests.cpp
@@ -16,7 +16,9 @@ namespace osquery {
 
 class RocksDBDatabasePluginTests : public DatabasePluginTests {
  protected:
-  std::string name() override { return "rocksdb"; }
+  std::string name() override {
+    return "rocksdb";
+  }
 };
 
 // Define the default set of database plugin operation tests.

--- a/osquery/database/plugins/tests/sqlite_tests.cpp
+++ b/osquery/database/plugins/tests/sqlite_tests.cpp
@@ -14,7 +14,9 @@ namespace osquery {
 
 class SQLiteDatabasePluginTests : public DatabasePluginTests {
  protected:
-  std::string name() override { return "sqlite"; }
+  std::string name() override {
+    return "sqlite";
+  }
 };
 
 // Define the default set of database plugin operation tests.

--- a/osquery/database/tests/database_tests.cpp
+++ b/osquery/database/tests/database_tests.cpp
@@ -72,13 +72,4 @@ TEST_F(DatabaseTests, test_delete_values) {
   EXPECT_FALSE(s.ok());
   EXPECT_TRUE(value.empty());
 }
-
-TEST_F(DatabaseTests, test_reset) {
-  setDatabaseValue(kLogs, "reset", "1");
-  resetDatabase();
-
-  std::string value;
-  EXPECT_TRUE(getDatabaseValue(kLogs, "reset", value));
-  EXPECT_EQ(value, "1");
-}
 }

--- a/osquery/database/tests/database_tests.cpp
+++ b/osquery/database/tests/database_tests.cpp
@@ -72,4 +72,13 @@ TEST_F(DatabaseTests, test_delete_values) {
   EXPECT_FALSE(s.ok());
   EXPECT_TRUE(value.empty());
 }
+
+TEST_F(DatabaseTests, test_reset) {
+  setDatabaseValue(kLogs, "reset", "1");
+  resetDatabase();
+
+  std::string value;
+  EXPECT_TRUE(getDatabaseValue(kLogs, "reset", value));
+  EXPECT_EQ(value, "1");
+}
 }

--- a/osquery/database/tests/plugin_tests.cpp
+++ b/osquery/database/tests/plugin_tests.cpp
@@ -38,6 +38,19 @@ void DatabasePluginTests::testPluginCheck() {
   EXPECT_TRUE(db_plugin->reset());
 }
 
+void DatabasePluginTests::testReset() {
+  RegistryFactory::get().setActive("database", getName());
+  setDatabaseValue(kLogs, "reset", "1");
+  resetDatabase();
+
+  if ("ephemeral" != getName()) {
+    // The ephemeral plugin is special and does not persist after reset.
+    std::string value;
+    EXPECT_TRUE(getDatabaseValue(kLogs, "reset", value));
+    EXPECT_EQ(value, "1");
+  }
+}
+
 void DatabasePluginTests::testPut() {
   auto s = getPlugin()->put(kQueries, "test_put", "bar");
   EXPECT_TRUE(s.ok());

--- a/osquery/database/tests/plugin_tests.h
+++ b/osquery/database/tests/plugin_tests.h
@@ -24,6 +24,9 @@
   TEST_F(n, test_plugin_check) {                                               \
     testPluginCheck();                                                         \
   }                                                                            \
+  TEST_F(n, test_reset) {                                                      \
+    testReset();                                                               \
+  }                                                                            \
   TEST_F(n, test_put) {                                                        \
     testPut();                                                                 \
   }                                                                            \
@@ -97,6 +100,7 @@ class DatabasePluginTests : public testing::Test {
 
  protected:
   void testPluginCheck();
+  void testReset();
   void testPut();
   void testGet();
   void testDelete();

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -20,6 +20,7 @@
 namespace osquery {
 
 DECLARE_bool(disable_logging);
+DECLARE_uint64(schedule_reload);
 
 class SchedulerTests : public testing::Test {
   void SetUp() override {
@@ -170,5 +171,18 @@ TEST_F(SchedulerTests, test_scheduler) {
   // Restore plugin settings.
   TablePlugin::kCacheStep = backup_step;
   TablePlugin::kCacheInterval = backup_interval;
+}
+
+TEST_F(SchedulerTests, test_scheduler_reload) {
+  std::string config =
+      "{\"schedule\":{\"1\":{"
+      "\"query\":\"select * from processes\", \"interval\":1}}}";
+  auto backup_reload = FLAGS_schedule_reload;
+
+  // Start the scheduler;
+  auto expire = static_cast<unsigned long int>(getUnixTime() + 1);
+  FLAGS_schedule_reload = 1;
+  SchedulerRunner runner(expire, 1);
+  FLAGS_schedule_reload = backup_reload;
 }
 }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -224,7 +224,7 @@ class BufferedLogSink : public google::LogSink, private boost::noncopyable {
 };
 
 /// Scoped helper to perform logging actions without races.
-class LoggerDisabler {
+class LoggerDisabler : private boost::noncopyable {
  public:
   LoggerDisabler()
       : stderr_status_(FLAGS_logtostderr),

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -251,7 +251,7 @@ void SQLiteDBInstance::clearAffectedTables() {
 }
 
 SQLiteDBInstance::~SQLiteDBInstance() {
-  if (!isPrimary()) {
+  if (!isPrimary() && db_ != nullptr) {
     sqlite3_close(db_);
   } else {
     db_ = nullptr;
@@ -266,6 +266,16 @@ SQLiteDBManager::SQLiteDBManager() : db_(nullptr) {
 bool SQLiteDBManager::isDisabled(const std::string& table_name) {
   const auto& element = instance().disabled_tables_.find(table_name);
   return (element != instance().disabled_tables_.end());
+}
+
+void SQLiteDBManager::resetPrimary() {
+  auto& self = instance();
+  WriteLock create_lock(self.create_mutex_);
+  WriteLock connection_lock(self.mutex_);
+
+  self.connection_.reset();
+  sqlite3_close(self.db_);
+  self.db_ = nullptr;
 }
 
 void SQLiteDBManager::setDisabledTables(const std::string& list) {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -143,6 +143,14 @@ class SQLiteDBManager : private boost::noncopyable {
   static SQLiteDBInstanceRef getUnique();
 
   /**
+   * @brief Reset the primary database connection.
+   *
+   * Over time it may be helpful to remove SQLite's arena.
+   * We can periodically close and re-initialize and connect virtual tables.
+   */
+  static void resetPrimary();
+
+  /**
    * @brief Check if `table_name` is disabled.
    *
    * Check if `table_name` is in the list of tables passed in to the

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -64,6 +64,16 @@ TEST_F(SQLiteUtilTests, test_sqlite_instance) {
   EXPECT_EQ(internal_db, SQLiteDBManager::get()->db());
 }
 
+TEST_F(SQLiteUtilTests, test_reset) {
+  auto internal_db = SQLiteDBManager::get()->db();
+  SQLiteDBManager::resetPrimary();
+  auto new_internal_db = SQLiteDBManager::get()->db();
+
+  // Assume the internal (primary) database we reset and recreated.
+  EXPECT_NE(nullptr, new_internal_db);
+  EXPECT_NE(internal_db, new_internal_db);
+}
+
 TEST_F(SQLiteUtilTests, test_direct_query_execution) {
   auto dbc = getTestDBC();
   QueryData results;


### PR DESCRIPTION
This is a work-in-progress feature that allows the scheduler to reset the database plugin and SQL plugin arenas. The goal is to smooth persistent memory allocations over several-day windows.