### PR TITLE
darwin: Use boost shared_mutex for OS X

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -12,9 +12,14 @@
 
 #include <csignal>
 #include <memory>
-#include <shared_mutex>
 #include <string>
 #include <vector>
+
+#ifdef __APPLE__
+#include <boost/thread/shared_mutex.hpp>
+#else
+#include <shared_mutex>
+#endif
 
 #include <osquery/status.h>
 
@@ -177,14 +182,20 @@ inline bool isPlatform(PlatformType a, const PlatformType& t = kPlatformType) {
   return (static_cast<int>(t) & static_cast<int>(a)) != 0;
 }
 
+#ifdef __APPLE__
+#define MUTEX_IMPL boost
+#else
+#define MUTEX_IMPL std
+#endif
+
 /// Helper alias for defining mutexes.
-using Mutex = std::shared_timed_mutex;
+using Mutex = MUTEX_IMPL::shared_timed_mutex;
 
 /// Helper alias for write locking a mutex.
-using WriteLock = std::unique_lock<Mutex>;
+using WriteLock = MUTEX_IMPL::unique_lock<Mutex>;
 
 /// Helper alias for read locking a mutex.
-using ReadLock = std::shared_lock<Mutex>;
+using ReadLock = MUTEX_IMPL::shared_lock<Mutex>;
 
 /// Helper alias for defining recursive mutexes.
 using RecursiveMutex = std::recursive_mutex;

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 
 if(APPLE)
   ADD_OSQUERY_LINK_CORE("liblzma libbz2")
+  ADD_OSQUERY_LINK_CORE("boost_thread-mt")
 else()
   if(NOT WINDOWS)
     ADD_OSQUERY_LINK_CORE("lzma")

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -185,7 +185,7 @@ void SQLiteSQLPlugin::detach(const std::string& name) {
 }
 
 SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, Mutex& mtx)
-    : db_(db), lock_(mtx, std::try_to_lock) {
+    : db_(db), lock_(mtx, MUTEX_IMPL::try_to_lock) {
   if (lock_.owns_lock()) {
     primary_ = true;
   } else {

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -6,6 +6,7 @@ class Boost < AbstractOsqueryFormula
   url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
   sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
   head "https://github.com/boostorg/boost.git"
+  revision 1
 
   # Handle compile failure with boost/graph/adjacency_matrix.hpp
   # https://github.com/Homebrew/homebrew/pull/48262
@@ -71,6 +72,7 @@ class Boost < AbstractOsqueryFormula
       "--with-filesystem",
       "--with-regex",
       "--with-system",
+      "--with-thread",
       "threading=multi",
       "link=static",
       "optimization=space",


### PR DESCRIPTION
With 2.3.2 OS X 10.10 will load not lazy-load shared libraries due to a missing `shared_mutex` implementation (C++14). We can use Boost's shared mutex timer code instead.