### PR TITLE
deps: bumping aws-sdk-cpp to 1.0.17-r1

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -271,7 +271,7 @@ function Install-ThirdParty {
   #      Once our chocolatey packages are added to the official repository, installing the third-party
   #      dependencies will be as easy as Install-ChocoPackage '<package-name>'.
   $packages = @(
-    "aws-sdk-cpp.1.0.107",
+    "aws-sdk-cpp.1.0.107-r1",
     "boost-msvc14.1.63.0-r1",
     "bzip2.1.0.6",
     "doxygen.1.8.11",


### PR DESCRIPTION
This bundles the debug libs for aws-sdk-cpp, as well as the core lib which was left out of the previous version.