### PR TITLE
deps: Update pcre to 8.40

### DIFF
--- a/tools/provision/formula/pcre.rb
+++ b/tools/provision/formula/pcre.rb
@@ -3,16 +3,15 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Pcre < AbstractOsqueryFormula
   desc "Perl compatible regular expressions library"
   homepage "http://www.pcre.org/"
-  url "https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.38.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre/8.38/pcre-8.38.tar.bz2"
-  sha256 "b9e02d36e23024d6c02a2e5b25204b3a4fa6ade43e0a5f869f254f49535079df"
+  url "https://ftp.pcre.org/pub/pcre/pcre-8.40.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre/8.40/pcre-8.40.tar.bz2"
+  sha256 "1d75ce90ea3f81ee080cdc04e68c9c25a9fb984861a0618be7bbf676b18eda3e"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b08e622fd735f2a3701f92e529aa9ab1a10de8261c6edc8ef66a7f5b15d81ba5" => :sierra
-    sha256 "d53bd23be25af381a8a5e645d90f4a83e4e5acf3111abd4e482160621cff6349" => :el_capitan
-    sha256 "3d2507879303c57941fa19972dc9eed980318751725908a5f8db1ba1104ea3d6" => :x86_64_linux
+    sha256 "be04cdca1805c738e7373eb15a2969114defb61c0782c8e15ab733564e89536a" => :sierra
+    sha256 "1c5d08457a82ed7b74e6c858232b1e846b196b71f7f56944fed44c5e2bbbdaef" => :x86_64_linux
   end
 
   head do


### PR DESCRIPTION
The `pcre` package on Linux and Darwin is out of date, packages for 8.38 may not be available (from 2015). 