### PR TITLE
Do not control stderr teeing automatically

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -293,6 +293,15 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
 #endif
   }
 
+  Flag::create("alsologtostderr",
+               {"Log messages to stderr in addition to the logger plugin(s)",
+                false,
+                false,
+                true,
+                false});
+  Flag::create("stderrthreshold",
+               {"Stderr log level threshold", false, false, true, false});
+
   // osquery implements a custom help/usage output.
   for (int i = 1; i < *argc_; i++) {
     auto help = std::string((*argv_)[i]);

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -293,7 +293,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
 #endif
   }
 
-  Flag::create("alsologtostderr",
+  Flag::create("logtostderr",
                {"Log messages to stderr in addition to the logger plugin(s)",
                 false,
                 false,

--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -6,6 +6,7 @@ if(WINDOWS)
     "plugins/buffered.cpp"
     "plugins/filesystem.cpp"
     "plugins/tls.cpp"
+    "plugins/stdout.cpp"
   )
   file(GLOB OSQUERY_LOGGER_PLUGIN_TESTS "plugins/tests/filesystem_logger_tests.cpp")
 else()

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -315,7 +315,6 @@ void setVerboseLevel() {
     // Do log only WARNING, ERROR to log sinks.
     if (kToolType == ToolType::DAEMON) {
       FLAGS_minloglevel = google::GLOG_INFO;
-      FLAGS_stderrthreshold = google::GLOG_INFO;
     } else {
       FLAGS_minloglevel = google::GLOG_WARNING;
       FLAGS_stderrthreshold = google::GLOG_WARNING;
@@ -335,7 +334,6 @@ void initStatusLogger(const std::string& name) {
   FLAGS_logbufsecs = 0; // flush the log buffer immediately
   FLAGS_stop_logging_if_full_disk = true;
   FLAGS_max_log_size = 10; // max size for individual log file is 10MB
-  FLAGS_logtostderr = true;
 
   setVerboseLevel();
   // Start the logging, and announce the daemon is starting.

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -315,6 +315,9 @@ void setVerboseLevel() {
     // Do log only WARNING, ERROR to log sinks.
     if (kToolType == ToolType::DAEMON) {
       FLAGS_minloglevel = google::GLOG_INFO;
+      if (Flag::isDefault("stderrthreshold")) {
+        FLAGS_stderrthreshold = google::GLOG_INFO;
+      }
     } else {
       FLAGS_minloglevel = google::GLOG_WARNING;
       FLAGS_stderrthreshold = google::GLOG_WARNING;

--- a/osquery/logger/plugins/stdout.cpp
+++ b/osquery/logger/plugins/stdout.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+
+namespace osquery {
+
+class StdoutLoggerPlugin : public LoggerPlugin {
+ public:
+  bool usesLogStatus() override {
+    return true;
+  }
+
+ protected:
+  Status logString(const std::string& s) override;
+
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override;
+
+  Status logStatus(const std::vector<StatusLogLine>& log) override;
+};
+
+REGISTER(StdoutLoggerPlugin, "logger", "stdout");
+
+Status StdoutLoggerPlugin::logString(const std::string& s) {
+  printf("%s\n", s.c_str());
+  return Status(0, "OK");
+}
+
+Status StdoutLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
+  for (const auto& item : log) {
+    std::string line = "severity=" + std::to_string(item.severity) +
+                       " location=" + item.filename + ":" +
+                       std::to_string(item.line) + " message=" + item.message;
+
+    printf("%s\n", line.c_str());
+  }
+  return Status(0, "OK");
+}
+
+void StdoutLoggerPlugin::init(const std::string& name,
+                              const std::vector<StatusLogLine>& log) {
+  // Now funnel the intermediate status logs provided to `init`.
+  logStatus(log);
+}
+}


### PR DESCRIPTION
This allows the "tee" of LOG lines output to `stderr` to be controlled by CLI flags and configuration options.

We should follow up with a change to the systemd service and stop stderr output. This will isolate the location of osquery status log lines to the osquery logger pipeline.