### PR TITLE
Adding support for quote wrapped windows event channels

### DIFF
--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
@@ -27,11 +28,11 @@ namespace pt = boost::property_tree;
 namespace osquery {
 
 /*
-* @brief the Windows Event log channels to subscribe to
-*
-* By default we subscribe to all system channels. To subscribe to additional
-* channels specify them via this flag as a comma separated list.
-*/
+ * @brief the Windows Event log channels to subscribe to
+ *
+ * By default we subscribe to all system channels. To subscribe to additional
+ * channels specify them via this flag as a comma separated list.
+ */
 FLAG(string,
      windows_event_channels,
      "System,Application,Setup,Security",
@@ -42,7 +43,10 @@ class WindowsEventSubscriber
  public:
   Status init() override {
     auto wc = createSubscriptionContext();
-    for (const auto& chan : osquery::split(FLAGS_windows_event_channels, ",")) {
+    for (auto& chan : osquery::split(FLAGS_windows_event_channels, ",")) {
+      // We remove quotes if they exist
+      boost::erase_all(chan, "\"");
+      boost::erase_all(chan, "\'");
       wc->sources.insert(stringToWstring(chan));
     }
     subscribe(&WindowsEventSubscriber::Callback, wc);


### PR DESCRIPTION
This checks for, and removes, quotes wrapping the Windows event log channel subscriptions. Now one can pass a coma delimited list, where channel names contain spaces, and they'll correctly be subscribed to.  Example output follows:
```
C:\Users\thor\work\repos\osquery [win-events-channel-quotes]> .\build\windows10\osquery\Release\osqueryi.exe --disable_events=false --windows_event_channels="System,Security,Windows PowerShell" --verbose
I0418 15:10:02.155122  7256 process_ops.cpp:162] Unable to find environment variable (0): OSQUERY_WORKER
I0418 15:10:02.161072  7256 init.cpp:380] osquery initialized [version=2.4.0-15-gef1f3975]
I0418 15:10:02.161072  7256 process_ops.cpp:162] Unable to find environment variable (203): OSQUERY_WORKER
I0418 15:10:02.161072  7256 extensions.cpp:295] Could not autoload extensions: Failed reading: \ProgramData\osquery\extensions.load
I0418 15:10:02.163064  7256 process_ops.cpp:162] Unable to find environment variable (203): OSQUERY_EXTENSIONS
I0418 15:10:02.163064  7256 extensions.cpp:301] Windows does not support loadable modules
I0418 15:10:02.163064  6104 interface.cpp:317] Extension manager service starting: \\.\pipe\shell.em
I0418 15:10:02.163064  7256 init.cpp:615] Error reading config: config file does not exist: \ProgramData\osquery\osquery.conf
I0418 15:10:02.167075  4576 events.cpp:748] Starting event publisher run loop: windows_event_log
I0418 15:10:02.167075  7256 process_ops.cpp:162] Unable to find environment variable (203): TERM
Using a virtual database. Need help, type '.help'
osquery> select * from windows_events where source="Windows PowerShell";
I0418 15:10:10.653786  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.653786  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.653786  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.655553  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.655553  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.655553  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.655553  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.657544  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.657544  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.657544  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0418 15:10:10.657544  7256 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
+------------+--------------------------------+--------------------+---------------+---------------+---------+------+-------+----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| time       | datetime                       | source             | provider_name | provider_guid | eventid | task | level | keywords | data
                                                                                                                                                                                                                                                                                                             |
+------------+--------------------------------+--------------------+---------------+---------------+---------+------+-------+----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 1492553407 | 2017-04-18T22:10:07.468019900Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=Registry\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=1\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                       |
| 1492553407 | 2017-04-18T22:10:07.468019900Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=Alias\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=3\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                          |
| 1492553407 | 2017-04-18T22:10:07.468019900Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=Environment\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=5\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                    |
| 1492553407 | 2017-04-18T22:10:07.470014000Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=FileSystem\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=7\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                     |
| 1492553407 | 2017-04-18T22:10:07.470014000Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=Function\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=9\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                       |
| 1492553407 | 2017-04-18T22:10:07.470014000Z | Windows PowerShell | PowerShell    |               | 600     | 6    | 4     | -1       | {
    "EventData": {
        "Data": "\tProviderName=Variable\r\n\tNewProviderState=Started\r\n\r\n\tSequenceNumber=11\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=\r\n\tRunspaceId=\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
                                                      |
| 1492553407 | 2017-04-18T22:10:07.480059100Z | Windows PowerShell | PowerShell    |               | 400     | 4    | 4     | -1       | {
    "EventData": {
        "Data": "\tNewEngineState=Available\r\n\tPreviousEngineState=None\r\n\r\n\tSequenceNumber=13\r\n\r\n\tHostName=ConsoleHost\r\n\tHostVersion=5.1.14393.1066\r\n\tHostId=e1399cca-ce07-42ec-aac2-b80aaf14979b\r\n\tHostApplication=C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n\tEngineVersion=5.1.14393.1066\r\n\tRunspaceId=e9600d22-0d0f-4f20-b2c7-ecaecb3fbbbd\r\n\tPipelineId=\r\n\tCommandName=\r\n\tCommandType=\r\n\tScriptName=\r\n\tCommandPath=\r\n\tCommandLine="
    }
}
 |
+------------+--------------------------------+--------------------+---------------+---------------+---------+------+-------+----------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```