### PR TITLE
rocksdb: Set a max size for RocksDB MANIFEST logs

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -163,6 +163,7 @@ Status RocksDBDatabasePlugin::setUp() {
     options_.keep_log_file_num = 10;
     options_.max_log_file_size = 1024 * 1024 * 1;
     options_.stats_dump_period_sec = 0;
+    options_.max_manifest_file_size = 1024 * 500;
 
     // Performance and optimization settings.
     options_.compression = rocksdb::kNoCompression;


### PR DESCRIPTION
For long running `osqueryd` processes that process lots of events within a 2-hour period, the `MANIFEST` transaction log may grow to 1G+ in size. We do not need to maintain replays beyond 500KB.