### PR TITLE
Remove include of thrift/TOutput

### DIFF
--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -10,8 +10,6 @@
 
 #include <string>
 
-#include <thrift/TOutput.h>
-
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>


### PR DESCRIPTION
Testing to see if this include is needed for any OS build.