### PR TITLE
Add getQueryTables to inspect tables scanned

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -56,6 +56,11 @@ class ExternalSQLPlugin : public SQLPlugin {
     return queryExternal(q, results);
   }
 
+  Status getQueryTables(const std::string& q,
+                        std::vector<std::string>& tables) const override {
+    return Status(0, "Not used");
+  }
+
   Status getQueryColumns(const std::string& q,
                          TableColumns& columns) const override {
     return getQueryColumnsExternal(q, columns);

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -192,6 +192,10 @@ class SQLPlugin : public Plugin {
   virtual Status getQueryColumns(const std::string& q,
                                  TableColumns& columns) const = 0;
 
+  /// Given a query, return the list of scanned tables.
+  virtual Status getQueryTables(const std::string& q,
+                                std::vector<std::string>& tables) const = 0;
+
   /**
    * @brief Attach a table at runtime.
    *
@@ -250,4 +254,17 @@ Status query(const std::string& query, QueryData& results);
  * @return status indicating success or failure of the operation.
  */
 Status getQueryColumns(const std::string& q, TableColumns& columns);
+
+/**
+ * @brief Extract table names from an input query.
+ *
+ * This should return the scanned virtual tables, not aliases or intermediate
+ * tables, from a given query.
+ *
+ * @param q the query to analyze.
+ * @param tables the output vector to fill with table names.
+ *
+ * @return status indicating success or failure of the operation.
+ */
+Status getQueryTables(const std::string& q, std::vector<std::string>& tables);
 }

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -226,6 +226,11 @@ class QueryPlanner : private boost::noncopyable {
    */
   Status applyTypes(TableColumns& columns);
 
+  /// Get the list of tables filtered by this query.
+  std::vector<std::string> tables() const {
+    return tables_;
+  }
+
   /**
    * @brief A helper structure to represent an opcode's result and type.
    *

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -175,6 +175,17 @@ TEST_F(SQLiteUtilTests, test_get_query_columns) {
   ASSERT_FALSE(status.ok());
 }
 
+TEST_F(SQLiteUtilTests, test_get_query_tables) {
+  std::string query =
+      "SELECT * FROM time, osquery_info, (SELECT * FROM file) ff GROUP BY pid";
+  std::vector<std::string> tables;
+  auto status = getQueryTables(query, tables);
+  EXPECT_TRUE(status.ok());
+
+  std::vector<std::string> expected = {"file", "time", "osquery_info"};
+  EXPECT_EQ(expected, tables);
+}
+
 std::vector<ColumnType> getTypes(const TableColumns& columns) {
   std::vector<ColumnType> types;
   for (const auto& col : columns) {


### PR DESCRIPTION
This adds a new automation API method to the `SQL` implementation plugin. The only available built-in plugin, SQLite, is updated to include its implementation too.

`getQueryTables`: will return all of the _actual_ virtual tables scanned by a query.

This new API forces a unit test and has discovered a bug in the `QueryPlanner` abstraction, which is used to help identify the types of columns used in a query.