### PR TITLE
Add checks for existing installation to chocolatey installer

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -13,6 +13,16 @@ $destClientBin = Join-Path $targetFolder 'osqueryi.exe'
 $packageParameters = $env:chocolateyPackageParameters
 $arguments = @{}
 
+# Before modifying we ensure to stop the service, if it exists
+if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and (Get-Service $serviceName).Status -eq 'Running') {
+  Stop-Service $serviceName
+}
+
+# Lastly, ensure that the Deny Write ACLs have been removed before modifying
+if (Test-Path $daemonFolder) {
+  Set-DenyWriteAcl $daemonFolder 'Remove'
+}
+
 # Now parse the packageParameters using good old regular expression
 if ($packageParameters) {
   $match_pattern = "\/(?<option>([a-zA-Z]+)):(?<value>([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"


### PR DESCRIPTION
To bring our internal chocolatey package recipe up to speed with our external, we need to make some checks for an existing installation as we don't _currently_ make use of the `upgrade` functionality. This diff checks for an existing Chocolatey installation before proceeding to install a newer version, as we require removing the Deny-Write ACLs from the installation folder before dropping the new version.