### PR TITLE
carving: Adding distributed request_id to carver

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -50,6 +50,9 @@ extern const std::string kQueries;
 /// The "domain" where event results are stored, queued for querytime retrieval.
 extern const std::string kEvents;
 
+/// The "domain" where the results of carve queries are stored.
+extern const std::string kCarves;
+
 /**
  * @brief The "domain" where buffered log results are stored.
  *

--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -230,6 +230,9 @@ class Distributed {
   /// Process and execute queued queries
   Status runQueries();
 
+  // Getter for ID of currently executing request
+  static std::string getCurrentRequestId();
+
  protected:
   /**
    * @brief Process several queries from a distributed plugin
@@ -261,8 +264,13 @@ class Distributed {
    */
   Status flushCompleted();
 
- protected:
+  // Setter for ID of currently executing request
+  static void setCurrentRequestId(const std::string& cReqId);
+
   std::vector<DistributedQueryResult> results_;
+
+  // ID of the currently executing query
+  static std::string currentRequestId_;
 
  private:
   friend class DistributedTests;

--- a/osquery/carver/carver.h
+++ b/osquery/carver/carver.h
@@ -17,7 +17,9 @@ namespace osquery {
 
 class Carver : public InternalRunnable {
  public:
-  Carver(const std::set<std::string>& paths, const std::string& guid);
+  Carver(const std::set<std::string>& paths,
+         const std::string& guid,
+         const std::string& requestId);
 
   ~Carver();
 
@@ -98,6 +100,14 @@ class Carver : public InternalRunnable {
    * session key for exfiltration.
    */
   std::string carveGuid_;
+
+  /**
+   * @brief the distributed work ID of a carve
+   *
+   * This value should be used by the TLS endpoints where carve data is
+   * aggregated, to tie together a distributed query with the carve data
+   */
+  std::string requestId_;
 
   /*
    * @brief the uri used to begin POSTing carve data

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -70,7 +70,8 @@ class CarverTests : public testing::Test {
 TEST_F(CarverTests, test_carve_files_locally) {
   auto guid_ = genGuid();
   auto paths_ = getCarvePaths();
-  Carver carve(getCarvePaths(), guid_);
+  std::string requestId = "";
+  Carver carve(getCarvePaths(), guid_, requestId);
 
   Status s;
   for (const auto& p : paths_) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -40,10 +40,11 @@ const std::string kInternalDatabase = "rocksdb";
 const std::string kPersistentSettings = "configurations";
 const std::string kQueries = "queries";
 const std::string kEvents = "events";
+const std::string kCarves = "carves";
 const std::string kLogs = "logs";
 
 const std::vector<std::string> kDomains = {
-    kPersistentSettings, kQueries, kEvents, kLogs};
+    kPersistentSettings, kQueries, kEvents, kLogs, kCarves};
 
 std::atomic<bool> DatabasePlugin::kDBAllowOpen(false);
 std::atomic<bool> DatabasePlugin::kDBRequireWrite(false);

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -35,6 +35,8 @@ FLAG(bool,
 
 const std::string kDistributedQueryPrefix{"distributed."};
 
+std::string Distributed::currentRequestId_{""};
+
 Status DistributedPlugin::call(const PluginRequest& request,
                                PluginResponse& response) {
   if (request.count("action") == 0) {
@@ -124,6 +126,9 @@ Status Distributed::runQueries() {
     auto request = popRequest();
     LOG(INFO) << "Executing distributed query: " << request.id << ": "
               << request.query;
+
+    // Keep track of the currently executing request
+    Distributed::setCurrentRequestId(request.id);
 
     SQL sql(request.query);
     if (!sql.getStatus().ok()) {
@@ -238,6 +243,14 @@ DistributedQueryRequest Distributed::popRequest() {
   getDatabaseValue(kQueries, next, request.query);
   deleteDatabaseValue(kQueries, next);
   return request;
+}
+
+std::string Distributed::getCurrentRequestId() {
+  return currentRequestId_;
+}
+
+void Distributed::setCurrentRequestId(const std::string& cReqId) {
+  currentRequestId_ = cReqId;
 }
 
 Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -17,6 +17,7 @@
 #include <osquery/core.h>
 #include <osquery/database.h>
 #include <osquery/dispatcher.h>
+#include <osquery/distributed.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
@@ -116,7 +117,8 @@ QueryData genCarves(QueryContext& context) {
       LOG(WARNING) << "Error inserting new carve entry into the database: "
                    << s.getMessage();
     } else {
-      Dispatcher::addService(std::make_shared<Carver>(paths, guid));
+      auto requestId = Distributed::getCurrentRequestId();
+      Dispatcher::addService(std::make_shared<Carver>(paths, guid, requestId));
     }
   }
   enumerateCarves(results);


### PR DESCRIPTION
This adds the distributed request ID to the file carver so requests made by a distributed TLS endpoint can be connected on the endpoints.