### PR TITLE
inotify: Use poll over select in inotify publisher

### DIFF
--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -210,8 +210,22 @@ class INotifyEventPublisher
   /// Time in seconds of the last inotify restart.
   std::atomic<int> last_restart_{-1};
 
+  /**
+   * @brief Scratch space for reading INotify responses.
+   *
+   * We place this here, and include a mutex to do heap/lazy allocation of the
+   * near-3k buffer when the publisher loads. This reduces the need to stack
+   * allocate a local buffer every 200mils and also improves the eventless-case.
+   *
+   * Allocated during setUp, removed in tearDown, protected by scratch_mutex_.
+   */
+  char* scratch_{nullptr};
+
   /// Access to path and descriptor mappings.
   mutable Mutex path_mutex_;
+
+  /// Access the Inofity response scratch space.
+  mutable Mutex scratch_mutex_;
 
  public:
   friend class INotifyTests;


### PR DESCRIPTION
This fixes a large issue with the use of `::select`, it does not expect a FD > 1024 and thus corrupts the stack when a target FD is passed to the `FD_` macros.

It also attempts to improve performance with the `inotify` publisher but move stack-local scratch buffers to an instance-life-long buffer. The chosen configuration had been allocing 2.7k bytes for every 400ms.