### PR TITLE
Adding Fox-IT IOCs for OSX port of Snake malware

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -391,5 +391,17 @@
       "description" : "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
       "value" : "Artifact used by this malware"
     }
+    "OSX_Snake": {
+      "query" : "select * from file \
+         where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR \
+           path = '/Library/Scripts/installd.sh' OR \
+           path = '/Library/Scripts/queue' OR \
+           path = '/tmp/.gdm-socket' OR \
+           path = '/tmp/.gdm-selinux' OR \
+           path LIKE '/var/tmp/.ur-%%';",
+      "interval" : "3600",
+      "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
+      "value" : "Artifacts created by this malware"
+    }
   }
 }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -390,7 +390,7 @@
       "interval" : "3600",
       "description" : "DOK malicious app (http://blog.checkpoint.com/2017/04/27/osx-malware-catching-wants-read-https-traffic/)",
       "value" : "Artifact used by this malware"
-    }
+    },
     "OSX_Snake": {
       "query" : "select * from file \
          where path = '/Library/LaunchDaemons/com.adobe.update.plist' OR \


### PR DESCRIPTION
Adding File Artifact names for an OS X port of the Snake malware, as reported here: https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/ -- info taken from the IOCs section.

I didn't feel that the hashes or network indicators would work well in query pack (since we don't know what files the hashes correspond to), though we could do process open sockets to look for the IP. I just don't feel that is likely to have any value.

