### PR TITLE
Updating it-compliance pack with windows queries

### DIFF
--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -76,6 +76,14 @@
       "description" : "Retrieves the current list of Network File System mounted shares.",
       "value" : "Verify if shares are accessible to those who need it"
     },
+    "windows_shared_resources": {
+      "query" : "select * from shared_resources;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.0.0",
+      "description" : "Retrieves the list of shared resources in the target Windows system.",
+      "value" : "General security posture."
+    },
     "browser_plugins": {
       "query" : "select * from browser_plugins;",
       "interval" : "86400",
@@ -95,7 +103,6 @@
     "chrome_extensions": {
       "query" : "select * from chrome_extensions;",
       "interval" : "86400",
-      "platform" : "darwin",
       "version" : "1.4.5",
       "description" : "Retrieves the list of extensions for Chrome in the target system.",
       "value" : "General security posture."
@@ -115,6 +122,21 @@
       "version" : "1.4.5",
       "description" : "Retrieves the list of brew packages installed in the target OSX system.",
       "value" : "General security posture."
+    },
+    "windows_programs": {
+      "query" : "select * from programs;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.0.0",
+      "description" : "Retrieves the list of products as they are installed by Windows Installer in the target Windows system.",
+      "value" : "General security posture."
+    },
+    "windows_patches": {
+      "query" : "select * from patches;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
     },
     "package_receipts": {
       "query" : "select * from package_receipts;",
@@ -171,6 +193,13 @@
       "description" : "Retrieves the current list of loaded kernel modules in the target Linux system.",
       "value" : "General security posture."
     },
+    "windows_drivers": {
+      "query" : "select * from drivers;",
+      "interval" : "86400",
+      "platform" : "windows",
+      "version" : "2.2.0",
+      "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
+    },
     "rpm_packages": {
       "query" : "select * from rpm_packages;",
       "interval" : "86400",
@@ -191,6 +220,7 @@
       "query" : "select * from disk_encryption;",
       "interval" : "86400",
       "version" : "1.4.5",
+      "platform" : "posix",
       "description" : "Retrieves the current disk encryption status for the target system.",
       "value" : "Identifies a system potentially vulnerable to disk cloning."
     },


### PR DESCRIPTION
New queries for the pack `it-compliance.pack` to cover the Windows platform and a couple of tweaks to more accurate platform selection.