### PR TITLE
Allow autoload extensions to retry loading

### DIFF
--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -134,7 +134,7 @@ class MockWithWatchWatcherRunner : public WatcherRunner {
                             PerformanceState& watcher_state));
 
   /// The state machine is starting, and is forking a managed extension.
-  MOCK_METHOD1(createExtension, bool(const std::string& extension));
+  MOCK_METHOD1(createExtension, void(const std::string& extension));
 
   /// The state machine is starting, and is forking the managed 'worker'.
   MOCK_METHOD0(createWorker, void());

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -302,7 +302,7 @@ class WatcherRunner : public InternalRunnable {
   virtual void createWorker();
 
   /// Fork an extension process.
-  virtual bool createExtension(const std::string& extension);
+  virtual void createExtension(const std::string& extension);
 
   /// If a worker/extension has otherwise gone insane, stop it.
   virtual void stopChild(const PlatformProcess& child) const;


### PR DESCRIPTION
If an extension fails to load during autoload it will not be retried (there is a bug in the retry logic). This fixes the bug and retries the failed extension (3 more times).