### PR TITLE
Adding warning line for registry queries against HKCU

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -23,6 +23,7 @@
 #include <boost/filesystem.hpp>
 
 #include <osquery/core.h>
+#include <osquery/logger.h>
 #include <osquery/tables.h>
 
 #include "osquery/filesystem/fileops.h"
@@ -267,6 +268,11 @@ QueryData genRegistry(QueryContext& context) {
   if (context.constraints["hive"].exists(EQUALS) &&
       context.constraints["hive"].getAll(EQUALS).size() > 0) {
     rHives = context.constraints["hive"].getAll(EQUALS);
+    if (rHives.find("HKEY_CURRENT_USER") != rHives.end() ||
+        rHives.find("HKEY_CURRENT_USER_LOCAL_SETTINGS") != rHives.end()) {
+      LOG(WARNING) << "CURRENT_USER hives are not queryable by osqueryd; query "
+                      "HKEY_USERS with the desired users SID instead";
+    }
   } else {
     for (auto& h : kRegistryHives) {
       rHives.insert(h.first);


### PR DESCRIPTION
We encountered a bug a while back with our internal deployment, where we were scheduling queries against the Windows HKEY_CURRENT_USER registry hive. This seemed like a perfectly valid thing to do, until you remember that HKEY_CURRENT_USER doesn't exist for a service running as `SYSTEM`. The fix was to query `HKEY_USERS`, and append the SID of the users of interest. A query might look something like:
```
> select username, uuid, hive || key, mtime, data from registry, users where hive='HKEY_USERS' and key=uuid || "\Environment";
```
Note: this query has a bug - will fix tomorrow when I have the working version in front of me -.-;