### PR TITLE
Fix crash caused by boost's unhandled exception

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -124,7 +124,11 @@ Status readFile(const fs::path& path,
   if (dry_run) {
     // The caller is only interested in performing file read checks.
     boost::system::error_code ec;
-    return Status(0, fs::canonical(path, ec).string());
+    try {
+      return Status(0, fs::canonical(path, ec).string());
+    } catch (const boost::filesystem::filesystem_error& err) {
+      return Status(1, err.what());
+    }
   }
 
   PlatformTime times;


### PR DESCRIPTION
zwass caught that boost has a bug where it throws an exception when we aren't expecting it to. This catches that error and prevent osquery from crashing. It does not address what might be a logic bug in osquery dropping privileges before trying to read the plist. @theopolis can you weigh in on this?

Fix #3279 