### PR TITLE
Adding OSX/Proton to osx-attacks.conf

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -402,6 +402,15 @@
       "interval" : "3600",
       "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
       "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton": {
+      "query" : "select path from file \
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
+        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' UNION ALL \
+        select path from processes where name = 'activity_agent';",
+      "interval" : "3600",
+      "description" : "OSX/Proton bundled with a tampered version of handbrake: https://objective-see.com/blog/blog_0x1D.html",
+      "value" : "Artifacts created by this malware"
     }
   }
 }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -403,11 +403,17 @@
       "description" : "OS X port of Snake malware discovered by Fox-IT (https://blog.fox-it.com/2017/05/03/snake-coming-soon-in-mac-os-x-flavour/)",
       "value" : "Artifacts created by this malware"
     },
-    "OSX_Proton": {
-      "query" : "select path from file \
+    "OSX_Proton_Files": {
+      "query" : "select * from file \
         where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
-        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' UNION ALL \
-        select path from processes where name = 'activity_agent';",
+        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist';",
+      "interval" : "3600",
+      "description" : "OSX/Proton bundled with a tampered version of handbrake: https://objective-see.com/blog/blog_0x1D.html",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton_Process": {
+      "query" : "select * from processes \
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent';",
       "interval" : "3600",
       "description" : "OSX/Proton bundled with a tampered version of handbrake: https://objective-see.com/blog/blog_0x1D.html",
       "value" : "Artifacts created by this malware"


### PR DESCRIPTION
Adds detection for the malware that came packaged with the tampered version of Handbrake: https://objective-see.com/blog/blog_0x1D.html

• Check for file presence of the binary, plist
• Check for presence of running process named "activity_agent"