### PR TITLE
[Fix #3039] Fixing stringToWstring crashes with wide character strings

### DIFF
--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -1,12 +1,12 @@
 /*
-*  Copyright (c) 2014-present, Facebook, Inc.
-*  All rights reserved.
-*
-*  This source code is licensed under the BSD-style license found in the
-*  LICENSE file in the root directory of this source tree. An additional grant
-*  of patent rights can be found in the PATENTS file in the same directory.
-*
-*/
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #define _WIN32_DCOM
 #define WIN32_LEAN_AND_MEAN
@@ -41,17 +41,17 @@ int getUidFromSid(PSID sid) {
   unsigned long domNameSize = 1;
 
   // LookupAccountSid first gets the size of the username buff required.
-  LookupAccountSid(
+  LookupAccountSidW(
       nullptr, sid, nullptr, &unameSize, nullptr, &domNameSize, &eUse);
-  std::vector<char> uname(unameSize);
-  std::vector<char> domName(domNameSize);
-  auto ret = LookupAccountSid(nullptr,
-                              sid,
-                              uname.data(),
-                              &unameSize,
-                              domName.data(),
-                              &domNameSize,
-                              &eUse);
+  std::vector<wchar_t> uname(unameSize);
+  std::vector<wchar_t> domName(domNameSize);
+  auto ret = LookupAccountSidW(nullptr,
+                               sid,
+                               uname.data(),
+                               &unameSize,
+                               domName.data(),
+                               &domNameSize,
+                               &eUse);
 
   if (ret == 0) {
     return -1;
@@ -59,8 +59,7 @@ int getUidFromSid(PSID sid) {
   // USER_INFO_3 struct contains the RID (uid) of our user
   unsigned long userInfoLevel = 3;
   unsigned char* userBuff = nullptr;
-  auto wideUserName = stringToWstring(uname.data());
-  ret = NetUserGetInfo(nullptr, wideUserName.c_str(), userInfoLevel, &userBuff);
+  ret = NetUserGetInfo(nullptr, uname.data(), userInfoLevel, &userBuff);
 
   if (ret != NERR_Success || userBuff == nullptr) {
     return -1;
@@ -76,17 +75,17 @@ int getGidFromSid(PSID sid) {
   unsigned long domNameSize = 1;
 
   // LookupAccountSid first gets the size of the username buff required.
-  LookupAccountSid(
+  LookupAccountSidW(
       nullptr, sid, nullptr, &unameSize, nullptr, &domNameSize, &eUse);
-  std::vector<char> uname(unameSize);
-  std::vector<char> domName(domNameSize);
-  auto ret = LookupAccountSid(nullptr,
-                              sid,
-                              uname.data(),
-                              &unameSize,
-                              domName.data(),
-                              &domNameSize,
-                              &eUse);
+  std::vector<wchar_t> uname(unameSize);
+  std::vector<wchar_t> domName(domNameSize);
+  auto ret = LookupAccountSidW(nullptr,
+                               sid,
+                               uname.data(),
+                               &unameSize,
+                               domName.data(),
+                               &domNameSize,
+                               &eUse);
 
   if (ret == 0) {
     return -1;
@@ -94,8 +93,7 @@ int getGidFromSid(PSID sid) {
   // USER_INFO_3 struct contains the RID (uid) of our user
   unsigned long userInfoLevel = 3;
   unsigned char* userBuff = nullptr;
-  auto wideUserName = stringToWstring(uname.data());
-  ret = NetUserGetInfo(nullptr, wideUserName.c_str(), userInfoLevel, &userBuff);
+  ret = NetUserGetInfo(nullptr, uname.data(), userInfoLevel, &userBuff);
 
   if (ret != NERR_Success || userBuff == nullptr) {
     return -1;

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -11,12 +11,20 @@
 #include <locale>
 #include <string>
 
+#include <osquery/logger.h>
+
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
 
 std::wstring stringToWstring(const std::string& src) {
-  std::wstring utf16le_str = converter.from_bytes(src);
+  std::wstring utf16le_str;
+  try {
+    utf16le_str = converter.from_bytes(src);
+  } catch (std::exception /* e */) {
+    LOG(WARNING) << "Failed to convert string to wstring " << src;
+  }
+
   return utf16le_str;
 }
 


### PR DESCRIPTION
If a `std::wstring` is passed to `stringToWstring` we are throwing a range exception. This wraps the converter call in a `try` clause, and returns an empty string on fail with a `WARNING` log line. I've also updated our helper functions which were causing this issue to use the wide string versions of the Windows API calls, as we're not making use of the user/group names in the helper functions.