### PR TITLE
tests: Rewrite and add filesystem tests

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -37,6 +37,7 @@ inline GlobLimits operator|(GlobLimits a, GlobLimits b) {
 
 /// Globbing wildcard character.
 const std::string kSQLGlobWildcard{"%"};
+
 /// Globbing wildcard recursive character (double wildcard).
 const std::string kSQLGlobRecursive{kSQLGlobWildcard + kSQLGlobWildcard};
 
@@ -233,8 +234,8 @@ std::set<boost::filesystem::path> getHomeDirectories();
  *
  * @return true if the file is 'safe' else false.
  */
-bool safePermissions(const std::string& dir,
-                     const std::string& path,
+bool safePermissions(const boost::filesystem::path& dir,
+                     const boost::filesystem::path& path,
                      bool executable = false);
 
 /**

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -392,8 +392,8 @@ std::set<fs::path> getHomeDirectories() {
   return results;
 }
 
-bool safePermissions(const std::string& dir,
-                     const std::string& path,
+bool safePermissions(const fs::path& dir,
+                     const fs::path& path,
                      bool executable) {
   if (!platformIsFileAccessible(path).ok()) {
     // Path was not real, had too may links, or could not be accessed.
@@ -414,7 +414,7 @@ bool safePermissions(const std::string& dir,
     return false;
   }
 
-  PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
+  PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_READ);
   if (!fd.isValid()) {
     return false;
   }


### PR DESCRIPTION
This attempts to remove the PRE-PROCESSOR  based control flow for filesystem tests. It also adds `readFile` and `writeTextFile` basic tests. More are needed for directory/link-type checking.