### PR TITLE
freebsd: Add lldpd to dependencies

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -22,7 +22,18 @@
 #define NOMINMAX
 #endif
 
+#ifndef WIN32
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#endif
+
+/// Wrap this include with the above and below ignored warnings for FreeBSD.
 #include <boost/coroutine2/all.hpp>
+
+#ifndef WIN32
+#pragma clang diagnostic pop
+#endif
+
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -68,10 +68,12 @@ else()
   ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio beecrypt popt db")
 endif()
 
+if(APPLE OR LINUX OR FREEBSD)
+  ADD_OSQUERY_LINK_ADDITIONAL("lldpctl")
+endif()
+
 if(APPLE OR LINUX)
   file(GLOB OSQUERY_CROSS_EVENTS_TABLES "events/*.cpp")
-
-  ADD_OSQUERY_LINK_ADDITIONAL("lldpctl")
 else()
   # TODO: When we have Windows events, fill this in
   set(OSQUERY_CROSS_EVENTS_TABLES "")

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -23,11 +23,12 @@ function distro_main() {
   package thrift-cpp
   package yara
   package boost-libs
-  package cpp-netlib
   package magic
   package sleuthkit
   package augeas
 
+  ports net-mgmt/lldpd
   ports databases/rocksdb
   ports devel/linenoise-ng
+  ports devel/cpp-netlib
 }

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -311,6 +311,7 @@ function package() {
 function ports() {
   PKG="$1"
   log "building port $1"
+  (cd /usr/ports/$1; do_sudo make deinstall)
   (cd /usr/ports/$1; do_sudo make install clean BATCH=yes)
 }
 


### PR DESCRIPTION
This is meant to improve the CI for FreeBSD11. The `lldpd` package is needed for linking the `lldp` table. `cpp-netlib` > 0.11 is needed for the TLS SNI functions.