### PR TITLE
extensions: shell: Check for socket path ownership

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -273,7 +273,10 @@ void initShellSocket(const std::string& homedir) {
         (fs::path(homedir) / "shell.em").make_preferred().string();
   }
 
-  if (extensionPathActive(FLAGS_extensions_socket, false)) {
+  if (extensionPathActive(FLAGS_extensions_socket, false) ||
+      !socketExists(FLAGS_extensions_socket, true)) {
+    // If there is an existing shell using this socket, or the socket cannot
+    // be used (another user using the same path?)
     FLAGS_extensions_socket += std::to_string((uint16_t)rand());
   }
 }


### PR DESCRIPTION
This allows the `osqueryi` shell to pick a "random" socket path if the configured path cannot be removed. This may occur if another user chooses the same path and improperly stops the shell. Consider:
```
touch ~/.osquery/shell.em
chmod 000 ~/.osquery/shell.em
```

Currently this will prevent all `osqueryi` shells from starting their extension managers. The desired behavior is to select a new socket (append a short to the end of the path).

Daemons will fail if the path cannot be used.