### PR TITLE
[Fix #2816] Build single DEB/RPM package

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -26,21 +26,13 @@ elseif(LINUX)
   if(FPM_EXECUTABLE)
     add_custom_command(TARGET packages PRE_BUILD
       COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-        -t "deb" -i "1.14" -d '${DEB_PACKAGE_DEPENDENCIES}'
-    )
-    add_custom_command(TARGET packages PRE_BUILD
-      COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-        -t "deb" -i "1.16" -s -d '${DEB_PACKAGE_DEPENDENCIES}'
+        -t "deb" -i "1.u16" -d '${DEB_PACKAGE_DEPENDENCIES}'
     )
 
     if(RPMBUILD_EXECUTABLE)
       add_custom_command(TARGET packages PRE_BUILD
         COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-          -t "rpm" -i "1.el6" -d '${RPM_PACKAGE_DEPENDENCIES}'
-      )
-      add_custom_command(TARGET packages PRE_BUILD
-        COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-          -t "rpm" -i "1.el7" -s -d '${RPM_PACKAGE_DEPENDENCIES}'
+          -t "rpm" -i "1.el7" -d '${RPM_PACKAGE_DEPENDENCIES}'
       )
     else()
       WARNING_LOG("Skipping RPM/CentOS packages: Cannot find rpmbuild")


### PR DESCRIPTION
This initial implementation installs all three files `/etc/init.d/osqueryd`, `/etc/{sysconfig | default}/osqueryd` & `/usr/lib/systemd/system/osqueryd.service` to the appropriate location (based on whether the system is Debian based or CentOS based), then runs a helper script to remove the extraneous files (based on the init system running on the target machine).