### PR TITLE
Add specified identifier via GFlags

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -74,7 +74,13 @@ FLAG(string,
      host_identifier,
      "hostname",
      "Field used to identify the host running osquery (hostname, uuid, "
-     "instance, ephemeral)");
+     "instance, ephemeral, specified)");
+
+// Only used when host_identifier=specified
+FLAG(string,
+     specified_identifier,
+     "hostname",
+     "Field used to specify the host_identifier when set to \"specified\"");
 
 FLAG(bool, utc, true, "Convert all UNIX times to UTC");
 
@@ -188,6 +194,14 @@ Status getHostUUID(std::string& ident) {
   return status;
 }
 
+Status getSpecifiedUUID(std::string& ident) {
+  if (FLAGS_specified_identifier.empty()) {
+    return Status(1, "No specified identifier for host");
+  }
+  ident = FLAGS_specified_identifier;
+  return Status(0, "OK");
+}
+
 std::string getHostIdentifier() {
   static std::string ident;
 
@@ -198,6 +212,8 @@ std::string getHostIdentifier() {
       getInstanceUUID(ident);
     } else if (FLAGS_host_identifier == "ephemeral") {
       getEphemeralUUID(ident);
+    } else if (FLAGS_host_identifier == "specified") {
+      getSpecifiedUUID(ident);
     } else {
       // assuming the default of "hostname" as the machine identifier
       // intentionally not set to `ident` because the hostname may change

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -205,7 +205,7 @@ Status getSpecifiedUUID(std::string& ident) {
 std::string getHostIdentifier() {
   static std::string ident;
 
-  Status result;
+  Status result(2);
   if (ident.size() == 0) {
     if (FLAGS_host_identifier == "uuid") {
       result = getHostUUID(ident);
@@ -215,15 +215,17 @@ std::string getHostIdentifier() {
       result = getEphemeralUUID(ident);
     } else if (FLAGS_host_identifier == "specified") {
       result = getSpecifiedUUID(ident);
-    } else {
+    }
+
+    if (!result.ok()) {
+      // TODO log result.getMessage() when getCode() == 1 once logging
+      //  deadlock is fixed
+
       // assuming the default of "hostname" as the machine identifier
       // intentionally not set to `ident` because the hostname may change
       // throughout the life of the process and we always want to be using the
       // most current hostname
       return osquery::getHostname();
-    }
-    if (!result.ok()) {
-      VLOG(1) << "Not ok host identifier: " << result.getMessage();
     }
   }
   return ident;

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -79,7 +79,7 @@ FLAG(string,
 // Only used when host_identifier=specified
 FLAG(string,
      specified_identifier,
-     "hostname",
+     "",
      "Field used to specify the host_identifier when set to \"specified\"");
 
 FLAG(bool, utc, true, "Convert all UNIX times to UTC");
@@ -205,21 +205,25 @@ Status getSpecifiedUUID(std::string& ident) {
 std::string getHostIdentifier() {
   static std::string ident;
 
+  Status result;
   if (ident.size() == 0) {
     if (FLAGS_host_identifier == "uuid") {
-      getHostUUID(ident);
+      result = getHostUUID(ident);
     } else if (FLAGS_host_identifier == "instance") {
-      getInstanceUUID(ident);
+      result = getInstanceUUID(ident);
     } else if (FLAGS_host_identifier == "ephemeral") {
-      getEphemeralUUID(ident);
+      result = getEphemeralUUID(ident);
     } else if (FLAGS_host_identifier == "specified") {
-      getSpecifiedUUID(ident);
+      result = getSpecifiedUUID(ident);
     } else {
       // assuming the default of "hostname" as the machine identifier
       // intentionally not set to `ident` because the hostname may change
       // throughout the life of the process and we always want to be using the
       // most current hostname
       return osquery::getHostname();
+    }
+    if (!result.ok()) {
+      VLOG(1) << "Not ok host identifier: " << result.getMessage();
     }
   }
   return ident;

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -218,8 +218,7 @@ std::string getHostIdentifier() {
     }
 
     if (!result.ok()) {
-      // TODO log result.getMessage() when getCode() == 1 once logging
-      //  deadlock is fixed
+      // https://github.com/facebook/osquery/issues/3174
 
       // assuming the default of "hostname" as the machine identifier
       // intentionally not set to `ident` because the hostname may change


### PR DESCRIPTION
Adds a new option for host identifier, which is to specify the value via the CLI. Also adds assigning the result status from each UUID generation function inside getHostIdentifier() so we can log any non-ok results. 

Built everything on windows via `.\tools\make-win64-binaries.bat`. This includes tests, which all passed. I tried running the osqueryi.exe shell with `--host_identifier specified --specified_identifier` and got an error from GFlags that I needed to set a value for `specified_identifier`. I also tried running the shell with both values set, and osqueryi ran fine (but wasn't sure how to select the host identifier).

I also ported this over to a local project where I'm including osquery as a library. Specifying host_identifier via `osquery::FLAGS_host_identifier = "specified";` and not assigning anything to `specified_identifier` results in the error message `Not ok host identifier: No specified identifier for host`. The weird part was the scheduler seemed to not want to run anymore, likely because hostIdentifier was set to the empty string... Later, I added `osquery::FLAGS_specified_identifier = "123456789";` and was able to observe this properly showing up in the hostIdentifier field in (1) enrollment, and (2) machine logs. 