### PR TITLE
database: Remove SKIP_ROCKSDB build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,9 +274,6 @@ endif()
 
 # Feature environment variables (flags), their use is highly discouraged.
 # The recommended osquery build, and distributed packages, do not use these.
-if(DEFINED ENV{SKIP_ROCKSDB})
-  set(SKIP_ROCKSDB TRUE)
-endif()
 if(DEFINED ENV{SKIP_AWS})
   set(SKIP_AWS TRUE)
 endif()

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -46,6 +46,47 @@ else()
   endif()
 endif()
 
+if(DEFINED ENV{SANITIZE})
+  if(DEFINED ENV{SANITIZE_THREAD})
+    ADD_OSQUERY_LINK_CORE(-fsanitize=thread)
+  else()
+    ADD_OSQUERY_LINK_CORE(-fsanitize=address -fsanitize=leak)
+  endif()
+  ADD_OSQUERY_LINK_CORE(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
+endif()
+
+# Construct a set of all object files, starting with third-party and all
+# of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
+set(OSQUERY_OBJECTS $<TARGET_OBJECTS:osquery_sqlite>)
+
+# Add subdirectories
+add_subdirectory(config)
+add_subdirectory(core)
+add_subdirectory(database)
+add_subdirectory(devtools)
+add_subdirectory(dispatcher)
+add_subdirectory(distributed)
+add_subdirectory(events)
+add_subdirectory(extensions)
+add_subdirectory(filesystem)
+add_subdirectory(logger)
+add_subdirectory(registry)
+add_subdirectory(sql)
+add_subdirectory(remote)
+add_subdirectory(carver)
+
+# Add externals directory from parent
+add_subdirectory("${CMAKE_SOURCE_DIR}/external" "${CMAKE_BINARY_DIR}/external")
+
+if(NOT SKIP_TABLES)
+  add_subdirectory(tables)
+
+  # Amalgamate the utility tables needed to compile.
+  GENERATE_UTILITIES("${CMAKE_SOURCE_DIR}")
+  AMALGAMATE("${CMAKE_SOURCE_DIR}" "utils" AMALGAMATION_UTILS)
+  ADD_OSQUERY_LIBRARY_CORE(osquery_amalgamation ${AMALGAMATION_UTILS})
+endif()
+
 if(WINDOWS)
   ADD_OSQUERY_LINK_CORE("ws2_32.lib")
   ADD_OSQUERY_LINK_CORE("iphlpapi.lib")
@@ -114,6 +155,7 @@ if(POSIX)
   ADD_OSQUERY_LINK_ADDITIONAL("crypto")
   ADD_OSQUERY_LINK_ADDITIONAL("libpthread")
   ADD_OSQUERY_LINK_ADDITIONAL("linenoise")
+  ADD_OSQUERY_LINK_ADDITIONAL("magic")
 endif()
 
 if(APPLE)
@@ -157,47 +199,6 @@ if(LINUX)
   endif()
   # For Ubuntu/CentOS packages add the build SHA1.
   ADD_OSQUERY_LINK_CORE("-Wl,--build-id")
-endif()
-
-if(DEFINED ENV{SANITIZE})
-  if(DEFINED ENV{SANITIZE_THREAD})
-    ADD_OSQUERY_LINK_CORE(-fsanitize=thread)
-  else()
-    ADD_OSQUERY_LINK_CORE(-fsanitize=address -fsanitize=leak)
-  endif()
-  ADD_OSQUERY_LINK_CORE(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
-endif()
-
-# Construct a set of all object files, starting with third-party and all
-# of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
-set(OSQUERY_OBJECTS $<TARGET_OBJECTS:osquery_sqlite>)
-
-# Add subdirectories
-add_subdirectory(config)
-add_subdirectory(core)
-add_subdirectory(database)
-add_subdirectory(devtools)
-add_subdirectory(dispatcher)
-add_subdirectory(distributed)
-add_subdirectory(events)
-add_subdirectory(extensions)
-add_subdirectory(filesystem)
-add_subdirectory(logger)
-add_subdirectory(registry)
-add_subdirectory(sql)
-add_subdirectory(remote)
-add_subdirectory(carver)
-
-# Add externals directory from parent
-add_subdirectory("${CMAKE_SOURCE_DIR}/external" "${CMAKE_BINARY_DIR}/external")
-
-if(NOT SKIP_TABLES)
-  add_subdirectory(tables)
-
-  # Amalgamate the utility tables needed to compile.
-  GENERATE_UTILITIES("${CMAKE_SOURCE_DIR}")
-  AMALGAMATE("${CMAKE_SOURCE_DIR}" "utils" AMALGAMATION_UTILS)
-  ADD_OSQUERY_LIBRARY_CORE(osquery_amalgamation ${AMALGAMATION_UTILS})
 endif()
 
 # Bubble the subdirectory (component) sources and links for this build.

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -36,13 +36,7 @@ FLAG(bool, disable_database, false, "Disable the persistent RocksDB storage");
 
 DECLARE_bool(decorations_top_level);
 
-#if defined(SKIP_ROCKSDB)
-#define DATABASE_PLUGIN "sqlite"
-#else
-#define DATABASE_PLUGIN "rocksdb"
-#endif
-const std::string kInternalDatabase = DATABASE_PLUGIN;
-
+const std::string kInternalDatabase = "rocksdb";
 const std::string kPersistentSettings = "configurations";
 const std::string kQueries = "queries";
 const std::string kEvents = "events";

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -143,8 +143,3 @@ if(NOT SKIP_LLDPD AND POSIX)
 
   ADD_OSQUERY_LINK_ADDITIONAL("lldpctl")
 endif()
-
-# Include magic after tables
-if(POSIX)
-  ADD_OSQUERY_LINK_ADDITIONAL("magic")
-endif()


### PR DESCRIPTION
Remove the ability to set `SKIP_ROCKSDB` in build.