### PR TITLE
Add hardware_disabled_types flag to control hardware_events

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -293,6 +293,12 @@ Maximum number of events to buffer in the backing store while waiting for a quer
 
 List of Windows event log channels to subscribe to. By default the Windows event log publisher will subscribe to some of the more common major event log channels. However you can subscribe to additional channels using the `Log Name` field value in the Windows event viewer. Note the lack of quotes around the channel names. For example, to subscribe to Windows Powershell script block logging one would first enable the feature and then subscribe to the channel with `--windows_event_channels=Microsoft-Windows-PowerShell/Operational`
 
+**Linux Only**
+
+`--hardware_disabled_types=partition`
+
+This is a comma-separated list of UDEV types to drop. On machines with flash-backed storage it is likely you'll encounter lots of noise from `disk` and `partition` types.
+
 ### Logging/results flags
 
 `--logger_plugin=filesystem`

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -8,16 +8,22 @@
  *
  */
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <osquery/core.h>
+#include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
 #include "osquery/events/linux/udev.h"
 
 namespace osquery {
+
+FLAG(string,
+     hardware_disabled_types,
+     "partition",
+     "List of disabled hardware event types");
 
 /**
  * @brief Track udev events in Linux
@@ -50,9 +56,13 @@ Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   }
 
   struct udev_device* device = ec->device;
+  r["type"] = ec->devtype;
+  if (FLAGS_hardware_disabled_types.find(r.at("type")) != std::string::npos) {
+    return Status(0, "Disabled type.");
+  }
+
   r["action"] = ec->action_string;
   r["path"] = ec->devnode;
-  r["type"] = ec->devtype;
   r["driver"] = ec->driver;
 
   // UDEV properties.
@@ -70,6 +80,6 @@ Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
       INTEGER(UdevEventPublisher::getValue(device, "ID_SERIAL_SHORT"));
   r["revision"] = INTEGER(UdevEventPublisher::getValue(device, "ID_REVISION"));
   add(r);
-  return Status(0, "OK");
+  return Status(0);
 }
 }


### PR DESCRIPTION
This is a small optimization for `hardware_events` on Linux. It allows hosts to be configured to skip reporting some types of UDEV events. This is helpful for flash-backed machines that experience lots of `disk` and `partition` events.