### PR TITLE
Update osx-attakcs pack: Adding ProntoApp

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -360,6 +360,12 @@
       "interval" : "3600",
       "description" : "Quimitchin Launch Agent (https://blog.malwarebytes.com/threat-analysis/2017/01/new-mac-backdoor-using-antiquated-code/)",
       "value" : "Artifact used by this malware"
+    },
+    "Pronto": {
+      "query" : "select * from launchd where name = 'pronto.notification.plist' or name = 'pronto.update.plist';",
+      "interval" : "3600",
+      "description" : "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
+      "value" : "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Adding detection for ProntoApp Launch Agents: 

https://malwarefixes.com/remove-pronto-video-converter/