### PR TITLE
Fix an reading past the end of buffer

### DIFF
--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -347,7 +347,7 @@ TEST_F(FileOpsTests, test_large_read_write) {
     EXPECT_TRUE(fd.isValid());
     auto read_len = fd.read(buffer.data(), expected_len);
     EXPECT_EQ(expected_len, read_len);
-    EXPECT_EQ(expected, std::string(buffer.data()));
+    EXPECT_EQ(expected, std::string(buffer.data(), buffer.size())); 
   }
 }
 


### PR DESCRIPTION
ASAN caught in a test we were reading past the end of buffer. Add the size to fix and make the tests happy when running through ASAN.