### PR TITLE
packages: Fix packman/bsdtar library path

### DIFF
--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -1,22 +1,24 @@
 # Generate the thrift intermediate/interface code.
+set(THRIFT_COMPILE_COMMAND "")
 if(LINUX OR DARWIN)
-  add_custom_command(
-    COMMAND
-      LD_LIBRARY_PATH=${BUILD_DEPS}/lib:$ENV{LD_LIBRARY_PATH}
-      ${THRIFT_COMPILER} --gen cpp --gen py "${CMAKE_SOURCE_DIR}/osquery.thrift"
-    DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
-    OUTPUT ${OSQUERY_THRIFT_GENERATED_FILES}
-  )
-else()
-  add_custom_command(
-    COMMAND
-      ${THRIFT_COMPILER} --gen cpp --gen py "${CMAKE_SOURCE_DIR}/osquery.thrift"
-    DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
-    OUTPUT ${OSQUERY_THRIFT_GENERATED_FILES}
+  list(APPEND THRIFT_COMPILE_COMMAND
+    "LD_LIBRARY_PATH=${BUILD_DEPS}/lib:$ENV{LD_LIBRARY_PATH}"
   )
 endif()
+
+list(APPEND THRIFT_COMPILE_COMMAND
+  ${THRIFT_COMPILER}
+  --gen cpp
+  --gen py
+  "${CMAKE_SOURCE_DIR}/osquery.thrift"
+)
+
+add_custom_command(
+  COMMAND ${THRIFT_COMPILE_COMMAND}
+  DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
+  OUTPUT ${OSQUERY_THRIFT_GENERATED_FILES}
+)
 
 if(NOT WINDOWS)
   add_compile_options(

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -14,6 +14,7 @@ SOURCE_DIR="$SCRIPT_DIR/../.."
 BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build/linux"}
 
 export PATH="/usr/local/osquery/bin:/usr/local/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/local/osquery/lib:${LD_LIBRARY_PATH}"
 source "$SOURCE_DIR/tools/lib.sh"
 
 PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`


### PR DESCRIPTION
This sets the library search path for `bsdtar`, which needs LZMA, when making `packages`.