### PR TITLE
profile: Fix Zombie check and disable extensions

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -50,8 +50,8 @@ def check_leaks_linux(shell, query, count=1, supp_file=None):
         shell,
         "--profile",
         "%d" % count,
-        "--query",
         query,
+        "--disable_extensions",
     ]
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -138,7 +138,8 @@ def run_query(shell, query, timeout=0, count=1):
         str(count),
         "--profile_delay",
         "1",
-        query
+        query,
+        "--disable_extensions",
     ], timeout=timeout, count=count)
 
 

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -172,6 +172,8 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
             percents.append(stats["utilization"])
         except psutil.AccessDenied:
             break
+        except psutil.ZombieProcess:
+            break
         delay += step
         if timeout > 0 and delay >= timeout + 2:
             proc.kill()


### PR DESCRIPTION
The newer version of `psutils` can throw a zombie exception, in most cases we are waiting for the process to become a zombie and must handle this. The tests should also be performed without extensions (when checking leads/etc) as the tooling does not handle profiling of child processes.