### PR TITLE
[Fix #2973] alter SIP-protected paths on darwin

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -91,7 +91,7 @@
 #define OSQUERY_DB_HOME "/var/osquery"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/local/share/osquery/certs/"
+#define OSQUERY_CERTS_HOME "/var/osquery/certs/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -91,7 +91,7 @@
 #define OSQUERY_DB_HOME "/var/osquery"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
+#define OSQUERY_CERTS_HOME "/usr/local/share/osquery/certs/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
@@ -103,7 +103,7 @@
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
+#define OSQUERY_CERTS_HOME "/usr/local/share/osquery/certs/"
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -51,7 +51,7 @@ OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/local/share/osquery/certs/certs.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/var/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
 

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -51,7 +51,7 @@ OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/local/share/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
 


### PR DESCRIPTION
This target locations on 10.11+ that are protected by SIP, altering to
target valid paths inside /usr/local. Addresses issues introduced in https://github.com/facebook/osquery/pull/2950 and reported in #2973