### PR TITLE
Adding hostIdentifier, calendarTime, unixTime to status logging

### DIFF
--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -52,6 +52,12 @@ struct StatusLogLine {
   int line;
   /// The string-formatted status message.
   std::string message;
+  /// The host identifier
+  std::string identifier;
+  /// The ASCII time stamp for when the status message was emitted
+  std::string calendar_time;
+  /// The UNIX time for when the status message was emitted
+  size_t time;
 };
 
 /**

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -320,7 +320,8 @@ size_t toUnixTime(const struct tm* tm_time);
 size_t getUnixTime();
 
 /**
- * @brief Converts a struct tm into a human-readable format.
+ * @brief Converts a struct tm into a human-readable format. This expected the
+ * struct tm to be already in UTC time/
  *
  * @param tm_time the time/date to convert to ASCII
  *
@@ -329,9 +330,10 @@ size_t getUnixTime();
 std::string toAsciiTime(const struct tm* tm_time);
 
 /**
- * @brief Converts a struct tm to ASCII time UTC
+ * @brief Converts a struct tm to ASCII time UTC by converting the tm_time to
+ * epoch and then running gmtime() on the new epoch
  *
- * @param tm_time the time/data to covert to UTC ASCII time
+ * @param tm_time the local time/date to covert to UTC ASCII time
  *
  * @return the data/time of tm_time in the format: "Wed Sep 21 10:27:52 2011"
  */

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -304,11 +304,38 @@ std::string generateHostUUID();
 std::string getHostIdentifier();
 
 /**
+ * @brief Converts struct tm to a size_t
+ *
+ * @param tm_time the time/date to convert to UNIX epoch time
+ *
+ * @return an int representing the UNIX epoch time of the struct tm
+ */
+size_t toUnixTime(const struct tm* tm_time);
+
+/**
  * @brief Getter for the current UNIX time.
  *
  * @return an int representing the amount of seconds since the UNIX epoch
  */
 size_t getUnixTime();
+
+/**
+ * @brief Converts a struct tm into a human-readable format.
+ *
+ * @param tm_time the time/date to convert to ASCII
+ *
+ * @return the data/time of tm_time in the format: "Wed Sep 21 10:27:52 2011"
+ */
+std::string toAsciiTime(const struct tm* tm_time);
+
+/**
+ * @brief Converts a struct tm to ASCII time UTC
+ *
+ * @param tm_time the time/data to covert to UTC ASCII time
+ *
+ * @return the data/time of tm_time in the format: "Wed Sep 21 10:27:52 2011"
+ */
+std::string toAsciiTimeUTC(const struct tm* tm_time);
 
 /**
  * @brief Getter for the current time, in a human-readable format.

--- a/osquery/core/posix/utils.cpp
+++ b/osquery/core/posix/utils.cpp
@@ -23,22 +23,6 @@ std::string platformAsctime(const struct tm* timeptr) {
   return ::asctime(timeptr);
 }
 
-Status platformGmtime(const size_t epoch, struct tm* result) {
-  struct tm* tptr = nullptr;
-
-  if (result == nullptr) {
-    return Status(1, "result is NULL");
-  }
-
-  tptr = gmtime((time_t*)&epoch);
-  if (tptr == nullptr) {
-    return Status(1, "gmtime returned NULL");
-  }
-
-  memcpy(result, tptr, sizeof(*result));
-  return Status(0, "OK");
-}
-
 std::string platformStrerr(int errnum) {
   return ::strerror(errnum);
 }

--- a/osquery/core/posix/utils.cpp
+++ b/osquery/core/posix/utils.cpp
@@ -23,6 +23,22 @@ std::string platformAsctime(const struct tm* timeptr) {
   return ::asctime(timeptr);
 }
 
+Status platformGmtime(const size_t epoch, struct tm* result) {
+  struct tm* tptr = nullptr;
+
+  if (result == nullptr) {
+    return Status(1, "result is NULL");
+  }
+
+  tptr = gmtime((time_t*)&epoch);
+  if (tptr == nullptr) {
+    return Status(1, "gmtime returned NULL");
+  }
+
+  memcpy(result, tptr, sizeof(*result));
+  return Status(0, "OK");
+}
+
 std::string platformStrerr(int errnum) {
   return ::strerror(errnum);
 }

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -229,10 +229,7 @@ std::string toAsciiTimeUTC(const struct tm* tm_time) {
     return "";
   }
 
-  if (!platformGmtime(epoch, &tptr).ok()) {
-    return "";
-  }
-
+  gmtime_r((time_t*)&epoch, &tptr);
   return toAsciiTime(&tptr);
 }
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -221,10 +221,19 @@ std::string toAsciiTime(const struct tm* tm_time) {
 
 std::string toAsciiTimeUTC(const struct tm* tm_time) {
   size_t epoch = toUnixTime(tm_time);
+  struct tm tptr;
+
+  memset(&tptr, 0, sizeof(tptr));
+
   if (epoch == (size_t)-1) {
     return "";
   }
-  return toAsciiTime(gmtime((time_t*)&epoch));
+
+  if (!platformGmtime(epoch, &tptr).ok()) {
+    return "";
+  }
+
+  return toAsciiTime(&tptr);
 }
 
 std::string getAsciiTime() {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -209,15 +209,39 @@ std::string getHostIdentifier() {
   return ident;
 }
 
+std::string toAsciiTime(const struct tm* tm_time) {
+  if (tm_time == nullptr) {
+    return "";
+  }
+
+  auto time_str = platformAsctime(tm_time);
+  boost::algorithm::trim(time_str);
+  return time_str + " UTC";
+}
+
+std::string toAsciiTimeUTC(const struct tm* tm_time) {
+  size_t epoch = toUnixTime(tm_time);
+  if (epoch == (size_t)-1) {
+    return "";
+  }
+  return toAsciiTime(gmtime((time_t*)&epoch));
+}
+
 std::string getAsciiTime() {
   auto result = std::time(nullptr);
 
   struct tm now;
   gmtime_r(&result, &now);
 
-  auto time_str = platformAsctime(&now);
-  boost::algorithm::trim(time_str);
-  return time_str + " UTC";
+  return toAsciiTime(&now);
+}
+
+size_t toUnixTime(const struct tm* tm_time) {
+  struct tm result;
+  memset(&result, 0, sizeof(result));
+
+  memcpy(&result, tm_time, sizeof(result));
+  return mktime(&result);
 }
 
 size_t getUnixTime() {

--- a/osquery/core/tests/time_tests.cpp
+++ b/osquery/core/tests/time_tests.cpp
@@ -18,14 +18,6 @@
 
 namespace osquery {
 
-#ifdef WIN32
-static struct tm* localtime_r(const time_t* timep, struct tm* result) {
-  _localtime64_s(result, timep);
-  return result;
-}
-
-#endif
-
 class TimeTests : public testing::Test {};
 
 TEST_F(TimeTests, test_asciitime) {

--- a/osquery/core/tests/time_tests.cpp
+++ b/osquery/core/tests/time_tests.cpp
@@ -45,6 +45,6 @@ TEST_F(TimeTests, test_asciitimeutc) {
   struct tm result;
   localtime_r((time_t*)&epoch, &result);
 
-  EXPECT_EQ(expected, toAsciiTime(&result));
+  EXPECT_EQ(expected, toAsciiTimeUTC(&result));
 }
 }

--- a/osquery/core/tests/time_tests.cpp
+++ b/osquery/core/tests/time_tests.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/core.h>
+#include <osquery/system.h>
+
+#include "osquery/core/utils.h"
+#include "osquery/tests/test_util.h"
+
+namespace osquery {
+
+#ifdef WIN32
+static struct tm* localtime_r(const time_t* timep, struct tm* result) {
+  _localtime64_s(result, timep);
+  return result;
+}
+
+#endif
+
+class TimeTests : public testing::Test {};
+
+TEST_F(TimeTests, test_asciitime) {
+  const size_t epoch = 1491518994;
+  const std::string expected = "Thu Apr  6 22:49:54 2017 UTC";
+
+  struct tm result;
+  gmtime_r((time_t*)&epoch, &result);
+
+  EXPECT_EQ(expected, toAsciiTime(&result));
+}
+
+TEST_F(TimeTests, test_asciitimeutc) {
+  const size_t epoch = 1491518994;
+  const std::string expected = "Thu Apr  6 22:49:54 2017 UTC";
+
+  struct tm result;
+  localtime_r((time_t*)&epoch, &result);
+
+  EXPECT_EQ(expected, toAsciiTime(&result));
+}
+}

--- a/osquery/core/utils.h
+++ b/osquery/core/utils.h
@@ -21,6 +21,9 @@ namespace osquery {
 /// Returns the ASCII version of the timeptr as a C++ string
 std::string platformAsctime(const struct tm* timeptr);
 
+/// Converts a UTC epoch into a struct tm*
+Status platformGmtime(const size_t epoch, struct tm* result);
+
 /// Returns a C++ string explaining the errnum
 std::string platformStrerr(int errnum);
 

--- a/osquery/core/utils.h
+++ b/osquery/core/utils.h
@@ -21,9 +21,6 @@ namespace osquery {
 /// Returns the ASCII version of the timeptr as a C++ string
 std::string platformAsctime(const struct tm* timeptr);
 
-/// Converts a UTC epoch into a struct tm*
-Status platformGmtime(const size_t epoch, struct tm* result);
-
 /// Returns a C++ string explaining the errnum
 std::string platformStrerr(int errnum);
 

--- a/osquery/core/windows/utils.cpp
+++ b/osquery/core/windows/utils.cpp
@@ -34,6 +34,16 @@ std::string platformAsctime(const struct tm* timeptr) {
   return time_str;
 }
 
+Status platformGmtime(const size_t epoch, struct tm* result) {
+  // gmtime_s checks result for nullptr, no need to add extra checks
+  errno_t ret = gmtime_s(result, (time_t*)&epoch);
+  if (ret != = 0) {
+    return Status(1, "gmtime_s errored with errno=" + ret);
+  }
+
+  return Status(0, "OK");
+}
+
 std::string platformStrerr(int errnum) {
   std::vector<char> buffer;
   buffer.assign(MAX_BUFFER_SIZE, '\0');

--- a/osquery/core/windows/utils.cpp
+++ b/osquery/core/windows/utils.cpp
@@ -34,16 +34,6 @@ std::string platformAsctime(const struct tm* timeptr) {
   return time_str;
 }
 
-Status platformGmtime(const size_t epoch, struct tm* result) {
-  // gmtime_s checks result for nullptr, no need to add extra checks
-  errno_t ret = gmtime_s(result, (time_t*)&epoch);
-  if (ret != = 0) {
-    return Status(1, "gmtime_s errored with errno=" + ret);
-  }
-
-  return Status(0, "OK");
-}
-
 std::string platformStrerr(int errnum) {
   std::vector<char> buffer;
   buffer.assign(MAX_BUFFER_SIZE, '\0');

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -191,6 +191,9 @@ Status BufferedLogForwarder::logStatus(const std::vector<StatusLogLine>& log,
   for (const auto& item : log) {
     // Convert the StatusLogLine into ptree format, to convert to JSON.
     pt::ptree buffer;
+    buffer.put("hostIdentifier", item.identifier);
+    buffer.put("calendarTime", item.calendar_time);
+    buffer.put("unixTime", item.time);
     buffer.put("severity", (google::LogSeverity)item.severity);
     buffer.put("filename", item.filename);
     buffer.put("line", item.line);

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -34,7 +34,7 @@ class LoggerTests : public testing::Test {
     log_lines.clear();
     status_messages.clear();
     statuses_logged = 0;
-    last_status = {O_INFO, "", -1, ""};
+    last_status = {O_INFO, "", -1, "", "host", "cal_time", 0};
   }
 
   void TearDown() override {


### PR DESCRIPTION
Currently, logger plugins that use `BufferedLogForwarder` for status logging do not receive information about the `hostIdentifier`, `calendarTime`, and `unixTime`. This adds the following fields to a status log entry: `hostIdentifier`, `calendarTime`, and `unixTime`.