### PR TITLE
events: Execute schedule before expiring

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -668,6 +668,8 @@ void resetDatabase() {
   WriteLock lock(kDatabaseReset);
 
   // Prevent RocksDB reentrancy by logger plugins during plugin setup.
+  VLOG(1) << "Resetting the database plugin: "
+          << Registry::get().getActive("database");
   LoggerForwardingDisabler disable_logging;
   PluginRequest request = {{"action", "reset"}};
   if (!Registry::call("database", request)) {

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -384,8 +384,10 @@ Status RocksDBDatabasePlugin::removeRange(const std::string& domain,
   if (kEvents != domain) {
     options.sync = true;
   }
-  auto s = (low != high) ? getDB()->DeleteRange(options, cfh, low, high)
-                         : getDB()->Delete(options, cfh, low);
+  auto s = getDB()->DeleteRange(options, cfh, low, high);
+  if (low <= high) {
+    s = getDB()->Delete(options, cfh, high);
+  }
   return Status(s.code(), s.ToString());
 }
 

--- a/osquery/database/tests/plugin_tests.cpp
+++ b/osquery/database/tests/plugin_tests.cpp
@@ -93,6 +93,8 @@ void DatabasePluginTests::testDeleteRange() {
   EXPECT_FALSE(s.ok());
   s = getPlugin()->get(kQueries, "test2", r);
   EXPECT_FALSE(s.ok());
+  s = getPlugin()->get(kQueries, "test3", r);
+  EXPECT_FALSE(s.ok());
 
   // Expect invalid logically ranges to have no effect.
   getPlugin()->put(kQueries, "new_test1", "1");

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -31,8 +31,13 @@ FLAG(uint64, schedule_timeout, 0, "Limit the schedule, 0 for no limit");
 
 FLAG(uint64,
      schedule_reload,
-     7200,
+     300,
      "Interval in seconds to reload database arenas");
+
+HIDDEN_FLAG(bool,
+            schedule_reload_sql,
+            false,
+            "Reload the SQL implementation during schedule reload");
 
 /// Used to bypass (optimize-out) the set-differential of query results.
 DECLARE_bool(events_optimize);
@@ -159,7 +164,9 @@ void SchedulerRunner::start() {
       runDecorators(DECORATE_INTERVAL, i);
     }
     if (FLAGS_schedule_reload > 0 && (i % FLAGS_schedule_reload) == 0) {
-      SQLiteDBManager::resetPrimary();
+      if (FLAGS_schedule_reload_sql) {
+        SQLiteDBManager::resetPrimary();
+      }
       resetDatabase();
     }
 

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -100,9 +100,9 @@ TEST_F(EventsDatabaseTests, test_event_module_id) {
 
   // Not normally available outside of EventSubscriber->Add().
   auto event_id1 = sub->getEventID();
-  EXPECT_EQ(event_id1, "1");
+  EXPECT_EQ(event_id1, "0000000001");
   auto event_id2 = sub->getEventID();
-  EXPECT_EQ(event_id2, "2");
+  EXPECT_EQ(event_id2, "0000000002");
 }
 
 TEST_F(EventsDatabaseTests, test_event_add) {
@@ -260,8 +260,8 @@ TEST_F(EventsDatabaseTests, test_gentable) {
 
   // Expect all non-expired results: 11, +
   EXPECT_EQ(9U, results.size());
-  // The expiration time is now - events_expiry.
-  EXPECT_LT(t - (sub->getEventsExpiry() * 2), sub->expire_time_);
+  // The expiration time is now - events_expiry +/ 60.
+  EXPECT_LT(t - (sub->getEventsExpiry() * 2), sub->expire_time_ + 60);
   EXPECT_GT(t, sub->expire_time_);
   // The optimize time will not be changed.
   ASSERT_EQ(0U, sub->optimize_time_);

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -460,9 +460,10 @@ TEST_F(EventsTests, test_event_subscriber_configure) {
       {{"data",
         "{\"schedule\": {\"1\": {\"query\": \"select * from fake_events\", "
         "\"interval\": 10}, \"2\":{\"query\": \"select * from time, "
-        "fake_events\", \"interval\": 20}, \"3\":{\"query\": \"select * "
+        "fake_events\", \"interval\": 19}, \"3\":{\"query\": \"select * "
         "from fake_events, fake_events\", \"interval\": 5}}}"}});
-  EXPECT_EQ(sub->min_expiration_, 20U * 3);
+  // This will become 19 * 3, rounded up 60.
+  EXPECT_EQ(sub->min_expiration_, 60U);
   EXPECT_EQ(sub->query_count_, 3U);
 
   // Register it within the event factory too.

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -59,10 +59,6 @@ void WindowsEventLogEventPublisher::configure() {
   }
 }
 
-void WindowsEventLogEventPublisher::restart() {
-  configure();
-}
-
 Status WindowsEventLogEventPublisher::run() {
   pause();
   return Status(0, "OK");

--- a/osquery/events/windows/windows_event_log.h
+++ b/osquery/events/windows/windows_event_log.h
@@ -94,9 +94,6 @@ class WindowsEventLogEventPublisher
       EVT_HANDLE evt, boost::property_tree::ptree& propTree);
 
  private:
-  /// Restarts the osquery Windows Event Log Events publisher
-  void restart();
-
   /// Ensures that all Windows event log subscriptions are removed
   void stop() override;
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -20,8 +20,7 @@ if(APPLE)
 
   ADD_OSQUERY_LINK_ADDITIONAL("libresolv.dylib")
   ADD_OSQUERY_LINK_ADDITIONAL("libxar.dylib")
-  ADD_OSQUERY_LINK_ADDITIONAL("magic")
-  ADD_OSQUERY_LINK_ADDITIONAL("tsk")
+  ADD_OSQUERY_LINK_ADDITIONAL("libiconv")
 elseif(FREEBSD)
   include_directories("/usr/local/include/libxml2")
 
@@ -37,8 +36,6 @@ elseif(FREEBSD)
   ADD_OSQUERY_LINK_ADDITIONAL("util")
   ADD_OSQUERY_LINK_ADDITIONAL("kvm")
   ADD_OSQUERY_LINK_ADDITIONAL("elf")
-  ADD_OSQUERY_LINK_ADDITIONAL("magic")
-  ADD_OSQUERY_LINK_ADDITIONAL("tsk")
 elseif(WINDOWS)
   # Additional Windows libraries
   ADD_OSQUERY_LINK_ADDITIONAL("Advapi32.lib")
@@ -61,29 +58,11 @@ else()
   file(GLOB OSQUERY_LINUX_TABLES_TESTS "*/linux/tests/*.cpp")
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_LINUX_TABLES_TESTS})
 
-  if(REDHAT_BASED)
-    # CentOS specific tables
-    # file(GLOB OSQUERY_REDHAT_TABLES "*/centos/*.cpp")
-    # ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_redhat
-    #   ${OSQUERY_REDHAT_TABLES}
-    # )
-
-  elseif(DEBIAN_BASED)
-    # Ubuntu specific tables
-    # file(GLOB OSQUERY_UBUNTU_TABLES "*/ubuntu/*.cpp")
-    # ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_ubuntu
-    #   ${OSQUERY_UBUNTU_TABLES}
-    # )
-
-  endif()
-
   ADD_OSQUERY_LINK_ADDITIONAL("libresolv.so")
   ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup devmapper")
   ADD_OSQUERY_LINK_ADDITIONAL("gcrypt gpg-error")
   ADD_OSQUERY_LINK_ADDITIONAL("blkid")
   ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")
-  ADD_OSQUERY_LINK_ADDITIONAL("magic")
-  ADD_OSQUERY_LINK_ADDITIONAL("tsk")
 
   ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg lzma lz4 bz2")
   ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio beecrypt popt db")
@@ -93,17 +72,9 @@ if(APPLE OR LINUX)
   file(GLOB OSQUERY_CROSS_EVENTS_TABLES "events/*.cpp")
 
   ADD_OSQUERY_LINK_ADDITIONAL("lldpctl")
-
-  if(APPLE)
-    ADD_OSQUERY_LINK_ADDITIONAL("libiconv")
-  endif()
 else()
   # TODO: When we have Windows events, fill this in
   set(OSQUERY_CROSS_EVENTS_TABLES "")
-endif()
-
-if(APPLE OR LINUX OR FREEBSD)
-  ADD_OSQUERY_LINK_ADDITIONAL("augeas fa xml2")
 endif()
 
 # TODO: These tables should be made Windows-compatible
@@ -124,9 +95,12 @@ if(NOT WINDOWS)
 
   file(GLOB OSQUERY_POSIX_TABLES_TESTS "*/posix/tests/*.cpp")
   ADD_OSQUERY_TABLE_TEST(${OSQUERY_POSIX_TABLES_TESTS})
+
+  ADD_OSQUERY_LINK_ADDITIONAL("magic")
+  ADD_OSQUERY_LINK_ADDITIONAL("tsk")
+  ADD_OSQUERY_LINK_ADDITIONAL("augeas fa xml2")
 endif()
 
-# No cross-platform application tables yet.
 file(GLOB OSQUERY_CROSS_APPLICATIONS_TABLES "applications/*.cpp")
 ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_tables_applications
   ${OSQUERY_CROSS_APPLICATIONS_TABLES}

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -31,7 +31,6 @@ extern const std::set<std::string> kCommonFileColumns;
 class FileEventSubscriber : public EventSubscriber<FSEventsEventPublisher> {
  public:
   Status init() override {
-    configure();
     return Status(0);
   }
 

--- a/osquery/tables/events/darwin/process_file_events.cpp
+++ b/osquery/tables/events/darwin/process_file_events.cpp
@@ -36,7 +36,6 @@ Status ProcessFileEventSubscriber::init() {
     return Status(1, "No kernel event publisher");
   }
 
-  configure();
   return Status(0);
 }
 

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -29,7 +29,6 @@ namespace osquery {
 class FileEventSubscriber : public EventSubscriber<INotifyEventPublisher> {
  public:
   Status init() override {
-    configure();
     return Status(0);
   }
 

--- a/osquery/tables/events/yara_events.cpp
+++ b/osquery/tables/events/yara_events.cpp
@@ -52,7 +52,6 @@ using FileSubscriptionContextRef = INotifySubscriptionContextRef;
 class YARAEventSubscriber : public FileEventSubscriber {
  public:
   Status init() override {
-    configure();
     return Status(0);
   }
 


### PR DESCRIPTION
This builds on the foundation from #3087.

With this we improve events in several ways:
- All queries that use a subscriber must execute once before events can be expired.
- Expiration happens on the index-level (`% 60`).
- Several bug fixes to RocksDB's `deleteRange` abstraction (newly introduced).
- Several performance improvements to expiration and event index recording.
