### PR TITLE
Add stderr control to CLI docs

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -329,6 +329,14 @@ Set the syslog facility (number) 0-23 for the results log. When using the **sysl
 
 Prepend a `@cee:` cookie to JSON-formatted messages sent to the **syslog** logger plugin. Several syslog parsers use this cookie to indicate that the message payload is parseable JSON. The default value is false.
 
+`--logtostderr=true`
+
+This is default `true` and will also send log messages in GLog format to the process's `stderr`. The logs are limited by severity and the following flag: `--stderrthreshold`.
+
+`--stderrthreshold=2`
+
+This controls the types of logs sent to the process's `stderr`. It does NOT limit or control the types sent to the logger plugin. The default value 2 is `ERROR`, set this to `0` for all non-verbose types. If the `--verbose` flag is set this value is overridden to `0`.
+
 ## Distributed query service flags
 
 `--distributed_plugin=tls`

--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -1,6 +1,4 @@
-Continuous integration currently tests stable release versions of osquery against 10.9 and 10.11 (as listed under the _Build_status_ column on the project [README](https://github.com/facebook/osquery/blob/master/README.md)). There are no reported issues which block expected core functionality on 10.12.
-
-Each tagged release of osquery may be installed on all versions of OS X.
+Continuous integration currently tests stable release versions of osquery against macOS 10.12 (as listed under the _Build_status_ column on the project [README](https://github.com/facebook/osquery/blob/master/README.md)). There are no reported issues which block expected core functionality on 10.10, however 10.9 and previous OS X versions do not work.
 
 ## Package Installation
 
@@ -26,7 +24,7 @@ This package does NOT install a LaunchDaemon to start **osqueryd**. You may use 
 
 ### Post installation steps
 
-Only applies if you have never installed and run osqueryd on this Mac.
+Only applies if you have never installed and run **osqueryd** on this Mac.
 
 After completing the brew installation run the following commands. If you are using the chef recipe to install osquery then these steps are not necessary, the [recipe](http://osquery.readthedocs.io/en/stable/deployment/configuration/#chef-os-x) has this covered.
 


### PR DESCRIPTION
Adds `logtostderr` and `stderrthreshold` to the CLI docs page.