### PR TITLE
extensions: Catch Thrift transport close exception

### DIFF
--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -373,7 +373,11 @@ class EXInternal : private boost::noncopyable {
         protocol_(new TBinaryProtocol(transport_)) {}
 
   virtual ~EXInternal() {
-    transport_->close();
+    try {
+      transport_->close();
+    } catch (const std::exception& /* e */) {
+      // The transport/socket may have exited.
+    }
   }
 
  protected:


### PR DESCRIPTION
The `TSocket` may throw in rare occasions (e.g., https://github.com/apache/thrift/blob/master/lib/cpp/src/thrift/transport/TSocket.cpp#L832) we should not allow this exception to escape the destructor. This bug will be seen in C++ extensions in rare situations after the core osquery process is stoped.