### PR TITLE
Emit only ERROR logs to osqueryd stderr

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -344,6 +344,11 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
     }
     // Initialize the shell after setting modified defaults and parsing flags.
     initShell();
+  } else {
+    // The daemon will only output ERROR logs to stderr.
+    if (Flag::isDefault("stderrthreshold")) {
+      Flag::updateValue("stderrthreshold", "2");
+    }
   }
 
 #ifndef WIN32


### PR DESCRIPTION
The daemon (and osquery in general) implements its own logging pipeline. For systems capturing service stderr output we have the potential to duplicate log content. The daemon should not output INFO and WARNING messages to stderr, these should go through the normal logger flow. The ERROR logs may be important to capture in os_log or syslog.