### PR TITLE
Update vulnerability-management pack

### DIFF
--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -42,7 +42,7 @@
       "query" : "select browser_plugins.* from users join browser_plugins using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
-      "version" : "1.4.5",
+      "version" : "1.6.1",
       "description" : "Retrieves the list of C/NPAPI browser plugins in the target system.",
       "value" : "General security posture."
     },
@@ -50,23 +50,31 @@
       "query" : "select safari_extensions.* from users join safari_extensions using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
-      "version" : "1.4.5",
+      "version" : "1.6.1",
       "description" : "Retrieves the list of extensions for Safari in the target system.",
+      "value" : "General security posture."
+    },
+    "opera_extensions": {
+      "query" : "select opera_extensions.* from users join opera_extensions using (uid);",
+      "interval" : "86400",
+      "platform" : "posix",
+      "version" : "1.6.1",
+      "description" : "Retrieves the list of extensions for Opera in the target system.",
       "value" : "General security posture."
     },
     "chrome_extensions": {
       "query" : "select chrome_extensions.* from users join chrome_extensions using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
-      "version" : "1.4.5",
+      "version" : "1.6.1",
       "description" : "Retrieves the list of extensions for Chrome in the target system.",
       "value" : "General security posture."
     },
     "firefox_addons": {
       "query" : "select firefox_addons.* from users join firefox_addons using (uid);",
       "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.5",
+      "platform" : "posix",
+      "version" : "1.6.1",
       "description" : "Retrieves the list of addons for Firefox in the target system.",
       "value" : "General security posture."
     },

--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -65,7 +65,6 @@
     "chrome_extensions": {
       "query" : "select chrome_extensions.* from users join chrome_extensions using (uid);",
       "interval" : "86400",
-      "platform" : "darwin",
       "version" : "1.6.1",
       "description" : "Retrieves the list of extensions for Chrome in the target system.",
       "value" : "General security posture."


### PR DESCRIPTION
Added `opera_extensions` table to the `vulnerability-management` pack and also updated some fields for other browser related tables, like the platform and the version when they join another table with a column introduced later.