### PR TITLE
Bundle cURL PEM into packages

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -91,16 +91,19 @@
 #define OSQUERY_DB_HOME "/var/osquery"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
+#define OSQUERY_CERTS_HOME "/usr/share/osquery/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
 #define OSQUERY_LOG_HOME "\\ProgramData\\osquery\\log\\"
+#define OSQUERY_CERTS_HOME "\\ProgramData\\osquery\\"
 #else
 #define OSQUERY_HOME "/var/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
+#define OSQUERY_CERTS_HOME "/usr/share/osquery/"
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -91,19 +91,19 @@
 #define OSQUERY_DB_HOME "/var/osquery"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/share/osquery/"
+#define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
 #define OSQUERY_LOG_HOME "\\ProgramData\\osquery\\log\\"
-#define OSQUERY_CERTS_HOME "\\ProgramData\\osquery\\"
+#define OSQUERY_CERTS_HOME "\\ProgramData\\osquery\\certs\\"
 #else
 #define OSQUERY_HOME "/var/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/share/osquery/"
+#define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -37,7 +37,7 @@ CLI_FLAG(string,
 /// Path to optional TLS server/CA certificate(s), used for pinning.
 CLI_FLAG(string,
          tls_server_certs,
-         "",
+         OSQUERY_CERTS_HOME "certs.pem",
          "Optional path to a TLS server PEM certificate(s) bundle");
 
 /// Path to optional TLS client certificate, used for enrollment/requests.

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -41,6 +41,8 @@ OSQUERY_POSTINSTALL=${OSQUERY_POSTINSTALL:-""}
 OSQUERY_PREUNINSTALL=${OSQUERY_PREUNINSTALL:-""}
 OSQUERY_CONFIG_SRC=${OSQUERY_CONFIG_SRC:-""}
 OSQUERY_TLS_CERT_CHAIN_SRC=${OSQUERY_TLS_CERT_CHAIN_SRC:-""}
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"
 OSQUERY_LOG_DIR="/var/log/osquery/"
@@ -61,7 +63,8 @@ function usage() {
   This will generate an Linux package with:
   (1) An example config /usr/share/osquery/osquery.example.conf
   (2) An init.d script /etc/init.d/osqueryd
-  (3) The osquery toolset /usr/bin/osquery*"
+  (3) A default TLS certificate bundle (provided by cURL)
+  (4) The osquery toolset /usr/bin/osquery*"
 }
 
 function parse_args() {
@@ -147,8 +150,14 @@ function main() {
   fi
 
   if [[ $OSQUERY_TLS_CERT_CHAIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_SRC ]]; then
-    log "tls server certs file setup"
+    log "custom tls server certs file setup"
     cp $OSQUERY_TLS_CERT_CHAIN_SRC $INSTALL_PREFIX/$OSQUERY_ETC_DIR/tls-server-certs.pem
+  fi
+
+  if [[ $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST ]]; then
+    log "built-in tls server certs file setup"
+    mkdir -p `dirname $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST`
+    cp $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST
   fi
 
   if [[ $PACKAGE_TYPE = "deb" && $USE_SYSTEMD = "1" ]]; then

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -50,6 +50,8 @@ OSQUERY_CONFIG_SRC=""
 OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
 
@@ -114,7 +116,8 @@ function usage() {
   (1) An example config /var/osquery/osquery.example.config
   (2) An optional config /var/osquery/osquery.config if [-c] is used
   (3) A LaunchDaemon plist /var/osquery/com.facebook.osqueryd.plist
-  (4) The osquery toolset /usr/local/bin/osquery*
+  (4) A default TLS certificate bundle (provided by cURL)
+  (5) The osquery toolset /usr/local/bin/osquery*
 
   To enable osqueryd to run at boot using Launchd, pass the -a flag.
   If the LaunchDaemon was previously installed a newer version of this package
@@ -205,6 +208,11 @@ function main() {
   cp $PACKS_SRC/* $INSTALL_PREFIX$PACKS_DST
   if [[ "$TLS_CERT_CHAIN_SRC" != "" && -f "$TLS_CERT_CHAIN_SRC" ]]; then
     cp $TLS_CERT_CHAIN_SRC $INSTALL_PREFIX$TLS_CERT_CHAIN_DST
+  fi
+
+  if [[ $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC != "" ]] && [[ -f $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC ]]; then
+    mkdir -p `dirname $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST`
+    cp $OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC $INSTALL_PREFIX/$OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST
   fi
 
   # Move/install pre/post install scripts within the packaging root.


### PR DESCRIPTION
Now, on macOS:

```
$ ./tools/deployment/make_osx_package.sh
[+] notice: no config source specified
[+] using /Users/marpaia/git/osquery/tools/deployment/com.facebook.osqueryd.plist as the launchd source
[+] copying osquery binaries
[+] copying osquery configurations
[+] finalizing preinstall and postinstall scripts
[+] creating package
[+] package created at /Users/marpaia/git/osquery/tools/deployment/../../build/darwin/osquery-2.2.3-15-g2f6c8f5.pkg
[+] Skipping OS X RPM package build: Cannot find fpm and rpmbuild
[+] skipping kernel package, no kext found

$ pkgutil --payload-files ./build/darwin/osquery-2.2.3-15-g2f6c8f5.pkg
.
./private
./private/var
./private/var/log
./private/var/log/osquery
./private/var/osquery
./private/var/osquery/com.facebook.osqueryd.conf
./private/var/osquery/com.facebook.osqueryd.plist
./private/var/osquery/osquery.example.conf
./private/var/osquery/packs
./private/var/osquery/packs/hardware-monitoring.conf
./private/var/osquery/packs/incident-response.conf
./private/var/osquery/packs/it-compliance.conf
./private/var/osquery/packs/osquery-monitoring.conf
./private/var/osquery/packs/osx-attacks.conf
./private/var/osquery/packs/vuln-management.conf
./usr
./usr/local
./usr/local/bin
./usr/local/bin/osqueryctl
./usr/local/bin/osqueryd
./usr/local/bin/osqueryi
./usr/share
./usr/share/osquery
./usr/share/osquery/certs
./usr/share/osquery/certs/certs.pem
$
```

I haven't tested this on any of the Linux packages due to #2949.

close #2850