### PR TITLE
Adding discovery query support to distributed queries

### DIFF
--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -45,6 +45,17 @@ EXAMPLE_DISTRIBUTED = {
     }
 }
 
+EXAMPLE_DISTRIBUTED_DISCOVERY = {
+    "queries": {
+        "windows_info": "select * from system_info",
+        "darwin_chrome_ex": "select users.username, ce.* from users join chrome_extensions ce using (uid)",
+    },
+    "discovery": {
+        "windows_info": "select * from os_version where platform='windows'",
+        "darwin_chrome_ex": "select * from os_version where platform='darwin'"
+    }
+}
+
 EXAMPLE_DISTRIBUTED_ACCELERATE = {
     "queries": {
         "info": "select * from osquery_info",


### PR DESCRIPTION
Adding the ability to gate queries using discovery queries in ad hoc scheduling. This should not affect any system that relies on the format of distributed queries as they are now. The discovery query is achieved by adding an extra sub-dictionary to queries containing a map of names to discovery queries.

```json
EXAMPLE_DISTRIBUTED_DISCOVERY = {
    "queries": {
        "windows_info": "select * from system_info",
        "darwin_chrome_ex": "select users.username, ce.* from users join chrome_extensions ce using (uid)",
    },
    "discovery": {
        "windows_info": "select * from os_version where platform='windows'",
        "darwin_chrome_ex": "select * from os_version where platform='darwin'"
    }
}
```

This test block for distributed queries will return system_info only on Windows systems and chrome extensions only on OS X systems.

If there is no discovery block, all queries will run. If there is a discovery block with some elements, only queries that have a discovery query that returns at least one row will run.

**All queries run**
```json
EXAMPLE_DISTRIBUTED_DISCOVERY = {
    "queries": {
        "windows_info": "select * from system_info",
        "darwin_chrome_ex": "select users.username, ce.* from users join chrome_extensions ce using (uid)",
    }
}
```

```json
EXAMPLE_DISTRIBUTED_DISCOVERY = {
    "queries": {
        "windows_info": "select * from system_info",
        "darwin_chrome_ex": "select users.username, ce.* from users join chrome_extensions ce using (uid)",
    },
    "discovery": {
    }
}
```

**No queries run**

```json
EXAMPLE_DISTRIBUTED_DISCOVERY = {
    "queries": {
        "windows_info": "select * from system_info",
        "darwin_chrome_ex": "select users.username, ce.* from users join chrome_extensions ce using (uid)",
    },
    "discovery": {
        "a_non_existant_name": "select * from os_version where platform='windows'",
    }
}
```