### PR TITLE
extensions: Select ephemeral path for shell socket

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -123,6 +123,17 @@ Status loadModules(const std::string& loadfile);
 Status loadModuleFile(const std::string& path);
 
 /**
+ * @brief Initialize the extensions socket path variable for osqueryi.
+ *
+ * If the shell is invoked with a default extensions_socket flag there is a
+ * chance the path is 'overloaded' by multiple shells, use this method to
+ * determine a unique user-local path.
+ *
+ * @param Path to user's home directory.
+ */
+void initShellSocket(const std::string& home);
+
+/**
  * @brief Call a Plugin exposed by an Extension Registry route.
  *
  * This is mostly a Registry%-internal method used to call an ExtensionHandler

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -446,14 +446,7 @@ void Initializer::initShell() const {
       osquery::FLAGS_database_path =
           (fs::path(homedir) / "shell.db").make_preferred().string();
     }
-    if (Flag::isDefault("extensions_socket")) {
-      if (isPlatform(PlatformType::TYPE_WINDOWS)) {
-        osquery::FLAGS_extensions_socket = "\\\\.\\pipe\\shell.em";
-      } else {
-        osquery::FLAGS_extensions_socket =
-            (fs::path(homedir) / "shell.em").make_preferred().string();
-      }
-    }
+    initShellSocket(homedir);
   } else {
     fprintf(
         stderr, "Cannot access or create osquery home: %s", homedir.c_str());

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -261,6 +261,23 @@ void ExtensionManagerWatcher::watch() {
   }
 }
 
+void initShellSocket(const std::string& homedir) {
+  if (!Flag::isDefault("extensions_socket")) {
+    return;
+  }
+
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    osquery::FLAGS_extensions_socket = "\\\\.\\pipe\\shell.em";
+  } else {
+    osquery::FLAGS_extensions_socket =
+        (fs::path(homedir) / "shell.em").make_preferred().string();
+  }
+
+  if (extensionPathActive(FLAGS_extensions_socket, false)) {
+    FLAGS_extensions_socket += std::to_string((uint16_t)rand());
+  }
+}
+
 void loadExtensions() {
   // Disabling extensions will disable autoloading.
   if (FLAGS_disable_extensions) {


### PR DESCRIPTION
If there are multiple shell's using `~/.osquery/shell.em` this will append a random word to the end.