### PR TITLE
events: Use generator-tables for event subscribers

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -434,11 +434,12 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    *
    * This is used internally (for the most part) by EventSubscriber::genTable.
    *
+   * @param yield The Row yield method.
    * @param start Inclusive lower bound time limit.
    * @param stop Inclusive upper bound time limit.
    * @return Set of event rows matching time limits.
    */
-  virtual QueryData get(EventTime start, EventTime stop) final;
+  virtual void get(RowYield& yield, EventTime start, EventTime stop) final;
 
  private:
   /// Overload add for tests and allow them to override the event time.
@@ -575,9 +576,11 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * 'subscribing' and acting. The `genTable` static entrypoint is the
    * suggested method for table specs.
    *
+   * @param yield The Row yield method.
+   * @param ctx The query context (used for time windows).
    * @return The query-time table data, retrieved from a backing store.
    */
-  virtual QueryData genTable(QueryContext& context) USED_SYMBOL;
+  virtual void genTable(RowYield& yield, QueryContext& ctx) USED_SYMBOL;
 
   /// Number of Subscription%s this EventSubscriber has used.
   size_t numSubscriptions() const {

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -18,8 +18,12 @@
 #include <vector>
 
 #ifdef WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #endif
 
 #ifndef WIN32
@@ -549,6 +553,7 @@ struct QueryContext : private only_movable {
   ~QueryContext() {
     if (!enable_cache_ && table_ != nullptr) {
       delete table_;
+      table_ = nullptr;
     }
   }
 

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -113,7 +113,7 @@ static inline void setOptimizeData(EventTime time,
   setDatabaseValue(kEvents, "optimize_eid." + query_name, toIndex(eid));
 }
 
-QueryData EventSubscriberPlugin::genTable(QueryContext& context) {
+void EventSubscriberPlugin::genTable(RowYield& yield, QueryContext& context) {
   // Stop is an unsigned (-1), our end of time equivalent.
   EventTime start = 0, stop = 0;
   if (context.constraints["time"].getAll().size() > 0) {
@@ -147,7 +147,7 @@ QueryData EventSubscriberPlugin::genTable(QueryContext& context) {
       queries_.insert(query_name);
     }
   }
-  return get(start, stop);
+  get(yield, start, stop);
 }
 
 void EventPublisherPlugin::fire(const EventContextRef& ec, EventTime time) {
@@ -501,9 +501,9 @@ EventID EventSubscriberPlugin::getEventID() {
   return toIndex(last_eid_);
 }
 
-QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
-  QueryData results;
-
+void EventSubscriberPlugin::get(RowYield& yield,
+                                EventTime start,
+                                EventTime stop) {
   // Get the records for this time range.
   auto indexes = getIndexes(start, stop);
   auto records = getRecords(indexes);
@@ -536,7 +536,7 @@ QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
     status = deserializeRowJSON(data_value, r);
     data_value.clear();
     if (status.ok()) {
-      results.push_back(std::move(r));
+      yield(r);
     }
   }
 
@@ -557,8 +557,6 @@ QueryData EventSubscriberPlugin::get(EventTime start, EventTime stop) {
   if (FLAGS_events_optimize) {
     setOptimizeData(optimize_time_, optimize_eid_, dbNamespace());
   }
-
-  return results;
 }
 
 Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -19,6 +19,7 @@
 #include <osquery/config.h>
 #include <osquery/core.h>
 #include <osquery/database.h>
+#include <osquery/events.h>
 #include <osquery/filesystem.h>
 
 namespace pt = boost::property_tree;
@@ -150,6 +151,9 @@ struct SplitStringTestData {
 
 // generate a set of test data to test osquery::splitString
 std::vector<SplitStringTestData> generateSplitStringTestData();
+
+// Helper function to generate all rows from a generator-based table.
+QueryData genRows(EventSubscriberPlugin* sub);
 
 // generate a small directory structure for testing
 void createMockFileStructure();

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -209,6 +209,8 @@ class TableState(Singleton):
                 self.has_column_aliases = True
         if len(all_options) > 0:
             self.has_options = True
+        if "event_subscriber" in self.attributes:
+            self.generator = True
         if "cacheable" in self.attributes:
             if len(set(all_options).intersection(NON_CACHEABLE)) > 0:
                 print(lightred("Table cannot be marked cacheable: %s" % (path)))

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -29,7 +29,7 @@ osquery::QueryData {{function}}(QueryContext& context);
 {% else %}
 class {{class_name}} {
  public:
-  osquery::QueryData {{function}}(QueryContext& context);
+  void {{function}}(RowYield& yield, QueryContext& context);
 };
 {% endif %}\
 }
@@ -86,19 +86,19 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
   bool usesGenerator() const override { return true; }
 
   void generator(RowYield& yield, QueryContext& context) override {
-    tables::{{function}}(yield, context);
-  }
-{% else %}\
-  QueryData generate(QueryContext& context) override {
 {% if class_name != "" %}\
     if (EventFactory::exists(getName())) {
       auto subscriber = EventFactory::getEventSubscriber(getName());
-      return subscriber->{{function}}(context);
+      return subscriber->{{function}}(yield, context);
     } else {
       LOG(ERROR) << "Subscriber table missing: " << getName();
-      return QueryData();
     }
 {% else %}\
+    tables::{{function}}(yield, context);
+{% endif %}\
+  }
+{% else %}\
+  QueryData generate(QueryContext& context) override {
 {% if attributes.cacheable %}\
     if (isCached(kCacheStep)) {
       return getCache();
@@ -109,7 +109,6 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
     setCache(kCacheStep, kCacheInterval, results);
 {% endif %}
     return results;
-{% endif %}\
   }
 {% endif %}\
 


### PR DESCRIPTION
After several days of tests with occasional runs of:
```
./tools/analysis/system_stress.py -n 10 -i lo0
```

This shows about a 20M RSS decrease (60M peak compared to a new 41M peak). With this implementation only 1 copy of the event set is in memory at any given moment, previously there were 2.