### PR TITLE
[Fix 3248] git submodule now inits new modules on windows

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -350,9 +350,10 @@ function Update-GitSubmodule {
     Write-Host "[-] ERROR: Git was not found on the system. Install git." -foregroundcolor Red
     Exit -1
   }
+  $repoRoot = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, '..'))
   $thirdPartyPath = Resolve-Path ([System.IO.Path]::Combine($PSScriptRoot, '..', 'third-party'))
   Write-Host " => Updating git submodules in $thirdPartyPath ..." -foregroundcolor Yellow
-  Push-Location $thirdPartyPath
+  Push-Location $repoRoot
   git submodule --quiet update --init
   Pop-Location
   Write-Host "[+] Submodules updated!" -foregroundcolor Yellow


### PR DESCRIPTION
This addresses #3248. The dev environment provisioning script was calling `git submodule update --init` in the `third-party` directory, however this needs to be run in the repo root.