### PR TITLE
Adding 32-bit Items to Windows startup_info table

### DIFF
--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -31,7 +31,11 @@ namespace tables {
 
 const std::set<std::string> kStartupRegKeys = {
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_LOCAL_MACHINE\\Software\\Microsoft\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
     "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_USERS\\%\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_USERS\\%\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
 };
 const std::set<std::string> kStartupFolderDirectories = {
     "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\%%",

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -31,11 +31,16 @@ namespace tables {
 
 const std::set<std::string> kStartupRegKeys = {
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
+    "HKEY_LOCAL_"
+    "MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_LOCAL_"
+    "MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+    "\\Run%",
     "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_USERS\\%\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
+    "HKEY_USERS\\%"
+    "\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
+    "HKEY_USERS\\%"
+    "\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
 };
 const std::set<std::string> kStartupFolderDirectories = {
     "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\%%",
@@ -58,15 +63,21 @@ QueryData genStartupItems(QueryContext& context) {
 
   // These are UNION instead of OR to workaround #3145
   std::string startupSubQuery =
-      "SELECT name,data,key FROM (select name,data,key,type from registry WHERE key LIKE \"" +
-      boost::join(kStartupRegKeys, "\" UNION SELECT name,data,key,type FROM registry WHERE key LIKE \"") +
+      "SELECT name,data,key FROM (select name,data,key,type from registry "
+      "WHERE key LIKE \"" +
+      boost::join(kStartupRegKeys,
+                  "\" UNION SELECT name,data,key,type FROM registry WHERE key "
+                  "LIKE \"") +
       "\") WHERE NOT (type = \"subkey\" OR name = \"" + kDefaultRegName + "\")";
   std::string startupFolderSubQuery =
       "SELECT filename,path,directory FROM file WHERE path LIKE \"" +
       boost::join(kStartupFolderDirectories, "\" OR path LIKE \"") + "\"";
   std::string statusSubQuery =
-      "SELECT name,data AS status FROM (select name,data from registry WHERE key LIKE \"" +
-      boost::join(kStartupStatusRegKeys, "\" UNION SELECT name,data FROM registry WHERE key LIKE \"") + "\")";
+      "SELECT name,data AS status FROM (select name,data from registry WHERE "
+      "key LIKE \"" +
+      boost::join(kStartupStatusRegKeys,
+                  "\" UNION SELECT name,data FROM registry WHERE key LIKE \"") +
+      "\")";
 
   SQL startupResults("SELECT key,R1.name as name,data,status FROM (" +
                      startupSubQuery + " UNION " + startupFolderSubQuery +

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -32,7 +32,7 @@ namespace tables {
 const std::set<std::string> kStartupRegKeys = {
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_LOCAL_MACHINE\\Software\\Microsoft\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
+    "HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
     "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
     "HKEY_USERS\\%\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
     "HKEY_USERS\\%\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -56,6 +56,7 @@ const auto kStartupDisabledRegex = boost::regex("^0[0-9](?!0+$).*$");
 QueryData genStartupItems(QueryContext& context) {
   QueryData results;
 
+  // These are UNION instead of OR to workaround #3145
   std::string startupSubQuery =
       "SELECT name,data,key FROM (select name,data,key,type from registry WHERE key LIKE \"" +
       boost::join(kStartupRegKeys, "\" UNION SELECT name,data,key,type FROM registry WHERE key LIKE \"") +

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -31,16 +31,15 @@ namespace tables {
 
 const std::set<std::string> kStartupRegKeys = {
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_LOCAL_"
-    "MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_LOCAL_"
-    "MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
-    "\\Run%",
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows"
+    "\\CurrentVersion\\Run%",
+    "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion"
+    "\\Policies\\Explorer\\Run%",
     "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_USERS\\%"
-    "\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run%",
-    "HKEY_USERS\\%"
-    "\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run%",
+    "HKEY_USERS\\%\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows"
+    "\\CurrentVersion\\Run%",
+    "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion"
+    "\\Policies\\Explorer\\Run%",
 };
 const std::set<std::string> kStartupFolderDirectories = {
     "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\%%",


### PR DESCRIPTION
Startup items can live in the WOW6432Node keys as well for 32-bit compatibility.

Note I had to change the SQL from 'OR' to 'UNION' to workaround a bug with how the 'OR' is being rendered. 