### PR TITLE
packages: Use 'linux' for OS version and build .tar.gz

### DIFF
--- a/CMake/Packages.cmake
+++ b/CMake/Packages.cmake
@@ -28,13 +28,13 @@ elseif(LINUX)
   if(FPM_EXECUTABLE)
     add_custom_command(TARGET packages PRE_BUILD
       COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-        -t "deb" -i "1.u16" -d '${DEB_PACKAGE_DEPENDENCIES}'
+        -t "deb" -i "1.linux" -d '${DEB_PACKAGE_DEPENDENCIES}'
     )
 
     if(RPMBUILD_EXECUTABLE)
       add_custom_command(TARGET packages PRE_BUILD
         COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
-          -t "rpm" -i "1.el7" -d '${RPM_PACKAGE_DEPENDENCIES}'
+          -t "rpm" -i "1.linux" -d '${RPM_PACKAGE_DEPENDENCIES}'
       )
     else()
       WARNING_LOG("Skipping RPM/CentOS packages: Cannot find rpmbuild")
@@ -48,6 +48,11 @@ elseif(LINUX)
     else()
       WARNING_LOG("Skipping ArchLinux packages: Cannot find bsdtar")
     endif()
+
+    add_custom_command(TARGET packages PRE_BUILD
+      COMMAND bash "${CMAKE_SOURCE_DIR}/tools/deployment/make_linux_package.sh"
+        -t "tar" -i "1.linux" -d "none"
+    )
 
   else()
     WARNING_LOG("Cannot find fpm executable in path")

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -110,6 +110,8 @@ function get_pkg_suffix() {
     echo "-${V}-${PACKAGE_ITERATION}.${PACKAGE_ARCH}.${PACKAGE_TYPE}"
   elif [[ $PACKAGE_TYPE == "pacman" ]]; then
     echo "-${PACKAGE_VERSION}-${PACKAGE_ITERATION}-${PACKAGE_ARCH}.pkg.tar.xz"
+  else
+    echo "-${PACKAGE_VERSION}_${PACKAGE_ITERATION}_${PACKAGE_ARCH}.tar.gz"
   fi
 }
 


### PR DESCRIPTION
The previous `deb` and `rpm` packages included a `u16` for Ubuntu 16.04, and `el7` for Enterprise Linux (CentOS) 7-- but these packages can be installed to tons of flavors, so we should move the name to `linux`. If there's a Linux OS that uses either package manager, and the OS was constructed after 2011, targeting general purpose use, we should support it.

This also produces a `.tar.gz` with the install layout from `/` for OSes that do not use `dpkg` or `rpm`.