### PR TITLE
rpm: Improve librpm safety

### DIFF
--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -3,14 +3,14 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Librpm < AbstractOsqueryFormula
   desc "The RPM Package Manager (RPM) development libraries"
   homepage "http://rpm.org/"
-  sha256 "8d65bc5df3056392d7fdfbe00e8f84eb0e828582aa96ef4d6b6afac35a07e8b3"
-  url "https://github.com/rpm-software-management/rpm/archive/rpm-4.13.0-rc1.tar.gz"
-  version "4.13.0-rc1"
+  url "https://github.com/rpm-software-management/rpm/releases/download/rpm-4.13.0-release/rpm-4.13.0.tar.bz2"
+  sha256 "221166b61584721a8ca979d7d8576078a5dadaf09a44208f69cc1b353240ba1b"
+  version "4.13.0"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "58c1fcaf9b237561ae03212c7d4047f6d2d39c7262bf823fa26002238fb08c11" => :x86_64_linux
+    sha256 "37824eb9fb907943a05421425675f74ca87436bfef18167eb28185be82c9a508" => :x86_64_linux
   end
 
   depends_on "berkeley-db"
@@ -37,7 +37,6 @@ class Librpm < AbstractOsqueryFormula
       "--with-beecrypt",
     ]
 
-    system "./autogen.sh", "--noconfigure"
     system "./configure", "--prefix=#{prefix}", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
This attempts to improve `librpm` safety.

1. Upgrade to version `4.13.0`.
2. Add `isUserAdmin` checks to the privilege dropper check (do not allow `root` to query if privileges are not dropped).
3. Collect the `librpm` errors and send them to `VLOG(1)`.