### PR TITLE
Use logtostderr in initStatusLogger

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -337,6 +337,7 @@ void initStatusLogger(const std::string& name) {
   FLAGS_logbufsecs = 0; // flush the log buffer immediately
   FLAGS_stop_logging_if_full_disk = true;
   FLAGS_max_log_size = 10; // max size for individual log file is 10MB
+  FLAGS_logtostderr = true;
 
   setVerboseLevel();
   // Start the logging, and announce the daemon is starting.

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -62,9 +62,11 @@ CONFIG_DIR = "/tmp/osquery-tests-python%d/" % (os.getuid())
 CONFIG_NAME = CONFIG_DIR + "tests"
 DEFAULT_CONFIG = {
     "options": {
+        "flagfile": "/dev/null",
         "database_path": "%s.db" % CONFIG_NAME,
         "pidfile": "%s.pid" % CONFIG_NAME,
         "config_path": "%s.conf" % CONFIG_NAME,
+        "extensions_autoload": "/dev/null",
         "extensions_socket": "%s.em" % CONFIG_NAME,
         "extensions_interval": "1",
         "extensions_timeout": "0",

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -140,5 +140,26 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
         daemon.kill()
 
+    def test_7_logger_stdout(self):
+        logger_path = test_base.getTestDirectory(test_base.CONFIG_DIR)
+        daemon = self._run_daemon({
+            "disable_watchdog": True,
+            "disable_extensions": True,
+            "disable_logging": False,
+            "logger_plugin": "stdout",
+            "logger_path": logger_path,
+            "verbose": True,
+        })
+
+        info_path = os.path.join(logger_path, "osqueryd.INFO")
+        def pathDoesntExist():
+            if os.path.exists(info_path):
+                return False
+            return True
+        self.assertTrue(daemon.isAlive())
+        self.assertTrue(pathDoesntExist())
+        daemon.kill()
+
+
 if __name__ == '__main__':
     test_base.Tester().run()


### PR DESCRIPTION
There's an untested regression from: https://github.com/facebook/osquery/commit/b2a90cd6e4b3b5813730a87fd5c5ce122c9cf289 that causes GLOG files to be created in `/tmp/` when the `filesystem` logger plugin is NOT used.