### PR TITLE
audit: Optimize user_events and add auid

### DIFF
--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -63,7 +63,7 @@ struct AuditRuleInternal {
 };
 
 /// The audit ID is a smaller integer.
-using Auid = size_t;
+using AuditId = size_t;
 
 /// Alias the field container so we can replace and improve with refactors.
 using AuditFields = std::map<std::string, std::string>;
@@ -105,30 +105,30 @@ class AuditAssembler : private boost::noncopyable {
   void start(size_t capacity, std::vector<size_t> types, AuditUpdate update);
 
   /// Add a message from audit.
-  boost::optional<AuditFields> add(Auid id,
+  boost::optional<AuditFields> add(AuditId id,
                                    size_t type,
                                    const AuditFields& fields);
 
   /// Allow the publisher to explicit-set fields.
-  void set(Auid id, const std::string& key, const std::string& value) {
+  void set(AuditId id, const std::string& key, const std::string& value) {
     m_[id][key] = value;
   }
 
   /// Remove an audit ID from the queue and clear associated messages/types.
-  void evict(Auid id);
+  void evict(AuditId id);
 
   /// Shuffle an audit ID to the front of the queue.
-  void shuffle(Auid id);
+  void shuffle(AuditId id);
 
   /// Check if the audit ID has completed each required message types.
-  bool complete(Auid id);
+  bool complete(AuditId id);
 
  private:
   /// A map of audit ID to aggregate message fields.
-  std::unordered_map<Auid, AuditFields> m_;
+  std::unordered_map<AuditId, AuditFields> m_;
 
   /// A map of audit ID to current set of types seen.
-  std::unordered_map<Auid, std::vector<size_t>> mt_;
+  std::unordered_map<AuditId, std::vector<size_t>> mt_;
 
   /// A functional callable to sanitize individual messages.
   AuditUpdate update_{nullptr};
@@ -137,7 +137,7 @@ class AuditAssembler : private boost::noncopyable {
   size_t capacity_{0};
 
   /// The in-order (by time) queue of audit IDs.
-  std::vector<Auid> queue_;
+  std::vector<AuditId> queue_;
 
   /// The set of required types.
   std::vector<size_t> types_;
@@ -202,7 +202,7 @@ struct AuditEventContext : public EventContext {
   AuditFields fields;
 
   /// Each message will contain the audit ID.
-  size_t auid{0};
+  AuditId audit_id{0};
 
   /// Each message will contain the event time.
   size_t time{0};

--- a/osquery/events/linux/benchmarks/audit_benchmarks.cpp
+++ b/osquery/events/linux/benchmarks/audit_benchmarks.cpp
@@ -92,7 +92,7 @@ static void AUDIT_assembler(benchmark::State& state) {
   size_t i = 0;
   while (state.KeepRunning()) {
     const auto& ec = contexts[i++ % 6];
-    asmb.add(ec->auid, ec->type, ec->fields);
+    asmb.add(ec->audit_id, ec->type, ec->fields);
   }
 
   for (auto& r : replies) {

--- a/osquery/events/linux/tests/audit_tests.cpp
+++ b/osquery/events/linux/tests/audit_tests.cpp
@@ -58,7 +58,7 @@ TEST_F(AuditTests, test_handle_reply) {
 
   EXPECT_EQ(reply.type, ec->type);
   EXPECT_EQ(1440542781U, ec->time);
-  EXPECT_EQ(403030U, ec->auid);
+  EXPECT_EQ(403030U, ec->audit_id);
   EXPECT_EQ(ec->fields.size(), 4U);
   EXPECT_EQ(ec->fields.count("argc"), 1U);
   EXPECT_EQ(ec->fields["argc"], "3");

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -26,6 +26,7 @@ extern long getUptime();
 
 bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   if (type == AUDIT_SYSCALL) {
+    r["auid"] = (fields.count("auid")) ? fields.at("auid") : "0";
     r["pid"] = (fields.count("pid")) ? fields.at("pid") : "0";
     r["parent"] = fields.count("ppid") ? fields.at("ppid") : "0";
     r["uid"] = fields.count("uid") ? fields.at("uid") : "0";
@@ -130,7 +131,7 @@ Status ProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return Status(0, "OK");
   }
 
-  auto fields = asm_.add(ec->auid, ec->type, ec->fields);
+  auto fields = asm_.add(ec->audit_id, ec->type, ec->fields);
   if (fields.is_initialized()) {
     add(*fields);
   }

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -124,6 +124,7 @@ bool SocketUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
     return true;
   }
 
+  r["auid"] = fields.at("auid");
   r["pid"] = fields.at("pid");
   r["path"] = decodeAuditValue(fields.at("exe"));
   // TODO: This is a hex value.
@@ -162,11 +163,11 @@ Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef&) {
     return Status(0);
   }
 
-  auto fields = asm_.add(ec->auid, ec->type, ec->fields);
+  auto fields = asm_.add(ec->audit_id, ec->type, ec->fields);
   if (ec->syscall == AUDIT_SYSCALL_CONNECT) {
-    asm_.set(ec->auid, "action", "connect");
+    asm_.set(ec->audit_id, "action", "connect");
   } else if (ec->syscall == AUDIT_SYSCALL_BIND) {
-    asm_.set(ec->auid, "action", "bind");
+    asm_.set(ec->audit_id, "action", "bind");
   }
 
   if (fields.is_initialized()) {

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -49,7 +49,11 @@ Status UserEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   Row r;
   r["uid"] = ec->fields["uid"];
   r["pid"] = ec->fields["pid"];
-  r["message"] = ec->fields["msg"];
+  if (ec->fields.count("msg") && ec->fields.at("msg").size() > 1) {
+    ec->fields["msg"].erase(0, 1);
+    r["message"] = std::move(ec->fields["msg"]);
+  }
+  r["auid"] = ec->fields["auid"];
   r["type"] = INTEGER(ec->type);
   r["path"] = decodeAuditValue(ec->fields["exe"]);
   r["address"] = ec->fields["addr"];

--- a/specs/linux/socket_events.table
+++ b/specs/linux/socket_events.table
@@ -5,6 +5,7 @@ schema([
     Column("pid", BIGINT, "Process (or thread) ID"),
     Column("path", TEXT, "Path of executed file"),
     Column("fd", TEXT, "The file description for the process socket"),
+    Column("auid", BIGINT, "Audit User ID"),
     Column("success", INTEGER, "The socket open attempt status"),
     Column("family", INTEGER, "The Internet protocol family ID"),
     Column("protocol", INTEGER, "The network protocol ID"),

--- a/specs/linux/user_events.table
+++ b/specs/linux/user_events.table
@@ -2,6 +2,7 @@ table_name("user_events")
 description("Track user events from the audit framework.")
 schema([
     Column("uid", BIGINT, "User ID"),
+    Column("auid", BIGINT, "Audit User ID"),
     Column("pid", BIGINT, "Process (or thread) ID"),
     Column("message", TEXT, "Path of executed file"),
     Column("type", INTEGER, "The file description for the process socket"),

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -12,6 +12,7 @@ schema([
         aliases=["environment_count"]),
     Column("env_size", BIGINT, "Actual size (bytes) of environment list",
         aliases=["environment_size"]),
+    Column("auid", BIGINT, "Audit User ID at process start"),
     Column("uid", BIGINT, "User ID at process start"),
     Column("euid", BIGINT, "Effective user ID at process start"),
     Column("gid", BIGINT, "Group ID at process start"),


### PR DESCRIPTION
This fixes an oversight with the `user_events` table. The audit events are replayed about 5x and an event is recorded in the table for each. We add a small 10-sized audit ID cache to stem the number of events. From observation this dedups all user events.

We also add `auid` to `process_events`, `socket_events`, and `user_events`.