### PR TITLE
FreeBSD: Fix os_version, add pkgng package table

### DIFF
--- a/osquery/tables/system/freebsd/os_version.cpp
+++ b/osquery/tables/system/freebsd/os_version.cpp
@@ -10,66 +10,55 @@
 
 #include <unistd.h>
 
-#include <boost/algorithm/string.hpp>
+#include <map>
+#include <string>
 
+#include <boost/algorithm/string/find.hpp>
+#include <boost/regex.hpp>
+#include <boost/xpressive/xpressive.hpp>
+
+#include <osquery/core/conversions.h>
 #include <osquery/filesystem.h>
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
+namespace xp = boost::xpressive;
+
 namespace osquery {
 namespace tables {
 
 QueryData genOSVersion(QueryContext& context) {
+  static const std::string kSysctlName = "kern.osrelease";
+
+  auto result =
+      SQL::selectAllFrom("system_controls", "name", EQUALS, kSysctlName);
+
   Row r;
 
-  r["major"] = "10";
-  r["minor"] = "2";
-  r["patch"] = "";
-  r["name"] = "";
-  r["build"] = "RELEASE";
+  r["name"] = "FreeBSD";
+
+  // TODO: Patchlevel isn't matched for some reason
+  auto rx = xp::sregex::compile(
+      "(?P<major>[0-9]+)\\.(?P<minor>[0-9]+)-(?P<build>\\w+)-?(?P<patch>\\w+)"
+      "?");
+
+  xp::smatch matches;
+  for (auto& line : osquery::split(result[0]["current_value"], "\n")) {
+    if (xp::regex_search(line, matches, rx)) {
+      r["major"] = INTEGER(matches["major"]);
+      r["minor"] = INTEGER(matches["minor"]);
+      r["build"] = matches["build"];
+      r["patch"] = matches["patch"];
+      break;
+    }
+  }
+
   return {r};
 }
 
 QueryData genSystemInfo(QueryContext& context) {
-  Row r;
-  r["hostname"] = osquery::getHostname();
-  r["computer_name"] = r["hostname"];
-
-  std::string uuid;
-  r["uuid"] = (osquery::getHostUUID(uuid)) ? uuid : "";
-
-  auto qd = SQL::selectAllFrom("cpuid");
-  for (const auto& row : qd) {
-    if (row.at("feature") == "product_name") {
-      r["cpu_brand"] = row.at("value");
-      boost::trim(r["cpu_brand"]);
-    }
-  }
-
-  // Can parse /proc/cpuinfo or /proc/meminfo for this data.
-  static long cores = sysconf(_SC_NPROCESSORS_CONF);
-  if (cores > 0) {
-    r["cpu_logical_cores"] = INTEGER(cores);
-    r["cpu_physical_cores"] = INTEGER(cores);
-  } else {
-    r["cpu_logical_cores"] = "-1";
-    r["cpu_physical_cores"] = "-1";
-  }
-
-  static long pages = sysconf(_SC_PHYS_PAGES);
-  static long pagesize = sysconf(_SC_PAGESIZE);
-
-  if (pages > 0 && pagesize > 0) {
-    r["physical_memory"] = BIGINT((long long)pages * (long long)pagesize);
-  } else {
-    r["physical_memory"] = "-1";
-  }
-
-  r["cpu_type"] = "0";
-  r["cpu_subtype"] = "0";
-
-  return {r};
+  return QueryData();
 }
 
 QueryData genPlatformInfo(QueryContext& context) {

--- a/osquery/tables/system/freebsd/pkg_packages.cpp
+++ b/osquery/tables/system/freebsd/pkg_packages.cpp
@@ -37,6 +37,9 @@ void genPkgRow(sqlite3_stmt* stmt, Row& r) {
       if (value != nullptr) {
         r[column_name] = std::string((const char*)value);
       }
+    } else if (column_type == SQLITE_INTEGER) {
+      auto value = sqlite3_column_int(stmt, i);
+      r[column_name] = INTEGER(value);
     }
   }
 }

--- a/osquery/tables/system/freebsd/pkg_packages.cpp
+++ b/osquery/tables/system/freebsd/pkg_packages.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/sql/sqlite_util.h"
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+const std::string kPkgDb = "/var/db/pkg/local.sqlite";
+
+void genPkgRow(sqlite3_stmt* stmt, Row& r) {
+  for (int i = 0; i < sqlite3_column_count(stmt); i++) {
+    auto column_name = std::string(sqlite3_column_name(stmt, i));
+    auto column_type = sqlite3_column_type(stmt, i);
+    if (column_type == SQLITE_TEXT) {
+      auto value = sqlite3_column_text(stmt, i);
+      if (value != nullptr) {
+        r[column_name] = std::string((const char*)value);
+      }
+    }
+  }
+}
+
+QueryData genPkgPackages(QueryContext& context) {
+  QueryData results;
+
+  sqlite3* db = nullptr;
+
+  auto rc = sqlite3_open_v2(
+      kPkgDb.c_str(),
+      &db,
+      (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
+      nullptr);
+  if (rc != SQLITE_OK || db == nullptr) {
+    VLOG(1) << "Cannot open pkgdb: " << rc << " "
+            << getStringForSQLiteReturnCode(rc);
+    if (db != nullptr) {
+      free(db);
+    }
+  }
+
+  std::string query = "SELECT name, version, flatsize, arch FROM packages;";
+  sqlite3_stmt* stmt = nullptr;
+  rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+  while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
+    Row r;
+
+    genPkgRow(stmt, r);
+
+    results.push_back(r);
+  }
+
+  // Clean up.
+  sqlite3_finalize(stmt);
+  free(db);
+
+  return results;
+}
+}
+}

--- a/specs/freebsd/pkg_packages.table
+++ b/specs/freebsd/pkg_packages.table
@@ -1,0 +1,10 @@
+table_name("pkg_packages")
+description("pkgng packages that are currently installed on the host system.")
+schema([
+    Column("name", TEXT, "Package name"),
+    Column("version", TEXT, "Package version"),
+    Column("flatsize", BIGINT, "Package size in bytes"),
+    Column("arch", TEXT, "Architecture(s) supported"),
+])
+attributes(cacheable=True)
+implementation("@genPkgPackages")


### PR DESCRIPTION
* Basic os_version functionality using results read from system_controls.

* Table for installed pkgng packages, read from the SQLite database because libpkg isn't guaranteed to be available.