### PR TITLE
[Fix #2989] Updating users table to pickup users with no profile

### DIFF
--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -25,6 +25,16 @@
 
 namespace osquery {
 
+std::string psidToString(PSID sid) {
+  LPTSTR sidOut = nullptr;
+  auto ret = ConvertSidToStringSidA(sid, &sidOut);
+  if (ret == 0) {
+    VLOG(1) << "ConvertSidToString failed with " << GetLastError();
+    return std::string("");
+  }
+  return std::string(sidOut);
+}
+
 int getUidFromSid(PSID sid) {
   auto eUse = SidTypeUnknown;
   unsigned long unameSize = 0;


### PR DESCRIPTION
The users table will now first scan for any profiles existing on the local computer. This will give us all roaming profile users (AD accounts), as well as most local users. Lastly, we do a sweep for any accounts that have not yet established a profile on the machine, such as users _just_ made with `net add <user>`