### PR TITLE
chrome_extensions table with basic localization support

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -48,7 +48,7 @@ void genExtension(const std::string& uid,
 
   pt::ptree messagetree;
   // Find out if there are localized values for fields
-  if (tree.get<std::string>("default_locale", "") != "") {
+  if (!tree.get<std::string>("default_locale", "").empty()) {
     // Read the localized variables into a second ptree
     std::string messages_json;
     std::string localized_path = path + "/_locales/" +
@@ -76,12 +76,12 @@ void genExtension(const std::string& uid,
   for (const auto& it : kExtensionKeys) {
     std::string key = tree.get<std::string>(it.first, "");
     // If the value is an i18n reference, grab referenced value
-    if (key.compare(0, localized_prefix.length(), localized_prefix) == 0) {
+    if (key.compare(0, localized_prefix.length(), localized_prefix) == 0 &&
+        key.length() > 8) {
       r[it.second] = messagetree.get<std::string>(
-          key.substr(6, key.length() - 8) + ".message",
-          tree.get<std::string>(it.first, ""));
+          key.substr(6, key.length() - 8) + ".message", key);
     } else {
-      r[it.second] = tree.get<std::string>(it.first, "");
+      r[it.second] = key;
     }
     // Convert JSON bool-types to an integer.
     if (r[it.second] == "true") {

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <osquery/logger.h>
-
 #include "osquery/tables/applications/browser_utils.h"
 #include "osquery/tables/system/system_utils.h"
 
@@ -36,7 +35,7 @@ void genExtension(const std::string& uid,
     return;
   }
 
-  // Read the extensions data into a JSON blob, then property tree.
+  // Read the extension metadata into a JSON blob, then property tree.
   pt::ptree tree;
   try {
     std::stringstream json_stream;
@@ -47,12 +46,43 @@ void genExtension(const std::string& uid,
     return;
   }
 
+  pt::ptree messagetree;
+  // Find out if there are localized values for fields
+  if (tree.get<std::string>("default_locale", "") != "") {
+    // Read the localized variables into a second ptree
+    std::string messages_json;
+    std::string localized_path = path + "/_locales/" +
+                                 tree.get<std::string>("default_locale") +
+                                 "/messages.json";
+    if (!forensicReadFile(localized_path, messages_json).ok()) {
+      VLOG(1) << "Could not read file: " << localized_path;
+      return;
+    }
+
+    try {
+      std::stringstream messages_stream;
+      messages_stream << messages_json;
+      pt::read_json(messages_stream, messagetree);
+    } catch (const pt::json_parser::json_parser_error& /* e */) {
+      VLOG(1) << "Could not parse JSON from: " << localized_path;
+      return;
+    }
+  }
+
+  std::string localized_prefix = "__MSG_";
   Row r;
   r["uid"] = uid;
   // Most of the keys are in the top-level JSON dictionary.
   for (const auto& it : kExtensionKeys) {
-    r[it.second] = tree.get<std::string>(it.first, "");
-
+    std::string key = tree.get<std::string>(it.first, "");
+    // If the value is an i18n reference, grab referenced value
+    if (key.compare(0, localized_prefix.length(), localized_prefix) == 0) {
+      r[it.second] = messagetree.get<std::string>(
+          key.substr(6, key.length() - 8) + ".message",
+          tree.get<std::string>(it.first, ""));
+    } else {
+      r[it.second] = tree.get<std::string>(it.first, "");
+    }
     // Convert JSON bool-types to an integer.
     if (r[it.second] == "true") {
       r[it.second] = INTEGER(1);


### PR DESCRIPTION
An initial attempt at addressing #3011 

This is the first time I've written any C++, please make sure I didn't do anything stupid. I'm very open to feedback.

When `default_locale` is present in a `manifest.json`, genExtension now reads the contents of `path/_locales/<value of deafult_locale>/messages.json` into another propertytree. When populating row data, it looks for values prefixed with `__MSG_`, strips them, and then tries to match to a value in this messages.json-based propertytree. If there's no match, it falls back to supplying the raw value, which is how this function has worked thus far.

One limitation is that currently, the variable in manifest.json is case-sensitively checked against the key in messages.json. Most extensions in my testing match case, but one in particular does not: Google Wallet (`nmmhkkegccagdldgiimedpiccmgmieda`) which leads me to believe that Chrome's implementation of i18n is not case-sensitive.

I'd very much like to match this behavior to account for these edge cases, but std::string has a pretty lame feature set compared to other languages and I'm not sure what the most efficient solution would be.