### PR TITLE
Allow querying Windows Registry by 'path' column

### DIFF
--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -442,8 +442,7 @@ QueryData genRegistry(QueryContext& context) {
         context.hasConstraint("path", LIKE))) {
     // We default to display all HIVEs
     expandRegistryGlobs(kSQLGlobWildcard, keys);
-  }
-  else {
+  } else {
     if (context.hasConstraint("key", EQUALS)) {
       keys = context.constraints["key"].getAll(EQUALS);
     }
@@ -463,7 +462,7 @@ QueryData genRegistry(QueryContext& context) {
     if (context.hasConstraint("path", LIKE)) {
       for (const auto& path : context.constraints["path"].getAll(LIKE)) {
         auto status = expandRegistryGlobs(
-          path.substr(0, path.find_last_of(kRegSep)), keys);
+            path.substr(0, path.find_last_of(kRegSep)), keys);
         if (!status.ok()) {
           LOG(INFO) << "Failed to expand globs: " + status.getMessage();
         }
@@ -471,12 +470,12 @@ QueryData genRegistry(QueryContext& context) {
     }
   }
 
-    maybeWarnLocalUsers(keys);
+  maybeWarnLocalUsers(keys);
 
-    for (const auto& key : keys) {
-      queryKey(key, results);
-    }
-    return results;
+  for (const auto& key : keys) {
+    queryKey(key, results);
   }
+  return results;
+}
 } // namespace tables
-} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -89,14 +89,23 @@ TEST_F(RegistryTablesTest, test_explode_registry_path_just_hive) {
 
 TEST_F(RegistryTablesTest, test_basic_registry_globbing) {
   auto testKey = kTestKey + "\\Micro%\\%";
-  SQL results("select * from registry where key like \"" + testKey + "\"");
-  EXPECT_TRUE(results.rows().size() > 1);
+  SQL keyResults("select * from registry where key like \"" + testKey + "\"");
+  SQL pathResults("select * from registry where path like \"" + testKey + "\"");
+  EXPECT_TRUE(keyResults.rows().size() > 1);
+  EXPECT_TRUE(pathResults.rows().size() > 1);
   std::for_each(
-      results.rows().begin(), results.rows().end(), [&](const auto& row) {
+      keyResults.rows().begin(), keyResults.rows().end(), [&](const auto& row) {
         auto key = row.at("key");
         EXPECT_TRUE(boost::starts_with(key, kTestKey + "\\Micro"));
         EXPECT_TRUE(std::count(key.begin(), key.end(), '\\') == 3);
       });
+  std::for_each(pathResults.rows().begin(),
+                pathResults.rows().end(),
+                [&](const auto& row) {
+                  auto key = row.at("path");
+                  EXPECT_TRUE(boost::starts_with(key, kTestKey + "\\Micro"));
+                  EXPECT_TRUE(std::count(key.begin(), key.end(), '\\') == 3);
+                });
 }
 
 TEST_F(RegistryTablesTest, test_recursive_registry_globbing) {
@@ -129,5 +138,5 @@ TEST_F(RegistryTablesTest, test_get_username_from_key) {
     EXPECT_FALSE(status.ok());
   }
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -11,4 +11,6 @@ schema([
 implementation("system/windows/registry@genRegistry")
 examples([
   "select * from registry",
+  "select * from registry where key like 'HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run%'",
+  "select * from registry where path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run'",
 ])

--- a/specs/windows/registry.table
+++ b/specs/windows/registry.table
@@ -1,8 +1,8 @@
 table_name("registry")
 description("All of the Windows registry hives.")
 schema([
-    Column("key", TEXT, "Name of the key to search for", additional=True, index=True),
-    Column("path", TEXT, "Full path to the value"),
+    Column("key", TEXT, "Name of the key to search for", additional=True),
+    Column("path", TEXT, "Full path to the value", index=True),
     Column("name", TEXT, "Name of the registry value entry"),
     Column("type", TEXT, "Type of the registry value, or 'subkey' if item is a subkey"),
     Column("data", TEXT, "Data content of registry value"),


### PR DESCRIPTION
'path' is a standard column we use around the codebase, and up until now we could not query the registry using it. This adds support to query a registry value by a full path, not simply just a key. 

It does this somewhat naively, by stripping off the final token of a registry query (in case it's a value and not a subkey), querying the subkey in the registry, then letting SQL do the rest. It's a little inefficient but I couldn't think of a clean way to verify that the path refers to a value vs a subkey without actually querying the registry and checking, which I'm doing in this case anyway.

I've also made path the new primary key for the registry table, since it is actually a unique identifier for each result, and will fix some weirdness we were seeing with OR clauses on the table.

Fixes #3145 