### PR TITLE
freebsd: Link rocksdb-lite

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -87,7 +87,7 @@ elseif(FREEBSD)
   ADD_OSQUERY_LINK_CORE("boost_thread")
   ADD_OSQUERY_LINK_CORE("boost_context")
 
-  ADD_OSQUERY_LINK_ADDITIONAL("rocksdb")
+  ADD_OSQUERY_LINK_ADDITIONAL("rocksdb-lite")
   ADD_OSQUERY_LINK_ADDITIONAL("boost_regex")
 endif()
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -445,10 +445,6 @@ bool addUniqueRowToQueryData(QueryData& q, const Row& r) {
 bool DatabasePlugin::initPlugin() {
   // Initialize the database plugin using the flag.
   auto plugin = (FLAGS_disable_database) ? "ephemeral" : kInternalDatabase;
-  if (isPlatform(PlatformType::TYPE_FREEBSD) && !FLAGS_disable_database) {
-    // Issue #3111: Override the internal plugin to SQLite for FreeBSD.
-    plugin = "sqlite";
-  }
   return RegistryFactory::get().setActive("database", plugin).ok();
 }
 

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -28,7 +28,7 @@ function distro_main() {
   package augeas
 
   ports net-mgmt/lldpd
-  ports databases/rocksdb
+  ports databases/rocksdb-lite
   ports devel/linenoise-ng
   ports devel/cpp-netlib
 }


### PR DESCRIPTION
With: https://bugs.freebsd.org/bugzilla/attachment.cgi?id=181519&action=diff we should use the `rocksdb-lite` port.

Closes #3111.