### PR TITLE
Add additional regions to AWS Kinesis

### DIFF
--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -66,7 +66,12 @@ static const std::set<std::string> kAwsRegions = {"us-east-1",
                                                   "ap-southeast-2",
                                                   "ap-northeast-1",
                                                   "ap-northeast-2",
-                                                  "sa-east-1"};
+                                                  "sa-east-1",
+                                                  "ap-south-1",
+                                                  "us-east-2",
+                                                  "ca-central-1",
+                                                  "eu-west-1",
+                                                  "eu-west-2"};
 
 // Default AWS region to use when no region set in flags or profile
 static RegionName kDefaultAWSRegion = Aws::Region::US_EAST_1;


### PR DESCRIPTION
This supersedes #3004.

Add several 'missing' regions to the existing AWS Kinesis plugin.