### PR TITLE
darwin: Fix FreeBSD genapi, ASL warnings

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -362,12 +362,14 @@ Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
 }
 
 QueryData WatcherRunner::getProcessRow(pid_t pid) const {
+#ifdef WIN32
+  pid = (pid == ULONG_MAX) ? -1 : pid;
+#endif
+
   // On Windows, pid_t = DWORD, which is unsigned. However invalidity
   // of processes is denoted by a pid_t of -1. We check for this
   // by comparing the max value of DWORD, or ULONG_MAX
-  int p =
-      (isPlatform(PlatformType::TYPE_WINDOWS) && pid == ULONG_MAX) ? -1 : pid;
-  return SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(p));
+  return SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(pid));
 }
 
 Status WatcherRunner::isChildSane(const PlatformProcess& child) const {

--- a/osquery/tables/system/darwin/asl.cpp
+++ b/osquery/tables/system/darwin/asl.cpp
@@ -13,7 +13,11 @@
 namespace osquery {
 namespace tables {
 
-QueryData genAsl(QueryContext &context) {
+// macOS ASL is deprecated in 10.12
+_Pragma("clang diagnostic push");
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"");
+
+QueryData genAsl(QueryContext& context) {
   QueryData results;
 
   aslmsg query = createAslQuery(context);
@@ -30,5 +34,7 @@ QueryData genAsl(QueryContext &context) {
 
   return results;
 }
+
+_Pragma("clang diagnostic pop");
 }
 }

--- a/osquery/tables/system/darwin/asl_utils.cpp
+++ b/osquery/tables/system/darwin/asl_utils.cpp
@@ -23,34 +23,46 @@ namespace tables {
  * @brief Map osquery ConstraintOperator to the corresponding ASL op code
  */
 const std::map<ConstraintOperator, uint32_t> kSupportedAslOps = {
-  {EQUALS, ASL_QUERY_OP_EQUAL},
-  {GREATER_THAN, ASL_QUERY_OP_GREATER},
-  {GREATER_THAN_OR_EQUALS, ASL_QUERY_OP_GREATER_EQUAL},
-  {LESS_THAN, ASL_QUERY_OP_LESS},
-  {LESS_THAN_OR_EQUALS, ASL_QUERY_OP_LESS_EQUAL},
-  {LIKE, ASL_QUERY_OP_EQUAL | ASL_QUERY_OP_REGEX | ASL_QUERY_OP_CASEFOLD}};
+    {EQUALS, ASL_QUERY_OP_EQUAL},
+    {GREATER_THAN, ASL_QUERY_OP_GREATER},
+    {GREATER_THAN_OR_EQUALS, ASL_QUERY_OP_GREATER_EQUAL},
+    {LESS_THAN, ASL_QUERY_OP_LESS},
+    {LESS_THAN_OR_EQUALS, ASL_QUERY_OP_LESS_EQUAL},
+    {LIKE, ASL_QUERY_OP_EQUAL | ASL_QUERY_OP_REGEX | ASL_QUERY_OP_CASEFOLD}};
 
 /**
  * @brief Map ASL keys to the corresponding osquery column name
  */
 const std::map<std::string, std::string> kAslKeyToColumnMap = {
-    {"Time", "time"},         {"TimeNanoSec", "time_nano_sec"},
-    {"Host", "host"},         {"Sender", "sender"},
-    {"Facility", "facility"}, {"PID", "pid"},
-    {"UID", "uid"},           {"GID", "gid"},
-    {"Level", "level"},       {"Message", "message"},
-    {"RefPID", "ref_pid"},    {"RefProc", "ref_proc"}};
+    {"Time", "time"},
+    {"TimeNanoSec", "time_nano_sec"},
+    {"Host", "host"},
+    {"Sender", "sender"},
+    {"Facility", "facility"},
+    {"PID", "pid"},
+    {"UID", "uid"},
+    {"GID", "gid"},
+    {"Level", "level"},
+    {"Message", "message"},
+    {"RefPID", "ref_pid"},
+    {"RefProc", "ref_proc"}};
 
 /**
  * @brief Map osquery column names to the corresponding ASL keys
  */
 const std::map<std::string, std::string> kColumnToAslKeyMap = {
-    {"time", "Time"},         {"time_nano_sec", "TimeNanoSec"},
-    {"host", "Host"},         {"sender", "Sender"},
-    {"facility", "Facility"}, {"pid", "PID"},
-    {"uid", "UID"},           {"gid", "GID"},
-    {"level", "Level"},       {"message", "Message"},
-    {"ref_pid", "RefPID"},    {"ref_proc", "RefProc"}};
+    {"time", "Time"},
+    {"time_nano_sec", "TimeNanoSec"},
+    {"host", "Host"},
+    {"sender", "Sender"},
+    {"facility", "Facility"},
+    {"pid", "PID"},
+    {"uid", "UID"},
+    {"gid", "GID"},
+    {"level", "Level"},
+    {"message", "Message"},
+    {"ref_pid", "RefPID"},
+    {"ref_proc", "RefProc"}};
 
 /**
  * @brief Column name for the extra column.
@@ -75,6 +87,10 @@ static inline bool isNumeric(ColumnType coltype) {
     return false;
   }
 }
+
+// macOS ASL is deprecated in 10.12
+_Pragma("clang diagnostic push");
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"");
 
 void addQueryOp(aslmsg& query,
                 const std::string& key,
@@ -117,7 +133,11 @@ aslmsg createAslQuery(const QueryContext& context) {
     const std::string& key = it.first;
     ColumnType col_type = it.second.affinity;
     for (const auto& constraint : it.second.getAll()) {
-      addQueryOp(query, key, constraint.expr, static_cast<ConstraintOperator>(constraint.op), col_type);
+      addQueryOp(query,
+                 key,
+                 constraint.expr,
+                 static_cast<ConstraintOperator>(constraint.op),
+                 col_type);
     }
   }
   return query;
@@ -159,5 +179,7 @@ std::string convertLikeRegex(const std::string& like_str) {
   ba::replace_all(res, "_", ".");
   return res;
 }
+
+_Pragma("clang diagnostic pop");
 }
 }

--- a/osquery/tables/system/darwin/tests/asl_tests.cpp
+++ b/osquery/tables/system/darwin/tests/asl_tests.cpp
@@ -29,6 +29,10 @@ namespace tables {
 
 class AslTests : public testing::Test {};
 
+// macOS ASL is deprecated in 10.12
+_Pragma("clang diagnostic push");
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"");
+
 #ifndef OLD_ASL_API
 TEST_F(AslTests, test_add_query_op) {
   aslmsg query = asl_new(ASL_TYPE_QUERY);
@@ -193,5 +197,7 @@ TEST_F(AslTests, test_actual_query) {
   ASSERT_EQ("osquery_test", results.rows()[0].at("sender"));
   ASSERT_EQ("user", results.rows()[0].at("facility"));
 }
+
+_Pragma("clang diagnostic pop");
 }
 }

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -34,9 +34,10 @@ CANONICAL_PLATFORMS = {
     "specs": "All Platforms",
     "darwin": "Darwin (Apple OS X)",
     "linux": "Ubuntu, CentOS",
-    "utility": "Utility",
-    "windows": "Microsoft Windows",
+    "freebsd": "FreeBSD",
     "posix": "POSIX-compatible Plaforms",
+    "windows": "Microsoft Windows",
+    "utility": "Utility",
     "yara": "YARA",
     "lldpd": "LLDPD",
     "sleuthkit": "The Sleuth Kit"


### PR DESCRIPTION
There are three things fixed here:
- There's a warning on Linux/Darwin about comparing signed/unsigned in `WatcherRunner::getProcessRow`.
- All of the macOS ASL APIs are deprecated.
- `freebsd` is not in the `genapi.py` list of platforms.