### PR TITLE
events: Inspect schedule and improve tests

### DIFF
--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -108,11 +108,9 @@ class Plugin : private boost::noncopyable {
                       PluginResponse& response) = 0;
 
   /// Allow the plugin to introspect into the registered name (for logging).
-  virtual void setName(const std::string& name) final {
-    name_ = name;
-  }
+  virtual void setName(const std::string& name) final;
 
-  /// Force callsites to use #getName to access the plugin item's name.
+  /// Force call-sites to use #getName to access the plugin item's name.
   virtual const std::string& getName() const {
     return name_;
   }
@@ -147,6 +145,7 @@ class Plugin : private boost::noncopyable {
   static void removeExternal(const std::string& name) {}
 
  protected:
+  /// Customized name for the plugin, usually set by the registry.
   std::string name_;
 };
 

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -17,6 +17,7 @@
 
 #include <osquery/config.h>
 #include <osquery/database.h>
+#include <osquery/events.h>
 #include <osquery/filesystem.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -67,7 +68,6 @@ CLI_FLAG(uint64,
 
 DECLARE_string(config_plugin);
 DECLARE_string(pack_delimiter);
-DECLARE_bool(disable_events);
 
 /**
  * @brief The backing store key name for the executing query.
@@ -573,11 +573,7 @@ Status Config::update(const std::map<std::string, std::string>& config) {
       registry.second->configure();
     }
 
-    // If events are enabled configure the subscribers before publishers.
-    if (!FLAGS_disable_events) {
-      RegistryFactory::get().registry("event_subscriber")->configure();
-      RegistryFactory::get().registry("event_publisher")->configure();
-    }
+    EventFactory::configUpdate();
   }
 
   return Status(0, "OK");

--- a/osquery/config/parsers/events.cpp
+++ b/osquery/config/parsers/events.cpp
@@ -19,7 +19,9 @@ namespace osquery {
  */
 class EventsConfigParserPlugin : public ConfigParserPlugin {
  public:
-  std::vector<std::string> keys() const override { return {"events"}; }
+  std::vector<std::string> keys() const override {
+    return {"events"};
+  }
 
   Status setUp() override;
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -504,7 +504,6 @@ void WatcherRunner::createExtension(const std::string& extension) {
   Watcher::resetExtensionCounters(extension, getUnixTime());
   VLOG(1) << "Created and monitoring extension child (" << ext_process->pid()
           << "): " << extension;
-
 }
 
 void WatcherWatcherRunner::start() {

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -71,9 +71,16 @@ TEST_F(EventsTests, test_event_publisher) {
 TEST_F(EventsTests, test_register_event_publisher) {
   auto basic_pub = std::make_shared<BasicEventPublisher>();
   auto status = EventFactory::registerEventPublisher(basic_pub);
+  EXPECT_FALSE(status.ok());
+
+  // Set a name for the publisher, which becomes the type by default.
+  basic_pub->setName("BasicPublisher");
+  status = EventFactory::registerEventPublisher(basic_pub);
+  EXPECT_TRUE(status.ok());
 
   // This class is the SAME, there was no type override.
   auto another_basic_pub = std::make_shared<AnotherBasicEventPublisher>();
+  another_basic_pub->setName(basic_pub->getName());
   status = EventFactory::registerEventPublisher(another_basic_pub);
   EXPECT_FALSE(status.ok());
 
@@ -82,10 +89,25 @@ TEST_F(EventsTests, test_register_event_publisher) {
   status = EventFactory::registerEventPublisher(fake_pub);
   EXPECT_TRUE(status.ok());
 
-  // May also register the event_pub instance
+  // May also register a similar (same EC, SC), but different publisher.
   auto another_fake_pub = std::make_shared<AnotherFakeEventPublisher>();
   status = EventFactory::registerEventPublisher(another_fake_pub);
   EXPECT_TRUE(status.ok());
+
+  status = EventFactory::deregisterEventPublisher(basic_pub->type());
+  EXPECT_TRUE(status.ok());
+  status = EventFactory::deregisterEventPublisher(fake_pub->type());
+  EXPECT_TRUE(status.ok());
+  status = EventFactory::deregisterEventPublisher(another_fake_pub->type());
+  EXPECT_TRUE(status.ok());
+
+  // Attempting to deregister a publisher a second time.
+  status = EventFactory::deregisterEventPublisher(another_fake_pub->type());
+  EXPECT_FALSE(status.ok());
+
+  // Attempting to deregister a publish that failed registering.
+  status = EventFactory::deregisterEventPublisher(another_basic_pub->type());
+  EXPECT_FALSE(status.ok());
 }
 
 TEST_F(EventsTests, test_event_publisher_types) {
@@ -95,10 +117,18 @@ TEST_F(EventsTests, test_event_publisher_types) {
   EventFactory::registerEventPublisher(pub);
   auto pub2 = EventFactory::getEventPublisher("FakePublisher");
   EXPECT_EQ(pub->type(), pub2->type());
+
+  // It is possible to deregister by base event publisher type.
+  auto status = EventFactory::deregisterEventPublisher(pub2);
+  EXPECT_TRUE(status.ok());
+  // And attempting to deregister by type afterward will fail.
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_FALSE(status.ok());
 }
 
 TEST_F(EventsTests, test_duplicate_event_publisher) {
   auto pub = std::make_shared<BasicEventPublisher>();
+  pub->setName("BasicPublisher");
   auto status = EventFactory::registerEventPublisher(pub);
   EXPECT_TRUE(status.ok());
 
@@ -129,10 +159,16 @@ TEST_F(EventsTests, test_create_using_registry) {
   // Now attach and make sure it was added.
   attachEvents();
   EXPECT_EQ(EventFactory::numEventPublishers(), default_publisher_count + 1U);
+
+  auto status = EventFactory::deregisterEventPublisher("unique");
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_create_subscription) {
+  std::string basic_publisher_type = "BasicPublisher";
+
   auto pub = std::make_shared<BasicEventPublisher>();
+  pub->setName(basic_publisher_type);
   EventFactory::registerEventPublisher(pub);
 
   // Make sure a subscription cannot be added for a non-existent event type.
@@ -143,24 +179,33 @@ TEST_F(EventsTests, test_create_subscription) {
 
   // In this case we can still add a blank subscription to an existing event
   // type.
-  status = EventFactory::addSubscription("publisher", subscription);
+  status = EventFactory::addSubscription(basic_publisher_type, subscription);
   EXPECT_TRUE(status.ok());
 
   // Make sure the subscription is added.
-  EXPECT_EQ(EventFactory::numSubscriptions("publisher"), 1U);
+  EXPECT_EQ(EventFactory::numSubscriptions(basic_publisher_type), 1U);
+
+  status = EventFactory::deregisterEventPublisher(basic_publisher_type);
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_multiple_subscriptions) {
-  Status status;
+  std::string basic_publisher_type = "BasicPublisher";
 
   auto pub = std::make_shared<BasicEventPublisher>();
+  pub->setName(basic_publisher_type);
   EventFactory::registerEventPublisher(pub);
 
   auto subscription = Subscription::create("subscriber");
-  status = EventFactory::addSubscription("publisher", subscription);
-  status = EventFactory::addSubscription("publisher", subscription);
+  auto status =
+      EventFactory::addSubscription(basic_publisher_type, subscription);
+  status = EventFactory::addSubscription(basic_publisher_type, subscription);
+  EXPECT_TRUE(status.ok());
 
-  EXPECT_EQ(EventFactory::numSubscriptions("publisher"), 2U);
+  EXPECT_EQ(EventFactory::numSubscriptions(basic_publisher_type), 2U);
+
+  status = EventFactory::deregisterEventPublisher(basic_publisher_type);
+  EXPECT_TRUE(status.ok());
 }
 
 struct TestSubscriptionContext : public SubscriptionContext {
@@ -209,22 +254,30 @@ class TestEventPublisher
 
 TEST_F(EventsTests, test_create_custom_event_publisher) {
   auto basic_pub = std::make_shared<BasicEventPublisher>();
+  basic_pub->setName("BasicPublisher");
   EventFactory::registerEventPublisher(basic_pub);
+
   auto pub = std::make_shared<TestEventPublisher>();
   auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   // These event types have unique event type IDs
-  EXPECT_TRUE(status.ok());
   EXPECT_EQ(EventFactory::numEventPublishers(), 2U);
 
   // Make sure the setUp function was called.
   EXPECT_EQ(pub->getTestValue(), 1);
+
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_TRUE(status.ok());
+  status = EventFactory::deregisterEventPublisher(basic_pub->type());
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_custom_subscription) {
   // Step 1, register event type
   auto pub = std::make_shared<TestEventPublisher>();
   auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   // Step 2, create and configure a subscription context
   auto sc = std::make_shared<TestSubscriptionContext>();
@@ -240,29 +293,39 @@ TEST_F(EventsTests, test_custom_subscription) {
   // The event type must run configure for each added subscription.
   EXPECT_TRUE(pub->configure_run);
   EXPECT_EQ(pub->getTestValue(), -1);
+
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_tear_down) {
   auto pub = std::make_shared<TestEventPublisher>();
   auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   // Make sure set up incremented the test value.
   EXPECT_EQ(pub->getTestValue(), 1);
 
-  status = EventFactory::deregisterEventPublisher("TestPublisher");
+  status = EventFactory::deregisterEventPublisher(pub->type());
   EXPECT_TRUE(status.ok());
 
-  // Make sure tear down inremented the test value.
+  // Make sure tear down incremented the test value.
   EXPECT_EQ(pub->getTestValue(), 2);
 
   // Once more, now deregistering all event types.
   status = EventFactory::registerEventPublisher(pub);
+  EXPECT_TRUE(status.ok());
+
   EXPECT_EQ(pub->getTestValue(), 3);
   EventFactory::end();
   EXPECT_EQ(pub->getTestValue(), 4);
 
   // Make sure the factory state represented.
   EXPECT_EQ(EventFactory::numEventPublishers(), 0U);
+
+  // Implicit deregister due to end of event factory.
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_FALSE(status.ok());
 }
 
 static int kBellHathTolled = 0;
@@ -281,7 +344,13 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
   size_t timesConfigured{0};
 
   FakeEventSubscriber() {
-    setName("FakeSubscriber");
+    setName("fake_events");
+  }
+
+  explicit FakeEventSubscriber(bool skip_name) {
+    if (!skip_name) {
+      FakeEventSubscriber();
+    }
   }
 
   void configure() override {
@@ -315,12 +384,13 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
 
  private:
   FRIEND_TEST(EventsTests, test_subscriber_names);
+  FRIEND_TEST(EventsTests, test_event_subscriber_configure);
 };
 
 TEST_F(EventsTests, test_event_subscriber) {
   auto sub = std::make_shared<FakeEventSubscriber>();
   EXPECT_EQ(sub->getType(), "FakePublisher");
-  EXPECT_EQ(sub->getName(), "FakeSubscriber");
+  EXPECT_EQ(sub->getName(), "fake_events");
 }
 
 TEST_F(EventsTests, test_event_subscriber_subscribe) {
@@ -339,6 +409,11 @@ TEST_F(EventsTests, test_event_subscriber_subscribe) {
   pub->fire(ec, 0);
 
   EXPECT_TRUE(sub->bellHathTolled);
+
+  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  EXPECT_TRUE(status.ok());
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_event_subscriber_context) {
@@ -355,15 +430,23 @@ TEST_F(EventsTests, test_event_subscriber_context) {
   pub->fire(ec, 0);
 
   EXPECT_TRUE(sub->contextBellHathTolled);
+
+  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  EXPECT_TRUE(status.ok());
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(EventsTests, test_event_subscriber_configure) {
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EventFactory::registerEventSubscriber(sub);
   // Register this subscriber (within the RegistryFactory), so it receives
   // configure/reconfigure events.
   auto& rf = RegistryFactory::get();
-  rf.registry("event_subscriber")->add("fake", sub);
+  rf.registry("event_subscriber")->add("fake_events", sub);
+
+  // Register it within the event factory too.
+  auto status = EventFactory::registerEventSubscriber(sub);
+  EXPECT_TRUE(status.ok());
 
   // Assure we start from a base state.
   EXPECT_EQ(sub->timesConfigured, 0U);
@@ -372,23 +455,40 @@ TEST_F(EventsTests, test_event_subscriber_configure) {
   Config::getInstance().update({{"data", "{}"}});
   EXPECT_EQ(sub->timesConfigured, 1U);
 
+  // Now update the config to contain sets of scheduled queries.
+  Config::getInstance().update(
+      {{"data",
+        "{\"schedule\": {\"1\": {\"query\": \"select * from fake_events\", "
+        "\"interval\": 10}, \"2\":{\"query\": \"select * from time, "
+        "fake_events\", \"interval\": 20}, \"3\":{\"query\": \"select * "
+        "from fake_events, fake_events\", \"interval\": 5}}}"}});
+  EXPECT_EQ(sub->min_expiration_, 20U * 3);
+  EXPECT_EQ(sub->query_count_, 3U);
+
+  // Register it within the event factory too.
+  EventFactory::deregisterEventSubscriber(sub->getName());
   rf.registry("event_subscriber")->remove(sub->getName());
+
+  // Final check to make sure updates are not effecting this subscriber.
   Config::getInstance().update({{"data", "{}"}});
-  EXPECT_EQ(sub->timesConfigured, 1U);
+  EXPECT_EQ(sub->timesConfigured, 2U);
 }
 
 TEST_F(EventsTests, test_fire_event) {
-  Status status;
-
   auto pub = std::make_shared<BasicEventPublisher>();
-  status = EventFactory::registerEventPublisher(pub);
+  pub->setName("BasicPublisher");
+  auto status = EventFactory::registerEventPublisher(pub);
+  ASSERT_TRUE(status.ok());
 
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EventFactory::registerEventSubscriber(sub);
+  status = EventFactory::registerEventSubscriber(sub);
+  ASSERT_TRUE(status.ok());
 
-  auto subscription = Subscription::create("FakeSubscriber");
+  auto subscription = Subscription::create("fake_events");
   subscription->callback = TestTheeCallback;
-  status = EventFactory::addSubscription("publisher", subscription);
+  status = EventFactory::addSubscription("BasicPublisher", subscription);
+  ASSERT_TRUE(status.ok());
+
   pub->configure();
 
   // The event context creation would normally happen in the event type.
@@ -396,8 +496,10 @@ TEST_F(EventsTests, test_fire_event) {
   pub->fire(ec, 0);
   EXPECT_EQ(kBellHathTolled, 1);
 
-  auto second_subscription = Subscription::create("FakeSubscriber");
-  status = EventFactory::addSubscription("publisher", second_subscription);
+  auto second_subscription = Subscription::create("fake_events");
+  status = EventFactory::addSubscription("BasicPublisher", second_subscription);
+  ASSERT_TRUE(status.ok());
+
   pub->configure();
 
   // Now there are two subscriptions (one sans callback).
@@ -408,12 +510,18 @@ TEST_F(EventsTests, test_fire_event) {
   second_subscription->callback = TestTheeCallback;
   pub->fire(ec, 0);
   EXPECT_EQ(kBellHathTolled, 4);
+
+  status = EventFactory::deregisterEventSubscriber(sub->getName());
+  EXPECT_TRUE(status.ok());
+
+  status = EventFactory::deregisterEventPublisher(pub->type());
+  EXPECT_TRUE(status.ok());
 }
 
 class SubFakeEventSubscriber : public FakeEventSubscriber {
  public:
-  SubFakeEventSubscriber() {
-    setName("SubFakeSubscriber");
+  SubFakeEventSubscriber() : FakeEventSubscriber(true) {
+    setName("sub_fake_events");
   }
 
  private:
@@ -421,17 +529,14 @@ class SubFakeEventSubscriber : public FakeEventSubscriber {
 };
 
 TEST_F(EventsTests, test_subscriber_names) {
-  auto pub = std::make_shared<BasicEventPublisher>();
-  EventFactory::registerEventPublisher(pub);
-
   auto subsub = std::make_shared<SubFakeEventSubscriber>();
   EXPECT_EQ(subsub->getType(), "FakePublisher");
-  EXPECT_EQ(subsub->getName(), "SubFakeSubscriber");
-  EXPECT_EQ(subsub->dbNamespace(), "FakePublisher.SubFakeSubscriber");
+  EXPECT_EQ(subsub->getName(), "sub_fake_events");
+  EXPECT_EQ(subsub->dbNamespace(), "FakePublisher.sub_fake_events");
 
   auto sub = std::make_shared<FakeEventSubscriber>();
-  EXPECT_EQ(sub->getName(), "FakeSubscriber");
-  EXPECT_EQ(sub->dbNamespace(), "FakePublisher.FakeSubscriber");
+  EXPECT_EQ(sub->getName(), "fake_events");
+  EXPECT_EQ(sub->dbNamespace(), "FakePublisher.fake_events");
 }
 
 class DisabledEventSubscriber : public EventSubscriber<FakeEventPublisher> {
@@ -443,7 +548,9 @@ TEST_F(EventsTests, test_event_toggle_subscribers) {
   // Make sure subscribers can disable themselves using the event subscriber
   // constructor parameter.
   auto sub = std::make_shared<DisabledEventSubscriber>();
+  sub->setName("disabled_events");
   EXPECT_TRUE(sub->disabled);
+
   // Normal subscribers will be enabled.
   auto sub2 = std::make_shared<SubFakeEventSubscriber>();
   EXPECT_FALSE(sub2->disabled);
@@ -451,5 +558,8 @@ TEST_F(EventsTests, test_event_toggle_subscribers) {
   // Registering a disabled subscriber will put it into a paused state.
   EventFactory::registerEventSubscriber(sub);
   EXPECT_EQ(sub->state(), EventState::EVENT_PAUSED);
+
+  auto status = EventFactory::deregisterEventSubscriber(sub->getName());
+  EXPECT_TRUE(status.ok());
 }
 }

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -127,9 +127,8 @@ int main(int argc, char* argv[]) {
   } else if ((val = osquery::getEnvVar("OSQUERY_EXTENSION"))) {
     return extensionMain(argc, argv);
   }
-  osquery::registryAndPluginInit();
-  osquery::kProcessTestExecPath = argv[0];
 
+  osquery::kProcessTestExecPath = argv[0];
   osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -608,6 +608,15 @@ RegistryModuleLoader::~RegistryModuleLoader() {
   handle_ = nullptr;
 }
 
+void Plugin::setName(const std::string& name) {
+  if (!name_.empty() && name != name_) {
+    std::string error = "Cannot rename plugin " + name_ + " to " + name;
+    throw std::runtime_error(error);
+  }
+
+  name_ = name;
+}
+
 void Plugin::getResponse(const std::string& key,
                          const PluginResponse& response,
                          boost::property_tree::ptree& tree) {

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -162,7 +162,7 @@ class BenchmarkLongTablePlugin : public TablePlugin {
 
   QueryData generate(QueryContext& ctx) {
     QueryData results;
-    for (int i = 0; i < 1000; i++) {
+    for (size_t i = 0; i < 1000; i++) {
       results.push_back({{"test_int", "0"}, {"test_text", "hello"}});
     }
     return results;
@@ -195,7 +195,7 @@ class BenchmarkWideTablePlugin : public TablePlugin {
  protected:
   TableColumns columns() const override {
     TableColumns cols;
-    for (int i = 0; i < 20; i++) {
+    for (size_t i = 0; i < 20; i++) {
       cols.push_back(std::make_tuple(
           "test_" + std::to_string(i), INTEGER_TYPE, ColumnOptions::DEFAULT));
     }
@@ -204,9 +204,9 @@ class BenchmarkWideTablePlugin : public TablePlugin {
 
   QueryData generate(QueryContext& ctx) override {
     QueryData results;
-    for (int k = 0; k < kWideCount; k++) {
+    for (size_t k = 0; k < kWideCount; k++) {
       Row r;
-      for (int i = 0; i < 20; i++) {
+      for (size_t i = 0; i < 20; i++) {
         r["test_" + std::to_string(i)] = "0";
       }
       results.push_back(r);
@@ -222,9 +222,9 @@ class BenchmarkWideTableYieldPlugin : public BenchmarkWideTablePlugin {
   }
 
   void generator(RowYield& yield, QueryContext& ctx) override {
-    for (int k = 0; k < kWideCount; k++) {
+    for (size_t k = 0; k < kWideCount; k++) {
       Row r;
-      for (int i = 0; i < 20; i++) {
+      for (size_t i = 0; i < 20; i++) {
         r["test_" + std::to_string(i)] = "0";
       }
       yield(r);

--- a/osquery/tables/events/linux/syslog_events.cpp
+++ b/osquery/tables/events/linux/syslog_events.cpp
@@ -50,7 +50,7 @@ class SyslogEventSubscriber : public EventSubscriber<SyslogEventPublisher> {
   Status Callback(const ECRef& ec, const SCRef& sc);
 };
 
-REGISTER(SyslogEventSubscriber, "event_subscriber", "syslog");
+REGISTER(SyslogEventSubscriber, "event_subscriber", "syslog_events");
 
 Status SyslogEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   Row r(ec->fields);

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -65,6 +65,8 @@ DECLARE_bool(disable_database);
 typedef std::chrono::high_resolution_clock chrono_clock;
 
 void initTesting() {
+  osquery::kToolType = ToolType::TEST;
+
   registryAndPluginInit();
   // Allow unit test execution from anywhere in the osquery source/build tree.
   while (osquery::kTestDataPath != "/") {

--- a/specs/linux/syslog_events.table
+++ b/specs/linux/syslog_events.table
@@ -1,4 +1,4 @@
-table_name("syslog")
+table_name("syslog_events", aliases=["syslog"])
 schema([
     Column("time", BIGINT, "Current unix epoch time"),
     Column("datetime", TEXT, "Time known to syslog"),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -370,6 +370,9 @@ def implementation(impl_string, generator=False):
 
     '''Check if the table has a subscriber attribute, if so, enforce time.'''
     if "event_subscriber" in table.attributes:
+        if not table.table_name.endswith("_events"):
+            print(lightred("Event subscriber must use a '_events' suffix"))
+            sys.exit(1)
         columns = {}
         # There is no dictionary comprehension on all supported platforms.
         for column in table.schema:


### PR DESCRIPTION
This commit aims to improve events in two ways:
- The events will inspect the schedule and inform each subscriber of the intervals and count.
- The tests for publishers and subscribers should be enhanced to follow the expected register and deregister expectations.

The assertion we make is that no subscriber should expire events before each query that uses the subscriber has a chance to run on the related events. This is achieved by enforcing a minimum expiration as the maximum interval * 3 to handle splay and a minor stretch in time as it applies to the counter and the time needed to run a complete schedule.