### PR TITLE
Fix #2838: Adds the event_taps table to Darwin

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -14,6 +14,7 @@ if(APPLE)
 
   ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreFoundation")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreWLAN")
+  ADD_OSQUERY_LINK_ADDITIONAL("-framework CoreGraphics")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework Security")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework OpenDirectory")
   ADD_OSQUERY_LINK_ADDITIONAL("-framework DiskArbitration")

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -16,56 +16,57 @@
 
 namespace osquery {
 namespace tables {
-  
-const std::map <CGEventType, std::string> kEventMap =
-{
-  {kCGEventNull, "EventNull"},
-  {kCGEventLeftMouseDown, "LeftMouseDown"},
-  {kCGEventLeftMouseUp, "EventLeftMouseUp"},
-  {kCGEventRightMouseDown, "EventRightMouseDown"},
-  {kCGEventRightMouseUp, "EventRightMouseUp"},
-  {kCGEventMouseMoved, "EventMouseMoved"},
-  {kCGEventLeftMouseDragged, "EventLeftMouseDragged"},
-  {kCGEventKeyDown, "EventKeyDown"},
-  {kCGEventKeyUp, "EventKeyUp"},
-  {kCGEventFlagsChanged, "EventFlagsChanged"},
-  {kCGEventScrollWheel, "EventScrollWheel"},
-  {kCGEventTabletPointer, "EventTabletPointer"},
-  {kCGEventTabletPointer, "EventTabletPointer"},
-  {kCGEventOtherMouseDown, "EventOtherMouseDown"},
-  {kCGEventOtherMouseUp, "EventOtherMouseUp"},
-  {kCGEventOtherMouseDragged, "EventOtherMouseDragged"},
+
+const std::map<CGEventType, std::string> kEventMap = {
+    {kCGEventNull, "EventNull"},
+    {kCGEventLeftMouseDown, "LeftMouseDown"},
+    {kCGEventLeftMouseUp, "EventLeftMouseUp"},
+    {kCGEventRightMouseDown, "EventRightMouseDown"},
+    {kCGEventRightMouseUp, "EventRightMouseUp"},
+    {kCGEventMouseMoved, "EventMouseMoved"},
+    {kCGEventLeftMouseDragged, "EventLeftMouseDragged"},
+    {kCGEventKeyDown, "EventKeyDown"},
+    {kCGEventKeyUp, "EventKeyUp"},
+    {kCGEventFlagsChanged, "EventFlagsChanged"},
+    {kCGEventScrollWheel, "EventScrollWheel"},
+    {kCGEventTabletPointer, "EventTabletPointer"},
+    {kCGEventTabletPointer, "EventTabletPointer"},
+    {kCGEventOtherMouseDown, "EventOtherMouseDown"},
+    {kCGEventOtherMouseUp, "EventOtherMouseUp"},
+    {kCGEventOtherMouseDragged, "EventOtherMouseDragged"},
 };
 
-  QueryData genEventTaps(QueryContext &context) {
-    QueryData results;
-    uint32_t tapCount = 0;
-    CGError err;
-    err = CGGetEventTapList(NULL, NULL, &tapCount);
-    if(err != 0) {
-      return results;
-    }
-    CGEventTapInformation taps[tapCount];
-    err = CGGetEventTapList(tapCount, taps, &tapCount);
-    if(err != 0) {
-      return results;
-    }
-    for (size_t i = 0; i < tapCount; ++i) {
-      for (const auto &type: kEventMap) {
-        if ((taps[i].eventsOfInterest & CGEventMaskBit(type.first)) == 0) {
-          continue;
-        }
-        Row r;
-        r["enabled"] = std::to_string(taps[i].enabled);
-        r["event_tap_id"] = std::to_string(taps[i].eventTapID);
-        r["event_tapped"] = type.second;
-        r["process_being_tapped"] = std::to_string(taps[i].processBeingTapped);
-        r["tapping_process"] = std::to_string(taps[i].tappingProcess);
-        results.push_back(r);
-      }
-    }
+QueryData genEventTaps(QueryContext& context) {
+  QueryData results;
+  uint32_t tapCount = 0;
+  CGError err;
+  err = CGGetEventTapList(0, nullptr, &tapCount);
+  if (err != kCGErrorSuccess) {
     return results;
   }
-
- }
+  CGEventTapInformation* taps =
+      (CGEventTapInformation*)malloc(sizeof(CGEventTapInformation) * tapCount);
+  err = CGGetEventTapList(tapCount, taps, &tapCount);
+  if (err != kCGErrorSuccess) {
+    free(taps);
+    return results;
+  }
+  for (size_t i = 0; i < tapCount; ++i) {
+    for (const auto& type : kEventMap) {
+      if ((taps[i].eventsOfInterest & CGEventMaskBit(type.first)) == 0) {
+        continue;
+      }
+      Row r;
+      r["enabled"] = std::to_string(taps[i].enabled);
+      r["event_tap_id"] = std::to_string(taps[i].eventTapID);
+      r["event_tapped"] = type.second;
+      r["process_being_tapped"] = std::to_string(taps[i].processBeingTapped);
+      r["tapping_process"] = std::to_string(taps[i].tappingProcess);
+      results.push_back(r);
+    }
+  }
+  free(taps);
+  return results;
+}
+}
 }

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -46,6 +46,9 @@ QueryData genEventTaps(QueryContext& context) {
   }
   CGEventTapInformation* taps =
       (CGEventTapInformation*)malloc(sizeof(CGEventTapInformation) * tapCount);
+  if (taps == nullptr) {
+    return results;
+  }
   err = CGGetEventTapList(tapCount, taps, &tapCount);
   if (err != kCGErrorSuccess) {
     free(taps);

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -45,7 +45,7 @@ QueryData genEventTaps(QueryContext& context) {
     return results;
   }
   CGEventTapInformation* taps =
-      (CGEventTapInformation*)malloc(sizeof(CGEventTapInformation) * tapCount);
+      static_cast<CGEventTapInformation*>(malloc(sizeof(CGEventTapInformation) * tapCount));
   if (taps == nullptr) {
     return results;
   }

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -60,11 +60,11 @@ QueryData genEventTaps(QueryContext& context) {
         continue;
       }
       Row r;
-      r["enabled"] = std::to_string(taps[i].enabled);
-      r["event_tap_id"] = std::to_string(taps[i].eventTapID);
+      r["enabled"] = INTEGER(taps[i].enabled);
+      r["event_tap_id"] = INTEGER(taps[i].eventTapID);
       r["event_tapped"] = type.second;
-      r["process_being_tapped"] = std::to_string(taps[i].processBeingTapped);
-      r["tapping_process"] = std::to_string(taps[i].tappingProcess);
+      r["process_being_tapped"] = INTEGER(taps[i].processBeingTapped);
+      r["tapping_process"] = INTEGER(taps[i].tappingProcess);
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <ApplicationServices/ApplicationServices.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <osquery/system.h>
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+const std::map <CGEventMask, std::string> kEventMap =
+{
+  {CGEventMaskBit(kCGEventNull), "EventNull"},
+  {CGEventMaskBit(kCGEventLeftMouseDown), "LeftMouseDown"},
+  {CGEventMaskBit(kCGEventLeftMouseUp), "EventLeftMouseUp"},
+  {CGEventMaskBit(kCGEventRightMouseDown), "EventRightMouseDown"},
+  {CGEventMaskBit(kCGEventRightMouseUp), "EventRightMouseUp"},
+  {CGEventMaskBit(kCGEventMouseMoved), "EventMouseMoved"},
+  {CGEventMaskBit(kCGEventLeftMouseDragged), "EventLeftMouseDragged"},
+  {CGEventMaskBit(kCGEventKeyDown), "EventKeyDown"},
+  {CGEventMaskBit(kCGEventKeyUp), "EventKeyUp"},
+  {CGEventMaskBit(kCGEventFlagsChanged), "EventFlagsChanged"},
+  {CGEventMaskBit(kCGEventScrollWheel), "EventScrollWheel"},
+  {CGEventMaskBit(kCGEventTabletPointer), "EventTabletPointer"},
+  {CGEventMaskBit(kCGEventTabletPointer), "EventTabletPointer"},
+  {CGEventMaskBit(kCGEventOtherMouseDown), "EventOtherMouseDown"},
+  {CGEventMaskBit(kCGEventOtherMouseUp), "EventOtherMouseUp"},
+  {CGEventMaskBit(kCGEventOtherMouseDragged), "EventOtherMouseDragged"},
+};
+
+  QueryData genEventTaps(QueryContext & context) {
+    QueryData results;
+    uint32_t tapCount = 0;
+    CGError err;
+    err = CGGetEventTapList(NULL, NULL, & tapCount);
+    if(err != 0) {
+      return results;
+    }
+    CGEventTapInformation taps[tapCount];
+    err = CGGetEventTapList(tapCount, taps, & tapCount);
+    if(err != 0) {
+      return results;
+    }
+    for (size_t i = 0; i < tapCount; ++i) {
+      for (const auto & type: kEventMap) {
+        if ((taps[i].eventsOfInterest & type.first) == 0) {
+          continue;
+        }
+        Row r;
+        r["enabled"] = std::to_string(taps[i].enabled);
+        r["event_tap_id"] = std::to_string(taps[i].eventTapID);
+        r["event_tapped"] = type.second;
+        r["process_being_tapped"] = std::to_string(taps[i].processBeingTapped);
+        r["tapping_process"] = std::to_string(taps[i].tappingProcess);
+        results.push_back(r);
+      }
+    }
+    return results;
+  }
+
+ }
+}

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -10,47 +10,49 @@
 
 #include <ApplicationServices/ApplicationServices.h>
 #include <CoreGraphics/CoreGraphics.h>
+
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
-const std::map <CGEventMask, std::string> kEventMap =
+  
+const std::map <CGEventType, std::string> kEventMap =
 {
-  {CGEventMaskBit(kCGEventNull), "EventNull"},
-  {CGEventMaskBit(kCGEventLeftMouseDown), "LeftMouseDown"},
-  {CGEventMaskBit(kCGEventLeftMouseUp), "EventLeftMouseUp"},
-  {CGEventMaskBit(kCGEventRightMouseDown), "EventRightMouseDown"},
-  {CGEventMaskBit(kCGEventRightMouseUp), "EventRightMouseUp"},
-  {CGEventMaskBit(kCGEventMouseMoved), "EventMouseMoved"},
-  {CGEventMaskBit(kCGEventLeftMouseDragged), "EventLeftMouseDragged"},
-  {CGEventMaskBit(kCGEventKeyDown), "EventKeyDown"},
-  {CGEventMaskBit(kCGEventKeyUp), "EventKeyUp"},
-  {CGEventMaskBit(kCGEventFlagsChanged), "EventFlagsChanged"},
-  {CGEventMaskBit(kCGEventScrollWheel), "EventScrollWheel"},
-  {CGEventMaskBit(kCGEventTabletPointer), "EventTabletPointer"},
-  {CGEventMaskBit(kCGEventTabletPointer), "EventTabletPointer"},
-  {CGEventMaskBit(kCGEventOtherMouseDown), "EventOtherMouseDown"},
-  {CGEventMaskBit(kCGEventOtherMouseUp), "EventOtherMouseUp"},
-  {CGEventMaskBit(kCGEventOtherMouseDragged), "EventOtherMouseDragged"},
+  {kCGEventNull, "EventNull"},
+  {kCGEventLeftMouseDown, "LeftMouseDown"},
+  {kCGEventLeftMouseUp, "EventLeftMouseUp"},
+  {kCGEventRightMouseDown, "EventRightMouseDown"},
+  {kCGEventRightMouseUp, "EventRightMouseUp"},
+  {kCGEventMouseMoved, "EventMouseMoved"},
+  {kCGEventLeftMouseDragged, "EventLeftMouseDragged"},
+  {kCGEventKeyDown, "EventKeyDown"},
+  {kCGEventKeyUp, "EventKeyUp"},
+  {kCGEventFlagsChanged, "EventFlagsChanged"},
+  {kCGEventScrollWheel, "EventScrollWheel"},
+  {kCGEventTabletPointer, "EventTabletPointer"},
+  {kCGEventTabletPointer, "EventTabletPointer"},
+  {kCGEventOtherMouseDown, "EventOtherMouseDown"},
+  {kCGEventOtherMouseUp, "EventOtherMouseUp"},
+  {kCGEventOtherMouseDragged, "EventOtherMouseDragged"},
 };
 
-  QueryData genEventTaps(QueryContext & context) {
+  QueryData genEventTaps(QueryContext &context) {
     QueryData results;
     uint32_t tapCount = 0;
     CGError err;
-    err = CGGetEventTapList(NULL, NULL, & tapCount);
+    err = CGGetEventTapList(NULL, NULL, &tapCount);
     if(err != 0) {
       return results;
     }
     CGEventTapInformation taps[tapCount];
-    err = CGGetEventTapList(tapCount, taps, & tapCount);
+    err = CGGetEventTapList(tapCount, taps, &tapCount);
     if(err != 0) {
       return results;
     }
     for (size_t i = 0; i < tapCount; ++i) {
-      for (const auto & type: kEventMap) {
-        if ((taps[i].eventsOfInterest & type.first) == 0) {
+      for (const auto &type: kEventMap) {
+        if ((taps[i].eventsOfInterest & CGEventMaskBit(type.first)) == 0) {
           continue;
         }
         Row r;

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -44,8 +44,8 @@ QueryData genEventTaps(QueryContext& context) {
   if (err != kCGErrorSuccess) {
     return results;
   }
-  CGEventTapInformation* taps =
-      static_cast<CGEventTapInformation*>(malloc(sizeof(CGEventTapInformation) * tapCount));
+  CGEventTapInformation* taps = static_cast<CGEventTapInformation*>(
+      malloc(sizeof(CGEventTapInformation) * tapCount));
   if (taps == nullptr) {
     return results;
   }

--- a/specs/darwin/event_taps.table
+++ b/specs/darwin/event_taps.table
@@ -1,0 +1,10 @@
+table_name("event_taps")
+description("Returns information about installed event taps")
+schema([
+    Column("enabled", INTEGER, "Is the Event Tap enabled"),
+    Column("event_tap_id", TEXT, "Unique ID for the Tap", index=True),
+    Column("event_tapped", TEXT, "The mask that identifies the set of events to be observed."),
+    Column("process_being_tapped", TEXT, "The process ID of the target application"),
+    Column("tapping_process", TEXT, "The process ID of the application that created the event tap."),
+])
+implementation("event_taps@genEventTaps")

--- a/specs/darwin/event_taps.table
+++ b/specs/darwin/event_taps.table
@@ -2,9 +2,9 @@ table_name("event_taps")
 description("Returns information about installed event taps")
 schema([
     Column("enabled", INTEGER, "Is the Event Tap enabled"),
-    Column("event_tap_id", TEXT, "Unique ID for the Tap", index=True),
+    Column("event_tap_id", INTEGER, "Unique ID for the Tap", index=True),
     Column("event_tapped", TEXT, "The mask that identifies the set of events to be observed."),
-    Column("process_being_tapped", TEXT, "The process ID of the target application"),
-    Column("tapping_process", TEXT, "The process ID of the application that created the event tap."),
+    Column("process_being_tapped", INTEGER, "The process ID of the target application"),
+    Column("tapping_process", INTEGER, "The process ID of the application that created the event tap."),
 ])
 implementation("event_taps@genEventTaps")


### PR DESCRIPTION
Commit adds the event_taps table to Darwin. This will enumerate a list of processes that have a registered event tap. Useful in detecting userland keyloggers.

@evenfowler