### PR TITLE
logger: Add logger_min_status and disable stderr with stdout

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -206,6 +206,10 @@ It is common for TLS/HTTPS servers to enforce a maximum request body size. The d
 
 Use this only in emergency situations as size violations are dropped. It is extremely uncommon for this to occur, as the `--value_max` for each column would need to be drastically larger, or the offending table would have to implement several hundred columns.
 
+`--logger_min_status=0`
+
+The minimum level for status log recording. Use the following values: `INFO = 0, WARNING = 1, ERROR = 2`. To disable all status messages use 3+. When using `--verbose` this value is ignored.
+
 `--distributed_tls_read_endpoint=""`
 
 The URI path which will be used, in conjunction with `--tls_hostname`, to create the remote URI for retrieving distributed queries when using the **tls** distributed plugin.

--- a/osquery/logger/plugins/stdout.cpp
+++ b/osquery/logger/plugins/stdout.cpp
@@ -48,6 +48,10 @@ Status StdoutLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
 
 void StdoutLoggerPlugin::init(const std::string& name,
                               const std::vector<StatusLogLine>& log) {
+  // Stop the internal Glog facilities.
+  FLAGS_alsologtostderr = false;
+  FLAGS_logtostderr = false;
+
   // Now funnel the intermediate status logs provided to `init`.
   logStatus(log);
 }

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -13,6 +13,8 @@
 #include <osquery/core.h>
 #include <osquery/logger.h>
 
+DECLARE_int32(minloglevel);
+
 namespace osquery {
 
 DECLARE_bool(logger_secondary_status_only);
@@ -171,6 +173,19 @@ TEST_F(LoggerTests, test_logger_log_status) {
 
   // The second warning status will be sent to the logger plugin.
   EXPECT_EQ(1U, LoggerTests::statuses_logged);
+}
+
+TEST_F(LoggerTests, test_logger_status_level) {
+  FLAGS_minloglevel = 0;
+  // This will be printed to stdout.
+  LOG(INFO) << "Logger test is generating an info status";
+  EXPECT_EQ(1U, LoggerTests::statuses_logged);
+
+  FLAGS_minloglevel = 1;
+  LOG(INFO) << "Logger test is generating an info status";
+  EXPECT_EQ(1U, LoggerTests::statuses_logged);
+  LOG(WARNING) << "Logger test is generating a warning status";
+  EXPECT_EQ(2U, LoggerTests::statuses_logged);
 }
 
 TEST_F(LoggerTests, test_feature_request) {


### PR DESCRIPTION
This closes #3041 by introducing a `--logger_min_status` that can be set to `=3` to disable status messages.

This also addresses a UX issue with `--logger_plugin=stdout` where the messages we also reported to stderr.