### PR TITLE
Converting fileops to support Windows 7

### DIFF
--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -818,8 +818,7 @@ ssize_t PlatformFile::getOverlappedResultForRead(void* buf,
   DWORD bytes_read = 0;
   DWORD last_error = 0;
 
-  if (::GetOverlappedResultEx(
-          handle_, &last_read_.overlapped_, &bytes_read, 0, TRUE)) {
+  if (::GetOverlappedResult(handle_, &last_read_.overlapped_, &bytes_read, 0)) {
     // Read operation has finished
 
     // NOTE: We do NOT support situations where the second read operation uses a
@@ -919,8 +918,8 @@ ssize_t PlatformFile::write(const void* buf, size_t nbyte) {
     if (ret == 0) {
       last_error = ::GetLastError();
       if (last_error == ERROR_IO_PENDING) {
-        ret = ::GetOverlappedResultEx(
-            handle_, &write_event.overlapped_, &bytes_written, 0, TRUE);
+        ret = ::GetOverlappedResult(
+            handle_, &write_event.overlapped_, &bytes_written, 0);
         if (ret == 0) {
           last_error = ::GetLastError();
           if (last_error == ERROR_IO_INCOMPLETE) {


### PR DESCRIPTION
This makes the necessary changes to the osquery code base to support Windows 7 x64. To get the binaries running on Windows 7 x86 requires repackaging of all of our third party libs, which is do-able, but at the potential cost of stability.

Further, when I built this on Windows 7 x64 I was getting a single test fail with file perms, however this test fail didn't seem to exist on Windows 10 so there may have been an environment issue.

Lastly, I have not tested any of this on Server 2008. I'll get some VMs up and running and see if the changes apply, but I'm confident they will.