### PR TITLE
Allow reloading config from disk

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -231,9 +231,17 @@ class Config : private boost::noncopyable {
    * @brief Call the genConfig method of the config retriever plugin.
    *
    * This may perform a resource load such as TCP request or filesystem read.
+   * If a non-zero value is passed to --config_refresh, this starts a thread
+   * that periodically calls genConfig to reload config state
+   */
+  Status refresh();
+
+  /**
+   * @brief Check if a config plugin is registered and load configs.
+   *
+   * Calls refresh after confirming a config plugin is registered
    */
   Status load();
-  Status refresh();
 
   /// A step method for Config::update.
   Status updateSource(const std::string& source, const std::string& json);
@@ -519,10 +527,11 @@ class ConfigParserPlugin : public Plugin {
   friend class Config;
 };
 
+// A thread that periodically reloads configuration state
 class ConfigRefreshRunner : public InternalRunnable {
-  public:
-    /// A simple wait/interruptible lock.
-    void start();
+ public:
+  /// A simple wait/interruptible lock.
+  void start();
 };
 
 /**

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -20,6 +20,7 @@
 
 #include <osquery/core.h>
 #include <osquery/database.h>
+#include <osquery/dispatcher.h>
 #include <osquery/registry.h>
 #include <osquery/status.h>
 
@@ -232,6 +233,7 @@ class Config : private boost::noncopyable {
    * This may perform a resource load such as TCP request or filesystem read.
    */
   Status load();
+  Status refresh();
 
   /// A step method for Config::update.
   Status updateSource(const std::string& source, const std::string& json);
@@ -311,6 +313,8 @@ class Config : private boost::noncopyable {
   /// or the initialization load step.
   bool loaded_{false};
 
+  bool started_thread_{false};
+
   /// A UNIX timestamp recorded when the config started.
   size_t start_time_{0};
 
@@ -319,6 +323,7 @@ class Config : private boost::noncopyable {
 
  private:
   friend class ConfigTests;
+  friend class ConfigRefreshRunner;
   friend class FilePathsConfigParserPluginTests;
   friend class FileEventsTableTests;
   friend class DecoratorsConfigParserPluginTests;
@@ -512,6 +517,12 @@ class ConfigParserPlugin : public Plugin {
 
  private:
   friend class Config;
+};
+
+class ConfigRefreshRunner : public InternalRunnable {
+  public:
+    /// A simple wait/interruptible lock.
+    void start();
 };
 
 /**

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -362,8 +362,9 @@ Status Config::refresh() {
     }
     status = update(response[0]);
 
-    // If the initial configuration includes a non-0 refresh, start an additional
-    // service that sleeps and periodically regenerates the configuration.
+    // If the initial configuration includes a non-0 refresh, start an
+    // additional service that sleeps and periodically regenerates the
+    // configuration.
     if (!started_thread_ && FLAGS_config_refresh >= 1) {
       Dispatcher::addService(std::make_shared<ConfigRefreshRunner>());
       started_thread_ = true;

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -60,6 +60,11 @@ CLI_FLAG(bool,
 
 CLI_FLAG(bool, config_dump, false, "Dump the contents of the configuration");
 
+CLI_FLAG(uint64,
+         config_refresh,
+         0,
+         "Optional interval in seconds to re-read configuration");
+
 DECLARE_string(config_plugin);
 DECLARE_string(pack_delimiter);
 DECLARE_bool(disable_events);
@@ -332,13 +337,7 @@ void Config::packs(std::function<void(PackRef& pack)> predicate) {
   }
 }
 
-Status Config::load() {
-  valid_ = false;
-  auto config_plugin = RegistryFactory::get().getActive("config");
-  if (!RegistryFactory::get().exists("config", config_plugin)) {
-    return Status(1, "Missing config plugin " + config_plugin);
-  }
-
+Status Config::refresh() {
   PluginResponse response;
   auto status = Registry::call("config", {{"action", "genConfig"}}, response);
   if (!status.ok()) {
@@ -362,10 +361,27 @@ Status Config::load() {
       Initializer::requestShutdown();
     }
     status = update(response[0]);
+
+    // If the initial configuration includes a non-0 refresh, start an additional
+    // service that sleeps and periodically regenerates the configuration.
+    if (!started_thread_ && FLAGS_config_refresh >= 1) {
+      Dispatcher::addService(std::make_shared<ConfigRefreshRunner>());
+      started_thread_ = true;
+    }
   }
 
   loaded_ = true;
   return status;
+}
+
+Status Config::load() {
+  valid_ = false;
+  auto config_plugin = RegistryFactory::get().getActive("config");
+  if (!RegistryFactory::get().exists("config", config_plugin)) {
+    return Status(1, "Missing config plugin " + config_plugin);
+  }
+
+  return refresh();
 }
 
 void stripConfigComments(std::string& json) {
@@ -806,5 +822,21 @@ Status ConfigParserPlugin::setUp() {
     data_.put(key, "");
   }
   return Status(0, "OK");
+}
+
+void ConfigRefreshRunner::start() {
+  while (!interrupted()) {
+    // Cool off and time wait the configured period.
+    // Apply this interruption initially as at t=0 the config was read.
+    pauseMilli(FLAGS_config_refresh * 1000);
+    // Since the pause occurs before the logic, we need to check for an
+    // interruption request.
+    if (interrupted()) {
+      return;
+    }
+
+    LOG(INFO) << "Refreshing configuration state";
+    Config::getInstance().refresh();
+  }
 }
 }

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -356,15 +356,16 @@ Status Config::refresh() {
                 content.first.c_str(),
                 content.second.c_str());
       }
-      // Instead of forcing the shutdown, request one since the config plugin
-      // may have started services.
+      // Don't force because the config plugin may have started services.
       Initializer::requestShutdown();
     }
     status = update(response[0]);
 
-    // If the initial configuration includes a non-0 refresh, start an
-    // additional service that sleeps and periodically regenerates the
-    // configuration.
+    /*
+     * If the initial configuration includes a non-0 refresh, start an
+     * additional service that sleeps and periodically regenerates the
+     * configuration.
+     */
     if (!started_thread_ && FLAGS_config_refresh >= 1) {
       Dispatcher::addService(std::make_shared<ConfigRefreshRunner>());
       started_thread_ = true;
@@ -836,7 +837,7 @@ void ConfigRefreshRunner::start() {
       return;
     }
 
-    LOG(INFO) << "Refreshing configuration state";
+    VLOG(1) << "Refreshing configuration state";
     Config::getInstance().refresh();
   }
 }

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -163,4 +163,3 @@ void FilesystemConfigRefreshRunner::start() {
   }
 }
 }
-

--- a/osquery/config/plugins/filesystem.cpp
+++ b/osquery/config/plugins/filesystem.cpp
@@ -14,7 +14,6 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <osquery/config.h>
-#include <osquery/dispatcher.h>
 #include <osquery/filesystem.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -32,27 +31,12 @@ CLI_FLAG(string,
          (fs::path(OSQUERY_HOME) / "osquery.conf").make_preferred().string(),
          "Path to JSON config file");
 
-CLI_FLAG(uint64,
-         config_filesystem_refresh,
-         0,
-         "Optional interval in seconds to re-read configuration");
-
 class FilesystemConfigPlugin : public ConfigPlugin {
  public:
   Status genConfig(std::map<std::string, std::string>& config);
   Status genPack(const std::string& name,
                  const std::string& value,
                  std::string& pack);
-
- private:
-  bool started_thread_{false};
-  void start();
-};
-
-class FilesystemConfigRefreshRunner : public InternalRunnable {
- public:
-  /// A simple wait/interruptible lock.
-  void start();
 };
 
 REGISTER(FilesystemConfigPlugin, "config", "filesystem");
@@ -75,13 +59,6 @@ Status FilesystemConfigPlugin::genConfig(
     if (readFile(path, content).ok()) {
       config[path] = content;
     }
-  }
-
-  // If the initial configuration includes a non-0 refresh, start an additional
-  // service that sleeps and periodically regenerates the configuration.
-  if (!started_thread_ && FLAGS_config_filesystem_refresh >= 1) {
-    Dispatcher::addService(std::make_shared<FilesystemConfigRefreshRunner>());
-    started_thread_ = true;
   }
 
   return Status(0, "OK");
@@ -136,30 +113,5 @@ Status FilesystemConfigPlugin::genPack(const std::string& name,
   }
 
   return readFile(value, pack);
-}
-
-void FilesystemConfigRefreshRunner::start() {
-  while (!interrupted()) {
-    // Cool off and time wait the configured period.
-    // Apply this interruption initially as at t=0 the config was read.
-    pauseMilli(FLAGS_config_filesystem_refresh * 1000);
-    // Since the pause occurs before the logic, we need to check for an
-    // interruption request.
-    if (interrupted()) {
-      return;
-    }
-
-    // Access the configuration.
-    auto plugin = RegistryFactory::get().plugin("config", "filesystem");
-    if (plugin != nullptr) {
-      auto config_plugin = std::dynamic_pointer_cast<ConfigPlugin>(plugin);
-
-      std::map<std::string, std::string> config;
-      if (config_plugin->genConfig(config)) {
-        LOG(INFO) << "Reloading configuration from disk";
-        Config::getInstance().update(config);
-      }
-    }
-  }
 }
 }


### PR DESCRIPTION
Adds a `--config_filesystem_refresh` option that does the same thing as `--config_tls_refresh`. If set, tells osquery to re-read the configuration on disk every <arg> seconds.

The code has been copied wholesale from the tls plugin. Thoughts on just having the base `Config` class expose an auto-refresh option instead? 