### PR TITLE
[Fix #3129] Check malloc result for WEL XML buffer before calling EvtRender

### DIFF
--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -132,7 +132,7 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
                   &buffUsed,
                   &propCount);
       } else {
-        status = Status(GetLastError(), "malloc failed");
+        status = Status(GetLastError(), "Event log buffer malloc failed");
       }
     } else {
       status = Status(GetLastError(), "Event rendering failed");
@@ -144,7 +144,6 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
     ss << wstringToString(xml);
     read_xml(ss, propTree);
     free(xml);
-    xml = nullptr;
   }
   return status;
 }

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -111,7 +111,7 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
   DWORD buffSize = 0;
   DWORD buffUsed = 0;
   DWORD propCount = 0;
-  Status status;
+  Status status = Status(0, "OK");
   LPWSTR xml = nullptr;
   if (!EvtRender(nullptr,
                  evt,

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -124,7 +124,7 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
     if (ERROR_INSUFFICIENT_BUFFER == GetLastError()) {
       buffSize = buffUsed;
       xml = static_cast<LPWSTR>(malloc(buffSize));
-      if (xml) {
+      if (xml != nullptr) {
         EvtRender(nullptr,
                   evt,
                   EvtRenderEventXml,
@@ -146,7 +146,10 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
     status = Status(GetLastError(), "Event rendering failed");
   }
 
-  free(xml);
+  if (xml != nullptr) {
+    free(xml);
+  }
+
   return status;
 }
 

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -140,11 +140,14 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
   }
 
   if (xml != nullptr) {
-    std::stringstream ss;
-    ss << wstringToString(xml);
-    read_xml(ss, propTree);
+    if (GetLastError() == ERROR_SUCCESS) {
+      std::stringstream ss;
+      ss << wstringToString(xml);
+      read_xml(ss, propTree);
+    }
     free(xml);
   }
+
   return status;
 }
 


### PR DESCRIPTION
Add a check for the success of a malloc before continuing to parse the Windows Event Log in the case that the initial call to EvtRender returned with ERROR_INSUFFICIENT_BUFFER. 

nullptr can be provided to EvtRender to determine the needed buffer size, however there is no need to call this function if the malloc failed, and we also now have a safety issue with the code since we are assuming the malloc succeeded.

This fixes #3129.