### PR TITLE
Add Quimitchin backdoor IOCs to osx-attacks pack

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -354,6 +354,12 @@
       "interval" : "86400",
       "description" : "Xcode Ghost dropped files (http://researchcenter.paloaltonetworks.com/2015/09/novel-malware-xcodeghost-modifies-xcode-infects-apple-ios-apps-and-hits-app-store/)",
       "value" : "Artifact used by this malware"
+    },
+    "Quimitchin_Backdoor": {
+      "query" : "select * from launchd where name = 'com.client.client.plist';",
+      "interval" : "86400",
+      "description" : "Quimitchin Launch Agent (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
+      "value" : "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Add the IOCs (Launch Agent) for OSX Backdoor - https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/

Not sure if we would want to look for the ~/.client file but it should be located in the users home directory if we go off the plist file in the blog post:

com.client.client.plist:
`<string>/Users/xxxx/.client</string>`
possible query:
`"select * from file where path = '/Users/%/.client'"`