### PR TITLE
packages: Use /var/osquery on OS X for home

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -96,14 +96,14 @@
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
-#define OSQUERY_LOG_HOME "\\ProgramData\\osquery\\log\\"
-#define OSQUERY_CERTS_HOME "\\ProgramData\\osquery\\certs\\"
+#define OSQUERY_LOG_HOME OSQUERY_HOME "\\log\\"
+#define OSQUERY_CERTS_HOME OSQUERY_HOME "\\certs\\"
 #else
 #define OSQUERY_HOME "/var/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
+#define OSQUERY_CERTS_HOME OSQUERY_HOME "/certs/"
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -51,7 +51,7 @@ OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/private/var/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
 


### PR DESCRIPTION
This is a quick fix, supersedes: #2974. 