### PR TITLE
rocksdb: Update to 5.0 and use DeleteRange for expirations

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -467,6 +467,11 @@ class DatabasePlugin : public Plugin {
   /// Data removal method.
   virtual Status remove(const std::string& domain, const std::string& k) = 0;
 
+  /// Data removal with range bounds.
+  virtual Status removeRange(const std::string& domain,
+                             const std::string& low,
+                             const std::string& high) = 0;
+
   virtual Status scan(const std::string& domain,
                       std::vector<std::string>& results,
                       const std::string& prefix,
@@ -577,6 +582,11 @@ Status setDatabaseValue(const std::string& domain,
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);
+
+/// Remove a range of keys in domain.
+Status deleteDatabaseRange(const std::string& domain,
+                           const std::string& low,
+                           const std::string& high);
 
 /// Get a list of keys for a given domain.
 Status scanDatabaseKeys(const std::string& domain,

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -494,10 +494,8 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * The subscriber must count the number of buffered records and check if
    * that count exceeds the configured `events_max` limit. If an overflow
    * occurs the subscriber will expire N-events_max from the end of the queue.
-   *
-   * @param cleanup Perform an intense scan of zombie event IDs.
    */
-  void expireCheck(bool cleanup = false);
+  void expireCheck();
 
   /**
    * @brief Add an EventID, EventTime pair to all matching list types.

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -502,6 +502,12 @@ Status DatabasePlugin::call(const PluginRequest& request,
     return this->put(domain, key, request.at("value"));
   } else if (request.at("action") == "remove") {
     return this->remove(domain, key);
+  } else if (request.at("action") == "remove_range") {
+    auto key_high = (request.count("high") > 0) ? request.at("key_high") : "";
+    if (!key_high.empty() && !key.empty()) {
+      return this->removeRange(domain, key, key_high);
+    }
+    return Status(1, "Missing range");
   } else if (request.at("action") == "scan") {
     // Accumulate scanned keys into a vector.
     std::vector<std::string> keys;
@@ -535,8 +541,11 @@ static inline std::shared_ptr<DatabasePlugin> getDatabasePlugin() {
 Status getDatabaseValue(const std::string& domain,
                         const std::string& key,
                         std::string& value) {
-  ReadLock lock(kDatabaseReset);
+  if (domain.empty()) {
+    return Status(1, "Missing domain");
+  }
 
+  ReadLock lock(kDatabaseReset);
   if (RegistryFactory::get().external()) {
     // External registries (extensions) do not have databases active.
     // It is not possible to use an extension-based database.
@@ -560,8 +569,11 @@ Status getDatabaseValue(const std::string& domain,
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         const std::string& value) {
-  ReadLock lock(kDatabaseReset);
+  if (domain.empty()) {
+    return Status(1, "Missing domain");
+  }
 
+  ReadLock lock(kDatabaseReset);
   if (RegistryFactory::get().external()) {
     // External registries (extensions) do not have databases active.
     // It is not possible to use an extension-based database.
@@ -575,8 +587,11 @@ Status setDatabaseValue(const std::string& domain,
 }
 
 Status deleteDatabaseValue(const std::string& domain, const std::string& key) {
-  ReadLock lock(kDatabaseReset);
+  if (domain.empty()) {
+    return Status(1, "Missing domain");
+  }
 
+  ReadLock lock(kDatabaseReset);
   if (RegistryFactory::get().external()) {
     // External registries (extensions) do not have databases active.
     // It is not possible to use an extension-based database.
@@ -586,6 +601,28 @@ Status deleteDatabaseValue(const std::string& domain, const std::string& key) {
   } else {
     auto plugin = getDatabasePlugin();
     return plugin->remove(domain, key);
+  }
+}
+
+Status deleteDatabaseRange(const std::string& domain,
+                           const std::string& low,
+                           const std::string& high) {
+  if (domain.empty()) {
+    return Status(1, "Missing domain");
+  }
+
+  ReadLock lock(kDatabaseReset);
+  if (RegistryFactory::get().external()) {
+    // External registries (extensions) do not have databases active.
+    // It is not possible to use an extension-based database.
+    PluginRequest request = {{"action", "remove_range"},
+                             {"domain", domain},
+                             {"key", low},
+                             {"key_high", high}};
+    return Registry::call("database", request);
+  } else {
+    auto plugin = getDatabasePlugin();
+    return plugin->removeRange(domain, low, high);
   }
 }
 
@@ -600,8 +637,11 @@ Status scanDatabaseKeys(const std::string& domain,
                         std::vector<std::string>& keys,
                         const std::string& prefix,
                         size_t max) {
-  ReadLock lock(kDatabaseReset);
+  if (domain.empty()) {
+    return Status(1, "Missing domain");
+  }
 
+  ReadLock lock(kDatabaseReset);
   if (RegistryFactory::get().external()) {
     // External registries (extensions) do not have databases active.
     // It is not possible to use an extension-based database.

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -16,7 +16,7 @@ namespace osquery {
 DECLARE_string(database_path);
 
 class EphemeralDatabasePlugin : public DatabasePlugin {
-  using DBType = std::map<std::string, std::map<std::string, std::string> >;
+  using DBType = std::map<std::string, std::map<std::string, std::string>>;
 
  public:
   /// Data retrieval method.
@@ -31,6 +31,10 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
 
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;
+
+  Status removeRange(const std::string& domain,
+                     const std::string& low,
+                     const std::string& high) override;
 
   /// Key/index lookup method.
   Status scan(const std::string& domain,
@@ -73,6 +77,22 @@ Status EphemeralDatabasePlugin::put(const std::string& domain,
 Status EphemeralDatabasePlugin::remove(const std::string& domain,
                                        const std::string& k) {
   db_[domain].erase(k);
+  return Status(0);
+}
+
+Status EphemeralDatabasePlugin::removeRange(const std::string& domain,
+                                            const std::string& low,
+                                            const std::string& high) {
+  std::vector<std::string> keys;
+  for (const auto& it : db_[domain]) {
+    if (it.first >= low && it.first <= high) {
+      keys.push_back(it.first);
+    }
+  }
+
+  for (const auto& key : keys) {
+    db_[domain].erase(key);
+  }
   return Status(0);
 }
 

--- a/osquery/database/tests/plugin_tests.cpp
+++ b/osquery/database/tests/plugin_tests.cpp
@@ -74,6 +74,45 @@ void DatabasePluginTests::testDelete() {
   EXPECT_EQ(s.getMessage(), "OK");
 }
 
+void DatabasePluginTests::testDeleteRange() {
+  getPlugin()->put(kQueries, "test_delete", "baz");
+  getPlugin()->put(kQueries, "test1", "1");
+  getPlugin()->put(kQueries, "test2", "2");
+  getPlugin()->put(kQueries, "test3", "3");
+  getPlugin()->put(kQueries, "test4", "4");
+  auto s = getPlugin()->removeRange(kQueries, "test1", "test3");
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.getMessage(), "OK");
+
+  std::string r;
+  getPlugin()->get(kQueries, "test4", r);
+  EXPECT_EQ(r, "4");
+  getPlugin()->get(kQueries, "test_delete", r);
+  EXPECT_EQ(r, "baz");
+  s = getPlugin()->get(kQueries, "test1", r);
+  EXPECT_FALSE(s.ok());
+  s = getPlugin()->get(kQueries, "test2", r);
+  EXPECT_FALSE(s.ok());
+
+  // Expect invalid logically ranges to have no effect.
+  getPlugin()->put(kQueries, "new_test1", "1");
+  getPlugin()->put(kQueries, "new_test2", "2");
+  getPlugin()->put(kQueries, "new_test3", "3");
+  getPlugin()->put(kQueries, "new_test4", "4");
+  s = getPlugin()->removeRange(kQueries, "new_test3", "new_test2");
+  EXPECT_TRUE(s.ok());
+  getPlugin()->get(kQueries, "new_test2", r);
+  EXPECT_EQ(r, "2");
+  getPlugin()->get(kQueries, "new_test3", r);
+  EXPECT_EQ(r, "3");
+
+  // An equality range will not delete that single item.
+  s = getPlugin()->removeRange(kQueries, "new_test2", "new_test2");
+  EXPECT_TRUE(s.ok());
+  s = getPlugin()->get(kQueries, "new_test2", r);
+  EXPECT_FALSE(s.ok());
+}
+
 void DatabasePluginTests::testScan() {
   getPlugin()->put(kQueries, "test_scan_foo1", "baz");
   getPlugin()->put(kQueries, "test_scan_foo2", "baz");

--- a/osquery/database/tests/plugin_tests.h
+++ b/osquery/database/tests/plugin_tests.h
@@ -36,6 +36,9 @@
   TEST_F(n, test_delete) {                                                     \
     testDelete();                                                              \
   }                                                                            \
+  TEST_F(n, test_delete_range) {                                               \
+    testDeleteRange();                                                         \
+  }                                                                            \
   TEST_F(n, test_scan) {                                                       \
     testScan();                                                                \
   }                                                                            \
@@ -104,6 +107,7 @@ class DatabasePluginTests : public testing::Test {
   void testPut();
   void testGet();
   void testDelete();
+  void testDeleteRange();
   void testScan();
   void testScanLimit();
 };

--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -3,8 +3,8 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Rocksdb < AbstractOsqueryFormula
   desc "Persistent key-value store for fast storage environments"
   homepage "http://rocksdb.org"
-  url "https://github.com/facebook/rocksdb/archive/v4.11.2.tar.gz"
-  sha256 "9374be06fdfccbbdbc60de90b72b5db7040e1bc4e12532e4c67aaec8181b45be"
+  url "https://github.com/facebook/rocksdb/archive/v5.1.4.tar.gz"
+  sha256 "3ee7e791d12d5359d0cf61c8c22713811dfda024afdd724cdf66ca022992be35"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"


### PR DESCRIPTION
This updates RocksDB to v5.1.4 on Linux/macOS and introduces `DeleteRange` for expirations in events. This allows us to bulk-remove event data when events are buffered beyond the configured max.

This also disables the WAL for writes to events and forces a flush when the database is closed. 