### PR TITLE
logger: Fixes to allow plugins access to hostIDs

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -203,3 +203,28 @@ using RecursiveMutex = std::recursive_mutex;
 /// Helper alias for write locking a recursive mutex.
 using RecursiveLock = std::lock_guard<std::recursive_mutex>;
 }
+
+/**
+ * @brief An abstract similar to boost's noncopyable that defines moves.
+ *
+ * By defining protected move constructors we allow the children to assign
+ * their's as default.
+ */
+class only_movable {
+ protected:
+  /// Boilerplate self default constructor.
+  only_movable() {}
+
+  /// Boilerplate self destructor.
+  ~only_movable() {}
+
+  /// Important, existence of a move constructor.
+  only_movable(only_movable&&) {}
+
+ private:
+  /// Important, a private copy constructor prevents copying.
+  only_movable(const only_movable&);
+
+  /// Important, a private copy assignment constructor prevents copying.
+  only_movable& operator=(const only_movable&);
+};

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -22,6 +22,7 @@
 
 #include <boost/noncopyable.hpp>
 
+#include <osquery/core.h>
 #include <osquery/database.h>
 #include <osquery/flags.h>
 #include <osquery/registry.h>
@@ -44,20 +45,32 @@ enum StatusLogSeverity {
 /// An intermediate status log line.
 struct StatusLogLine {
  public:
-  /// An integer severity level mimicing Glog's.
+  /// An integer severity level mimicking Glog's.
   StatusLogSeverity severity;
+
   /// The name of the file emitting the status log.
   std::string filename;
+
   /// The line of the file emitting the status log.
-  int line;
+  size_t line;
+
   /// The string-formatted status message.
   std::string message;
-  /// The host identifier
-  std::string identifier;
+
   /// The ASCII time stamp for when the status message was emitted
   std::string calendar_time;
+
   /// The UNIX time for when the status message was emitted
   size_t time;
+
+  /**
+   * @brief The host identifier at the time when logs are flushed.
+   *
+   * There is occasionally a delay between logging a status and decorating
+   * with the host identifier. In most cases the identifier is static so this
+   * does not matter. In some cases the host identifier causes database lookups.
+   */
+  std::string identifier;
 };
 
 /**

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -58,31 +58,6 @@
 namespace osquery {
 
 /**
- * @brief An abstract similar to boost's noncopyable that defines moves.
- *
- * By defining protected move constructors we allow the children to assign
- * their's as default.
- */
-class only_movable {
- protected:
-  /// Boilerplate self default constructor.
-  only_movable() {}
-
-  /// Boilerplate self destructor.
-  ~only_movable() {}
-
-  /// Important, existance of a move constructor.
-  only_movable(only_movable&&) {}
-
- private:
-  /// Important, a private copy constructor prevents copying.
-  only_movable(const only_movable&);
-
-  /// Important, a private copy assignment constructor prevents copying.
-  only_movable& operator=(const only_movable&);
-};
-
-/**
  * @brief osquery does not yet use a NULL type.
  *
  * If a column type is non-TEXT a NULL is defined as an empty result. The APIs

--- a/osquery/logger/plugins/filesystem.cpp
+++ b/osquery/logger/plugins/filesystem.cpp
@@ -113,8 +113,9 @@ Status FilesystemLoggerPlugin::logStatus(
     const std::vector<StatusLogLine>& log) {
   for (const auto& item : log) {
     // Emit this intermediate log to the Glog filesystem logger.
-    google::LogMessage(
-        item.filename.c_str(), item.line, (google::LogSeverity)item.severity)
+    google::LogMessage(item.filename.c_str(),
+                       static_cast<int>(item.line),
+                       (google::LogSeverity)item.severity)
             .stream()
         << item.message;
   }

--- a/osquery/logger/plugins/tests/buffered_tests.cpp
+++ b/osquery/logger/plugins/tests/buffered_tests.cpp
@@ -39,7 +39,7 @@ MATCHER_P(MatchesStatus, expected, "") {
     pt::read_json(json_in, actual);
     return expected.severity == actual.get<int>("severity") &&
            expected.filename == actual.get<std::string>("filename") &&
-           expected.line == actual.get<int>("line") &&
+           expected.line == actual.get<size_t>("line") &&
            expected.message == actual.get<std::string>("message");
   } catch (const std::exception& e) {
     return false;

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -34,7 +34,7 @@ class LoggerTests : public testing::Test {
     log_lines.clear();
     status_messages.clear();
     statuses_logged = 0;
-    last_status = {O_INFO, "", -1, "", "host", "cal_time", 0};
+    last_status = {O_INFO, "", 10, "", "cal_time", 0, "host"};
   }
 
   void TearDown() override {
@@ -173,11 +173,19 @@ TEST_F(LoggerTests, test_log_string) {
 }
 
 TEST_F(LoggerTests, test_logger_log_status) {
+  std::string warning = "Logger test is generating a warning status (2)";
+  auto now = getUnixTime();
   // This will be printed to stdout.
-  LOG(WARNING) << "Logger test is generating a warning status (2)";
+  LOG(WARNING) << warning;
 
   // The second warning status will be sent to the logger plugin.
   EXPECT_EQ(1U, LoggerTests::statuses_logged);
+
+  EXPECT_EQ(O_WARNING, LoggerTests::last_status.severity);
+  EXPECT_GT(LoggerTests::last_status.line, 0U);
+  EXPECT_EQ(warning, LoggerTests::last_status.message);
+  EXPECT_GE(now, LoggerTests::last_status.time);
+  EXPECT_EQ(getHostIdentifier(), LoggerTests::last_status.identifier);
 }
 
 TEST_F(LoggerTests, test_logger_status_level) {


### PR DESCRIPTION
This addresses: #3195 but other improvements to DB access could be implemented too.

This prevents the early-logging from generating host identifiers within the Glog callbacks.