### PR TITLE
add Ubuntu Dockerfile to build osquery

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:14.04
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y \
+    git \
+    wget \
+    ruby \
+    ruby-dev \
+    python \
+    python-dev \
+    build-essential \
+    curl
+# create dev user
+RUN adduser --ingroup sudo --disabled-password --gecos '' dev && \
+    mkdir -p /home/dev && \
+    sed -i.bak 's/sudo\tALL=(ALL:ALL) ALL/sudo\tALL=(ALL:ALL) NOPASSWD: ALL/g' /etc/sudoers && \
+    mkdir -p /usr/local/osquery && \
+    chown -R dev /usr/local && \
+    mkdir -p /osquery && \
+    chown -R dev /osquery
+# fix locales
+RUN \
+    locale-gen en_US.UTF-8 && \
+    localedef en_US.UTF-8 -i en_US -fUTF-8 && \
+    dpkg-reconfigure locales && \
+    echo "LANG=en_US.UTF-8" >> /etc/default/locale && \
+    echo "LANGUAGE=en_US.UTF-8" >> /etc/default/locale && \
+    echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale && \
+    export LANG=en_US.UTF-8 && \
+    export LANGUAGE=en_US.UTF-8 && \
+    export LC_ALL=en_US.UTF-8 && \
+    LANG=en_US.UTF-8 && \
+    LANGUAGE=en_US.UTF-8 && \
+    LC_ALL=en_US.UTF-8 && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+USER dev
+ENV HOME /home/dev
+RUN git clone https://github.com/facebook/osquery.git
+RUN sudo chown -R dev /osquery
+WORKDIR /osquery
+RUN ./tools/provision.sh
+RUN make
+RUN sudo make install
+#
+USER root
+WORKDIR /osquery/build/linux/osquery
+#
+RUN mkdir -p /var/osquery && mkdir -p /var/log/osquery
+#
+CMD ["osqueryd", "--config_path=/etc/osquery/osquery.conf", "--verbose"]


### PR DESCRIPTION
I created this Dockerfile to be able to compile a linux version of the project source. After some discussion with @theopolis in Slack, I'm adding it here for review and to generate some discussion. 

There are a few reasons you might want to run osquery in a container. 

* Testing agents during development of a TLS server. @zwass created [CentOS and Ubuntu containers](https://github.com/kolide/docker-osquery) very early on in the development of the kolide TLS endpoints, which proved to be very useful. Eventually, I wanted to start testing not just the latest stable version of osquery, but to try catching any regressions that might come up, by creating a nightly build. The Dockerfile in this PR is one of my attempts. 

* It is possible to schedule osqueryd as a [kubernetes daemonset](https://kubernetes.io/docs/admin/daemons/). While I have not looked into this extensively, the strategy is used to schedule monitoring and  log collection agents in container environments. 

I am interested in feedback and iterating on the modest start here.