### PR TITLE
hash: Only return hashes for files hashed

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -114,8 +114,10 @@ Status readFile(const fs::path& path,
                              ? FLAGS_read_max
                              : std::min(FLAGS_read_max, FLAGS_read_user_max));
   if (file_size > read_max) {
-    VLOG(1) << "Cannot read " << path << " size exceeds limit: " << file_size
-            << " > " << read_max;
+    LOG(WARNING) << "Cannot read file that exceeds size limit: "
+                 << path.string();
+    VLOG(1) << "Cannot read " << path.string()
+            << " size exceeds limit: " << file_size << " > " << read_max;
     return Status(1, "File exceeds read limits");
   }
 


### PR DESCRIPTION
Closes #3080

This adds a WARNING for all files that were not read due to file size limits (a configuration option). It also removes the CommonCrypto usage on OS X, all platforms are using OpenSSL.