### PR TITLE
deps: Upgrade boost to 1.63 and patch optional usage

### DIFF
--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -3,32 +3,19 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Boost < AbstractOsqueryFormula
   desc "Collection of portable C++ source libraries"
   homepage "https://www.boost.org/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2"
-  sha256 "686affff989ac2488f79a97b9479efb9f2abae035b5ed4d8226de6857933fd3b"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
+  sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   head "https://github.com/boostorg/boost.git"
   revision 1
-
-  # Handle compile failure with boost/graph/adjacency_matrix.hpp
-  # https://github.com/Homebrew/homebrew/pull/48262
-  # https://svn.boost.org/trac/boost/ticket/11880
-  # patch derived from https://github.com/boostorg/graph/commit/1d5f43d
-  patch :DATA
-
-  # Fix auto-pointer registration in 1.60
-  # https://github.com/boostorg/python/pull/59
-  # patch derived from https://github.com/boostorg/python/commit/f2c465f
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/9e56b45/boost/boost1_60_0_python_class_metadata.diff"
-    sha256 "1a470c3a2738af409f68e3301eaecd8d07f27a8965824baf8aee0adef463b844"
-  end
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "b133a4ea9b79073a66ef11722dd94ea12f07c64c51ec0216dce193af73f438e9" => :sierra
-    sha256 "5d531037e8fc6760c3cd1522703dc816c1fa2ae22a4695bb9698dc359ffc16c7" => :el_capitan
     sha256 "638c0f9dbd32c9c40459d8a377dcd63406347eccdefccaf8bca344c16f5566b4" => :x86_64_linux
   end
+
+  patch :DATA
 
   env :userpaths
 
@@ -101,15 +88,20 @@ class Boost < AbstractOsqueryFormula
 end
 
 __END__
-diff -Nur boost_1_60_0/boost/graph/adjacency_matrix.hpp boost_1_60_0-patched/boost/graph/adjacency_matrix.hpp
---- boost_1_60_0/boost/graph/adjacency_matrix.hpp	2015-10-23 05:50:19.000000000 -0700
-+++ boost_1_60_0-patched/boost/graph/adjacency_matrix.hpp	2016-01-19 14:03:29.000000000 -0800
-@@ -443,7 +443,7 @@
-     // graph type. Instead, use directedS, which also provides the
-     // functionality required for a Bidirectional Graph (in_edges,
-     // in_degree, etc.).
--    BOOST_STATIC_ASSERT(type_traits::ice_not<(is_same<Directed, bidirectionalS>::value)>::value);
-+    BOOST_STATIC_ASSERT(!(is_same<Directed, bidirectionalS>::value));
-
-     typedef typename mpl::if_<is_directed,
-                                     bidirectional_tag, undirected_tag>::type
+diff --git a/boost/xpressive/match_results.hpp b/boost/xpressive/match_results.hpp
+index e7923f8..5b2790b 100644
+--- a/boost/xpressive/match_results.hpp
++++ b/boost/xpressive/match_results.hpp
+@@ -744,9 +744,9 @@ private:
+     ///
+     void set_prefix_suffix_(BidiIter begin, BidiIter end)
+     {
+-        this->base_ = begin;
+-        this->prefix_ = sub_match<BidiIter>(begin, this->sub_matches_[ 0 ].first, begin != this->sub_matches_[ 0 ].first);
+-        this->suffix_ = sub_match<BidiIter>(this->sub_matches_[ 0 ].second, end, this->sub_matches_[ 0 ].second != end);
++        this->base_ = make_optional(begin);
++        this->prefix_ = make_optional(sub_match<BidiIter>(begin, this->sub_matches_[ 0 ].first, begin != this->sub_matches_[ 0 ].first));
++        this->suffix_ = make_optional(sub_match<BidiIter>(this->sub_matches_[ 0 ].second, end, this->sub_matches_[ 0 ].second != end));
+ 
+         typename nested_results_type::iterator ibegin = this->nested_results_.begin();
+         typename nested_results_type::iterator iend = this->nested_results_.end();

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -6,13 +6,18 @@ class CppNetlib < AbstractOsqueryFormula
   url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-final.tar.gz"
   version "0.12.0"
   sha256 "d66e264240bf607d51b8d0e743a1fa9d592d96183d27e2abdaf68b0a87e64560"
+  revision 3
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "6847b96010d47388abd54587b2142b9fca3bec1e8172eb9ebf8f6742b2103a37" => :sierra
-    sha256 "63381c4bcf64028c92aaaf51df8637b1d3ab5ffd3a3c30736c04361c2e08af6a" => :el_capitan
     sha256 "e906fa8d5347a923fffe6443a8ec1346a6e798ed7bf6071b5a002958d25eca3a" => :x86_64_linux
+  end
+
+  patch do
+    url "https://github.com/cpp-netlib/cpp-netlib/commit/49e21a8.diff"
+    sha256 "5dcbfad8f08f11d706f4d0d644a6c2fb0ef424cc8089fd54dfe3792a0abedbea"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This fixes an odd change in the `boost::optional` API with the upgrade from 1.60->1.63 (confirmed it is the 1.63 release over 1.62). The issue appears in our use of the `cpp-netlib` and oddly the boost xpressive library.