### PR TITLE
freebsd: Add asio and aws-sdk-cpp dependencies

### DIFF
--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -13,24 +13,33 @@ function distro_main() {
 
   # Use it with caution -- unless the dependency is newly added
   # and the pre-built package is not ready yet.
-  #do_sudo portsnap --interactive fetch update
+  # do_sudo portsnap --interactive fetch update
 
+  # Build requirements.
   package gmake
   package cmake
   package git
   package python
   package py27-pip
+
+  # Core development requirements.
   package glog
   package snappy
   package thrift
   package thrift-cpp
-  package yara
   package boost-libs
   package magic
-  package sleuthkit
-  package augeas
-  package lldpd
   package rocksdb-lite
-  package linenoise-ng
+  package asio
   package cpp-netlib
+  package linenoise-ng
+
+  # Non-optional features.
+  package augeas
+
+  # Optional features.
+  package sleuthkit
+  package yara
+  package aws-sdk-cpp
+  package lldpd
 }


### PR DESCRIPTION
For the FreeBSD CI/CB we need all features enabled (AWS, YARA, SleuthKit are optional in the port). 