### PR TITLE
Moving default channel list to default flag value

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -278,6 +278,12 @@ Since event rows are only "added" it does not make sense to emit "removed" resul
 
 Maximum number of events to buffer in the backing store while waiting for a query to 'drain' or trigger an expiration. If the expiration (`events_expiry`) is set to 1 day, this max value indicates that only 1000 events will be stored before dropping each day. In this case the limiting time is almost always the scheduled query. If a scheduled query that select from events-based tables occurs sooner than the expiration time that interval becomes the limit.
 
+**Windows Only**
+
+`--windows_event_channels="System,Application,Setup,Security"`
+
+List of Windows event log channels to subscribe to. By default the Windows event log publisher will subscribe to some of the more common major event log channels. However you can subscribe to additional channels using the `Log Name` field value in the Windows event viewer. For example, to subscribe to Windows Powershell script block logging one would first enable the feature and then subscribe to the channel with `--windows_event_channels="Microsoft-Windows-PowerShell/Operational"`
+
 ### Logging/results flags
 
 `--logger_plugin=filesystem`

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -26,33 +26,24 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
-FLAG(string,
-     windows_additional_event_channels,
-     "",
-     "Comma-separated list of additional Windows event log channels");
-
 /*
 * @brief the Windows Event log channels to subscribe to
 *
 * By default we subscribe to all system channels. To subscribe to additional
-* channels one can hand them as a comma separated string to the
-* --windows_additional_event_channels flag.
+* channels specify them via this flag as a comma separated list.
 */
-const std::set<std::wstring> kDefaultSubscriptionChannels = {
-    L"System", L"Application", L"Setup", L"Security",
-};
+FLAG(string,
+     windows_event_channels,
+     "System,Application,Setup,Security",
+     "Comma-separated list of Windows event log channels");
 
 class WindowsEventSubscriber
     : public EventSubscriber<WindowsEventLogEventPublisher> {
  public:
   Status init() override {
     auto wc = createSubscriptionContext();
-    for (const auto& chan :
-         osquery::split(FLAGS_windows_additional_event_channels, ",")) {
+    for (const auto& chan : osquery::split(FLAGS_windows_event_channels, ",")) {
       wc->sources.insert(stringToWstring(chan));
-    }
-    for (const auto& chan : kDefaultSubscriptionChannels) {
-      wc->sources.insert(chan);
     }
     subscribe(&WindowsEventSubscriber::Callback, wc);
     return Status(0, "OK");


### PR DESCRIPTION
This PR Address #2980 by changing the hard coded channels we automatically subscribed to into default flag values. This should allow folks to subscribe to as many _or as few_ channels as they'd like.