### PR TITLE
packages: Build ArchLinux package on Linux

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -19,9 +19,11 @@ elseif(LINUX)
 
   set(DEB_PACKAGE_DEPENDENCIES "libc6 (>=2.12), zlib1g")
   set(RPM_PACKAGE_DEPENDENCIES "glibc >= 2.12, zlib")
+  set(PACMAN_PACKAGE_DEPENDENCIES "zlib")
 
   find_program(FPM_EXECUTABLE "fpm" ENV PATH)
   find_program(RPMBUILD_EXECUTABLE "rpmbuild" ENV PATH)
+  find_program(BSDTAR_EXECUTABLE "bsdtar" ENV PATH)
 
   if(FPM_EXECUTABLE)
     add_custom_command(TARGET packages PRE_BUILD
@@ -37,6 +39,16 @@ elseif(LINUX)
     else()
       WARNING_LOG("Skipping RPM/CentOS packages: Cannot find rpmbuild")
     endif()
+
+    if(BSDTAR_EXECUTABLE)
+      add_custom_command(TARGET packages PRE_BUILD
+        COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+          -t "pacman" -i "1.arch" -d '${PACMAN_PACKAGE_DEPENDENCIES}'
+      )
+    else()
+      WARNING_LOG("Skipping ArchLinux packages: Cannot find bsdtar")
+    endif()
+
   else()
     WARNING_LOG("Cannot find fpm executable in path")
   endif()

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -105,9 +105,11 @@ function get_pkg_suffix() {
   if [[ $PACKAGE_TYPE == "deb" ]]; then
     # stay compliant with Debian package naming convention
     echo "_${PACKAGE_VERSION}_${PACKAGE_ITERATION}.amd64.${PACKAGE_TYPE}"
-  else
+  elif [[ $PACKAGE_TYPE == "rpm" ]]; then
     V=`echo ${PACKAGE_VERSION}|tr '-' '_'`
     echo "-${V}-${PACKAGE_ITERATION}.${PACKAGE_ARCH}.${PACKAGE_TYPE}"
+  elif [[ $PACKAGE_TYPE == "pacman" ]]; then
+    echo "-${PACKAGE_VERSION}-${PACKAGE_ITERATION}-${PACKAGE_ARCH}.pkg.tar.xz"
   fi
 }
 
@@ -197,6 +199,9 @@ function main() {
   if [[ $OSQUERY_PREUNINSTALL != "" ]] && [[ -f $OSQUERY_PREUNINSTALL ]]; then
     PREUNINST_CMD="--before-remove $OSQUERY_PREUNINSTALL"
   fi
+
+  # Change directory modes
+  find $INSTALL_PREFIX/ -type d | xargs chmod 755
 
   EPILOG="--url https://osquery.io \
     -m osquery@osquery.io          \

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -241,6 +241,7 @@ function main() {
   FPM=$(which fpm || true)
   RPMBUILD=$(which rpmbuild || true)
   if [[ ! "$FPM" = "" && ! "$RPMBUILD" = "" ]]; then
+    rm -f "$OUTPUT_RPM_PATH"
     log "creating RPM equivalent"
 
     # Yes, RPMs on OS X like i386 as the arch.


### PR DESCRIPTION
This attempts to build a `pacman`-type packages on Linux with `make packages`. It will require a newer (1.6+) version of `fpm` and `bsdtar` installed.