### PR TITLE
linux: Fix SMBIOS reading from EFI systab

### DIFF
--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -36,7 +36,7 @@ void LinuxSMBIOSParser::readFromAddress(size_t address, size_t length) {
 
   // Search for the SMBIOS/DMI tables magic header string.
   size_t offset;
-  for (offset = 0; offset <= 0xFFF0; offset += 16) {
+  for (offset = 0; offset <= (length - sizeof(DMIEntryPoint)); offset += 16) {
     // Could look for "_SM_" for the SMBIOS header, but the DMI header exists
     // in both SMBIOS and the legacy DMI spec.
     if (memcmp(data_ + offset, "_DMI_", 5) == 0) {
@@ -60,16 +60,15 @@ void LinuxSMBIOSParser::readFromSystab(const std::string& systab) {
       if (details.size() == 2 && details[1].size() > 2) {
         long long int address;
         safeStrtoll(details[1], 16, address);
-        if (address < kLinuxSMBIOSRawAddress_ ||
-            address > (kLinuxSMBIOSRawAddress_ + kLinuxSMBIOSRawLength_)) {
-          VLOG(1) << "Invalid EFI provided SMBIOS start address: " << address;
-          return;
-        }
 
         // Be sure not to read past the 0x000F0000 - 0x00100000 range.
         // Otherwise strict /dev/mem access will generate a log line.
-        size_t offset = address - kLinuxSMBIOSRawAddress_;
-        size_t size = kLinuxSMBIOSRawLength_ - offset;
+        size_t size = 0x100;
+        if (address < 0x100000 && (address + size) > 0x100000) {
+          // If the address is within the 1M strict /dev/mem boundary, and is
+          // within 226 bytes of that boundary, reduce the read size.
+          size = 0x100000 - address;
+        }
         readFromAddress(address, size);
       }
     }


### PR DESCRIPTION
I haven't been able to reproduce a crash here, but the code looks nasty. The VMs/AMIs do not boot EFI so they do not fuzz this code path. On a VMware EFI-booted Ubuntu 14.04 the previous implementation was not crashing (even after removing the early break from scans to `0xFFF0`).