### PR TITLE
Introduce two new host identifier options

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -298,11 +298,13 @@ Log scheduled results as events.
 
 `--host_identifier=hostname`
 
-Field used to identify the host running osquery: **hostname**, **uuid**.
+Field used to identify the host running osquery: **hostname**, **uuid**, **ephemeral**, **instance**.
 
-Select either **hostname** or **uuid** for the host identifier.
-DHCP may assign variable hostnames, if this is the case, select UUID for a
-consistent logging label.
+DHCP may assign variable hostnames, if this is the case, you may need a consistent logging label. Three options are available to you:
+
+- `uuid` uses the platform (DMTF) host UUID, fetched at process start.
+- `instance` uses an instance-unique UUID generated at process start, persisted in the backing store.
+- `ephemeral` uses an instance-unique UUID generated at process start, not persisted.
 
 `--verbose=false`
 

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -267,6 +267,22 @@ class DropPrivileges : private boost::noncopyable {
 std::string getHostname();
 
 /**
+ * @brief Getter for an instance uuid
+ *
+ * @return ok on success and ident is set to the instance uuid, otherwise
+ * failure.
+ */
+Status getInstanceUUID(std::string& ident);
+
+/**
+ * @brief Getter for an ephemeral uuid
+ *
+ * @return ok on success and ident is set to the ephemeral uuid, otherwise
+ * failure.
+ */
+Status getEphemeralUUID(std::string& ident);
+
+/**
  * @brief Getter for a host's uuid.
  *
  * @return ok on success and ident is set to the host's uuid, otherwise failure.

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -229,6 +229,12 @@ QueryData genOsqueryInfo(QueryContext& context) {
     r["watcher"] = "-1";
   }
 
+  std::string uuid;
+  r["uuid"] = (getHostUUID(uuid)) ? uuid : "";
+
+  std::string instance;
+  r["instance_id"] = (getInstanceUUID(instance)) ? instance : "";
+
   results.push_back(r);
   return results;
 }

--- a/specs/utility/osquery_info.table
+++ b/specs/utility/osquery_info.table
@@ -2,6 +2,8 @@ table_name("osquery_info")
 description("Top level information about the running version of osquery.")
 schema([
     Column("pid", INTEGER, "Process (or thread/handle) ID"),
+    Column("uuid", TEXT, "Unique ID provided by the system"),
+    Column("instance_id", TEXT, "Unique, long-lived ID per instance of osquery"),
     Column("version", TEXT, "osquery toolkit version"),
     Column("config_hash", TEXT, "Hash of the working configuration state"),
     Column("config_valid", INTEGER, "1 if the config was loaded and considered valid, else 0"),


### PR DESCRIPTION
As discussed in #2819, this PR introduces two new host identifier
options:

- instance: an instance-unique UUID generated at process start,
  persisted in the backing store.
- ephemeral: an instance-unique UUID generated at process start, not
  persisted.

This PR also adds the following columns to the `osquery_info` table:

- `uuid`
- `instance_id`

```
$ ./build/debug_darwin/osquery/osqueryi --database_path=/tmp/db
osquery> select uuid, instance_id from osquery_info;
        uuid = B312055D-9209-5C89-9DDB-987299518FF7
 instance_id = be85e03b-1ae9-473a-989e-666351030e30

$ ./build/debug_darwin/osquery/osqueryi --database_path=/tmp/db
osquery> select uuid, instance_id from osquery_info;
        uuid = B312055D-9209-5C89-9DDB-987299518FF7
 instance_id = be85e03b-1ae9-473a-989e-666351030e30

$ ./build/debug_darwin/osquery/osqueryi --database_path=/tmp/db2
osquery> select uuid, instance_id from osquery_info;
        uuid = B312055D-9209-5C89-9DDB-987299518FF7
 instance_id = 3a3c8072-5a05-4ce8-bb19-d0799610cd6b
```

Notice how in the first two queries, the same database was used
(`/tmp/db`).  In the third query, a different database was used
(`/tmp/db2`). In all three queries, `uuid` is the same (because it's a
hardware identifier). In the first two queries, `instance_id` is the
same, thus illustrating that the `instance_id` is tied to a single
RocksDB database.

close #2819