### PR TITLE
linux: memory_map additional out of range check

### DIFF
--- a/osquery/tables/system/linux/memory_map.cpp
+++ b/osquery/tables/system/linux/memory_map.cpp
@@ -39,7 +39,7 @@ QueryData genMemoryMap(QueryContext& context) {
 
     Row r;
     r["start"] = "0x" + line.substr(0, b1);
-    if (b1 == line.length()) {
+    if (b1 == line.size() || line.size() <= b2 + 3) {
       continue;
     }
     r["end"] = "0x" + line.substr(b1 + 1, b2 - b1);


### PR DESCRIPTION
Fixed 1, but now the dynamic analysis breaks on the following line. We need to cover `b2` too.