### PR TITLE
[Fix #3135] Allowing OR clause in Windows Registry Table

### DIFF
--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -49,6 +49,26 @@ TEST_F(RegistryTablesTest, test_explode_registry_path_normal) {
   EXPECT_TRUE(rHive == "HKEY_LOCAL_MACHINE");
 }
 
+TEST_F(RegistryTablesTest, test_registry_or_clause) {
+  SQL results("SELECT * FROM registry WHERE key = \"" + kTestKey +
+              "\" OR key = \"" + kTestSpecificKey + "\"");
+  auto testKeyFound = false;
+  auto specificKeyFound = false;
+  EXPECT_TRUE(results.rows().size() > 0);
+  for (const auto& row : results.rows()) {
+    auto key = row.at("key");
+    if (boost::starts_with(key, kTestSpecificKey)) {
+      specificKeyFound = true;
+    } else if (boost::starts_with(key, kTestKey)) {
+      testKeyFound = true;
+    } else {
+      assert(false);
+    }
+  }
+  EXPECT_TRUE(testKeyFound);
+  EXPECT_TRUE(specificKeyFound);
+}
+
 TEST_F(RegistryTablesTest, test_explode_registry_path_just_hive) {
   auto path = "HKEY_LOCAL_MACHINE";
   std::string rKey;

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -1,7 +1,7 @@
 table_name("registry")
 description("All of the Windows registry hives.")
 schema([
-    Column("key", TEXT, "Name of the key to search for"),
+    Column("key", TEXT, "Name of the key to search for", additional=True),
     Column("path", TEXT, "Full path to the value"),
     Column("name", TEXT, "Name of the registry value entry"),
     Column("type", TEXT, "Type of the registry value, or 'subkey' if item is a subkey"),


### PR DESCRIPTION
The way we were computing the registry table prevented an OR clause from working on the key column. 

This fixes it by forcing SQLite to not optimize away the OR clause.

```
osquery> select * from registry where key = 'HKEY_LOCAL_MACHINE\SAM' or key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel';
+----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+---------------------+--------+------+------------+
| key                                                                        | path
              | name                | type   | data | mtime      |
+----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+---------------------+--------+------+------------+
| HKEY_LOCAL_MACHINE\SAM                                                     | HKEY_LOCAL_MACHINE\SAM\SAM
              | SAM                 | subkey |      | 1479693407 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Cpls
              | Cpls                | subkey |      | 1488908071 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Cursors             | Cursors             | subkey |      | 1468669748 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\don't load          | don't load          | subkey |      | 1468669715 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\DoNotUnload         | DoNotUnload         | subkey |      | 1468669748 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Extended Properties | Extended Properties | subkey |      | 1488907787 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Glass Colorization  | Glass Colorization  | subkey |      | 1479692834 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Settings            | Settings            | subkey |      | 1468669748 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\Theme
              | Theme               | subkey |      | 1479693398 |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel | HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Control Panel\ThemeVolatile       | ThemeVolatile       | subkey |      | 1479693398 |
+----------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+---------------------+--------+------+------------+
```
Resolves #3135 .