### PR TITLE
Refactor Windows Service Table to use std::unique_ptr

### DIFF
--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -42,14 +42,12 @@ const std::map<int, std::string> kServiceType = {
     {0x00000110, "OWN_PROCESS(Interactive)"},
     {0x00000120, "SHARE_PROCESS(Interactive)"}};
 
-typedef std::unique_ptr<SC_HANDLE__, std::function<void(SC_HANDLE)>>
-    svc_handle_t;
-
-void closeServiceHandle(SC_HANDLE sch) {
+auto closeServiceHandle = [](SC_HANDLE sch) {
   if (sch != nullptr) {
     CloseServiceHandle(sch);
   }
-}
+};
+typedef std::unique_ptr<SC_HANDLE__, decltype(closeServiceHandle)> svc_handle_t;
 
 static inline Status getService(const SC_HANDLE& scmHandle,
                                 const ENUM_SERVICE_STATUS_PROCESS& svc,

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -1,12 +1,12 @@
 /*
-*  Copyright (c) 2014-present, Facebook, Inc.
-*  All rights reserved.
-*
-*  This source code is licensed under the BSD-style license found in the
-*  LICENSE file in the root directory of this source tree. An additional grant
-*  of patent rights can be found in the PATENTS file in the same directory.
-*
-*/
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -42,86 +42,135 @@ const std::map<int, std::string> kServiceType = {
     {0x00000110, "OWN_PROCESS(Interactive)"},
     {0x00000120, "SHARE_PROCESS(Interactive)"}};
 
-bool QuerySvcInfo(const SC_HANDLE& schScManager,
-                  ENUM_SERVICE_STATUS_PROCESS& svc,
-                  Row& r) {
-  DWORD cbBufSize = 0;
+class WinSvc : private only_movable {
+ public:
+  explicit WinSvc(SC_HANDLE scmHandle, ENUM_SERVICE_STATUS_PROCESS serviceName);
+  WinSvc(WinSvc&&) = default;
+  WinSvc& operator=(WinSvc&&) = default;
+  ~WinSvc();
 
-  auto schService =
-      OpenService(schScManager, svc.lpServiceName, SERVICE_QUERY_CONFIG);
+ public:
+  Status status();
+  bool ok();
+  Row result();
 
-  if (schService == nullptr) {
-    TLOG << "OpenService failed (" << GetLastError() << ")";
-    return FALSE;
+ private:
+  SC_HANDLE scHandle_;
+  Row result_;
+  Status status_;
+};
+
+WinSvc::WinSvc(SC_HANDLE scmHandle, ENUM_SERVICE_STATUS_PROCESS svc) {
+  scHandle_ = OpenService(scmHandle, svc.lpServiceName, SERVICE_QUERY_CONFIG);
+  if (scHandle_ == nullptr) {
+    status_ = Status(GetLastError(), "Failed to open service handle");
+    return;
   }
 
-  QueryServiceConfig(schService, nullptr, 0, &cbBufSize);
-  auto lpsc = (LPQUERY_SERVICE_CONFIG)malloc(cbBufSize);
-  if (!QueryServiceConfig(schService, lpsc, cbBufSize, &cbBufSize)) {
-    TLOG << "QueryServiceConfig failed (" << GetLastError() << ")";
+  DWORD cbBufSize;
+  (void)QueryServiceConfig(scHandle_, nullptr, 0, &cbBufSize);
+  std::unique_ptr<QUERY_SERVICE_CONFIG> lpsc(
+      static_cast<LPQUERY_SERVICE_CONFIG>(malloc(cbBufSize)));
+  if (0 == QueryServiceConfig(scHandle_, lpsc.get(), cbBufSize, &cbBufSize)) {
+    status_ = Status(GetLastError(), "Failed to query service config");
+    return;
   }
 
-  QueryServiceConfig2(
-      schService, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &cbBufSize);
-  auto lpsd = (LPSERVICE_DESCRIPTION)malloc(cbBufSize);
-  if (!QueryServiceConfig2(schService,
-                           SERVICE_CONFIG_DESCRIPTION,
-                           (LPBYTE)lpsd,
-                           cbBufSize,
-                           &cbBufSize)) {
-    TLOG << "QueryServiceConfig2 failed (" << GetLastError() << ")";
+  (void)QueryServiceConfig2(
+      scHandle_, SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &cbBufSize);
+  std::unique_ptr<SERVICE_DESCRIPTION> lpsd(
+      static_cast<LPSERVICE_DESCRIPTION>(malloc(cbBufSize)));
+  if (0 == QueryServiceConfig2(scHandle_,
+                               SERVICE_CONFIG_DESCRIPTION,
+                               (LPBYTE)lpsd.get(),
+                               cbBufSize,
+                               &cbBufSize)) {
+    status_ = Status(GetLastError(), "Failed to query service description");
+    return;
   }
 
-  r["name"] = SQL_TEXT(svc.lpServiceName);
-  r["display_name"] = SQL_TEXT(svc.lpDisplayName);
-  r["status"] = SQL_TEXT(kSvcStatus[svc.ServiceStatusProcess.dwCurrentState]);
-  r["pid"] = INTEGER(svc.ServiceStatusProcess.dwProcessId);
-  r["win32_exit_code"] = INTEGER(svc.ServiceStatusProcess.dwWin32ExitCode);
-  r["service_exit_code"] =
+  result_["name"] = SQL_TEXT(svc.lpServiceName);
+  result_["display_name"] = SQL_TEXT(svc.lpDisplayName);
+  result_["status"] =
+      SQL_TEXT(kSvcStatus[svc.ServiceStatusProcess.dwCurrentState]);
+  result_["pid"] = INTEGER(svc.ServiceStatusProcess.dwProcessId);
+  result_["win32_exit_code"] =
+      INTEGER(svc.ServiceStatusProcess.dwWin32ExitCode);
+  result_["service_exit_code"] =
       INTEGER(svc.ServiceStatusProcess.dwServiceSpecificExitCode);
-  r["start_type"] = SQL_TEXT(kSvcStartType[lpsc->dwStartType]);
-  r["path"] = SQL_TEXT(lpsc->lpBinaryPathName);
-  r["user_account"] = SQL_TEXT(lpsc->lpServiceStartName);
+  result_["start_type"] = SQL_TEXT(kSvcStartType[lpsc->dwStartType]);
+  result_["path"] = SQL_TEXT(lpsc->lpBinaryPathName);
+  result_["user_account"] = SQL_TEXT(lpsc->lpServiceStartName);
 
   if (lpsd->lpDescription != nullptr) {
-    r["description"] = SQL_TEXT(lpsd->lpDescription);
+    result_["description"] = SQL_TEXT(lpsd->lpDescription);
   }
 
   if (kServiceType.count(lpsc->dwServiceType) > 0) {
-    r["service_type"] = SQL_TEXT(kServiceType.at(lpsc->dwServiceType));
+    result_["service_type"] = SQL_TEXT(kServiceType.at(lpsc->dwServiceType));
   } else {
-    r["service_type"] = SQL_TEXT("UNKNOWN");
+    result_["service_type"] = SQL_TEXT("UNKNOWN");
   }
 
   QueryData regResults;
   queryKey("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\" +
-               r["name"] + "\\Parameters",
+               result_["name"] + "\\Parameters",
            regResults);
   for (const auto& aKey : regResults) {
     if (aKey.at("name") == "ServiceDll") {
-      r["module_path"] = SQL_TEXT(aKey.at("data"));
+      result_["module_path"] = SQL_TEXT(aKey.at("data"));
     }
   }
-
-  free(lpsc);
-  free(lpsd);
-  CloseServiceHandle(schService);
-  return TRUE;
 }
 
-QueryData genServices(QueryContext& context) {
-  void* buf = nullptr;
-  DWORD bytesNeeded = 0;
-  DWORD serviceCount = 0;
-  QueryData results;
+WinSvc::~WinSvc() {
+  CloseServiceHandle(scHandle_);
+}
 
-  auto schScManager = OpenSCManager(nullptr, nullptr, GENERIC_READ);
-  if (schScManager == nullptr) {
-    TLOG << "EnumServiceStatusEx failed (" << GetLastError() << ")";
-    return {};
+Row WinSvc::result() {
+  return result_;
+}
+
+Status WinSvc::status() {
+  return status_;
+}
+
+class WinSvcQuery : private only_movable {
+ public:
+  WinSvcQuery();
+  WinSvcQuery(WinSvcQuery&&) = default;
+  WinSvcQuery& operator=(WinSvcQuery&&) = default;
+  ~WinSvcQuery();
+
+ public:
+  QueryData results();
+  Status status();
+
+ private:
+  SC_HANDLE scmHandle_;
+  QueryData results_;
+  Status status_;
+};
+
+QueryData WinSvcQuery::results() {
+  return results_;
+}
+
+Status WinSvcQuery::status() {
+  return status_;
+}
+
+WinSvcQuery::WinSvcQuery() {
+  scmHandle_ = OpenSCManager(nullptr, nullptr, GENERIC_READ);
+  if (scmHandle_ == nullptr) {
+    status_ = Status(GetLastError(),
+                     "Failed to connect to Service Connection Manager");
+    return;
   }
 
-  (void)EnumServicesStatusEx(schScManager,
+  DWORD bytesNeeded = 0;
+  DWORD serviceCount = 0;
+  (void)EnumServicesStatusEx(scmHandle_,
                              SC_ENUM_PROCESS_INFO,
                              SERVICE_WIN32,
                              SERVICE_STATE_ALL,
@@ -132,31 +181,38 @@ QueryData genServices(QueryContext& context) {
                              nullptr,
                              nullptr);
 
-  buf = malloc(bytesNeeded);
-  if (EnumServicesStatusEx(schScManager,
-                           SC_ENUM_PROCESS_INFO,
-                           SERVICE_WIN32,
-                           SERVICE_STATE_ALL,
-                           (LPBYTE)buf,
-                           bytesNeeded,
-                           &bytesNeeded,
-                           &serviceCount,
-                           nullptr,
-                           nullptr)) {
-    ENUM_SERVICE_STATUS_PROCESS* services = (ENUM_SERVICE_STATUS_PROCESS*)buf;
-    for (DWORD i = 0; i < serviceCount; ++i) {
-      Row r;
-      if (QuerySvcInfo(schScManager, services[i], r)) {
-        results.push_back(r);
-      }
-    }
-  } else {
-    TLOG << "EnumServiceStatusEx failed (" << GetLastError() << ")";
+  std::unique_ptr<ENUM_SERVICE_STATUS_PROCESS[]> buf(
+      static_cast<ENUM_SERVICE_STATUS_PROCESS*>(malloc(bytesNeeded)));
+  if (0 == EnumServicesStatusEx(scmHandle_,
+                                SC_ENUM_PROCESS_INFO,
+                                SERVICE_WIN32,
+                                SERVICE_STATE_ALL,
+                                (LPBYTE)buf.get(),
+                                bytesNeeded,
+                                &bytesNeeded,
+                                &serviceCount,
+                                nullptr,
+                                nullptr)) {
+    status_ = Status(GetLastError(), "Failed to enumerate services");
+    return;
   }
+  for (size_t i = 0; i < serviceCount; i++) {
+    results_.push_back(WinSvc(scmHandle_, buf[i]).result());
+  }
+}
 
-  free(buf);
-  CloseServiceHandle(schScManager);
-  return results;
+WinSvcQuery::~WinSvcQuery() {
+  CloseServiceHandle(scmHandle_);
 }
+
+QueryData genServices(QueryContext& context) {
+  WinSvcQuery q;
+  if (q.status().ok()) {
+    return q.results();
+  } else {
+    LOG(WARNING) << q.status().getMessage();
+    return QueryData();
+  }
 }
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -87,7 +87,9 @@ static inline Status getService(const SC_HANDLE& scmHandle,
                                (LPBYTE)lpsd.get(),
                                cbBufSize,
                                &cbBufSize)) {
-    return Status(GetLastError(), "Failed to query service description");
+    // This can fail for unclear reasons
+    LOG(WARNING) << "Error querying description for service " +
+                        (std::string)svc.lpDisplayName;
   }
 
   result["name"] = SQL_TEXT(svc.lpServiceName);

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -143,8 +143,8 @@ static inline Status getServices(QueryData& results) {
                   "Failed to connect to Service Connection Manager");
   }
 
-  DWORD bytesNeeded = 0;
-  DWORD serviceCount = 0;
+  DWORD bytesNeeded;
+  DWORD serviceCount;
   (void)EnumServicesStatusEx(scmHandle.get(),
                              SC_ENUM_PROCESS_INFO,
                              SERVICE_WIN32,

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -42,12 +42,20 @@ const std::map<int, std::string> kServiceType = {
     {0x00000110, "OWN_PROCESS(Interactive)"},
     {0x00000120, "SHARE_PROCESS(Interactive)"}};
 
+typedef std::unique_ptr<SC_HANDLE__, std::function<void(SC_HANDLE)>>
+    svc_handle_t;
+
+void closeServiceHandle(SC_HANDLE sch) {
+  if (sch != nullptr)
+    CloseServiceHandle(sch);
+}
+
 static inline Status getService(const SC_HANDLE& scmHandle,
                                 const ENUM_SERVICE_STATUS_PROCESS& svc,
                                 Row& result) {
-  std::unique_ptr<SC_HANDLE__, std::function<void(SC_HANDLE)>> svcHandle(
+  svc_handle_t svcHandle(
       OpenService(scmHandle, svc.lpServiceName, SERVICE_QUERY_CONFIG),
-      [](SC_HANDLE sch) { CloseServiceHandle(sch); });
+      closeServiceHandle);
   if (svcHandle == nullptr) {
     return Status(GetLastError(), "Failed to open service handle");
   }
@@ -56,22 +64,26 @@ static inline Status getService(const SC_HANDLE& scmHandle,
   (void)QueryServiceConfig(svcHandle.get(), nullptr, 0, &cbBufSize);
   std::unique_ptr<QUERY_SERVICE_CONFIG> lpsc(
       static_cast<LPQUERY_SERVICE_CONFIG>(malloc(cbBufSize)));
+  if (lpsc == nullptr)
+    return Status(1, "Failed to malloc service config buffer");
+
   if (0 ==
-      QueryServiceConfig(svcHandle.get(), lpsc.get(), cbBufSize, &cbBufSize)) {
+      QueryServiceConfig(svcHandle.get(), lpsc.get(), cbBufSize, &cbBufSize))
     return Status(GetLastError(), "Failed to query service config");
-  }
 
   (void)QueryServiceConfig2(
       svcHandle.get(), SERVICE_CONFIG_DESCRIPTION, nullptr, 0, &cbBufSize);
   std::unique_ptr<SERVICE_DESCRIPTION> lpsd(
       static_cast<LPSERVICE_DESCRIPTION>(malloc(cbBufSize)));
+  if (lpsd == nullptr)
+    return Status(1, "Failed to malloc service description buffer");
+
   if (0 == QueryServiceConfig2(svcHandle.get(),
                                SERVICE_CONFIG_DESCRIPTION,
                                (LPBYTE)lpsd.get(),
                                cbBufSize,
-                               &cbBufSize)) {
+                               &cbBufSize))
     return Status(GetLastError(), "Failed to query service description");
-  }
 
   result["name"] = SQL_TEXT(svc.lpServiceName);
   result["display_name"] = SQL_TEXT(svc.lpDisplayName);
@@ -104,17 +116,16 @@ static inline Status getService(const SC_HANDLE& scmHandle,
       result["module_path"] = SQL_TEXT(aKey.at("data"));
     }
   }
+
   return Status();
 }
 
 static inline Status getServices(QueryData& results) {
-  std::unique_ptr<SC_HANDLE__, std::function<void(SC_HANDLE)>> scmHandle(
-      OpenSCManager(nullptr, nullptr, GENERIC_READ),
-      [](SC_HANDLE sch) { CloseServiceHandle(sch); });
-  if (scmHandle == nullptr) {
+  svc_handle_t scmHandle(OpenSCManager(nullptr, nullptr, GENERIC_READ),
+                         closeServiceHandle);
+  if (scmHandle == nullptr)
     return Status(GetLastError(),
                   "Failed to connect to Service Connection Manager");
-  }
 
   DWORD bytesNeeded = 0;
   DWORD serviceCount = 0;
@@ -128,25 +139,28 @@ static inline Status getServices(QueryData& results) {
                              &serviceCount,
                              nullptr,
                              nullptr);
-
-  std::unique_ptr<ENUM_SERVICE_STATUS_PROCESS[]> buf(
+  std::unique_ptr<ENUM_SERVICE_STATUS_PROCESS[]> lpSvcBuf(
       static_cast<ENUM_SERVICE_STATUS_PROCESS*>(malloc(bytesNeeded)));
+  if (lpSvcBuf == nullptr)
+    return Status(1, "Failed to malloc service buffer");
+
   if (0 == EnumServicesStatusEx(scmHandle.get(),
                                 SC_ENUM_PROCESS_INFO,
                                 SERVICE_WIN32,
                                 SERVICE_STATE_ALL,
-                                (LPBYTE)buf.get(),
+                                (LPBYTE)lpSvcBuf.get(),
                                 bytesNeeded,
                                 &bytesNeeded,
                                 &serviceCount,
                                 nullptr,
-                                nullptr)) {
+                                nullptr))
     return Status(GetLastError(), "Failed to enumerate services");
-  }
+
   for (size_t i = 0; i < serviceCount; i++) {
     Row r;
-    auto s = getService(scmHandle.get(), buf[i], r);
-    if (!s.ok()) return s;
+    auto s = getService(scmHandle.get(), lpSvcBuf[i], r);
+    if (!s.ok())
+      return s;
     results.push_back(r);
   }
 
@@ -157,7 +171,9 @@ QueryData genServices(QueryContext& context) {
   QueryData results;
   auto status = getServices(results);
   if (!status.ok()) {
+    // Prefer no results to incomplete results
     LOG(WARNING) << status.getMessage();
+    results = QueryData();
   }
   return results;
 }

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -54,16 +54,19 @@ Get-ChocolateyUnzip -FileFullPath $packagePath -Destination $targetFolder
 Move-Item -Force -Path $targetDaemonBin -Destination $destDaemonBin
 Set-DenyWriteAcl $daemonFolder 'Add'
 
-if ($installService -and (-not (Get-Service $serviceName -ErrorAction SilentlyContinue))) {
-  Write-Debug '[+] Installing osquery daemon service.'
-  # If the 'install' parameter is passed, we create a Windows service with
-  # the flag file in the default location in \ProgramData\osquery\
-  New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
+if ($installService) {
+  if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
+    Write-Debug '[+] Installing osquery daemon service.'
+    # If the 'install' parameter is passed, we create a Windows service with
+    # the flag file in the default location in \ProgramData\osquery\
+    New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
 
-  # If the osquery.flags file doesn't exist, we create a blank one.
-  if (-not (Test-Path "$targetFolder\osquery.flags")) {
-    Add-Content "$targetFolder\osquery.flags" $null
+    # If the osquery.flags file doesn't exist, we create a blank one.
+    if (-not (Test-Path "$targetFolder\osquery.flags")) {
+      Add-Content "$targetFolder\osquery.flags" $null
+    }
   }
+  Start-Service $serviceName
 }
 
 # Add osquery binary path to machines path for ease of use.


### PR DESCRIPTION
I'm sick of Windows and it's raw pointers and C-style arrays. I also just read a book about c++11 and 14 at the recommendation of @poppyseedplehzr . So instead of simply adding some nullptr checks to the mallocs in this table I decided to un-C the code to satisfy my need to feel like a modern C++ programmer.

If the team is cool with this direction I'll continue to refactor other Windows tables in a similar manner. 