### PR TITLE
Do not exit watcher after failed autoloaded extensions

### DIFF
--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -64,6 +64,7 @@ ProcessState PlatformProcess::checkStatus(int& status) const {
 
   pid_t result = ::waitpid(nativeHandle(), &process_status, WNOHANG);
   if (result < 0) {
+    process_status = -1;
     if (errno == ECHILD) {
       return PROCESS_EXITED;
     }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -197,7 +197,7 @@ void WatcherRunner::start() {
 
     // Loop over every managed extension and check sanity.
     for (const auto& extension : Watcher::extensions()) {
-      if (!watch(*extension.second)) {
+      if (!isChildSane(*extension.second)) {
         // The extension manager also watches for extension-related failures.
         // The watchdog is more general, but may find failed extensions first.
         if (!createExtension(extension.first)) {
@@ -399,7 +399,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
   // The worker is sane, no action needed.
   // Attempt to flush status logs to the well-behaved worker.
-  if (use_worker_) {
+  if (use_worker_ && child.pid() == Watcher::getWorker().pid()) {
     relayStatusLogs();
   }
 


### PR DESCRIPTION
This fixes a bug introduced in 2.2.2 that will cause the watcher process to exit if an autoloaded extension fails.