### PR TITLE
packs: Run centos and ubuntu platforms on all Linux

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -309,8 +309,7 @@ The `platform` key can be:
 * `darwin` for OS X hosts
 * `freebsd` for FreeBSD hosts
 * `linux` for any RedHat or Debian-based hosts
-* `ubuntu` for Debian-based hosts (yes, we know)
-* `centos` for RedHat-based hosts (also, see above, we get it)
+* `windows` for any Windows desktop or server hosts
 * `any` or `all` for all, alternatively no platform key selects all
 
 The `shard` key works by hashing the hostname then taking the quotient 255 of the first byte. This allows us to select a deterministic 'preview' for the query, this helps when slow-rolling or testing new queries.

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -244,16 +244,18 @@ bool Pack::checkPlatform(const std::string& platform) const {
     return true;
   }
 
-#ifdef __linux__
-  if (platform.find("linux") != std::string::npos) {
-    return true;
-  }
-#endif
-
   if (platform.find("any") != std::string::npos ||
       platform.find("all") != std::string::npos) {
     return true;
   }
+
+  auto linux_type = (platform.find("linux") != std::string::npos ||
+                     platform.find("ubuntu") != std::string::npos ||
+                     platform.find("centos") != std::string::npos);
+  if (linux_type && isPlatform(PlatformType::TYPE_LINUX)) {
+    return true;
+  }
+
   return (platform.find(kSDKPlatform) != std::string::npos);
 }
 


### PR DESCRIPTION
This expands `platform = ubuntu || centos` to apply to all Linux hosts, similarly to `platform = linux` in pack and query configuration. 