### PR TITLE
deps: Update thrift to 0.10.0

### DIFF
--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Generate the thrift intermediate/interface code.
 add_custom_command(
   COMMAND
-    ${THRIFT_COMPILER} --gen cpp:dense --gen py:dense "${CMAKE_SOURCE_DIR}/osquery.thrift"
+    ${THRIFT_COMPILER} --gen cpp --gen py "${CMAKE_SOURCE_DIR}/osquery.thrift"
   DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
   OUTPUT ${OSQUERY_THRIFT_GENERATED_FILES}

--- a/tools/provision/formula/thrift.rb
+++ b/tools/provision/formula/thrift.rb
@@ -3,23 +3,20 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Thrift < AbstractOsqueryFormula
   desc "Framework for scalable cross-language services development"
   homepage "https://thrift.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=/thrift/0.9.3/thrift-0.9.3.tar.gz"
-  sha256 "b0740a070ac09adde04d43e852ce4c320564a292f26521c46b78e0641564969e"
-  revision 3
+  url "http://www-us.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz"
+  sha256 "2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "53780643a25a2d09098159f33415d274f43e6ef0f46ea7bcc64ca698dd180cd9" => :sierra
-    sha256 "f662c63b728d14c175103561e12681e5589a587140312e3ce641661ac6821e3d" => :x86_64_linux
+    sha256 "33597cefaff4c53602a628be01d7f85d90699552395d2947ac6e791dafeebdc0" => :sierra
+    sha256 "012df0c36a9ff168a553dacded7cd3905e66aa2be48e4858ce6432df455c550e" => :x86_64_linux
   end
 
   depends_on "bison" => :build
   depends_on "openssl"
   depends_on :python => :optional
 
-  # Remove SSLv3
-  # See https://github.com/apache/thrift/commit/b819260c653f6fd9602419ee2541060ecb930c4c
   patch :DATA
 
   def install
@@ -40,8 +37,8 @@ class Thrift < AbstractOsqueryFormula
       "--without-qt",
       "--without-qt4",
       "--without-nodejs",
+      "--without-python",
       "--with-cpp",
-      "--with-python",
       "--with-openssl=#{HOMEBREW_PREFIX}"
     ]
 
@@ -64,26 +61,11 @@ class Thrift < AbstractOsqueryFormula
 end
 
 __END__
-diff --git a/lib/cpp/src/thrift/transport/TSSLSocket.cpp b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
-index 98c5326..7c73f4e 100644
---- a/lib/cpp/src/thrift/transport/TSSLSocket.cpp
-+++ b/lib/cpp/src/thrift/transport/TSSLSocket.cpp
-@@ -139,8 +139,10 @@ static char uppercase(char c);
- SSLContext::SSLContext(const SSLProtocol& protocol) {
-   if (protocol == SSLTLS) {
-     ctx_ = SSL_CTX_new(SSLv23_method());
-+#ifndef OPENSSL_NO_SSL3
-   } else if (protocol == SSLv3) {
-     ctx_ = SSL_CTX_new(SSLv3_method());
-+#endif
-   } else if (protocol == TLSv1_0) {
-     ctx_ = SSL_CTX_new(TLSv1_method());
-   } else if (protocol == TLSv1_1) {
 diff --git a/lib/cpp/src/thrift/transport/TServerSocket.cpp b/lib/cpp/src/thrift/transport/TServerSocket.cpp
-index daa1524..c1e6676 100644
+index 87b6383..447c89d 100644
 --- a/lib/cpp/src/thrift/transport/TServerSocket.cpp
 +++ b/lib/cpp/src/thrift/transport/TServerSocket.cpp
-@@ -528,6 +528,12 @@ shared_ptr<TTransport> TServerSocket::acceptImpl() {
+@@ -584,6 +584,12 @@ shared_ptr<TTransport> TServerSocket::acceptImpl() {
          // a certain number
          continue;
        }


### PR DESCRIPTION
Thrift 0.10.0 includes a fix for a memory leak in `gethostbyaddr`. 