### PR TITLE
Fix test http server output getting lost

### DIFF
--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -75,7 +75,8 @@ RECEIVED_REQUESTS = []
 
 def debug(response):
     print("-- [DEBUG] %s" % str(response))
-
+    sys.stdout.flush()
+    sys.stderr.flush()
 
 ENROLL_RESET = {
     "count": 1,
@@ -201,7 +202,7 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
 
 
 def handler():
-    print("[DEBUG] Shutting down HTTP server via timeout (%d) seconds."
+    debug("Shutting down HTTP server via timeout (%d) seconds." 
           % (ARGS.timeout))
     thread.interrupt_main()
 


### PR DESCRIPTION
Noticed that much of the output from test_http_server.py was getting lost from LastTest.log; similarly, running osquery_additional_tests from cmd line and redirecting the output to a file would lose the test_http_server.py output. This is because python script output is buffered, and on kill (which is how we terminate test_http_server.py from TlsServerRunner::stop), stdout/stderr is not flushed. 

Fixed by adding a flush call after every output. A bit expensive, but not that SIGKILL cannot be hooked.

With this PR, the output from test_http_server.py is available in LastTest.log whenever you run make test