### PR TITLE
revert: deps: Update boost to version 1.64

### DIFF
--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -3,15 +3,16 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Boost < AbstractOsqueryFormula
   desc "Collection of portable C++ source libraries"
   homepage "https://www.boost.org/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2"
-  sha256 "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
+  sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   head "https://github.com/boostorg/boost.git"
+  revision 7
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "19317b7d4ec628ebfed8f88aa3e7a18322fcf851db9e60a4deeaab28ab45a599" => :sierra
-    sha256 "f6f3b08ada4648e5b3d210767323025dcd3616087fac1d0accd2b7b4cf3a45e0" => :x86_64_linux
+    sha256 "5f2e5ac7a4a04ce50f3f4a5d6f1d075fb88b100e876cc550380052f775ea3856" => :sierra
+    sha256 "210fbdf8d1430704d638126c13e07cf592a5229b503f14be2cc00212195d5c22" => :x86_64_linux
   end
 
   env :userpaths


### PR DESCRIPTION
Boost 1.64's coroutine2 project includes thread local storage. We're unsure if this will implicitly deprecate macOS 10.10 so to be safe, we'll stay at 1.63.