### PR TITLE
test: Always use gtest TR1 on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,7 @@ else()
   check_include_file_cxx("tr1/tuple" HAVE_TR1_TUPLE)
 endif()
 
-if("${HAVE_TR1_TUPLE}" STREQUAL "")
+if(FREEBSD OR "${HAVE_TR1_TUPLE}" STREQUAL "")
   set(GTEST_FLAGS "-DGTEST_USE_OWN_TR1_TUPLE=1")
 else()
   set(GTEST_FLAGS "-DGTEST_USE_OWN_TR1_TUPLE=0")


### PR DESCRIPTION
Skip detecting and potentially using the C++ `std::tr1` and instead always use `gtest`'s.