### PR TITLE
Bumping boost to source built libs

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -5,6 +5,9 @@
 #  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
 
+# Turn on support for Powershell Cmdlet Bindings
+[CmdletBinding(SupportsShouldProcess=$true)]
+
 # We make heavy use of Write-Host, because colors are awesome. #dealwithit.
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", '', Scope="Function", Target="*")]
 param()
@@ -268,7 +271,7 @@ function Install-ThirdParty {
   #      Once our chocolatey packages are added to the official repository, installing the third-party
   #      dependencies will be as easy as Install-ChocoPackage '<package-name>'.
   $packages = @(
-    "boost-msvc14.1.63.0",
+    "boost-msvc14.1.63.0-r1",
     "bzip2.1.0.6",
     "doxygen.1.8.11",
     "gflags-dev.2.2.0",
@@ -318,6 +321,7 @@ function Install-ThirdParty {
       Write-Host " => Downloading $downloadUrl" -foregroundcolor DarkCyan
       Try {
         (New-Object net.webclient).DownloadFile($downloadUrl, $tmpFilePath)
+        Write-Host " => Done." -foregroundcolor DarkCyan
       } catch [Net.WebException] {
         Write-Host "[-] ERROR: Downloading $package failed. Check connection?" -foregroundcolor Red
         Exit -1
@@ -327,7 +331,7 @@ function Install-ThirdParty {
         Write-Host "[-] ERROR: Install of $package failed." -foregroundcolor Red
         Exit -1
       }
-      Write-Host "[+] DONE" -foregroundcolor Green
+      Write-Host "[+] Done." -foregroundcolor Green
     }
   } Finally {
     Remove-Item $tmpDir -Recurse
@@ -399,4 +403,7 @@ function Main {
   Write-Host "[+] Done." -foregroundcolor Yellow
 }
 
+$startProvTime = Get-Date
 $null = Main
+$endProvTime = Get-Date
+Write-Verbose "[+] Provisioning completed in $(($endProvTime - $startProvTime).TotalSeconds) seconds."


### PR DESCRIPTION
Since we've ported osquery to Windows, a large portion of our third party libraries have been pre-built and hosted externally for the sake of moving fast. I've begun building out a large amount of our auto-build system that will hopefully function in a Homebrew-esk manner, and this diff tests out some of this functionality. Before our boost libraries took quite a bit of time to install:
```
C:\Users\Nicholas\projects\repos\osquery [boost-source-built +0 ~1 -0 !]> .\tools\provision.ps1 -verbose
[+] Provisioning a Win64 build environment for osquery
 => Verifying script is running with Admin privileges
[+] Success!
...
[*] PSScriptAnalyzer already installed.
 => Retrieving third-party dependencies
 => Determining whether boost-msvc14 is already installed...
 => Did not find. Installing boost-msvc14 1.63.0
 => Downloading https://osquery-packages.s3.amazonaws.com/choco/boost-msvc14.1.63.0.nupkg
 => Done.
[+] Done.
...
VERBOSE: [+] Provisioning completed in 531.4226224 seconds.
```
Roughly 8 minutes on my home system with 120 MBps down speeds. Unfortunately not everyone has such a nice pipe so this experience has been flaky at worst and took forever at best.  With this new setup we're building our own boost libraries, thus only including the headers and libs we need, and now our provision moves much faster, taking just over 3 minutes to finish the boost installation:
```
C:\Users\Nicholas\projects\repos\osquery [boost-source-built +0 ~1 -0 !]> .\tools\provision.ps1 -verbose
[+] Provisioning a Win64 build environment for osquery
 => Verifying script is running with Admin privileges
[+] Success!
...
[*] PSScriptAnalyzer already installed.
 => Retrieving third-party dependencies
 => Determining whether boost-msvc14 is already installed...
 => Did not find. Installing boost-msvc14 1.63.0-r1
 => Downloading https://osquery-packages.s3.amazonaws.com/choco/boost-msvc14.1.63.0-r1.nupkg
 => Done.
[+] Done.
...
VERBOSE: [+] Provisioning completed in 186.1449843 seconds.
```
Hopefully this makes the Windows provisioning experience a little better!