### PR TITLE
[Fix #3138] Adding index on 'key' column of Windows Registry table

### DIFF
--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -50,23 +50,24 @@ TEST_F(RegistryTablesTest, test_explode_registry_path_normal) {
 }
 
 TEST_F(RegistryTablesTest, test_registry_or_clause) {
-  SQL results("SELECT * FROM registry WHERE key = \"" + kTestKey +
-              "\" OR key = \"" + kTestSpecificKey + "\"");
-  auto testKeyFound = false;
-  auto specificKeyFound = false;
-  EXPECT_TRUE(results.rows().size() > 0);
-  for (const auto& row : results.rows()) {
-    auto key = row.at("key");
-    if (boost::starts_with(key, kTestSpecificKey)) {
-      specificKeyFound = true;
-    } else if (boost::starts_with(key, kTestKey)) {
-      testKeyFound = true;
-    } else {
-      assert(false);
-    }
-  }
-  EXPECT_TRUE(testKeyFound);
-  EXPECT_TRUE(specificKeyFound);
+  SQL result1("SELECT * FROM registry WHERE key = \"" + kTestKey + "\"");
+  SQL result2("SELECT * FROM registry WHERE key = \"" + kTestSpecificKey +
+              "\"");
+  SQL combinedResults("SELECT * FROM registry WHERE key = \"" + kTestKey +
+                      "\" OR key = \"" + kTestSpecificKey + "\"");
+
+  EXPECT_TRUE(result1.rows().size() > 0);
+  EXPECT_TRUE(result2.rows().size() > 0);
+  EXPECT_TRUE(combinedResults.rows().size() ==
+              result1.rows().size() + result2.rows().size());
+  EXPECT_TRUE(std::includes(combinedResults.rows().begin(),
+                            combinedResults.rows().end(),
+                            result1.rows().begin(),
+                            result1.rows().end()));
+  EXPECT_TRUE(std::includes(combinedResults.rows().begin(),
+                            combinedResults.rows().end(),
+                            result2.rows().begin(),
+                            result2.rows().end()));
 }
 
 TEST_F(RegistryTablesTest, test_explode_registry_path_just_hive) {

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -1,7 +1,7 @@
 table_name("registry")
 description("All of the Windows registry hives.")
 schema([
-    Column("key", TEXT, "Name of the key to search for", additional=True),
+    Column("key", TEXT, "Name of the key to search for", additional=True, index=True),
     Column("path", TEXT, "Full path to the value"),
     Column("name", TEXT, "Name of the registry value entry"),
     Column("type", TEXT, "Type of the registry value, or 'subkey' if item is a subkey"),


### PR DESCRIPTION
The missing 'index' flag resulted in incomplete results from an OR operation on the windows registry key, adding it allows complete results to be returned.

```
osquery> select key from registry where  key like "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\%%" or key like "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\%%";
W0405 10:38:26.914213  5184 registry.cpp:424] CURRENT_USER hives are not queryable by osqueryd; query HKEY_USERS with the desired users SID instead
+-----------------------------------------------------------------------------------------------------+
| key                                                                                                 |
+-----------------------------------------------------------------------------------------------------+
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run            |
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run            |
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run            |
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder  |
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder  |
| HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder  |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run           |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run           |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run           |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run32         |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run32         |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run32         |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run32         |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder |
| HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\StartupFolder |
+-----------------------------------------------------------------------------------------------------+
```
Resolves #3138.