### PR TITLE
tables: Fix table metadata when constraints are used

### DIFF
--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -68,7 +68,35 @@ TEST_F(VirtualTableTests, test_tableplugin_options) {
   EXPECT_EQ(INTEGER(index_required), response[0]["op"]);
 
   std::string expected_statement =
-      "(`id` INTEGER PRIMARY KEY, `username` TEXT, `name` TEXT) WITHOUT ROWID";
+      "(`id` INTEGER, `username` TEXT, `name` TEXT, PRIMARY KEY (`id`)) "
+      "WITHOUT ROWID";
+  EXPECT_EQ(expected_statement, columnDefinition(response, true));
+}
+
+class moreOptionsTablePlugin : public TablePlugin {
+ private:
+  TableColumns columns() const override {
+    return {
+        std::make_tuple("id", INTEGER_TYPE, ColumnOptions::INDEX),
+        std::make_tuple("username", TEXT_TYPE, ColumnOptions::ADDITIONAL),
+        std::make_tuple("name", TEXT_TYPE, ColumnOptions::DEFAULT),
+    };
+  }
+
+ private:
+  FRIEND_TEST(VirtualTableTests, test_tableplugin_moreoptions);
+};
+
+TEST_F(VirtualTableTests, test_tableplugin_moreoptions) {
+  auto table = std::make_shared<moreOptionsTablePlugin>();
+
+  PluginResponse response;
+  PluginRequest request = {{"action", "columns"}};
+  EXPECT_TRUE(table->call(request, response).ok());
+
+  std::string expected_statement =
+      "(`id` INTEGER, `username` TEXT, `name` TEXT, PRIMARY KEY (`id`, "
+      "`username`)) WITHOUT ROWID";
   EXPECT_EQ(expected_statement, columnDefinition(response, true));
 }
 

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -4,7 +4,7 @@ schema([
     Column("uid", BIGINT, "The local user that owns the extension",
         additional=True),
     Column("name", TEXT, "Extension display name"),
-    Column("identifier", TEXT, "Extension identifier"),
+    Column("identifier", TEXT, "Extension identifier", index=True),
     Column("version", TEXT, "Extension-supplied version"),
     Column("description", TEXT, "Extension-optional description"),
     Column("locale", TEXT, "Default locale supported by extension"),

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -4,7 +4,7 @@ schema([
     Column("uid", BIGINT, "The local user that owns the plugin",
       additional=True),
     Column("name", TEXT, "Plugin display name"),
-    Column("identifier", TEXT, "Plugin identifier"),
+    Column("identifier", TEXT, "Plugin identifier", index=True),
     Column("version", TEXT, "Plugin short version"),
     Column("sdk", TEXT, "Build SDK used to compile plugin"),
     Column("description", TEXT, "Plugin description text"),

--- a/specs/darwin/crashes.table
+++ b/specs/darwin/crashes.table
@@ -2,14 +2,15 @@ table_name("crashes")
 description("Application and System Crash Logs")
 schema([
     Column("type", TEXT, "Type of crash log"),
-    Column("pid", BIGINT, "Process (or thread) ID of the crashed process"),
-    Column("path", TEXT, "Path to the crashed process"),
+    Column("pid", BIGINT, "Process (or thread) ID of the crashed process",
+        index=True),
+    Column("path", TEXT, "Path to the crashed process", index=True),
     Column("crash_path", TEXT, "Location of log file"),
     Column("identifier", TEXT, "Identifier of the crashed process"),
     Column("version", TEXT, "Version info of the crashed process"),
-    Column("parent", BIGINT, "Parent PID of the crashed process"),
+    Column("parent", BIGINT, "Parent PID of the crashed process", index=True),
     Column("responsible", TEXT, "Process responsible for the crashed process"),
-    Column("uid", INTEGER, "User ID of the crashed process"),
+    Column("uid", INTEGER, "User ID of the crashed process", additional=True),
     Column("datetime", TEXT, "Date/Time at which the crash occurred"),
     Column("crashed_thread", BIGINT, "Thread ID which crashed"),
     Column("stack_trace", TEXT, "Most recent frame from the stack trace"),
@@ -18,6 +19,7 @@ schema([
     Column("exception_notes", TEXT, "Exception notes from the crash"),
     Column("registers", TEXT, "The value of the system registers")
 ])
+attributes(user_data=True)
 implementation("crashes@genCrashLogs")
 fuzz_paths([
     "/Library/Logs/DiagnosticReports",

--- a/specs/darwin/keychain_items.table
+++ b/specs/darwin/keychain_items.table
@@ -7,7 +7,6 @@ schema([
     Column("created", TEXT, "Data item was created"),
     Column("modified", TEXT, "Date of last modification"),
     Column("type", TEXT, "Keychain item type (class)"),
-    Column("path", TEXT, "Path to keychain containing item",
-      additional=True),
+    Column("path", TEXT, "Path to keychain containing item"),
 ])
 implementation("keychain_items@genKeychainItems")

--- a/specs/darwin/package_receipts.table
+++ b/specs/darwin/package_receipts.table
@@ -2,13 +2,13 @@ table_name("package_receipts", aliases=["packages"])
 description("OS X package receipt details.")
 schema([
     Column("package_id", TEXT, "Package domain identifier"),
-    Column("package_filename", TEXT, "Filename of original .pkg file"),
+    Column("package_filename", TEXT, "Filename of original .pkg file",
+      index=True),
     Column("version", TEXT, "Installed package version"),
     Column("location", TEXT, "Optional relative install path on volume"),
     Column("install_time", DOUBLE, "Timestamp of install time"),
     Column("installer_name", TEXT, "Name of installer process"),
-    Column("path", TEXT, "Path of receipt plist",
-      index=True, additional=True),
+    Column("path", TEXT, "Path of receipt plist", additional=True),
 ])
 implementation("packages@genPackageReceipts")
 examples([

--- a/specs/darwin/safari_extensions.table
+++ b/specs/darwin/safari_extensions.table
@@ -4,7 +4,7 @@ schema([
     Column("uid", BIGINT, "The local user that owns the extension",
       additional=True),
     Column("name", TEXT, "Extension display name"),
-    Column("identifier", TEXT, "Extension identifier"),
+    Column("identifier", TEXT, "Extension identifier", index=True),
     Column("version", TEXT, "Extension long version"),
     Column("sdk", TEXT, "Bundle SDK used to compile extension"),
     Column("update_url", TEXT, "Extension-supplied update URI"),

--- a/specs/posix/augeas.table
+++ b/specs/posix/augeas.table
@@ -1,10 +1,10 @@
 table_name("augeas", aliases=["configurations"])
 description("Configuration files parsed by augeas.")
 schema([
-    Column("node", TEXT, "The node path of the configuration item"),
+    Column("node", TEXT, "The node path of the configuration item", index=True),
     Column("value", TEXT, "The value of the configuration item"),
     Column("label", TEXT, "The label of the configuration item"),
-    Column("path", TEXT, "The path to the configuration file")
+    Column("path", TEXT, "The path to the configuration file", additional=True)
 ])
 implementation("other/augeas@genAugeas")
 examples([

--- a/specs/posix/authorized_keys.table
+++ b/specs/posix/authorized_keys.table
@@ -4,8 +4,8 @@ schema([
     Column("uid", BIGINT, "The local owner of authorized_keys file",
       additional=True),
     Column("algorithm",TEXT,"algorithim of key"),
-    Column("key", TEXT, "parsed authorized keys line"),
-    Column("key_file", TEXT, "Path to the authorized_keys file"),
+    Column("key", TEXT, "parsed authorized keys line", index=True),
+    Column("key_file", TEXT, "Path to the authorized_keys file", index=True),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/specs/posix/device_file.table
+++ b/specs/posix/device_file.table
@@ -1,11 +1,14 @@
 table_name("device_file")
 description("Similar to the file table, but use TSK and allow block address access.")
 schema([
-    Column("device", TEXT, "Absolute file path to device node", required=True),
-    Column("partition", TEXT, "A partition number", required=True),
-    Column("path", TEXT, "A logical path within the device node", additional=True),
+    Column("device", TEXT, "Absolute file path to device node",
+        index=True, required=True),
+    Column("partition", TEXT, "A partition number",
+        index=True, required=True),
+    Column("path", TEXT, "A logical path within the device node",
+        additional=True),
     Column("filename", TEXT, "Name portion of file path"),
-    Column("inode", BIGINT, "Filesystem inode number"),
+    Column("inode", BIGINT, "Filesystem inode number", index=True),
     Column("uid", BIGINT, "Owning user ID"),
     Column("gid", BIGINT, "Owning group ID"),
     Column("mode", TEXT, "Permission bits"),

--- a/specs/posix/firefox_addons.table
+++ b/specs/posix/firefox_addons.table
@@ -4,7 +4,7 @@ schema([
     Column("uid", BIGINT, "The local user that owns the addon",
         additional=True),
     Column("name", TEXT, "Addon display name"),
-    Column("identifier", TEXT, "Addon identifier"),
+    Column("identifier", TEXT, "Addon identifier", index=True),
     Column("creator", TEXT, "Addon-supported creator string"),
     Column("type", TEXT, "Extension, addon, webapp"),
     Column("version", TEXT, "Addon-supplied version string"),

--- a/specs/posix/known_hosts.table
+++ b/specs/posix/known_hosts.table
@@ -3,8 +3,8 @@ description("A line-delimited known_hosts table.")
 schema([
     Column("uid", BIGINT, "The local user that owns the known_hosts file",
       additional=True),
-    Column("key", TEXT, "parsed authorized keys line"),
-    Column("key_file", TEXT, "Path to known_hosts file"),
+    Column("key", TEXT, "parsed authorized keys line", index=True),
+    Column("key_file", TEXT, "Path to known_hosts file", index=True),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/specs/posix/opera_extensions.table
+++ b/specs/posix/opera_extensions.table
@@ -4,7 +4,7 @@ schema([
   Column("uid", BIGINT, "The local user that owns the extension",
     additional=True),
   Column("name", TEXT, "Extension display name"),
-  Column("identifier", TEXT, "Extension identifier"),
+  Column("identifier", TEXT, "Extension identifier", index=True),
   Column("version", TEXT, "Extension-supplied version"),
   Column("description", TEXT, "Extension-optional description"),
   Column("locale", TEXT, "Default locale supported by extension"),

--- a/specs/posix/shell_history.table
+++ b/specs/posix/shell_history.table
@@ -7,7 +7,7 @@ schema([
     Column("history_file", TEXT, "Path to the .*_history for this user"),
     ForeignKey(column="uid", table="users"),
 ])
-attributes(user_data=True)
+attributes(user_data=True, no_pkey=True)
 implementation("shell_history@genShellHistory")
 fuzz_paths([
     "/home",

--- a/specs/posix/ssh_keys.table
+++ b/specs/posix/ssh_keys.table
@@ -3,7 +3,7 @@ description("Returns the private keys in the users ~/.ssh directory and whether 
 schema([
     Column("uid", BIGINT, "The local user that owns the key file",
       additional=True),
-    Column("path", TEXT, "Path to key file"),
+    Column("path", TEXT, "Path to key file", index=True),
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
     ForeignKey(column="uid", table="users"),
 ])

--- a/specs/posix/system_controls.table
+++ b/specs/posix/system_controls.table
@@ -2,7 +2,7 @@ table_name("system_controls")
 description("sysctl names, values, and settings information.")
 schema([
     Column("name", TEXT, "Full sysctl MIB name", index=True),
-    Column("oid", TEXT, "Control MIB"),
+    Column("oid", TEXT, "Control MIB", additional=True),
     Column("subsystem", TEXT, "Subsystem ID, control type"),
     Column("current_value", TEXT, "Value of setting"),
     Column("config_value", TEXT, "The MIB value set in /etc/sysctl.conf"),

--- a/specs/posix/user_groups.table
+++ b/specs/posix/user_groups.table
@@ -1,7 +1,7 @@
 table_name("user_groups")
 description("Local system user group relationships.")
 schema([
-    Column("uid", BIGINT, "User ID"),
-    Column("gid", BIGINT, "Group ID")
+    Column("uid", BIGINT, "User ID", index=True),
+    Column("gid", BIGINT, "Group ID", index=True)
 ])
 implementation("user_groups@genUserGroups")

--- a/specs/posix/yara.table
+++ b/specs/posix/yara.table
@@ -1,11 +1,15 @@
 table_name("yara")
 description("Track YARA matches for files or PIDs.")
 schema([
-    Column("path", TEXT, "The path scanned"),
-    Column("matches", TEXT, "List of YARA matches"),
+    Column("path", TEXT, "The path scanned",
+        index=True, required=True),
+    Column("matches", TEXT, "List of YARA matches",
+        index=True),
     Column("count", INTEGER, "Number of YARA matches"),
-    Column("sig_group", TEXT, "Signature group used"),
-    Column("sigfile", TEXT, "Signature file used"),
+    Column("sig_group", TEXT, "Signature group used",
+        index=True, additional=True),
+    Column("sigfile", TEXT, "Signature file used",
+        index=True, additional=True),
     Column("strings", TEXT, "Matching strings"),
     Column("tags", TEXT, "Matching tags"),
 ])

--- a/specs/users.table
+++ b/specs/users.table
@@ -5,7 +5,7 @@ schema([
     Column("gid", BIGINT, "Group ID (unsigned)"),
     Column("uid_signed", BIGINT, "User ID as int64 signed (Apple)"),
     Column("gid_signed", BIGINT, "Default group ID as int64 signed (Apple)"),
-    Column("username", TEXT, "Username"),
+    Column("username", TEXT, "Username", additional=True),
     Column("description", TEXT, "Optional user description"),
     Column("directory", TEXT, "User's home directory"),
     Column("shell", TEXT, "User's configured default shell"),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -204,6 +204,10 @@ class TableState(Singleton):
                 if option in COLUMN_OPTIONS:
                     column_options.append("ColumnOptions::" + COLUMN_OPTIONS[option])
                     all_options.append(COLUMN_OPTIONS[option])
+                else:
+                    print(yellow(
+                        "Table %s column %s contains an unknown option: %s" % (
+                            self.table_name, column.name, option)))
             column.options_set = " | ".join(column_options)
             if len(column.aliases) > 0:
                 self.has_column_aliases = True
@@ -227,6 +231,13 @@ class TableState(Singleton):
                 print(lightred(("Cannot use column name: %s in table: %s "
                                 "(the column name is reserved)" % (
                                     column.name, self.table_name))))
+                exit(1)
+
+        if "ADDITIONAL" in all_options and "INDEX" not in all_options:
+            if "no_pkey" not in self.attributes:
+                print(lightred(
+                    "Table cannot have 'additional' columns without an index: %s" %(
+                    path)))
                 exit(1)
 
         path_bits = path.split("/")
@@ -255,7 +266,7 @@ class TableState(Singleton):
             has_options=self.has_options,
             has_column_aliases=self.has_column_aliases,
             generator=self.generator,
-            attribute_set=[TABLE_ATTRIBUTES[attr] for attr in self.attributes],
+            attribute_set=[TABLE_ATTRIBUTES[attr] for attr in self.attributes if attr in TABLE_ATTRIBUTES],
         )
 
         with open(path, "w+") as file_h:


### PR DESCRIPTION
Upon inspecting the virtual table implementations, several use `context.constraints` but do not indicate in the document + table `create` schema. This may lead to incorrect `rowid`s assigned to results in `OR` clauses.