### PR TITLE
Adding aws-sdk-cpp libraries to provisioning script

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -271,6 +271,7 @@ function Install-ThirdParty {
   #      Once our chocolatey packages are added to the official repository, installing the third-party
   #      dependencies will be as easy as Install-ChocoPackage '<package-name>'.
   $packages = @(
+    "aws-sdk-cpp.0.14.4",
     "boost-msvc14.1.63.0-r1",
     "bzip2.1.0.6",
     "doxygen.1.8.11",


### PR DESCRIPTION
This commit will install aws-sdk-cpp libraries (core, kinesis, firehose, and sts) for windows on provisioning. Note that this does not bring full support to windows, it's simply making the port possible.  More PRs will follow with changes to our CMake logic to try and get aws functionality on Windows.