### PR TITLE
hashing: Add sha1, sha256, md5 functions

### DIFF
--- a/docs/wiki/introduction/sql.md
+++ b/docs/wiki/introduction/sql.md
@@ -75,7 +75,7 @@ osquery> .mode line
 osquery> SELECT * FROM osquery_info;
            pid = 3811
        version = 1.7.4
-   config_hash = 
+   config_hash =
   config_valid = 0
     extensions = active
 build_platform = darwin
@@ -191,13 +191,16 @@ The following trig functions: `sin`, `cos`, `tan`, `cot`, `asin`, `acos`, `atan`
 
 String parsing functions are always helpful, some help within subqueries so they make sense as local-additions:
 
-- `split(COLUMN, TOKENS, INDEX)`: split `COLUMN` using any character token from `TOKENS` and return the `INDEX` result. If an `INDEX` result does not exist, a `NULL` type is returned. 
+- `split(COLUMN, TOKENS, INDEX)`: split `COLUMN` using any character token from `TOKENS` and return the `INDEX` result. If an `INDEX` result does not exist, a `NULL` type is returned.
 - `regex_split(COLUMN, PATTERN, INDEX)`: similar to split, but instead of `TOKENS`, apply the POSIX regex `PATTERN` (as interpreted by boost::regex).
 - `inet_aton(IPv4_STRING)`: return the integer representation of an IPv4 string.
+
+**Hashing functions**
+
+We have added `sha1`, `sha256`, and `md5` functions that take a single argument and return the hashed value.
 
 ### Table and column name deprecations
 
 Over time it may makes sense to rename tables and columns. osquery tries to apply plurals to table names and achieve the easiest foreign key JOIN syntax. This often means slightly skewing concept attributes or biasing towards diction used by POSIX.
 
 The tools makes an effort to mark deprecated tables and create 'clone' `VIEW`s so previously scheduled queries continue to work. Similarly for old column names, the column will be marked `HIDDEN` and only returned if explicitly selected. This does not make queries using `*` future-proof, as they will begin using the new column names when the client is updated. All of these changes are considered osquery API changes and marked as such in [release notes](https://github.com/facebook/osquery/releases) on Github.
-

--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -1,24 +1,26 @@
-ADD_OSQUERY_LIBRARY(TRUE osquery_sql
+ADD_OSQUERY_LIBRARY_CORE(osquery_sql
   sql.cpp
 )
 
 if(FREEBSD)
-  ADD_OSQUERY_LIBRARY(FALSE osquery_sql_internal
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
     sqlite_util.cpp
     sqlite_math.cpp
+    sqlite_hashing.cpp
     virtual_table.cpp
   )
 else()
-  ADD_OSQUERY_LIBRARY(FALSE osquery_sql_internal
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
     sqlite_util.cpp
     sqlite_math.cpp
     sqlite_string.cpp
+    sqlite_hashing.cpp
     virtual_table.cpp
   )
 endif()
 
 file(GLOB OSQUERY_SQL_TESTS "tests/*.cpp")
-ADD_OSQUERY_TEST(FALSE ${OSQUERY_SQL_TESTS})
+ADD_OSQUERY_TEST_ADDITIONAL(${OSQUERY_SQL_TESTS})
 
 file(GLOB OSQUERY_SQL_BENCHMARKS "benchmarks/*.cpp")
 ADD_OSQUERY_BENCHMARK(${OSQUERY_SQL_BENCHMARKS})

--- a/osquery/sql/sqlite_hashing.cpp
+++ b/osquery/sql/sqlite_hashing.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <functional>
+#include <string>
+
+#include "osquery/core/conversions.h"
+#include "osquery/tables/system/hash.h"
+
+#include <sqlite3.h>
+
+namespace osquery {
+
+static void hashSqliteValue(sqlite3_context* ctx,
+                            int argc,
+                            sqlite3_value** argv,
+                            HashType ht) {
+  if (argc == 0) {
+    return;
+  }
+
+  if (SQLITE_NULL == sqlite3_value_type(argv[0])) {
+    sqlite3_result_null(ctx);
+    return;
+  }
+
+  // Parse and verify the split input parameters.
+  std::string input((char*)sqlite3_value_text(argv[0]));
+
+  auto result = hashFromBuffer(ht, input.data(), input.size());
+  sqlite3_result_text(
+      ctx, result.c_str(), static_cast<int>(result.size()), SQLITE_TRANSIENT);
+}
+
+static void sqliteMD5Func(sqlite3_context* context,
+                          int argc,
+                          sqlite3_value** argv) {
+  hashSqliteValue(context, argc, argv, HASH_TYPE_MD5);
+}
+
+static void sqliteSHA1Func(sqlite3_context* context,
+                           int argc,
+                           sqlite3_value** argv) {
+  hashSqliteValue(context, argc, argv, HASH_TYPE_SHA1);
+}
+
+static void sqliteSHA256Func(sqlite3_context* context,
+                             int argc,
+                             sqlite3_value** argv) {
+  hashSqliteValue(context, argc, argv, HASH_TYPE_SHA256);
+}
+
+void registerHashingExtensions(sqlite3* db) {
+  sqlite3_create_function(
+      db, "md5", 1, SQLITE_UTF8, nullptr, sqliteMD5Func, nullptr, nullptr);
+  sqlite3_create_function(
+      db, "sha1", 1, SQLITE_UTF8, nullptr, sqliteSHA1Func, nullptr, nullptr);
+  sqlite3_create_function(db,
+                          "sha256",
+                          1,
+                          SQLITE_UTF8,
+                          nullptr,
+                          sqliteSHA256Func,
+                          nullptr,
+                          nullptr);
+}
+}

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -221,6 +221,7 @@ static inline void openOptimized(sqlite3*& db) {
 #if !defined(FREEBSD)
   registerStringExtensions(db);
 #endif
+  registerHashingExtensions(db);
 }
 
 void SQLiteDBInstance::init() {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -356,4 +356,9 @@ void registerMathExtensions(sqlite3* db);
  * @brief Register string-related 'custom' functions.
  */
 void registerStringExtensions(sqlite3* db);
+
+/**
+ * @brief Register hashing-related 'custom' functions.
+ */
+void registerHashingExtensions(sqlite3* db);
 }


### PR DESCRIPTION
```
~/local/osquery(branch:master)  » ./build/linux/osquery/osqueryi "select sha1('');"
+------------------------------------------+
| sha1('')                                 |
+------------------------------------------+
| da39a3ee5e6b4b0d3255bfef95601890afd80709 |
+------------------------------------------+
------------------------------------------------------------
~/local/osquery(branch:master)  » echo -n '' | shasum
da39a3ee5e6b4b0d3255bfef95601890afd80709  -
```