### PR TITLE
docs: Adding a note regarding osquery scheduler behavior

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -76,6 +76,13 @@ stored in RocksDB. On subsequent runs, only result-set-difference (changes) are 
 Scheduled queries can also set: `"removed":false` and `"snapshot":true`. See
 the next section on [logging](../deployment/logging.md), and the below configuration specification to learn how query options affect the output.
 
+**Note** that the `interval` time in seconds is how many seconds the _daemon_
+itself has been running before the scheduled query will be executed. If the
+system is suspended or put to sleep the progression of time "freezes" and
+resumes when the system comes back online. For example a scheduled query with
+an interval of `84600`, or 24 hours, running on a laptop system could take
+a few days before the query executes if the system is suspended at night.
+
 ## Query Packs
 
 Configuration supports sets, called packs, of queries that help define your


### PR DESCRIPTION
~~Currently the scheduler gets the time once during Initialization, and then executes scheduled queries based off of this initially obtained time. This diff updates that time if it ever happens to drift more than 60 seconds off of the real actual time, and further stores the last time of execution per scheduled query. This behavior should ensure that the sleeping/closing of laptops or system machines doesn't impeded the scheduler from executing queries as close to the time schedule as possible. Below is an example of the new behavior:~~
```
I0522 18:00:45.549796 262725632 scheduler.cpp:74] Executing scheduled query test_query_1: select * from processes;
I0522 18:00:45.549782 262189056 events.cpp:748] Starting event publisher run loop: iokit
I0522 18:00:45.653583 262725632 scheduler.cpp:74] Executing scheduled query test_query_2: select * from chrome_extensions;
I0522 18:12:11.111038 262725632 scheduler.cpp:74] Executing scheduled query test_query_1: select * from processes;
I0522 18:12:11.208741 262725632 scheduler.cpp:74] Executing scheduled query test_query_2: select * from chrome_extensions;
```
~~To generate this test case, I fired up `osqueryd` with two test scheduled queries, one with an interval of 5 minutes and the other with 10 minutes. I then closed my laptop immediately after their execeution and waited for roughly 10 minutes to pass. Upon opening my laptop we now see the queries both immediately executing to make up for the missed scheduled query time.~~