### PR TITLE
deps: Bumping windows aws-cpp-sdk to 1.0.107

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -271,7 +271,7 @@ function Install-ThirdParty {
   #      Once our chocolatey packages are added to the official repository, installing the third-party
   #      dependencies will be as easy as Install-ChocoPackage '<package-name>'.
   $packages = @(
-    "aws-sdk-cpp.0.14.4",
+    "aws-sdk-cpp.1.0.107",
     "boost-msvc14.1.63.0-r1",
     "bzip2.1.0.6",
     "doxygen.1.8.11",


### PR DESCRIPTION
This library package is still experimental, and this diff simply brings the libraries along with the development kit. The actual logic is still gated by CMake, and future diffs will work to ungate the logic.