### PR TITLE
Locking issue with osquery::resetDatabase

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -671,10 +671,11 @@ Status scanDatabaseKeys(const std::string& domain,
 void resetDatabase() {
   WriteLock lock(kDatabaseReset);
 
+  LoggerForwardingDisabler disable_logging;
+
   // Prevent RocksDB reentrancy by logger plugins during plugin setup.
   VLOG(1) << "Resetting the database plugin: "
           << Registry::get().getActive("database");
-  LoggerForwardingDisabler disable_logging;
   PluginRequest request = {{"action", "reset"}};
   if (!Registry::call("database", request)) {
     LOG(WARNING) << "Unable to reset database plugin: "


### PR DESCRIPTION
The `VLOG(1)` within `osquery::resetDatabase` is currently not protected under the `LoggerForwardingDisabler` scope. With `--verbose` flags, the `VLOG(1)` logging attempt will eventually hit `osquery::setDatabaseValue` with a `kDatabaseReset` lock already taken.