### PR TITLE
events: Add hidden EID to all events tables

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -1,6 +1,6 @@
-As of osquery version 1.4.2, file integrity monitoring support was introduced for Linux (using inotify) and Darwin (using FSEvents) platforms.  This module reads a list of files/directories to monitor for changes from the osquery config and details changes and hashes to those selected files in the [`file_events`](https://osquery.io/docs/tables/#file_events) table.
+File integrity monitoring (FIM) is available for Linux and Darwin using inotify and FSEvents. The daemon reads a list of files/directories from the osquery configuration. The actions (and hashes when appropriate) to those selected files populate the [`file_events`](https://osquery.io/docs/tables/#file_events) table.
 
-To get started with FIM (file integrity monitoring), you must first identify which files and directories you wish to monitor. Then use *fnmatch*-style, or filesystem globbing, patterns to represent the target paths. You may use standard wildcards "*\**" or SQL-style wildcards "*%*":
+To get started with FIM, you must first identify which files and directories you wish to monitor. Then use *fnmatch*-style, or filesystem globbing, patterns to represent the target paths. You may use standard wildcards "*\**" or SQL-style wildcards "*%*":
 
 **Matching wildcard rules**
 
@@ -19,7 +19,7 @@ To get started with FIM (file integrity monitoring), you must first identify whi
 
 For example, you may want to monitor `/etc` along with other files on a Linux system. After you identify your target files and directories you wish to monitor, add them to a new section in the config *file_paths*.
 
-The two areas below that are relevant to FIM are the `file_events` and `file_paths` sections. The `file_events` query is scheduled to collect all of the FIM events that have occurred on any files within the paths specified within `file_paths` on a five minute interval.
+The two areas below that are relevant to FIM are the scheduled query against `file_events` and the added `file_paths` section. The `file_events` query is scheduled to collect all of the FIM events that have occurred on any files within the paths specified within `file_paths` on a five minute interval. At a high level this means events are buffered within osquery and sent to the configured _logger_ every five minutes.
 
 ## Example FIM Config
 
@@ -53,7 +53,7 @@ The two areas below that are relevant to FIM are the `file_events` and `file_pat
 
 ## Sample Event Output
 
-As file changes happen, events will appear in the [**file_events**](https://osquery.io/docs/tables/#file_events) table.  During a file change event, the md5, sha1, and sha256 for the file will be calculated if possible.  A sample event looks like this:
+As file changes happen, events will appear in the [**file_events**](https://osquery.io/docs/tables/#file_events) table.  During a file change event, the md5, sha1, and sha256 for the file will be calculated if possible. A sample event looks like this:
 
 ```json
 {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -570,6 +570,7 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
   }
 
   r["time"] = std::to_string(event_time);
+  r["eid"] = eid;
   // Serialize and store the row data, for query-time retrieval.
   std::string data;
   auto status = serializeRowJSON(r, data);

--- a/specs/darwin/disk_events.table
+++ b/specs/darwin/disk_events.table
@@ -16,6 +16,7 @@ schema([
     Column("filesystem", TEXT, "Filesystem if available"),
     Column("checksum", TEXT, "UDIF Master checksum if available (CRC32)"),
     Column("time", BIGINT, "Time of appearance/disappearance in UNIX time"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("events/darwin/disk_events@disk_events::genTable")

--- a/specs/darwin/process_file_events.table
+++ b/specs/darwin/process_file_events.table
@@ -19,6 +19,7 @@ schema([
     Column("ctime", BIGINT, "Time of last status change"),
     Column("time", BIGINT, "Time of event in UNIX epoch time"),
     Column("uptime", BIGINT, "Time of event in system uptime"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("process_file_events@process_file_events::genTable")

--- a/specs/linux/socket_events.table
+++ b/specs/linux/socket_events.table
@@ -16,6 +16,7 @@ schema([
     Column("socket", TEXT, "The local path (UNIX domain socket only)"),
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("socket_events@socket_events::genTable")

--- a/specs/linux/syslog_events.table
+++ b/specs/linux/syslog_events.table
@@ -7,6 +7,7 @@ schema([
     Column("facility", TEXT, "Syslog facility"),
     Column("tag", TEXT, "The syslog tag"),
     Column("message", TEXT, "The syslog message"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("syslog_events@SyslogEventSubscriber::genTable")

--- a/specs/linux/user_events.table
+++ b/specs/linux/user_events.table
@@ -11,6 +11,7 @@ schema([
     Column("terminal", TEXT, "The network protocol ID"),
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("user_events@user_events::genTable")

--- a/specs/posix/file_events.table
+++ b/specs/posix/file_events.table
@@ -19,6 +19,7 @@ schema([
     Column("hashed", INTEGER,
       "1 if the file was hashed, 0 if not, -1 if hashing failed"),
     Column("time", BIGINT, "Time of file event"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("file_events@file_events::genTable")

--- a/specs/posix/hardware_events.table
+++ b/specs/posix/hardware_events.table
@@ -12,6 +12,7 @@ schema([
     Column("serial", TEXT, "Device serial (optional)"),
     Column("revision", TEXT, "Device revision (optional)"),
     Column("time", BIGINT, "Time of hardware event"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("events/hardware_events@hardware_events::genTable")

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -31,6 +31,7 @@ schema([
     Column("parent", BIGINT, "Process parent's PID"),
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("process_events@process_events::genTable")

--- a/specs/posix/yara_events.table
+++ b/specs/posix/yara_events.table
@@ -7,9 +7,10 @@ schema([
     Column("transaction_id", BIGINT, "ID used during bulk update"),
     Column("matches", TEXT, "List of YARA matches"),
     Column("count", INTEGER, "Number of YARA matches"),
-    Column("time", BIGINT, "Time of the scan"),
     Column("strings", TEXT, "Matching strings"),
     Column("tags", TEXT, "Matching tags"),
+    Column("time", BIGINT, "Time of the scan"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("yara@yara_events::genTable")

--- a/specs/windows/windows_events.table
+++ b/specs/windows/windows_events.table
@@ -11,6 +11,7 @@ schema([
     Column("level", INTEGER, "The severity level associated with the event"),
     Column("keywords", BIGINT, "A bitmask of the keywords defined in the event"),
     Column("data", TEXT, "Data associated with the event"),
+    Column("eid", TEXT, "Event ID", hidden=True),
 ])
 attributes(event_subscriber=True)
 implementation("windows_events@WindowsEventSubscriber::genTable")

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -72,6 +72,7 @@ COLUMN_OPTIONS = {
     "additional": "ADDITIONAL",
     "required": "REQUIRED",
     "optimized": "OPTIMIZED",
+    "hidden": "HIDDEN",
 }
 
 # Column options that render tables uncacheable.


### PR DESCRIPTION
This adds an `eid` column to all events tables. The column is marked `HIDDEN`, so it does not show up in results or with a `SELECT *`, this can be used to make sure all events are recorded, there should never be duplicates or skipped IDs when inspecting the entire table.