### PR TITLE
Chocolatey uninstall should remove path from Machine path

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -4,10 +4,10 @@ $serviceName = 'osqueryd'
 
 # Remove the osquery path from the System PATH variable. Note: Here
 # we don't make use of our local vars, as Regex requires escaping the '\'
-$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
 if ($oldPath -imatch [regex]::escape($targetFolder)) {
   $newPath = $oldPath -replace [regex]::escape($targetFolder),$NULL
-  [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+  [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
 }
 
 if ((Get-Service $serviceName -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
By default, we install the osquery path to the `Machine` PATH variable. This was not being removed correctly on uninstall, and this PR fixes that.