### PR TITLE
external: Enable external applications through make externals

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,6 +6,7 @@
 # If a directory includes: "module_NAME" it is built as a module.
 
 add_custom_target(externals)
+add_definitions(-DOSQUERY_EXTERNAL)
 
 macro(SUBDIRLIST OUTPUT PWD)
   file(GLOB children RELATIVE ${PWD} "${PWD}/*")

--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -20,7 +20,7 @@
 
 namespace osquery {
 
-SHELL_FLAG(string, nullvalue, "", "Set string for NULL values, default ''");
+DECLARE_string(nullvalue);
 
 static std::vector<char> kOffset = {0, 0};
 static std::string kToken = "|";

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -23,7 +23,7 @@ FLAG(string,
      "Not Specified",
      "Comma-delimited list of table names to be disabled");
 
-DECLARE_string(nullvalue);
+FLAG(string, nullvalue, "", "Set string for NULL values, default ''");
 
 using OpReg = QueryPlanner::Opcode::Register;
 

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -600,7 +600,10 @@ Status attachFunctionInternal(
 
 void attachVirtualTables(const SQLiteDBInstanceRef& instance) {
   if (FLAGS_enable_foreign) {
+#if !defined(OSQUERY_EXTERNAL)
+    // Foreign table schema is available for the shell and daemon only.
     registerForeignTables();
+#endif
   }
 
   PluginResponse response;

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -62,25 +62,29 @@ struct VirtualTable : private boost::noncopyable {
   sqlite3_vtab base;
 
   /// Added structure: A content structure with metadata about the table.
-  VirtualTableContent *content{nullptr};
+  VirtualTableContent* content{nullptr};
 
   /// Added structure: The thread-local DB instance associated with the query.
-  SQLiteDBInstance *instance{nullptr};
+  SQLiteDBInstance* instance{nullptr};
 };
 
 /// Attach a table plugin name to an in-memory SQLite database.
-Status attachTableInternal(const std::string &name,
-                           const std::string &statement,
-                           const SQLiteDBInstanceRef &instance);
+Status attachTableInternal(const std::string& name,
+                           const std::string& statement,
+                           const SQLiteDBInstanceRef& instance);
 
 /// Detach (drop) a table.
-Status detachTableInternal(const std::string &name, sqlite3 *db);
+Status detachTableInternal(const std::string& name, sqlite3* db);
 
 Status attachFunctionInternal(
-    const std::string &name,
+    const std::string& name,
     std::function<
-        void(sqlite3_context *context, int argc, sqlite3_value **argv)> func);
+        void(sqlite3_context* context, int argc, sqlite3_value** argv)> func);
 
+/// Attach all table plugins to an in-memory SQLite database.
+void attachVirtualTables(const SQLiteDBInstanceRef& instance);
+
+#if !defined(OSQUERY_EXTERNAL)
 /**
  * A generated foreign amalgamation file includes schema for all tables.
  *
@@ -90,7 +94,5 @@ Status attachFunctionInternal(
  * their filter generation functions.
  */
 void registerForeignTables();
-
-/// Attach all table plugins to an in-memory SQLite database.
-void attachVirtualTables(const SQLiteDBInstanceRef &instance);
+#endif
 }


### PR DESCRIPTION
Several changes to enable building "external apps" using the `make external` make target. This target was originally scoped to only produce extensions and modules (C++), but some projects want to build another binary, similar to the shell or daemon. We handle this already with a 'catch-all' that runs your custom `CMakeLists.txt` in an `./external/project_name` subdirectory. However, to link surgically against what we consider the SDK and pull in some tables these reorganizations are needed.