### PR TITLE
Adding signature for new OSX malware DOK

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -367,10 +367,28 @@
       "description" : "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
       "value" : "Artifact used by this malware"
     },
-    "DOK": {
+    "OSX_DOK_1": {
       "query" : "select * from launchd where name = 'com.apple.Safari.proxy.plist' or name = 'com.apple.Safari.proxy.pac';",
       "interval" : "3600",
       "description" : "DOK Launch Agents (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_2": {
+      "query" : "select common_name, sha1, subject_key_id from certificates where subject_key_id = 'e637d656f9f088ddca3b3b55c4fe698d8c97a552';",
+      "interval" : "3600",
+      "description" : "DOK certificate (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_3": {
+      "query" : "select * from file where path = '/Users/Shared/AppStore.app';",
+      "interval" : "3600",
+      "description" : "DOK dropped file (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
+    },
+    "OSX_DOK_4": {
+      "query" : "select * from apps where bundle_name = 'Truesteer.AppStore';",
+      "interval" : "3600",
+      "description" : "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
       "value" : "Artifact used by this malware"
     }
   }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -366,6 +366,12 @@
       "interval" : "3600",
       "description" : "ProntoApp Launch Agents (https://malwarefixes.com/remove-pronto-video-converter/)",
       "value" : "Artifact used by this malware"
+    },
+    "DOK": {
+      "query" : "select * from launchd where name = 'com.apple.Safari.proxy.plist' or name = 'com.apple.Safari.proxy.pac';",
+      "interval" : "3600",
+      "description" : "DOK Launch Agents (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
+      "value" : "Artifact used by this malware"
     }
   }
 }


### PR DESCRIPTION
Adding signature, more specifically the LaunchAgent names for new OSX malware, DOK. More information here http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/