### PR TITLE
build: Improve SO linking on Linux

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -264,12 +264,7 @@ macro(ADD_OSQUERY_MODULE TARGET)
     # This could implement a similar LINK_MODULE for gcc, libc, and libstdc++.
     # However it is only provided as an example for unit testing.
     target_link_libraries(${TARGET} "-static-libstdc++")
-    target_link_libraries(${TARGET} "-L${BUILD_DEPS}/legacy/lib")
-  endif()
-  if((LINUX OR APPLE) AND CMAKE_CXX_COMPILER MATCHES "clang")
-    #enable LTO builds of modules when building with clang on Unix
-    target_link_libraries(${TARGET} "-flto=thin")
-    if(LINUX)
+    if(CMAKE_CXX_COMPILER MATCHES "clang")
       target_link_libraries(${TARGET} "-fuse-ld=lld")
     endif()
   endif()

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
 endif
 
 PATH_SET := PATH="$(DEPS_DIR)/bin:/usr/local/bin:$(PATH)"
-CMAKE := $(PATH_SET) CXXFLAGS="-L$(DEPS_DIR)/lib" cmake ../../
+CMAKE := $(PATH_SET) CXXFLAGS="-L$(DEPS_DIR)/legacy/lib -L$(DEPS_DIR)/lib" cmake ../../
 CTEST := $(PATH_SET) ctest ../../
 FORMAT_COMMAND := python tools/formatting/git-clang-format.py \
 	"--commit" "master" "-f" "--style=file"


### PR DESCRIPTION
There was a bit of disorganization about providing linking arguments for shared objects. It looks odd by the safest way to assure the correct ABI linking with the embedded build is by providing the link search paths as compiler flags. This should only effect the output shared modules, which are tested with `./tools/tests/test_modules.py`.