### PR TITLE
Split Startup items 'path' column into 'path' and 'args'

### DIFF
--- a/specs/startup_items.table
+++ b/specs/startup_items.table
@@ -3,6 +3,7 @@ description("Applications and binaries set as user/login startup items.")
 schema([
     Column("name", TEXT, "Name of startup item"),
     Column("path", TEXT, "Path of startup item"),
+    Column("args", TEXT, "Arguments provided to startup executable"),
     Column("type", TEXT, "Startup Item or Login Item"),
     Column("source", TEXT, "Directory or plist containing startup item"),
     Column("status", TEXT, "Startup status; either enabled or disabled"),


### PR DESCRIPTION
One current issue with startup_items is that it contains both the path to the executable and also the args in one string, this makes it a pain to parse out the executable for e.g. hash analysis.

Right now this only will have results for windows. darwin will report empty columns.
```
osquery> select * from startup_items;                                                                                                                                                                                                                                                  
    name = Dropbox                                                                   
    path = C:\Program Files (x86)\Dropbox\Client\Dropbox.exe                         
    args = /systemstartup                                                            
    type = Startup Item                                                              
  source = HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\R
un                                                                                   
  status = enabled                                                                   
username = SYSTEM   
    
    name = OneDrive
    path = C:\Users\ryanheffernan\AppData\Local\Microsoft\OneDrive\OneDrive.exe
    args = /background
    type = Startup Item
  source = HKEY_USERS\S-1-5-21-4286658467-4243823776-1656315635-229991\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
  status = enabled
username = ryanheffernan                                                             
```