### PR TITLE
deps: Update aws-sdk-cpp to version 1.0.107

### DIFF
--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -3,24 +3,20 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class AwsSdkCpp < AbstractOsqueryFormula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/0.14.4.tar.gz"
-  sha256 "2e935275c6f7eb25e7d850b354344c92cacb7c193b708ec64ffce10ec6afa7f4"
-  revision 1
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.0.107.tar.gz"
+  sha256 "0560918ef2a4b660e49981378af42d999b91482a31e720be2d9c427f21ac8ad0"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "0b9d7b11f5c6e7cf7de5b20c5cc19bb2e4f844df4afa00a535d648b99ef3a747" => :sierra
-    sha256 "4a46a467ea1a8e1bd4c10b42dfe30055f6d3eb0bddee4f64c108a7ca780915ce" => :el_capitan
-    sha256 "99c11985fc79446a442055eae1c1eecdf14d33434f40df91bd99f97c0b7dadce" => :x86_64_linux
+    sha256 "0c346bb985bcac896906d5376ac221e9a214e36e6b7949cea65aa5ce79858b0d" => :sierra
+    sha256 "4672b55ad19eb76b8a273fb518cb5e6dd58c334bc7476b59853b9d07c50607d7" => :x86_64_linux
   end
 
   depends_on "cmake" => :build
 
   def install
     ENV.cxx11
-
-    inreplace "CMakeLists.txt", "${CMAKE_CXX_FLAGS_RELEASE} -s", "${CMAKE_CXX_FLAGS_RELEASE}"
 
     args = osquery_cmake_args
     args << "-DSTATIC_LINKING=1"

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -11,8 +11,8 @@ class CppNetlib < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b1eb76a594f0956b0b854025dd7e600a52f25b35dabdeb5a3a3e3bc811ab23b6" => :sierra
-    sha256 "c309b5585b06eb2c43385049d1d764968bf69eb2669f5227d42d8c6606bbd468" => :x86_64_linux
+    sha256 "dde06a76f9fd7ace5f1686056d821e1856f273611f9adff8a5d40e6c5272e33c" => :sierra
+    sha256 "79e2556904cd25fa16c3781de7087dd4ab31e89c3c833a6f6d40e3843808057e" => :x86_64_linux
   end
 
   patch :DATA


### PR DESCRIPTION
1. Update `aws-ask-cpp` to version 1.0.107
2. Rebuild the bottles for `cpp-netlib` as this was also needed after rebuilding OpenSSL.