### PR TITLE
Start osqueryd on install with chocolatey

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -54,16 +54,19 @@ Get-ChocolateyUnzip -FileFullPath $packagePath -Destination $targetFolder
 Move-Item -Force -Path $targetDaemonBin -Destination $destDaemonBin
 Set-DenyWriteAcl $daemonFolder 'Add'
 
-if ($installService -and (-not (Get-Service $serviceName -ErrorAction SilentlyContinue))) {
-  Write-Debug '[+] Installing osquery daemon service.'
-  # If the 'install' parameter is passed, we create a Windows service with
-  # the flag file in the default location in \ProgramData\osquery\
-  New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
+if ($installService) {
+  if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
+    Write-Debug '[+] Installing osquery daemon service.'
+    # If the 'install' parameter is passed, we create a Windows service with
+    # the flag file in the default location in \ProgramData\osquery\
+    New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
 
-  # If the osquery.flags file doesn't exist, we create a blank one.
-  if (-not (Test-Path "$targetFolder\osquery.flags")) {
-    Add-Content "$targetFolder\osquery.flags" $null
+    # If the osquery.flags file doesn't exist, we create a blank one.
+    if (-not (Test-Path "$targetFolder\osquery.flags")) {
+      Add-Content "$targetFolder\osquery.flags" $null
+    }
   }
+  Start-Service $serviceName
 }
 
 # Add osquery binary path to machines path for ease of use.


### PR DESCRIPTION
When doing an install with /InstallService using choco, let's start the service as well. IMO this is more intuitive behavior, and also ensures we restart the service after e.g an upgrade.

Note that on a fresh install, this doesn't make a ton of sense because there will be no osquery.flags file, however we decided this was worth it to prevent the unintuitive 'shutdown service after upgrade' behaviour.