### PR TITLE
flags: Allow custom flags in configuration

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -270,6 +270,8 @@ If a flag value is specified on the CLI as a switch, or specified in the Gflags 
 
 There are LOTs of CLI flags that CANNOT be set with the `options` key. These flags determine the start and initialization of osquery and configuration loading usually depends on these CLI-only flags. Refer to the `--help` list to determine the appropriateness of options.
 
+It is possible to set "custom" options that do not exist as flags. These will not do anything without adding appropriate code. Options using the prefix `custom_` can be accessed via `osquery::Flag::updateValue("custom_NAME", value)` and `osquery::Flag::getValue("custom_NAME");`.
+
 ### Schedule
 
 The `schedule` key defines a map of scheduled query names to the query details. You will see mention of the schedule throughout osquery's documentation. It is the focal point of osqueryd's capabilities.

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -35,6 +35,8 @@ Include line-delimited switches to be interpreted and used as CLI-flags:
 
 If no `--flagfile` is provided, osquery will try to find and use a "default" flagfile at `/etc/osquery/osquery.flags.default`. Both the shell and daemon will discover and use the defaults.
 
+**Note:** Flags in a `flagfile` should not be wrapped in quotes, shell-macro/variable expansion is not applied!
+
 ### Configuration control flags
 
 `--config_plugin="filesystem"`
@@ -394,7 +396,7 @@ There are several flags that control the shell's output format: `--json`, `--lis
 
 `--planner=false`
 
-When prototyping new queries the planner enables verbose decisions made by the SQLites virtual table API module. This module is implemented by osquery code so it is very helpful to learn what predicate constraints are selected and what full table scans are required for JOINs and nested queries.
+When prototyping new queries the planner enables verbose decisions made by the SQLite virtual table API. This is customized by osquery code so it is very helpful to learn what predicate constraints are selected and what full table scans are required for JOINs and nested queries.
 
 `--header=true`
 

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -340,6 +340,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ViewsConfigParserPluginTests, test_add_view);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_swap_view);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_update_view);
+  FRIEND_TEST(OptionsConfigParserPluginTests, test_unknown_option);
   FRIEND_TEST(EventsConfigParserPluginTests, test_get_event);
   FRIEND_TEST(PacksTests, test_discovery_cache);
   FRIEND_TEST(PacksTests, test_multi_pack);

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -154,6 +154,9 @@ class Flag : private boost::noncopyable {
 
   /// A container for hidden or aliased (legacy, compatibility) flags.
   std::map<std::string, FlagDetail> aliases_;
+
+  /// Configurations may set "custom_" flags.
+  std::map<std::string, std::string> custom_;
 };
 
 /**

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -21,7 +21,9 @@ namespace osquery {
  */
 class OptionsConfigParserPlugin : public ConfigParserPlugin {
  public:
-  std::vector<std::string> keys() const override { return {"options"}; }
+  std::vector<std::string> keys() const override {
+    return {"options"};
+  }
 
   Status setUp() override;
 
@@ -47,9 +49,9 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
       continue;
     }
 
-    if (Flag::getType(option.first).empty()) {
+    bool is_custom = option.first.find("custom_") == 0;
+    if (!is_custom && Flag::getType(option.first).empty()) {
       LOG(WARNING) << "Cannot set unknown or invalid flag: " << option.first;
-      return Status(1, "Unknown flag");
     }
 
     Flag::updateValue(option.first, value);

--- a/osquery/config/parsers/tests/options_tests.cpp
+++ b/osquery/config/parsers/tests/options_tests.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include <osquery/config.h>
+#include <osquery/flags.h>
 #include <osquery/registry.h>
 
 #include "osquery/tests/test_util.h"
@@ -29,5 +30,32 @@ TEST_F(OptionsConfigParserPluginTests, test_get_option) {
                 "enable_monitor"),
             true);
   c.reset();
+}
+
+TEST_F(OptionsConfigParserPluginTests, test_unknown_option) {
+  Config c;
+  std::map<std::string, std::string> update;
+
+  update["awesome"] =
+      "{\"options\": {\"fake\": 1, \"custom_fake\": 1, \"fake_custom_fake\": "
+      "1}}";
+  auto s = c.update(update);
+
+  // This looks funky, because the parser is named 'options' and it claims
+  // ownership of a single top-level-key called 'options'.
+  auto options = c.getParser("options")->getData().get_child("options");
+
+  // Since 'fake' was not defined as a flag, it is not an option.
+  EXPECT_EQ(1U, options.count("fake"));
+  EXPECT_TRUE(Flag::getValue("fake").empty());
+
+  // The word 'custom_' must be a prefix.
+  EXPECT_EQ(1U, options.count("fake_custom_fake"));
+  EXPECT_TRUE(Flag::getValue("fake_custom_fake").empty());
+
+  // This should work.
+  EXPECT_EQ(1U, options.count("custom_fake"));
+  EXPECT_EQ(1U, options.get<size_t>("custom_fake", 0U));
+  EXPECT_FALSE(Flag::getValue("custom_fake").empty());
 }
 }


### PR DESCRIPTION
This allows a configuration to set "custom" flags.

The `options` top-level JSON key sets a dictionary of key-value flags for osquery. If these contain `custom_` as the absolute prefix, they are stored as a flag accessible via `Flag::getValue("custom_NAME");` (see included unit tests). Unlike normal flags, they do not have to be created at compile time.