### PR TITLE
Updating hardware-monitoring pack with new intervals, platforms and queries

### DIFF
--- a/packs/hardware-monitoring.conf
+++ b/packs/hardware-monitoring.conf
@@ -3,6 +3,7 @@
     "acpi_tables": {
       "query": "select * from acpi_tables;",
       "interval": 86400,
+      "platform": "posix",
       "description": "General reporting and heuristics monitoring."
     },
     "cpuid": {
@@ -13,11 +14,12 @@
     "smbios_tables": {
       "query": "select * from smbios_tables;",
       "interval": 86400,
+      "platform": "posix",
       "description": "General reporting and heuristics monitoring."
     },
     "nvram": {
       "query": "select * from nvram where name not in ('backlight-level', 'SystemAudioVolumeDB', 'SystemAudioVolume');",
-      "interval": 1200,
+      "interval": 7200,
       "platform": "darwin",
       "description": "Report on crashes, alternate boots, and boot arguments."
     },
@@ -29,16 +31,33 @@
     "pci_devices": {
       "query": "select * from pci_devices;",
       "interval": 7200,
+      "platform": "posix",
       "description": "Report an inventory of PCI devices. Attaches and detaches will show up in hardware_events."
+    },
+    "fan_speeds": {
+      "query": "select * from fan_speed_sensors;",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.7.1",
+      "description": "Report current fan speeds in the target OSX system."
+    },
+    "temperatures": {
+      "query": "select * from temperature_sensors;",
+      "interval": 7200,
+      "platform": "darwin",
+      "version": "1.7.1",
+      "description": "Report current machine temperatures in the target OSX system."
     },
     "usb_devices": {
       "query": "select * from usb_devices;",
       "interval": 7200,
+      "platform": "posix",
       "description": "Report an inventory of USB devices. Attaches and detaches will show up in hardware_events."
     },
     "hardware_events": {
       "query" : "select * from hardware_events where path <> '' or model <> '';",
       "interval" : 7200,
+      "platform": "posix",
       "removed": false,
       "version" : "1.4.5",
       "description" : "Retrieves all the hardware related events in the target OSX system.",
@@ -66,21 +85,29 @@
     },
     "kernel_extensions": {
       "query" : "select * from kernel_extensions;",
-      "interval" : "3600",
+      "interval" : "7200",
       "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves all the information about the current kernel extensions for the target OSX system."
     },
     "kernel_modules": {
       "query" : "select * from kernel_modules;",
-      "interval" : "3600",
+      "interval" : "7200",
       "platform" : "linux",
       "version" : "1.4.5",
       "description" : "Retrieves all the information for the current kernel modules in the target Linux system."
     },
+    "windows_drivers": {
+      "query" : "select * from drivers;",
+      "interval" : "7200",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+    },
     "device_nodes": {
       "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, mode, type from file where directory = '/dev/';",
-      "interval": "600",
+      "interval": "7200",
+      "platform": "posix",
       "version": "1.6.0",
       "description": "Inventory all 'device' nodes in /dev/."
     }


### PR DESCRIPTION
Some new tables were never added to the packs, in this case `hardware-monitoring.pack`. Also some intervals and platforms needed a bit of tweaking and newer tables were added too (ex: Windows)
This has been tested with the following configuration:
```
$ cat /tmp/osquery.conf
{
  "options": {
    "config_plugin": "filesystem",
    "logger_plugin": "filesystem",
    "logger_path": "/tmp/osquery",
    "pidfile": "/tmp/osquery/osquery.pidfile",
    "events_expiry": "3600",
    "database_path": "/tmp/osquery/osquery.db"
  },
  // Define a schedule of queries:
  "schedule": {
    // This is a simple example query that outputs basic system information.
    "system_info": {
      // The exact query to run.
      "query": "SELECT hostname, cpu_brand, physical_memory FROM system_info;",
      // The interval in seconds to run this query, not an exact interval.
      "interval": 3600
    }
  },
  "packs": {
    "hardware-monitoring": "/tmp/osquery/pack.conf"
  }
}
```
And the command was:
```
$ sudo ./build/darwin/osquery/osqueryi --config_path /tmp/osquery.conf --extensions_autoload /tmp/osquery --modules_autoload /tmp/osquery
Using a virtual database. Need help, type '.help'
osquery> .mode line
osquery> select * from osquery_packs;
                name = main
            platform =
             version =
               shard = 0
discovery_cache_hits = 0
discovery_executions = 1
              active = 1

                name = hardware-monitoring
            platform =
             version =
               shard = 0
discovery_cache_hits = 0
discovery_executions = 1
              active = 1
osquery>
```