### PR TITLE
sql: Reorder SQLite manager mutex locking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DEFINES := CTEST_OUTPUT_ON_FAILURE=1 \
 	LSAN_OPTIONS="detect_container_overflow=0 \
 	suppressions=${ANALYSIS}/lsan.supp" \
 	ASAN_OPTIONS="suppressions=${ANALYSIS}/asan.supp" \
-	TSAN_OPTIONS="suppressions=${ANALYSIS}/tsan.supp"
+	TSAN_OPTIONS="suppressions=${ANALYSIS}/tsan.supp,second_deadlock_stack=1"
 
 .PHONY: docs build
 

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -270,12 +270,15 @@ bool SQLiteDBManager::isDisabled(const std::string& table_name) {
 
 void SQLiteDBManager::resetPrimary() {
   auto& self = instance();
-  WriteLock create_lock(self.create_mutex_);
-  WriteLock connection_lock(self.mutex_);
 
+  WriteLock connection_lock(self.mutex_);
   self.connection_.reset();
-  sqlite3_close(self.db_);
-  self.db_ = nullptr;
+
+  {
+    WriteLock create_lock(self.create_mutex_);
+    sqlite3_close(self.db_);
+    self.db_ = nullptr;
+  }
 }
 
 void SQLiteDBManager::setDisabledTables(const std::string& list) {

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -66,12 +66,22 @@ TEST_F(SQLiteUtilTests, test_sqlite_instance) {
 
 TEST_F(SQLiteUtilTests, test_reset) {
   auto internal_db = SQLiteDBManager::get()->db();
+  ASSERT_NE(nullptr, internal_db);
+
+  sqlite3_exec(internal_db,
+               "create view test_view as select 'test';",
+               nullptr,
+               nullptr,
+               nullptr);
+
   SQLiteDBManager::resetPrimary();
-  auto new_internal_db = SQLiteDBManager::get()->db();
+  auto instance = SQLiteDBManager::get();
+
+  QueryData results;
+  queryInternal("select * from test_view", results, instance->db());
 
   // Assume the internal (primary) database we reset and recreated.
-  EXPECT_NE(nullptr, new_internal_db);
-  EXPECT_NE(internal_db, new_internal_db);
+  EXPECT_EQ(results.size(), 0U);
 }
 
 TEST_F(SQLiteUtilTests, test_direct_query_execution) {


### PR DESCRIPTION
First this fixes a locking order in the SQLite connection manager's new `resetPrimary` method. This also enhances the `test_reset` test that had been comparing pointer values. This is undeterministic, the new test creates a view then tests to assure the view does not exist after resetting.