### PR TITLE
deps: Add patch to cpp-netlib for HTTPS IPv6

### DIFF
--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -25,6 +25,8 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
+DECLARE_string(tls_server_certs);
+
 class TLSTransportsTests : public testing::Test {
  public:
   bool verify(const Status& status) {
@@ -49,16 +51,20 @@ class TLSTransportsTests : public testing::Test {
   }
 
   void SetUp() override {
+    certs_ = FLAGS_tls_server_certs;
+    FLAGS_tls_server_certs = "";
     TLSServerRunner::start();
     port_ = TLSServerRunner::port();
   }
 
   void TearDown() override {
     TLSServerRunner::stop();
+    FLAGS_tls_server_certs = certs_;
   }
 
  protected:
   std::string port_;
+  std::string certs_;
 };
 
 TEST_F(TLSTransportsTests, test_call) {

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -6,7 +6,7 @@ class Boost < AbstractOsqueryFormula
   url "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
   sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   head "https://github.com/boostorg/boost.git"
-  revision 2
+  revision 4
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -6,7 +6,7 @@ class CppNetlib < AbstractOsqueryFormula
   url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-final.tar.gz"
   version "0.12.0"
   sha256 "d66e264240bf607d51b8d0e743a1fa9d592d96183d27e2abdaf68b0a87e64560"
-  revision 4
+  revision 6
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -14,6 +14,8 @@ class CppNetlib < AbstractOsqueryFormula
     sha256 "6847b96010d47388abd54587b2142b9fca3bec1e8172eb9ebf8f6742b2103a37" => :sierra
     sha256 "e906fa8d5347a923fffe6443a8ec1346a6e798ed7bf6071b5a002958d25eca3a" => :x86_64_linux
   end
+
+  patch :DATA
 
   depends_on "cmake" => :build
   depends_on "openssl"
@@ -43,3 +45,20 @@ class CppNetlib < AbstractOsqueryFormula
     end
   end
 end
+
+__END__
+diff --git a/boost/network/protocol/http/client/connection/ssl_delegate.ipp b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+index b303a24..cb9c2cf 100644
+--- a/boost/network/protocol/http/client/connection/ssl_delegate.ipp
++++ b/boost/network/protocol/http/client/connection/ssl_delegate.ipp
+@@ -64,7 +64,10 @@ void boost::network::http::impl::ssl_delegate::connect(
+     context_->use_private_key_file(*private_key_file_, asio::ssl::context::pem);
+ 
+   tcp_socket_.reset(new asio::ip::tcp::socket(
+-      service_, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), source_port)));
++      service_, asio::ip::tcp::endpoint(endpoint.address().is_v4() 
++                                            ? asio::ip::tcp::v4()
++                                            : asio::ip::tcp::v6(),
++                                        source_port)));
+   socket_.reset(new asio::ssl::stream<asio::ip::tcp::socket &>(
+       *(tcp_socket_.get()), *context_));


### PR DESCRIPTION
This moves us to the `0.13.0` branch of `cpp-netlib` and that includes a patch for IPv6 with HTTPS.