### PR TITLE
Update make-win64-dev-env.bat

### DIFF
--- a/tools/make-win64-dev-env.bat
+++ b/tools/make-win64-dev-env.bat
@@ -1,5 +1,5 @@
 @echo off
-%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass .\tools\provision.ps1
+%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass .\provision.ps1
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 %ALLUSERSPROFILE%\chocolatey\bin\refreshenv.cmd
 

--- a/tools/manage-osqueryd.ps1
+++ b/tools/manage-osqueryd.ps1
@@ -18,7 +18,7 @@ param(
 )
 
 $kServiceName = "osquery daemon service"
-$kServiceBinaryPath = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, '..', 'build', 'windows10', 'osquery', 'Release', 'osqueryd.exe'))
+$kServiceBinaryPath = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, '..', 'osquery', 'osqueryd', 'osqueryd.exe'))
 
 # Adapted from http://www.jonathanmedd.net/2014/01/testing-for-admin-privileges-in-powershell.html
 function Test-IsAdmin {


### PR DESCRIPTION
The powershell script, provision.ps1 is already present in the tools directory. The batch script is searching for it in the 'tools\' directory and it produces an error.

[d9817c7](https://github.com/raviteja7/osquery/commit/d9817c70982a564b8da3b7e16c7b234034bea680)


![image](https://cloud.githubusercontent.com/assets/2549509/23325638/c6d2e812-fac4-11e6-959c-5f5a3274276d.png)
