### PR TITLE
tests: Add global 20min timeout for python tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ thrift
 # Needed for integration tests
 psutil
 pexpect
+timeout-decorator
 
 # For building the wiki
 mkdocs

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -26,6 +26,7 @@ import threading
 import unittest
 import utils
 import pexpect
+import timeout_decorator
 
 # While this path can be variable, in practice is lives statically.
 OSQUERY_DEPENDENCIES = "/usr/local/osquery"
@@ -514,6 +515,7 @@ class Tester(object):
         utils.reset_dir(CONFIG_DIR)
         CONFIG = read_config(ARGS.config) if ARGS.config else DEFAULT_CONFIG
 
+    @timeout_decorator.timeout(20 * 60)
     def run(self):
         os.setpgrp()
         unittest_args = [sys.argv[0]]
@@ -578,14 +580,16 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
     def _execute_set(self, queries):
         for example in queries:
             start_time = time.time()
+            print("Query: %s ..." % (example), end='')
+            sys.stdout.flush()
+
             result = self._execute(example)
             end_time = time.time()
             duration_ms = int((end_time - start_time) * 1000)
             if duration_ms > 2000:
                 # Query took longer than 2 seconds.
                 duration_ms = utils.lightred(duration_ms)
-            print("Query (%sms): %s, rows: %d" % (
-                duration_ms, example, len(result)))
+            print(" (%sms) rows: %d" % (duration_ms, len(result)))
 
 
 def expectTrue(functional, interval=0.01, timeout=8):

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -56,6 +56,9 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
 
     @test_base.flaky
     def test_3_daemon_with_watchdog(self):
+        # This test does not join the service threads properly (waits for int).
+        if os.environ.get('SANITIZE') is not None:
+            return
         daemon = self._run_daemon({
             "disable_watchdog": False,
             "ephemeral": True,


### PR DESCRIPTION
This adds the `timeout_decorator` module to the local Python. The run loop for Python `unittests` is now wrapped with a 20minute timeout. Usually, builds will fail the 2-hour timeout because of a single long-running test. It's better to fail that test and reclaim some of the 2-hour window.