### PR TITLE
Refactor Windows Registry Code to use std::unique_ptr and Fail on Error

### DIFF
--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -25,7 +25,7 @@ const std::string kDefaultRegName = "(Default)";
 const size_t kRegMaxRecursiveDepth = 32;
 
 /// Microsoft helper function for getting the contents of a registry key
-void queryKey(const std::string& keyPath, QueryData& results);
+Status queryKey(const std::string& keyPath, QueryData& results);
 
 /*
  * @brief Expand a globbing pattern into a set of registry keys to

--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -29,13 +29,15 @@ const std::string kInvalidTestKey = "HKEY_LOCAL_MACHINE\\PATH\\to\\madeup\\key";
 
 TEST_F(RegistryTablesTest, test_registry_existing_key) {
   QueryData results;
-  queryKey(kTestKey, results);
+  auto ret = queryKey(kTestKey, results);
+  EXPECT_TRUE(ret.ok());
   EXPECT_TRUE(results.size() > 0);
 }
 
 TEST_F(RegistryTablesTest, test_registry_non_existing_key) {
   QueryData results;
-  queryKey(kInvalidTestKey, results);
+  auto ret = queryKey(kInvalidTestKey, results);
+  EXPECT_TRUE(ret.ok());
   EXPECT_TRUE(results.size() == 0);
 }
 


### PR DESCRIPTION
All of those mallocs and delete[]s freak me out. Let's c++14ify them.

Also changing the registry function to return a status, so we can accurately know when a reg query failed vs. silently returning incomplete results.