### PR TITLE
[Fix #3230] windows deploy: Changing the ACL group from Everyone to the world SID

### DIFF
--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -24,7 +24,9 @@ function Set-DenyWriteAcl {
     $propagationFlag = [System.Security.AccessControl.PropagationFlags]::None
     $permType = [System.Security.AccessControl.AccessControlType]::Deny
 
-    $permission = "everyone", "write", $inheritanceFlag, $propagationFlag, $permType
+    $worldSIDObj = New-Object System.Security.Principal.SecurityIdentifier ('S-1-1-0')
+    $worldUser = $worldSIDObj.Translate( [System.Security.Principal.NTAccount])
+    $permission = $worldUser.Value, "write", $inheritanceFlag, $propagationFlag, $permType
     $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
     # We only support adding or removing the ACL
     if ($action -ieq 'add') {


### PR DESCRIPTION
This ensures that installations on non-English systems with the chocolatey package should correctly set the Deny-Write ACL on the daemon folder. Received a verification that this fix works from @ogoudron that this is working on French systems, will test on a Japanese install and verify it's working there also.