### PR TITLE
prometheus_metrics: exposed request timeout configuration

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -397,12 +397,13 @@ There is a strict relationship between the top-level `file_paths` key, and `yara
 
 ### Prometheus
 
-The `prometheus_targets` key can be used to configure Prometheus targets to be queried. The metric timestamp of millisecond precision is taken when the target response is received.  The `prometheus_targets` parent key consists of one child key `urls`, which contains a list target urls to be scraped.
+The `prometheus_targets` key can be used to configure Prometheus targets to be queried. The metric timestamp of millisecond precision is taken when the target response is received.  The `prometheus_targets` parent key consists of a child key `urls`, which contains a list target urls to be scraped, and an optional child key `timeout` which contains the request timeout duration in seconds (defaults to 1 second if not provided).
 
 Example:
 ```json
 {
   "prometheus_targets": {
+    "timeout": 5,
     "urls": [
       "http://localhost:9100/metrics",
       "http://localhost:9101/metrics"

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -49,7 +49,7 @@ void parseScrapeResults(
 }
 
 void scrapeTargets(std::map<std::string, PrometheusResponseData>& scrapeResults,
-                   int timeoutS) {
+                   size_t timeoutS) {
   http::client client(
       http::client::options().follow_redirects(true).timeout(timeoutS));
 
@@ -116,8 +116,8 @@ QueryData genPrometheusMetrics(QueryContext& context) {
     sr[url.second.data()] = PrometheusResponseData{};
   }
 
-  int timeout = config.get_child("timeout", boost::property_tree::ptree())
-                    .get_value<int>(1);
+  size_t timeout = config.get_child("timeout", boost::property_tree::ptree())
+                       .get_value<size_t>(1);
 
   scrapeTargets(sr, timeout);
   parseScrapeResults(sr, result);

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -48,10 +48,10 @@ void parseScrapeResults(
   }
 }
 
-void scrapeTargets(
-    std::map<std::string, PrometheusResponseData>& scrapeResults) {
+void scrapeTargets(std::map<std::string, PrometheusResponseData>& scrapeResults,
+                   int timeoutS) {
   http::client client(
-      http::client::options().follow_redirects(true).timeout(1));
+      http::client::options().follow_redirects(true).timeout(timeoutS));
 
   for (auto& target : scrapeResults) {
     try {
@@ -116,7 +116,10 @@ QueryData genPrometheusMetrics(QueryContext& context) {
     sr[url.second.data()] = PrometheusResponseData{};
   }
 
-  scrapeTargets(sr);
+  int timeout = config.get_child("timeout", boost::property_tree::ptree())
+                    .get_value<int>(1);
+
+  scrapeTargets(sr, timeout);
   parseScrapeResults(sr, result);
 
   return result;

--- a/osquery/tables/applications/posix/prometheus_metrics.h
+++ b/osquery/tables/applications/posix/prometheus_metrics.h
@@ -49,8 +49,10 @@ void parseScrapeResults(
  * @param scrapeResults map where the key is the target url to be scraped and
  * value is the struct PrometheusResponseData where payload and timestamp are to
  * be written to.
+ *
+ * @param int for request timeout in seconds.
  */
-void scrapeTargets(
-    std::map<std::string, PrometheusResponseData>& scrapeResults);
+void scrapeTargets(std::map<std::string, PrometheusResponseData>& scrapeResults,
+                   int timeoutS = 1);
 }
 }

--- a/osquery/tables/applications/posix/prometheus_metrics.h
+++ b/osquery/tables/applications/posix/prometheus_metrics.h
@@ -53,6 +53,6 @@ void parseScrapeResults(
  * @param int for request timeout in seconds.
  */
 void scrapeTargets(std::map<std::string, PrometheusResponseData>& scrapeResults,
-                   int timeoutS = 1);
+                   size_t timeoutS = 1);
 }
 }


### PR DESCRIPTION
The prometheus_targets configuration now exposes a request timeout field (in seconds).  If there is no timeout explicitly set, then a default value of 1 second will be used. 