### PR TITLE
worker: Prefer null character over spaces when clearing argv

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -495,7 +495,7 @@ void Initializer::initWorker(const std::string& name) const {
   auto original_name = std::string((*argv_)[0]);
   for (int i = 0; i < *argc_; i++) {
     if ((*argv_)[i] != nullptr) {
-      memset((*argv_)[i], ' ', strlen((*argv_)[i]));
+      memset((*argv_)[i], '\0', strlen((*argv_)[i]));
     }
   }
 


### PR DESCRIPTION
On OS X, when replacing the worker's `argv`, spaces will continue to show in various process listings. This is odd for invocations of `osqueryd` with long argument lists. It will appear that the worker includes a newline.