### PR TITLE
registry: Fix enable_foreign and add test

### DIFF
--- a/tools/codegen/templates/foreign.cpp.in
+++ b/tools/codegen/templates/foreign.cpp.in
@@ -64,8 +64,11 @@ auto {{table_name_cc}}Register = []() {
     QueryData generate(QueryContext& request) override { return QueryData(); }
   };
 
-  const registries::PI<{{table_name_cc}}TablePlugin>
-  k{{table_name_cc}}TablePlugin("table", "{{table_name}}");
+  {
+    auto registry = RegistryFactory::get().registry("table");
+    registry->add("{{table_name}}",
+      std::make_shared<{{table_name_cc}}TablePlugin>(), false);
+  }
 /// END[GENTABLE]
 };
 

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -184,6 +184,22 @@ class OsqueryiTest(unittest.TestCase):
         self.assertTrue(0 <= int(row['seconds']) <= 60)
 
     @test_base.flaky
+    def test_foreign_tables(self):
+        '''Requires the --enable_foreign flag to add at least one table.'''
+        self.osqueryi.run_command(' ')
+
+        query = 'SELECT count(1) c FROM osquery_registry;'
+        result = self.osqueryi.run_query(query)
+        before = int(result[0]['c'])
+
+        osqueryi2 = test_base.OsqueryWrapper(self.binary,
+            args={"enable_foreign": True})
+        osqueryi2.run_command(' ')
+        result = osqueryi2.run_query(query)
+        after = int(result[0]['c'])
+        self.assertGreater(after, before)
+
+    @test_base.flaky
     def test_time_using_all(self):
         self.osqueryi.run_command(' ')
         result = self.osqueryi.run_command('.all time')


### PR DESCRIPTION
The `--enable_foreign` flag is used for the shell and daemon to expose the schemas for all virtual tables. These tables are not attached to valid generate functions. Instead they use "blank" plugins that only describe the column and table attributes. They can be added to the registry.

This fixes a regression added with a refactor to the registry APIs. It also adds a test for the feature.