### PR TITLE
logger: Require an open DB for status logs

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -507,23 +507,26 @@ class DatabasePlugin : public Plugin {
 
   /// Require all DBHandle accesses to open a read and write handle.
   static void setRequireWrite(bool rw) {
-    kDBHandleOptionRequireWrite = rw;
+    kDBRequireWrite = rw;
   }
 
   /// Allow DBHandle creations.
   static void setAllowOpen(bool ao) {
-    kDBHandleOptionAllowOpen = ao;
+    kDBAllowOpen = ao;
   }
 
  public:
   /// Control availability of the RocksDB handle (default false).
-  static bool kDBHandleOptionAllowOpen;
+  static std::atomic<bool> kDBAllowOpen;
 
   /// The database must be opened in a R/W mode (default false).
-  static bool kDBHandleOptionRequireWrite;
+  static std::atomic<bool> kDBRequireWrite;
 
-  /// A queryable mutex around database sanity checking.
-  static std::atomic<bool> kCheckingDB;
+  /// An internal mutex around database sanity checking.
+  static std::atomic<bool> kDBChecking;
+
+  /// An internal status protecting database access.
+  static std::atomic<bool> kDBInitialized;
 
  public:
   /**

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -151,7 +151,7 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 }
 
 Status RocksDBDatabasePlugin::setUp() {
-  if (!kDBHandleOptionAllowOpen) {
+  if (!DatabasePlugin::kDBAllowOpen) {
     LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
@@ -201,7 +201,7 @@ Status RocksDBDatabasePlugin::setUp() {
     return Status(1, "Cannot read RocksDB path: " + path_);
   }
 
-  if (!DatabasePlugin::kCheckingDB) {
+  if (!DatabasePlugin::kDBChecking) {
     VLOG(1) << "Opening RocksDB handle: " << path_;
   }
 
@@ -221,12 +221,12 @@ Status RocksDBDatabasePlugin::setUp() {
   if (!s.ok() || db_ == nullptr) {
     LOG(INFO) << "Rocksdb open failed (" << s.code() << ":" << s.subcode()
               << ") " << s.ToString();
-    if (kDBHandleOptionRequireWrite) {
+    if (kDBRequireWrite) {
       // A failed open in R/W mode is a runtime error.
       return Status(1, s.ToString());
     }
 
-    if (!DatabasePlugin::kCheckingDB) {
+    if (!DatabasePlugin::kDBChecking) {
       LOG(INFO) << "Opening RocksDB failed: Continuing with read-only support";
     }
 #if !defined(ROCKSDB_LITE)

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -89,8 +89,8 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
 REGISTER_INTERNAL(SQLiteDatabasePlugin, "database", "sqlite");
 
 Status SQLiteDatabasePlugin::setUp() {
-  if (!DatabasePlugin::kDBHandleOptionAllowOpen) {
-    LOG(WARNING) << RLOG(1629) << "Not allowed to create DBHandle instance";
+  if (!DatabasePlugin::kDBAllowOpen) {
+    LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
   // Consume the current settings.
@@ -101,7 +101,7 @@ Status SQLiteDatabasePlugin::setUp() {
     return Status(1, "Cannot read database path: " + path_);
   }
 
-  if (!DatabasePlugin::kCheckingDB) {
+  if (!DatabasePlugin::kDBChecking) {
     VLOG(1) << "Opening database handle: " << path_;
   }
 
@@ -116,13 +116,13 @@ Status SQLiteDatabasePlugin::setUp() {
       nullptr);
 
   if (result != SQLITE_OK || db_ == nullptr) {
-    if (DatabasePlugin::kDBHandleOptionRequireWrite) {
+    if (DatabasePlugin::kDBRequireWrite) {
       close();
       // A failed open in R/W mode is a runtime error.
       return Status(1, "Cannot open database: " + std::to_string(result));
     }
 
-    if (!DatabasePlugin::kCheckingDB) {
+    if (!DatabasePlugin::kDBChecking) {
       VLOG(1) << "Opening database failed: Continuing with read-only support";
     }
 

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/noncopyable.hpp>
 
+#include <osquery/database.h>
 #include <osquery/events.h>
 #include <osquery/extensions.h>
 #include <osquery/filesystem.h>
@@ -594,7 +595,7 @@ size_t queuedSenders() {
 }
 
 void relayStatusLogs(bool async) {
-  if (FLAGS_disable_logging) {
+  if (FLAGS_disable_logging || !DatabasePlugin::kDBHandleOptionAllowOpen) {
     return;
   }
 

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -447,6 +447,10 @@ void BufferedLogSink::send(google::LogSeverity severity,
                            const struct ::tm* tm_time,
                            const char* message,
                            size_t message_len) {
+  if (FLAGS_disable_logging) {
+    return;
+  }
+
   // WARNING, be extremely careful when accessing data here.
   // This should not cause any persistent storage or logging actions.
   {
@@ -595,7 +599,10 @@ size_t queuedSenders() {
 }
 
 void relayStatusLogs(bool async) {
-  if (FLAGS_disable_logging || !DatabasePlugin::kDBHandleOptionAllowOpen) {
+  if (FLAGS_disable_logging || !DatabasePlugin::kDBInitialized) {
+    // The logger plugins may not be setUp if logging is disabled.
+    // If the database is not setUp, or is in a reset, status logs continue
+    // to buffer.
     return;
   }
 

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -163,6 +163,33 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         self.assertTrue(pathDoesntExist())
         daemon.kill()
 
+    def test_8_hostid_uuid(self):
+        # Test added to test using UUID as hostname ident for issue #3195
+        daemon = self._run_daemon({
+            "disable_watchdog": True,
+            "disable_extensions": True,
+            "disable_logging": False,
+            "logger_plugin": "stdout",
+            "host_identifier": "uuid",
+            "verbose": True,
+        })
+
+        self.assertTrue(daemon.isAlive())
+        daemon.kill()
+
+    def test_9_hostid_instance(self):
+        daemon = self._run_daemon({
+            "disable_watchdog": True,
+            "disable_extensions": True,
+            "disable_logging": False,
+            "logger_plugin": "stdout",
+            "host_identifier": "instance",
+            "verbose": True,
+        })
+
+        self.assertTrue(daemon.isAlive())
+        daemon.kill()
+
 
 if __name__ == '__main__':
     test_base.Tester().run()


### PR DESCRIPTION
The `relayStatusLogs` function will access the DB for certain options of `--host_identifier`. This method may be called (thus requiring DB access), before the DB is initialized. The method is called periodically during the daemon's life, returning before the DB is initialized will only delay forwarding status logs to the logger plugin.