### PR TITLE
[Fix #2881] Update glibc source URLs

### DIFF
--- a/tools/provision/formula/glibc-legacy.rb
+++ b/tools/provision/formula/glibc-legacy.rb
@@ -2,8 +2,8 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 
 class GlibcLegacy < AbstractOsqueryFormula
   desc "The GNU C Library"
-  homepage "https://www.gnu.org/software/libc/download.html"
-  url "https://ftp.heanet.ie/mirrors/gnu/glibc/glibc-2.13.tar.bz2"
+  homepage "https://www.gnu.org/software/libc"
+  url "ftp.gnu.org/gnu/glibc/glibc-2.13.tar.bz2"
   sha256 "0173c92a0545e6d99a46a4fbed2da00ba26556f5c6198e2f9f1631ed5318dbb2"
 
   bottle do

--- a/tools/provision/formula/glibc.rb
+++ b/tools/provision/formula/glibc.rb
@@ -2,8 +2,8 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 
 class Glibc < AbstractOsqueryFormula
   desc "The GNU C Library"
-  homepage "https://www.gnu.org/software/libc/download.html"
-  url "https://ftp.heanet.ie/mirrors/gnu/glibc/glibc-2.19.tar.bz2"
+  homepage "https://www.gnu.org/software/libc"
+  url "ftp.gnu.org/gnu/glibc/glibc-2.19.tar.bz2"
   sha256 "2e293f714187044633264cd9ce0183c70c3aa960a2f77812a6390a3822694d15"
 
   bottle do


### PR DESCRIPTION
Update URLs in the "glibc" and "glibc-legacy" provision scripts to point at mirrors with higher reliability.