### PR TITLE
deps: Fix libarchive bottle root URL

### DIFF
--- a/tools/provision/formula/libarchive.rb
+++ b/tools/provision/formula/libarchive.rb
@@ -8,6 +8,7 @@ class Libarchive < AbstractOsqueryFormula
   revision 1
 
   bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "d7da800fa873e8f7534649b159643b362d118324fb96151732ec30777857863b" => :sierra
     sha256 "4f1b4e3baf0e5303a6cf0f4a179b63ca1774e2306617f63243d018c35441a51e" => :x86_64_linux


### PR DESCRIPTION
An oversight in the `bottle` stanza for `libarchive` leads to a cache miss for binary packages and instead installs from source.