### PR TITLE
deps: additional packages for building osquery on the ubuntu vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -174,6 +174,12 @@ Vagrant.configure("2") do |config|
         build.vm.provision "shell",
           inline: "pkg install -y gmake"
       end
+      if name.start_with?('ubuntu')
+        build.vm.provision 'bootstrap', type: 'shell' do |s|
+          s.inline = 'sudo apt-get update;'\
+                     'sudo apt-get install --yes git;'
+        end
+      end
     end
   end
 end

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -16,7 +16,14 @@ function distro_main() {
   package autopoint
   package g++
   package ruby
+  package ruby-dev
   package curl
   package bison
   package flex
+  package bsdtar
+  package doxygen
+  package realpath
+
+  GEM=`which gem`
+  do_sudo $GEM install fpm 
 }


### PR DESCRIPTION
* Ensures `git` is installed in the `ubuntu14` box before running `make sysprep; make deps`
* Installs additional necessary dependencies to run through [all build steps ](https://osquery.readthedocs.io/en/stable/development/building/#building-on-linux) including packaging