### PR TITLE
[Fix #3268] extensions autoload now correctly spawns extension processes

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -143,10 +143,10 @@ class Initializer : private boost::noncopyable {
   static void platformSetup();
 
   /**
-  * @brief Before ending, tear down any platform specific setup
-  *
-  * On windows, we require the COM libraries be initialized just once
-  */
+   * @brief Before ending, tear down any platform specific setup
+   *
+   * On windows, we require the COM libraries be initialized just once
+   */
   static void platformTeardown();
 
  public:
@@ -358,10 +358,10 @@ std::string getAsciiTime();
 Status createPidFile();
 
 /**
-* @brief Getter for determining Admin status
-*
-* @return A bool indicating if the current process is running as admin
-*/
+ * @brief Getter for determining Admin status
+ *
+ * @return A bool indicating if the current process is running as admin
+ */
 bool isUserAdmin();
 
 #ifdef WIN32
@@ -371,4 +371,4 @@ struct tm* gmtime_r(time_t* t, struct tm* result);
 
 struct tm* localtime_r(time_t* t, struct tm* result);
 #endif
-}
+} // namespace osquery

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -71,7 +71,8 @@ bool PlatformProcess::operator!=(const PlatformProcess& process) const {
 }
 
 int PlatformProcess::pid() const {
-  return static_cast<int>(::GetProcessId(id_));
+  auto pid = (id_ == INVALID_HANDLE_VALUE) ? -1 : GetProcessId(id_);
+  return static_cast<int>(pid);
 }
 
 bool PlatformProcess::kill() const {
@@ -338,4 +339,4 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
 
   return process;
 }
-}
+} // namespace osquery

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -155,4 +155,4 @@ void Dispatcher::stopServices() {
     DLOG(INFO) << "Service: " << service.get() << " has been interrupted";
   }
 }
-}
+} // namespace osquery

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -751,4 +751,4 @@ Status startExtensionManager(const std::string& manager_path) {
 
   return Status(0, "OK");
 }
-}
+} // namespace osquery

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -229,7 +229,7 @@ bool ExtensionManagerHandler::exists(const std::string& name) {
   }
   return false;
 }
-}
+} // namespace extensions
 
 ExtensionRunnerCore::~ExtensionRunnerCore() {
   remove(path_);
@@ -322,4 +322,4 @@ void ExtensionManagerRunner::start() {
                  << path_ << ") (" << e.what() << ")";
   }
 }
-}
+} // namespace osquery

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -502,4 +502,4 @@ Status parseJSONContent(const std::string& content, pt::ptree& tree) {
   }
   return Status(0, "OK");
 }
-}
+} // namespace osquery


### PR DESCRIPTION
This addresses #3268 by ensuring that the initial checks of `isChildSane` for launching extensions _fails_, which ensures that the extension processes are launched on the first iteration through our `WatcherRunner::start` loop.