### PR TITLE
Add country_code to wifi_status and wifi_survey tables.

### DIFF
--- a/osquery/tables/networking/darwin/wifi_status.mm
+++ b/osquery/tables/networking/darwin/wifi_status.mm
@@ -39,6 +39,10 @@ QueryData genWifiStatus(QueryContext& context) {
     if (strptr != nil) {
       r["network_name"] = std::string([strptr UTF8String]);
     }
+    NSString* country_code = [interface countryCode];
+    if (country_code != nil) {
+      r["country_code"] = std::string([country_code UTF8String]);
+    }
     r["rssi"] = INTEGER([interface rssiValue]);
     r["noise"] = INTEGER([interface noiseMeasurement]);
     r["security_type"] = getSecurityName([interface security]);

--- a/osquery/tables/networking/darwin/wifi_survey.mm
+++ b/osquery/tables/networking/darwin/wifi_survey.mm
@@ -36,6 +36,10 @@ QueryData genWifiScan(QueryContext& context) {
       r["ssid"] = extractSsid((__bridge CFDataRef)[network ssidData]);
       r["bssid"] = std::string([[network bssid] UTF8String]);
       r["network_name"] = std::string([[network ssid] UTF8String]);
+      NSString* country_code = [network countryCode];
+      if (country_code != nil) {
+        r["country_code"] = std::string([country_code UTF8String]);
+      }
       r["rssi"] = INTEGER([network rssiValue]);
       r["noise"] = INTEGER([network noiseMeasurement]);
       CWChannel* cwc = [network wlanChannel];

--- a/specs/darwin/wifi_scan.table
+++ b/specs/darwin/wifi_scan.table
@@ -5,6 +5,7 @@ schema([
     Column("ssid", TEXT, "SSID octets of the network"),
     Column("bssid", TEXT, "The current basic service set identifier"),
     Column("network_name", TEXT, "Name of the network"),
+    Column("country_code", TEXT, "The country code (ISO/IEC 3166-1:1997) for the network"),
     Column("rssi", INTEGER, "The current received signal strength indication (dbm)"),
     Column("noise", INTEGER, "The current noise measurement (dBm)"),
     Column("channel_width", INTEGER, "Channel width"),

--- a/specs/darwin/wifi_status.table
+++ b/specs/darwin/wifi_status.table
@@ -5,6 +5,7 @@ schema([
     Column("ssid", TEXT, "SSID octets of the network"),
     Column("bssid", TEXT, "The current basic service set identifier"),
     Column("network_name", TEXT, "Name of the network"),
+    Column("country_code", TEXT, "The country code (ISO/IEC 3166-1:1997) for the network"),
     Column("security_type", TEXT, "Type of security on this network"),
     Column("rssi", INTEGER, "The current received signal strength indication (dbm)"),
     Column("noise", INTEGER, "The current noise measurement (dBm)"),


### PR DESCRIPTION
This returns the country code (ISO/IEC 3166-1:1997) for each network found.