### PR TITLE
freebsd: Fix process_tests and include wait

### DIFF
--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -49,7 +49,7 @@ TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
       "config_files", "logs", "logs"};
   std::vector<std::string> categories;
   std::vector<std::string> expected_values = {
-      "/dev", "/dev/zero", "/dev/null", "/dev/random", "/dev/urandom"};
+      "/dev", "/dev/zero", "/dev/null", "/dev/random"};
   std::vector<std::string> values;
 
   Config::getInstance().update(config_data_);

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -163,8 +163,13 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
 std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
     const std::string& args) {
   std::shared_ptr<PlatformProcess> process;
+  std::string argv;
 
-  std::string argv = "/usr/local/osquery/bin/python " + args;
+  if (!isPlatform(PlatformType::TYPE_FREEBSD)) {
+    argv = "/usr/local/osquery/bin/python " + args;
+  } else {
+    argv = "/usr/local/bin/python " + args;
+  }
 
   int process_pid = ::fork();
   if (process_pid == 0) {

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -8,6 +8,10 @@
  *
  */
 
+#ifndef WIN32
+#include <sys/wait.h>
+#endif
+
 #include <gtest/gtest.h>
 
 #include <osquery/core.h>

--- a/osquery/tables/system/freebsd/os_version.cpp
+++ b/osquery/tables/system/freebsd/os_version.cpp
@@ -8,7 +8,13 @@
  *
  */
 
+#include <unistd.h>
+
+#include <boost/algorithm/string.hpp>
+
 #include <osquery/filesystem.h>
+#include <osquery/sql.h>
+#include <osquery/system.h>
 #include <osquery/tables.h>
 
 namespace osquery {
@@ -26,7 +32,44 @@ QueryData genOSVersion(QueryContext& context) {
 }
 
 QueryData genSystemInfo(QueryContext& context) {
-  return QueryData();
+  Row r;
+  r["hostname"] = osquery::getHostname();
+  r["computer_name"] = r["hostname"];
+
+  std::string uuid;
+  r["uuid"] = (osquery::getHostUUID(uuid)) ? uuid : "";
+
+  auto qd = SQL::selectAllFrom("cpuid");
+  for (const auto& row : qd) {
+    if (row.at("feature") == "product_name") {
+      r["cpu_brand"] = row.at("value");
+      boost::trim(r["cpu_brand"]);
+    }
+  }
+
+  // Can parse /proc/cpuinfo or /proc/meminfo for this data.
+  static long cores = sysconf(_SC_NPROCESSORS_CONF);
+  if (cores > 0) {
+    r["cpu_logical_cores"] = INTEGER(cores);
+    r["cpu_physical_cores"] = INTEGER(cores);
+  } else {
+    r["cpu_logical_cores"] = "-1";
+    r["cpu_physical_cores"] = "-1";
+  }
+
+  static long pages = sysconf(_SC_PHYS_PAGES);
+  static long pagesize = sysconf(_SC_PAGESIZE);
+
+  if (pages > 0 && pagesize > 0) {
+    r["physical_memory"] = BIGINT((long long)pages * (long long)pagesize);
+  } else {
+    r["physical_memory"] = "-1";
+  }
+
+  r["cpu_type"] = "0";
+  r["cpu_subtype"] = "0";
+
+  return {r};
 }
 
 QueryData genPlatformInfo(QueryContext& context) {

--- a/tools/tests/test_parse_items.conf
+++ b/tools/tests/test_parse_items.conf
@@ -22,8 +22,7 @@
     "foobar_with_files": {
       "file_paths": {
         "logs": [
-          "/dev/random",
-          "/dev/urandom"
+          "/dev/random"
         ]
       },
       "file_accesses": [


### PR DESCRIPTION
The `osquery_tests` and `osquery_additional_tests` 'almost' run on FreeBSD. This PR adds the last few fixes to the tests themselves.