### PR TITLE
deps: Rebuild the world with RPATH

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -19,15 +19,15 @@ LINUXBREW_REPO="https://github.com/Linuxbrew/brew"
 
 # Set the SHA1 commit hashes for the pinned homebrew Taps.
 # Pinning allows determinism for bottle availability, expect to update often.
-HOMEBREW_CORE="0e6f293450cf9b54e324e92ea0b0475fd4e0d929"
+HOMEBREW_CORE="4e686a0a2a23d4075077eed5a1250fc020ab1864"
 LINUXBREW_CORE="501c656e81770ff64f12131a20535795e9229e44"
-HOMEBREW_DUPES="00df450f28f23aa1013564889d11440ab80b36a5"
+HOMEBREW_DUPES="9930b3257ac245c5e23f8db8b7f653169ec05bfa"
 LINUXBREW_DUPES="c0012f1a2f8ef3bce5a623cc3f75ab79110bbc9b"
-HOMEBREW_BREW="2be7999878702554f1e1b5f4118978e670e6156c"
+HOMEBREW_BREW="ea8be174f6009bc9bdec67b13ca501b5b83fc4b8"
 LINUXBREW_BREW="1d16368a177807663e1b3146d71fcd69e2061e27"
 
 # If the world needs to be rebuilt, increase the version
-DEPS_VERSION="3"
+DEPS_VERSION="4"
 
 source "$SCRIPT_DIR/lib.sh"
 source "$SCRIPT_DIR/provision/lib.sh"
@@ -48,7 +48,6 @@ function platform_linux_main() {
   brew_tool osquery/osquery-local/glibc
 
   # Build a bottle for a legacy glibc.
-  brew_clean osquery/osquery-local/curl
   brew_tool osquery/osquery-local/glibc-legacy
   brew_tool osquery/osquery-local/zlib-legacy
 
@@ -72,7 +71,6 @@ function platform_linux_main() {
 
   # OpenSSL is needed for the final build.
   brew_tool osquery/osquery-local/libxml2
-  brew_clean osquery/osquery-local/curl
   brew_tool osquery/osquery-local/openssl
 
   # Curl and Python are needed for LLVM mostly.
@@ -297,7 +295,7 @@ function main() {
   if [[ $OS = "freebsd" ]]; then
     PIP="sudo $PIP"
   fi
-  $PIP install -I -r requirements.txt
+  $PIP install --no-cache-dir -I -r requirements.txt
 
   log "running auxiliary initialization"
   initialize $OS

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -130,37 +130,29 @@ class AbstractOsqueryFormula < Formula
       end
 
       # Adding this one line to help gcc too.
-      if !["openssl"].include?(self.name) # JUST REMOVED
+      if !["openssl"].include?(self.name)
         append "LDFLAGS", "-L#{default_prefix}/lib"
         # We want the legacy path to be the last thing prepended.
         prepend "LDFLAGS", "-L#{legacy_prefix}/lib" if OS.linux?
-      end # JUST REMOVED
-
-      if OS.linux?
-        # Only Linux uses the Legacy prefix concept for glibc/zlib.
-        prepend "CFLAGS", "-L#{legacy_prefix}/lib" if OS.linux?
-        prepend "CXXFLAGS", "-I#{legacy_prefix}/include" if OS.linux?
-
-        # This used to be in the GCC/not-GCC logic, pulling out to compile GCC
-        # Using the system compilers with legacy runtime.
-        prepend "CFLAGS", "-isystem#{legacy_prefix}/include" if OS.linux?
-        prepend "CXXFLAGS", "-isystem#{legacy_prefix}/include" if OS.linux?
-
-        if !["util-linux"].include?(self.name) and ENV["CC"].to_s.include?("gcc")
-          append "LDFLAGS", "-Wl,--dynamic-linker=#{legacy_prefix}/lib/ld-linux-x86-64.so.2"
-          append "LDFLAGS", "-Wl,-rpath,#{legacy_prefix}/lib"
-          append "LDFLAGS", "-Wl,-rpath,#{default_prefix}/lib"
-        end
-
-        prepend_path "LIBRARY_PATH", legacy_prefix/"lib" if OS.linux?
-        append "LDFLAGS", "-lrt -lpthread -ldl" if OS.linux?
       end
+
+      # Only Linux uses the Legacy prefix concept for glibc/zlib.
+      prepend "CFLAGS", "-L#{legacy_prefix}/lib" if OS.linux?
+      prepend "CXXFLAGS", "-I#{legacy_prefix}/include" if OS.linux?
+
+      # This used to be in the GCC/not-GCC logic, pulling out to compile GCC
+      # Using the system compilers with legacy runtime.
+      prepend "CFLAGS", "-isystem#{legacy_prefix}/include" if OS.linux?
+      prepend "CXXFLAGS", "-isystem#{legacy_prefix}/include" if OS.linux?
+
+      prepend_path "LIBRARY_PATH", legacy_prefix/"lib" if OS.linux?
+
+      append "LDFLAGS", "-Wl,-rpath,#{default_prefix}/lib"
+      append "LDFLAGS", "-lrt -lpthread -ldl -lz" if OS.linux?
     end
 
-    if !OS.linux?
-      prepend_path "PATH", default_prefix/"bin"
-      prepend_path "PYTHONPATH", default_prefix/"lib/python2.7/site-packages"
-    end
+    prepend_path "PATH", default_prefix/"bin" if OS.mac?
+    prepend_path "PYTHONPATH", default_prefix/"lib/python2.7/site-packages" if OS.mac?
 
     # Everyone receives:
     append "CFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
@@ -174,7 +166,6 @@ class AbstractOsqueryFormula < Formula
 
       append "LDFLAGS", "-fuse-ld=lld" if OS.linux?
     end
-
 
     prepend_path "PKG_CONFIG_PATH", legacy_prefix/"lib/pkgconfig"
 

--- a/tools/provision/formula/asio.rb
+++ b/tools/provision/formula/asio.rb
@@ -7,13 +7,13 @@ class Asio < AbstractOsqueryFormula
   sha256 "fc475c6b737ad92b944babdc3e5dcf5837b663f54ba64055dc3d8fc4a3061372"
   head "https://github.com/chriskohlhoff/asio.git"
   version "1.10.8"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "cadcd03c335aa18e34f23cd7b0359c3086a048eb23abe3fc0ebbafc159764317" => :sierra
-    sha256 "eca07734acb0c03f8c717fe69e0eaf4e41b0f18be36e6300c2a0d7a73e78f6dd" => :x86_64_linux
+    sha256 "42d8a4f8c368cee3da90b9e0e0fca6e80833f2805e7aa208f8702a559b53323c" => :sierra
+    sha256 "05cb875e46c9b6be1d08597545ae57be181b3053207ef68dd4346fd460e670e7" => :x86_64_linux
   end
 
   needs :cxx11

--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -6,13 +6,13 @@ class Augeas < AbstractOsqueryFormula
   url "https://github.com/hercules-team/augeas.git",
     :revision => "f66a71dc22c0536853bb99585a4bf605018ba6db"
   version "1.8.0"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "0bfaf7c363918ef87f9c0fbfa2e5a348852fdfacdffd9d4d58f5192c8dffb485" => :sierra
-    sha256 "2d3bb6da8124202eddab30ffeeab36b25fdab5a6763b08a0a1c11da5a686d81f" => :x86_64_linux
+    sha256 "e0ded880bc60bbb596f107bf2a9eb36cc38e0e2b7471eb7ef655e30173f0e893" => :sierra
+    sha256 "dd74833c500244a44d11b78a282b9ad97fb282a5c04044fa296da5a80dd1525c" => :x86_64_linux
   end
 
   # The autoconfigure requests readline.

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -5,13 +5,13 @@ class AwsSdkCpp < AbstractOsqueryFormula
   homepage "https://github.com/aws/aws-sdk-cpp"
   url "https://github.com/aws/aws-sdk-cpp/archive/1.0.107.tar.gz"
   sha256 "0560918ef2a4b660e49981378af42d999b91482a31e720be2d9c427f21ac8ad0"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "9a95d4a25ef8e355af1b84eb5b4b798b9889cfe1a17811c774f1ec3b43cca5fe" => :sierra
-    sha256 "215135c775dc386c8ba52198587c7303b113710ae4b965c32332b98e3387c870" => :x86_64_linux
+    sha256 "ab2ad08c23fd765b02f1e961389b250f60e022e8d5ce94e822a998887e27286c" => :sierra
+    sha256 "0b2995f4546df02bcbebb8ea47f2cc276ecd1bcb0cb60787be02ff9a2748734b" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/beecrypt.rb
+++ b/tools/provision/formula/beecrypt.rb
@@ -5,12 +5,12 @@ class Beecrypt < AbstractOsqueryFormula
   homepage "http://beecrypt.sourceforge.net"
   url "https://downloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
   sha256 "286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "e136da012489c08903644f0654c93872cab3914468bebc2642f45cde66b09920" => :x86_64_linux
+    sha256 "20f9a37cd35bc4adf05f0e68bd5c430b3c010903cdc05f50bfc89d9216e9a797" => :x86_64_linux
   end
 
   depends_on "libtool" => :build
@@ -26,6 +26,8 @@ class Beecrypt < AbstractOsqueryFormula
       "--without-python",
       "--without-cplusplus",
       "--with-arch=x86_64",
+      "--disable-shared",
+      "--enable-static"
     ]
 
     system "./autogen.sh"

--- a/tools/provision/formula/berkeley-db.rb
+++ b/tools/provision/formula/berkeley-db.rb
@@ -5,12 +5,12 @@ class BerkeleyDb < AbstractOsqueryFormula
   homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
   url "http://download.oracle.com/berkeley-db/db-6.1.26.tar.gz"
   sha256 "dd1417af5443f326ee3998e40986c3c60e2a7cfb5bfa25177ef7cadb2afb13a6"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b402268eb6aee48c1c25385ca1152e226ec811936fd451400f4de3cdf1da27f0" => :x86_64_linux
+    sha256 "918bc7f64a50a3f8a397739e0476f801ef1fa8d734e9a1045975f1c75099c2b9" => :x86_64_linux
   end
 
   option "with-java", "Compile with Java support."
@@ -29,6 +29,8 @@ class BerkeleyDb < AbstractOsqueryFormula
       --mandir=#{man}
       --enable-cxx
       --enable-compat185
+      --disable-shared
+      --enable-static
     ]
     args << "--enable-java" if build.with? "java"
     args << "--enable-sql" if build.with? "sql"

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -6,13 +6,13 @@ class Boost < AbstractOsqueryFormula
   url "https://downloads.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2"
   sha256 "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0"
   head "https://github.com/boostorg/boost.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "020e6555fc57668533e8f5f2105bc70622eb6df121fd08968ee02ce55bb64d61" => :sierra
-    sha256 "6a5c696f4dc9739f3e511434a4c742c934e35811181c9d3a598f4d4ce27e1c12" => :x86_64_linux
+    sha256 "4c0c142976220ce6c5aafe451e5a92905e68468ab0bfd937c1396aa200efea40" => :sierra
+    sha256 "cbf4d81d465ab3453f9e0bb1d13babf74cf1a625782a5d1e4629a65864df42e0" => :x86_64_linux
   end
 
   env :userpaths

--- a/tools/provision/formula/bzip2.rb
+++ b/tools/provision/formula/bzip2.rb
@@ -5,12 +5,12 @@ class Bzip2 < AbstractOsqueryFormula
   homepage "http://www.bzip.org/"
   url "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
   sha256 "a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "414ad26300c70af4b99b9e09be497689e09fc5cc93f546bb6ae04ab780be6886" => :x86_64_linux
+    sha256 "9058d838c3cd7cb3e8e3dd978849b87bc6f9013c13b34e08d0875c2b3e68ce02" => :x86_64_linux
   end
 
   keg_only :provided_by_osx

--- a/tools/provision/formula/ccache.rb
+++ b/tools/provision/formula/ccache.rb
@@ -5,13 +5,13 @@ class Ccache < AbstractOsqueryFormula
   homepage "https://ccache.samba.org/"
   url "https://www.samba.org/ftp/ccache/ccache-3.3.1.tar.xz"
   sha256 "c6d87a49cc6d7639636d289ed9a5f560bc2acf7ab698fe8ee14e9c9f15ba41c6"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "4450907041a0156aacca7107a12a68302360e1d2b582dfa5daf0c1b2209eb11f" => :sierra
-    sha256 "32989e164299924d7feee3b04cc60f219197345a034ae5f969c0d807c4678b95" => :x86_64_linux
+    sha256 "47a4531aa257f9c6f0918cdd81d871cf6254be3bf72f6f89b1491f64b24aa1ae" => :sierra
+    sha256 "79632ac11d2f48809d9f1a1b5bf5c6698b904f1f0debf34769170a19f039ba79" => :x86_64_linux
   end
 
   head do

--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -5,15 +5,15 @@ class Cmake < AbstractOsqueryFormula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.6/cmake-3.6.1.tar.gz"
   sha256 "28ee98ec40427d41a45673847db7a905b59ce9243bb866eaf59dce0f58aaef11"
-  revision 100
+  revision 101
 
   head "https://cmake.org/cmake.git"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "a672cdd3a43a8917ac0311799384f57a6877ad67c9fed8755a011d1688fafbb2" => :sierra
-    sha256 "d8a743cf235812a0f99f0db59af3deeb856b10e14be194fc6001b9c5883e5022" => :x86_64_linux
+    sha256 "511eb3b6b8ff3381c2af2637ea57ed2034a8035a21c9551ba6163b23a1d24d8e" => :sierra
+    sha256 "b7d652e5b9661321b797e20ad03c7474eea34618235149fc1a01c8c93b0bd61b" => :x86_64_linux
   end
 
   option "without-docs", "Don't build man pages"

--- a/tools/provision/formula/cpp-netlib.rb
+++ b/tools/provision/formula/cpp-netlib.rb
@@ -6,13 +6,13 @@ class CppNetlib < AbstractOsqueryFormula
   url "https://github.com/cpp-netlib/cpp-netlib/archive/cpp-netlib-0.12.0-final.tar.gz"
   version "0.12.0"
   sha256 "d66e264240bf607d51b8d0e743a1fa9d592d96183d27e2abdaf68b0a87e64560"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "e0ece0b7e7dd44295e0d7848bc2f73f5fdd52a2cdf476703acb2f8fc06db9854" => :sierra
-    sha256 "e51c47b4c13d4f5439bdc79aa179befd5f5c2e345b4644bd6b57d32d92dbf1f8" => :x86_64_linux
+    sha256 "e31a4a6c1203918eeefaca7c7fc1cd66a4563ab4527dc594a3b70f8df656fd79" => :sierra
+    sha256 "cc52b85e5ea90bb133d5c06d3e1aece25fa56ee86581f9df7a67764e8355fa9c" => :x86_64_linux
   end
 
   patch :DATA

--- a/tools/provision/formula/cppcheck.rb
+++ b/tools/provision/formula/cppcheck.rb
@@ -6,13 +6,13 @@ class Cppcheck < AbstractOsqueryFormula
   url "https://github.com/danmar/cppcheck/archive/1.75.tar.gz"
   sha256 "d3732dba3fb4dee075009e2422cd9b48bbd095249994ec60550aee43026030e5"
   head "https://github.com/danmar/cppcheck.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b7dc822bd2b697914325e56fae1a5a6bf6d4a3ef38c678e58942f37cd7b5ec46" => :sierra
-    sha256 "46fcfe80187918d6dfdcbd5dfc5fac51b94e26fe8709fdc5b623c2810911defd" => :x86_64_linux
+    sha256 "f2a840d08824c49920678b68dd80b90e8b2fb542cc798c546600aa7e4997b018" => :sierra
+    sha256 "c90661a8669334718bab86d6768933dfed61c1d3f5c1c0fc16bfd679ac6dd7c3" => :x86_64_linux
   end
 
   option "without-rules", "Build without rules (no pcre dependency)"
@@ -24,6 +24,7 @@ class Cppcheck < AbstractOsqueryFormula
     args = []
     args << "-DHAVE_RULES=ON" if build.with? "rules"
 
+    rm_rf "build"
     mkdir "build" do
       args += osquery_cmake_args
       system "cmake", "..", *args

--- a/tools/provision/formula/curl.rb
+++ b/tools/provision/formula/curl.rb
@@ -5,12 +5,12 @@ class Curl < AbstractOsqueryFormula
   homepage "https://curl.haxx.se/"
   url "https://curl.haxx.se/download/curl-7.48.0.tar.bz2"
   sha256 "864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "d587d43bc43ebbcf053705c20fd700e14d0ec2bd8855ce29c2c770cd4622d1b1" => :x86_64_linux
+    sha256 "531eff9d3feb701a403322de8e0b1497e0acecad0356874bb8a7101a9f430048" => :x86_64_linux
   end
 
   keg_only :provided_by_osx

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -6,14 +6,14 @@ class Gcc < AbstractOsqueryFormula
   url "https://ftp.heanet.ie/mirrors/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
   mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
   sha256 "b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db"
-  revision 100
+  revision 101
 
   head "svn://gcc.gnu.org/svn/gcc/trunk"
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "e70c492633709bc1405cb89ad99f55e0228371ba7614bcffa0a13d52555ba66f" => :x86_64_linux
+    sha256 "648bf905127b7984c91bc9a8099d08702545c7630d3de86f8e595cae929c8797" => :x86_64_linux
   end
 
   option "with-java", "Build the gcj compiler"
@@ -106,7 +106,7 @@ class Gcc < AbstractOsqueryFormula
     inreplace "libitm/method-serial.cc", "assert (ok);", "(void) ok;"
 
     ENV.delete "LDFLAGS"
-    ENV.delete "LD_LIBRARY_PATH"
+    # ENV.delete "LD_LIBRARY_PATH"
 
     # osquery: speed up the build by skipping the bootstrap.
     args << "--disable-bootstrap"

--- a/tools/provision/formula/gflags.rb
+++ b/tools/provision/formula/gflags.rb
@@ -5,13 +5,13 @@ class Gflags < AbstractOsqueryFormula
   homepage "https://gflags.github.io/gflags/"
   url "https://github.com/gflags/gflags/archive/v2.2.0.tar.gz"
   sha256 "466c36c6508a451734e4f4d76825cf9cd9b8716d2b70ef36479ae40f08271f88"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "d5528bd0004861e969d6a5097042bc6437dd99c2b86f0176e158e93d218ecd0a" => :sierra
-    sha256 "3791fb55f49adafab0fd15a32060f0dd70609e021a2447f6cd0444406c744929" => :x86_64_linux
+    sha256 "bc53cf0242cec67e7892686ce64b1ce624e2a8b6f6f3ccc6f608b6c9c1d15a54" => :sierra
+    sha256 "1f146fd08755ffdd334f5fe07ba64e703e52aa11e8a3f2faf9ad57897dfbb47c" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/glibc-legacy.rb
+++ b/tools/provision/formula/glibc-legacy.rb
@@ -5,12 +5,12 @@ class GlibcLegacy < AbstractOsqueryFormula
   homepage "https://www.gnu.org/software/libc"
   url "ftp.gnu.org/gnu/glibc/glibc-2.13.tar.bz2"
   sha256 "0173c92a0545e6d99a46a4fbed2da00ba26556f5c6198e2f9f1631ed5318dbb2"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "e0b0abbaab4e0383cb1e93cb1dbeb5d1a0359eed7811bfcb681d9af42490b8da" => :x86_64_linux
+    sha256 "5613d3a040b2fdafd9c3de17aea7cae3291fa13f8b1998d05934ef5135c29735" => :x86_64_linux
   end
 
   # Must apply patches to allow compiling with newer versions of GCC/gmake.

--- a/tools/provision/formula/glibc.rb
+++ b/tools/provision/formula/glibc.rb
@@ -5,12 +5,12 @@ class Glibc < AbstractOsqueryFormula
   homepage "https://www.gnu.org/software/libc"
   url "ftp.gnu.org/gnu/glibc/glibc-2.19.tar.bz2"
   sha256 "2e293f714187044633264cd9ce0183c70c3aa960a2f77812a6390a3822694d15"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "c02f0cca73d38734378435624af77619c6035962309180e6d2fb1ad59038acaf" => :x86_64_linux
+    sha256 "8950b0697219adffa6f33a4e908d3416ade44d2dafb191e0308327568ff2a55c" => :x86_64_linux
   end
 
   # binutils 2.20 or later is required

--- a/tools/provision/formula/glog.rb
+++ b/tools/provision/formula/glog.rb
@@ -5,13 +5,13 @@ class Glog < AbstractOsqueryFormula
   homepage "https://github.com/google/glog"
   url "https://github.com/google/glog/archive/v0.3.4.tar.gz"
   sha256 "ce99d58dce74458f7656a68935d7a0c048fa7b4626566a71b7f4e545920ceb10"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "0188828615cf46f9c05e0ba5464613c9811eeba0486fe21c509ec62cb96bb02d" => :sierra
-    sha256 "448d73a90d5bdf68bf1de09f8848e326383ddbc112d9a2b72c20fa7b32239994" => :x86_64_linux
+    sha256 "020ea9bbbc0437cbe4aae54ace88c7ab0e7961602fd61e51ddd20d3d1e58710a" => :sierra
+    sha256 "b8e1f109493fd0c8ee7deb79da248fd94eca533822c26a6e0bce1c0f69aa9400" => :x86_64_linux
   end
 
   depends_on "gflags"

--- a/tools/provision/formula/google-benchmark.rb
+++ b/tools/provision/formula/google-benchmark.rb
@@ -6,13 +6,13 @@ class GoogleBenchmark < AbstractOsqueryFormula
   url "https://github.com/google/benchmark/archive/v1.0.0.tar.gz"
   sha256 "d2206c263fc1a7803d4b10e164e0c225f6bcf0d5e5f20b87929f137dee247b54"
   head "https://github.com/google/benchmark.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "e1b22a234863cc2ff50ca25c95d7a2120a6ae0248a205729d750b541972911c7" => :sierra
-    sha256 "79e9ed34b99971f8288be3a5a3521cf51840fc63690d6d583e2d607a30ceaf45" => :x86_64_linux
+    sha256 "9fadf0f008384d1b8f1c9c947d49de14716ca615af67e189edaa5f87f61e03a7" => :sierra
+    sha256 "288a64a4433c85fd71893eb8ca1a5f2b4ade8fce6a67c6cee21a850405197603" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/libaptpkg.rb
+++ b/tools/provision/formula/libaptpkg.rb
@@ -5,12 +5,12 @@ class Libaptpkg < AbstractOsqueryFormula
   homepage "https://apt.alioth.debian.org/python-apt-doc/library/apt_pkg.html"
   url "https://github.com/Debian/apt/archive/1.3.1.tar.gz"
   sha256 "a91a5e96417aad33f236234730b2a0bed3a028d6fc01c57d060b7d92746bf65a"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "cdecad1ae6bb89192a7df50c1f818f71696621239905eabc3ea2aeadddd0437e" => :x86_64_linux
+    sha256 "7bf998189b4fa8c3a18bce7216634e20bf1d9c2eb978b45b64290a307f7b42df" => :x86_64_linux
   end
 
   depends_on "lz4"

--- a/tools/provision/formula/libarchive.rb
+++ b/tools/provision/formula/libarchive.rb
@@ -5,13 +5,13 @@ class Libarchive < AbstractOsqueryFormula
   homepage "http://www.libarchive.org"
   url "http://www.libarchive.org/downloads/libarchive-3.2.2.tar.gz"
   sha256 "691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "dc82cff7fdb4932a2025efe6ee914d2a20e63e41ce44831cb0a413e3ab4c9818" => :sierra
-    sha256 "e8fcc61d81feeca6b63ece2e61e5d4bf812c183265bcf3918eaf10216f608e52" => :x86_64_linux
+    sha256 "edda4760384ef9ef69af0681d5bba2b2f508fd5188720ce1acbf3fc9890c91e7" => :sierra
+    sha256 "a608dc2be02fe57c7ca22cba2cfd5612cc7a80b32e87beb504830025d998ca8e" => :x86_64_linux
   end
 
   depends_on "xz" => :recommended
@@ -25,7 +25,9 @@ class Libarchive < AbstractOsqueryFormula
            "--without-nettle",  # xar hashing option but GPLv3
            "--without-xml2",    # xar hashing option but tricky dependencies
            "--without-openssl", # mtree hashing now possible without OpenSSL
-           "--with-expat"       # best xar hashing option
+           "--with-expat",       # best xar hashing option
+           "--disable-shared",
+           "--enable-static"
 
     system "make", "install"
 

--- a/tools/provision/formula/libaudit.rb
+++ b/tools/provision/formula/libaudit.rb
@@ -4,17 +4,19 @@ class Libaudit < AbstractOsqueryFormula
   desc "Linux auditing framework"
   url "https://github.com/Distrotech/libaudit/archive/audit-2.4.2.tar.gz"
   sha256 "63020c88b0f37a93438894e67e63ccede23d658277ecc6afb9d40e4043147d3f"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "60bf54676eb07529a2eaa326ef032c62c590437419b3551514b9501832ce9635" => :x86_64_linux
+    sha256 "a4f1e5f347690848cd2cf62ab10934d097c15989e23f3954033328b1d50e3334" => :x86_64_linux
   end
 
   def install
     system "./autogen.sh"
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", "--prefix=#{prefix}",
+                          "--disable-shared",
+                          "--enable-static"
     cd "lib" do
       system "make"
       system "make", "install"

--- a/tools/provision/formula/libcryptsetup.rb
+++ b/tools/provision/formula/libcryptsetup.rb
@@ -4,12 +4,12 @@ class Libcryptsetup < AbstractOsqueryFormula
   desc "Open source disk encryption libraries"
   homepage "https://gitlab.com/cryptsetup/cryptsetup"
   url "https://osquery-packages.s3.amazonaws.com/deps/cryptsetup-1.6.7.tar.gz"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "5acc82258d7ca40af7d822e03e561a57880879d15b8d8e9887213873206e5455" => :x86_64_linux
+    sha256 "78810ebd7cf24de3bc17cae28efbafe72fe1f2c6370a68b027e506c1e93805d8" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/libdevmapper.rb
+++ b/tools/provision/formula/libdevmapper.rb
@@ -5,12 +5,12 @@ class Libdevmapper < AbstractOsqueryFormula
   homepage "https://www.sourceware.org/dm/"
   url "https://osquery-packages.s3.amazonaws.com/deps/LVM2.2.02.145.tar.gz"
   sha256 "98b7c4c07c485a462c6a86e1a5265757133ceea36289ead8a419af29ef39560b"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "5a9df0067c5e4a5771bb65b1d380f1f27bd072773116838c2bd93025818053e8" => :x86_64_linux
+    sha256 "4e8e6f91ccf203bc96151700b6ce2a15a9ef056af2cfe1c791a37de296c6e596" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/libdpkg.rb
+++ b/tools/provision/formula/libdpkg.rb
@@ -5,12 +5,12 @@ class Libdpkg < AbstractOsqueryFormula
   homepage "https://wiki.debian.org/Teams/Dpkg"
   url "http://ftp.debian.org/debian/pool/main/d/dpkg/dpkg_1.18.23.tar.xz"
   sha256 "cc08802a0cea2ccd0c10716bc71531ff9b9234dd454b83a59f71117a37f36923"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "837fbbf8d84d29c95c103b134daf50b55854dd69aec79ca7adebee9351b716b6" => :x86_64_linux
+    sha256 "465cba5829f8380ed5da0e773a418e27a25eabed977a508911b1d8224a5191ce" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/libgcrypt.rb
+++ b/tools/provision/formula/libgcrypt.rb
@@ -6,12 +6,12 @@ class Libgcrypt < AbstractOsqueryFormula
   url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.6.5.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.5.tar.bz2"
   sha256 "f49ebc5842d455ae7019def33eb5a014a0f07a2a8353dc3aa50a76fd1dafa924"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "cbc6f0f88683ffc2aa525e6067dd392d783cc13f764c79f28d835668b2470a8e" => :x86_64_linux
+    sha256 "d33dac41ffc0fadad593ecafdd6bbd275826b3abfbefadfedfd76b5db1853d24" => :x86_64_linux
   end
 
   depends_on "libgpg-error"

--- a/tools/provision/formula/libgpg-error.rb
+++ b/tools/provision/formula/libgpg-error.rb
@@ -6,12 +6,12 @@ class LibgpgError < AbstractOsqueryFormula
   url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
   sha256 "9268e1cc487de5e6e4460fca612a06e4f383072ac43ae90603e5e46783d3e540"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "f17cb734505fbc59b1ce310406020b6217e58c5bdb521112e7ff680b6afde0b7" => :x86_64_linux
+    sha256 "1c397f85d9117da00482daccb758136c2e672fd8f2b6ac24aa68595766a799dd" => :x86_64_linux
   end
 
   option :universal

--- a/tools/provision/formula/libiptables.rb
+++ b/tools/provision/formula/libiptables.rb
@@ -5,12 +5,12 @@ class Libiptables < AbstractOsqueryFormula
   homepage "http://netfilter.samba.org/"
   url "https://osquery-packages.s3.amazonaws.com/deps/iptables-1.4.21.tar.gz"
   sha256 "ce1335c91764dc87a26978bd3725c510c2564853184c6e470e0a0f785f420f89"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "c34443f94393e351313cc35d5a0e4fd87ff25071bf4c1978b3b08829c1b3450d" => :x86_64_linux
+    sha256 "d3ae11309d313ecc6e7ae1d681e14cc7f7f5bd9a6a447d3bf70e1eb621041dfe" => :x86_64_linux
   end
 
   patch :DATA

--- a/tools/provision/formula/libmagic.rb
+++ b/tools/provision/formula/libmagic.rb
@@ -5,13 +5,13 @@ class Libmagic < AbstractOsqueryFormula
   homepage "https://www.darwinsys.com/file/"
   url "https://fossies.org/linux/misc/file-5.29.tar.gz"
   sha256 "ea661277cd39bf8f063d3a83ee875432cc3680494169f952787e002bdd3884c0"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "9f8ab6e8dd6959cdaacf06c08e25dcc4991a90cdba2616c7c83470411c11c381" => :sierra
-    sha256 "9fef726c4275e2d1910a6ef534edd51f2cfc0b9b1c7a14784c6e3c9f8690a5dc" => :x86_64_linux
+    sha256 "6f472165a18ab7c5587eeb3646db16c7a6659cb8ce27b57fb99cd6d64d8aaee8" => :sierra
+    sha256 "3778b2485218af6402419314b6702f355b8a0499586bc7d544bca993a408e02e" => :x86_64_linux
   end
 
   depends_on :python => :optional
@@ -25,7 +25,8 @@ class Libmagic < AbstractOsqueryFormula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           "--enable-fsect-man5",
-                          "--enable-static"
+                          "--enable-static",
+                          "--disable-shared"
     system "make", "install"
     (share+"misc/magic").install Dir["magic/Magdir/*"]
 

--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -6,12 +6,12 @@ class Librpm < AbstractOsqueryFormula
   url "https://github.com/rpm-software-management/rpm/releases/download/rpm-4.13.0-release/rpm-4.13.0.tar.bz2"
   sha256 "221166b61584721a8ca979d7d8576078a5dadaf09a44208f69cc1b353240ba1b"
   version "4.13.0"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "453653f8bc22c6d48117fa43d8db80d426d13bf4d7e0d2d7c8da0abc965662a7" => :x86_64_linux
+    sha256 "b1085e25afacc142900cc48cea97f04648c94541c741dbd77965cda98795d399" => :x86_64_linux
   end
 
   depends_on "berkeley-db"

--- a/tools/provision/formula/libudev.rb
+++ b/tools/provision/formula/libudev.rb
@@ -5,12 +5,12 @@ class Libudev < AbstractOsqueryFormula
   homepage "https://www.freedesktop.org/software/systemd/man/libudev.html"
   url "http://pkgs.fedoraproject.org/repo/pkgs/udev/udev-173.tar.bz2/91a88a359b60bbd074b024883cc0dbde/udev-173.tar.bz2"
   sha256 "70a18315a12f8fc1131f7da5b4dae3606988b69d5c08f96f443b84b8486caaaf"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "f74f0b0bb87bedaa403c2924f3078d75b182bc4f745181a52828906911fff4d4" => :x86_64_linux
+    sha256 "85bdd4b677b76f1739b64388f6c3b6ed2cfb6e58574bec953bd62ebe83968994" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/libxml2.rb
+++ b/tools/provision/formula/libxml2.rb
@@ -6,13 +6,13 @@ class Libxml2 < AbstractOsqueryFormula
   url "http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz"
   mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz"
   sha256 "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "047b1b45a9b4605d00121b27c4da164b348b331f4439a9bc42cc280f3a3c2fb6" => :sierra
-    sha256 "762ce429cf0f372111f00816a05b78ccc9389c010d79a8a6561fa299aca7ecbb" => :x86_64_linux
+    sha256 "73f8b62e310889441ff1f3ae2515fb3a6a2cac493f04489afd062d1c8ca5e48c" => :sierra
+    sha256 "779b194af3e967606fc801babdbe4e3454d2803ebce77eaa14d370b13245c05c" => :x86_64_linux
   end
 
   option :universal

--- a/tools/provision/formula/linenoise-ng.rb
+++ b/tools/provision/formula/linenoise-ng.rb
@@ -5,13 +5,13 @@ class LinenoiseNg < AbstractOsqueryFormula
   homepage "https://github.com/arangodb/linenoise-ng"
   url "https://github.com/theopolis/linenoise-ng/archive/v1.0.1.tar.gz"
   sha256 "c317f3ec92dcb4244cb62f6fb3b7a0a5a53729a85842225fcfce0d4a429a0dfa"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "ab006b71758c28c8d08621aabab61086150f03ff6e147a9f942317f38c7ac25e" => :sierra
-    sha256 "6aecbd0d97b3973d0e7fb5d6859ec985c6ee9da862fe22ffd13e0cfb738cb2f4" => :x86_64_linux
+    sha256 "9df286d60a0f36010be1dbf967f888e0ca6376ce2807042e1bf055ed5a2ebc93" => :sierra
+    sha256 "543c7d09ee67e59b795a4f910152fbb106be7e6bd7c1b13358ef5f810f210af7" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/lldpd.rb
+++ b/tools/provision/formula/lldpd.rb
@@ -5,13 +5,13 @@ class Lldpd < AbstractOsqueryFormula
   homepage "https://vincentbernat.github.io/lldpd"
   url "https://media.luffy.cx/files/lldpd/lldpd-0.9.6.tar.gz"
   sha256 "e74e2dd7e2a233ca1ff385c925ddae2a916d302819d1433741407d2f8fb0ddd8"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "f77c7e03dc2c1a658e2b1dcaa824b9da766c577be9d249996a734d98ec38be37" => :sierra
-    sha256 "51bb3a436d7dc9cebaf93067e524c4282ac49dc90e9da9f66b610ff8fd40d899" => :x86_64_linux
+    sha256 "6f5877f6de12d94d1ac0064cec8656bae93deed429d0d8d7d30475809c397b08" => :sierra
+    sha256 "20339d207fd97dcb2f83a96806555354ed7524664b766bdff1656e8d8750d249" => :x86_64_linux
   end
 
   option :universal

--- a/tools/provision/formula/llvm.rb
+++ b/tools/provision/formula/llvm.rb
@@ -22,7 +22,7 @@ end
 class Llvm < AbstractOsqueryFormula
   desc "Next-gen compiler infrastructure"
   homepage "http://llvm.org/"
-  revision 100
+  revision 101
 
   stable do
     url "http://releases.llvm.org/4.0.0/llvm-4.0.0.src.tar.xz"
@@ -84,7 +84,7 @@ class Llvm < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "1530776b4dc1a0a18d9eb701a146394d18cd219334159a81c808cce476defb4d" => :x86_64_linux
+    sha256 "92a00d9b9b4aad6a7461155aa7a913c6b541436c200b201b240150b76d4c6bd2" => :x86_64_linux
   end
 
   keg_only :provided_by_osx

--- a/tools/provision/formula/lz4.rb
+++ b/tools/provision/formula/lz4.rb
@@ -7,17 +7,20 @@ class Lz4 < AbstractOsqueryFormula
   version "r131"
   sha256 "9d4d00614d6b9dec3114b33d1224b6262b99ace24434c53487a0c8fd0b18cfed"
   head "https://github.com/Cyan4973/lz4.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "3d5b83d360ed5fcdcf04b98d6b54b77c3ac3a29b0a8b004789cd59b6301db210" => :sierra
-    sha256 "5d109b6dce79439b7736838e6034cafdf2526e8e31f3d3fe23e609dd6b7bcdef" => :x86_64_linux
+    sha256 "f20ebf1414ccf6f12d8e2c9196802be6e42e7426e2520da90618d517df9eb1bf" => :sierra
+    sha256 "c76439790f13b3c5b729d888a55826025a5bf54c832e7993d76692b47be7b28c" => :x86_64_linux
   end
 
   def install
     system "make", "install", "PREFIX=#{prefix}"
+
+    # Remove shared library
+    rm_rf lib/"liblz4.so"
   end
 
   test do

--- a/tools/provision/formula/ncurses.rb
+++ b/tools/provision/formula/ncurses.rb
@@ -6,12 +6,12 @@ class Ncurses < AbstractOsqueryFormula
   url "http://ftpmirror.gnu.org/ncurses/ncurses-6.0.tar.gz"
   mirror "https://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz"
   sha256 "f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "a94d47a827c849b48bb3850d8422ea1d5d7d17be17fa799367e310f93cc11ea8" => :x86_64_linux
+    sha256 "7647385400bdf6a04d8deab9892e0a6ebbb518a84453d587dce2048c9aab84d3" => :x86_64_linux
   end
 
   keg_only :provided_by_osx
@@ -47,7 +47,9 @@ class Ncurses < AbstractOsqueryFormula
                           "--mandir=#{man}",
                           "--with-manpage-format=normal",
                           "--with-shared",
-                          "--with-gpm=no"
+                          "--with-gpm=no",
+                          "--without-shared",
+                          "--with-static"
     system "make", "install"
     make_libncurses_symlinks
 
@@ -59,25 +61,12 @@ class Ncurses < AbstractOsqueryFormula
     major = version.to_s.split(".")[0]
 
     %w[form menu ncurses panel].each do |name|
-      if OS.mac?
-        lib.install_symlink "lib#{name}w.#{major}.dylib" => "lib#{name}.dylib"
-        lib.install_symlink "lib#{name}w.#{major}.dylib" => "lib#{name}.#{major}.dylib"
-      else
-        lib.install_symlink "lib#{name}w.so.#{major}" => "lib#{name}.so"
-        lib.install_symlink "lib#{name}w.so.#{major}" => "lib#{name}.so.#{major}"
-      end
       lib.install_symlink "lib#{name}w.a" => "lib#{name}.a"
       lib.install_symlink "lib#{name}w_g.a" => "lib#{name}_g.a"
     end
 
     lib.install_symlink "libncurses++w.a" => "libncurses++.a"
     lib.install_symlink "libncurses.a" => "libcurses.a"
-    if OS.mac?
-      lib.install_symlink "libncurses.dylib" => "libcurses.dylib"
-    else
-      lib.install_symlink "libncurses.so" => "libcurses.so"
-      lib.install_symlink "libncurses.so" => "libtinfo.so"
-    end
 
     (lib/"pkgconfig").install_symlink "ncursesw.pc" => "ncurses.pc"
 

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -7,13 +7,13 @@ class Openssl < AbstractOsqueryFormula
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2k.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2k.tar.gz"
   sha256 "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "967beaed429296f369d02fdc93dcef4af2cdc5dfa44e18173cde349f4f8e87bd" => :sierra
-    sha256 "e37e82ba5a5e96cfc7f902aa3a2b1a52b96c5579397e6aabd960666b03be0b95" => :x86_64_linux
+    sha256 "023a6f557c41015694c6508142687af7979d864f71a70b038b0aaafb945bc714" => :sierra
+    sha256 "79f095df9b09ea7b49165e2cc37e1ddd087365623d3186e499b70c30e6fcb25a" => :x86_64_linux
   end
 
   resource "cacert" do

--- a/tools/provision/formula/pcre.rb
+++ b/tools/provision/formula/pcre.rb
@@ -6,13 +6,13 @@ class Pcre < AbstractOsqueryFormula
   url "https://ftp.pcre.org/pub/pcre/pcre-8.40.tar.gz"
   mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre/8.40/pcre-8.40.tar.bz2"
   sha256 "1d75ce90ea3f81ee080cdc04e68c9c25a9fb984861a0618be7bbf676b18eda3e"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "53bbde521b2f44ac2ef57fe2595acfce941aafe02d289937b16cdda7a4caa057" => :sierra
-    sha256 "3738d56da99d3d05d54d35253c32b3183922d437083fecb33f96eee0515ad62d" => :x86_64_linux
+    sha256 "ac3137371bd766d83c3a99c165c8c2b0d5dc249b097650f4006c0ca63fc033d6" => :sierra
+    sha256 "65248970cef381a2b511c68004ae5344713bd4fa5fd22c70d06f789efd33586c" => :x86_64_linux
   end
 
   head do

--- a/tools/provision/formula/popt.rb
+++ b/tools/provision/formula/popt.rb
@@ -5,20 +5,23 @@ class Popt < AbstractOsqueryFormula
   homepage "http://rpm5.org"
   url "http://rpm5.org/files/popt/popt-1.16.tar.gz"
   sha256 "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "eec1f72feea34c0b5a20fdbebe33fc119b903c041642c847a9e3653337ef0d06" => :x86_64_linux
+    sha256 "b81b6365bcb253eb561bc43229eab24f849364fe56168eb3e0ced60cf4db183d" => :x86_64_linux
   end
 
   option :universal
 
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--disable-shared",
+                          "--enable-static"
     system "make", "install"
   end
 end

--- a/tools/provision/formula/python.rb
+++ b/tools/provision/formula/python.rb
@@ -6,13 +6,13 @@ class Python < AbstractOsqueryFormula
   url "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz"
   sha256 "d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978"
   head "https://hg.python.org/cpython", :using => :hg, :branch => "2.7"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "2895581daeec574c385abeca58aff5e37baed1f7c68ab6fc6ad731f2046bf2fe" => :sierra
-    sha256 "a5420996c1a69dd7a556da351c5df300b3b08ac2c35d934f242ea22e41c24a4b" => :x86_64_linux
+    sha256 "a43f382991e2636cd1fc01619b5790898e1e40e89da94d5997cc80a0775d8a54" => :sierra
+    sha256 "8245288b9906228f925215162ecba6925d23c7bf544e919ce3152d90398f738c" => :x86_64_linux
   end
 
   option :universal

--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -5,13 +5,13 @@ class Rocksdb < AbstractOsqueryFormula
   homepage "http://rocksdb.org"
   url "https://github.com/facebook/rocksdb/archive/v5.1.4.tar.gz"
   sha256 "3ee7e791d12d5359d0cf61c8c22713811dfda024afdd724cdf66ca022992be35"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "6cb5e835f90636c17cb12ab517919b589ec32c1e0cc663646c271f8292770dfc" => :sierra
-    sha256 "014104b40dd17fa89c4d62762da48489b043d2c5dcfcd35578dd45c9dd3c1880" => :x86_64_linux
+    sha256 "18a52b1e96c93b9a99cc33ad9a2eb0b6db0ecd864f25f24684bb6117a44f00f2" => :sierra
+    sha256 "5754ea9999e374273ab7d766e5bc0dae5ee43e544f3d93b4402cc57112dffbf6" => :x86_64_linux
   end
 
   needs :cxx11

--- a/tools/provision/formula/sleuthkit.rb
+++ b/tools/provision/formula/sleuthkit.rb
@@ -6,13 +6,13 @@ class Sleuthkit < AbstractOsqueryFormula
   url "https://github.com/sleuthkit/sleuthkit/archive/sleuthkit-4.3.0.tar.gz"
   sha256 "64a57a44955e91300e1ae69b34e8702afda0fb5bd72e2116429875c9f5f28980"
   head "https://github.com/sleuthkit/sleuthkit.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "6fcccb0afc71188b5703ed8129f361ba58fc2b277c1b916dd8ac028ebd9144f3" => :sierra
-    sha256 "d454fdb7bd7d4fa2870733f324d9f2e34eddf3ef471cbb3a2a2bc2ce504eb9ec" => :x86_64_linux
+    sha256 "bca72113e70b3d62b2f3e8b474ad3d10929f86b714d5164fbfc6d2345483db7f" => :sierra
+    sha256 "bd20cce6970fb7557b5db04c923ae0e3fe4f8e8e7a2eb3877867bcbf7e3c3277" => :x86_64_linux
   end
 
   conflicts_with "irods", :because => "both install `ils`"

--- a/tools/provision/formula/snappy.rb
+++ b/tools/provision/formula/snappy.rb
@@ -5,13 +5,13 @@ class Snappy < AbstractOsqueryFormula
   homepage "https://code.google.com/p/snappy/"
   url "https://github.com/google/snappy/releases/download/1.1.3/snappy-1.1.3.tar.gz"
   sha256 "2f1e82adf0868c9e26a5a7a3115111b6da7e432ddbac268a7ca2fae2a247eef3"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "ab880558e095b6015b86bba48b78c0c937f8a906fcb6e13df0a2875d0aaee82e" => :sierra
-    sha256 "556e3a859d8820966af0964aa974ef7c10aafa2d68c06ba8b33039560bb92c88" => :x86_64_linux
+    sha256 "a89983227587358ca9c9d1ecfd8946dfd89beaa9deadbee08ed84353ac5912d5" => :sierra
+    sha256 "f55c339fa79bc39c209c2f71847cfb8c553e571267c0b82cfbe834d273afb53f" => :x86_64_linux
   end
 
   head do

--- a/tools/provision/formula/thrift.rb
+++ b/tools/provision/formula/thrift.rb
@@ -5,13 +5,13 @@ class Thrift < AbstractOsqueryFormula
   homepage "https://thrift.apache.org/"
   url "http://www-us.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz"
   sha256 "2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "942f66f717ffc1b0a31871ddeb751cd53f0348270bda7b09c0eb71b6ebb974b5" => :sierra
-    sha256 "dbb1f33b8f326c7ac5758b8667da9c94265df3fdb0c0d2b83c26e93f996cd819" => :x86_64_linux
+    sha256 "f9bbba4aecd4de780e879dd71bcbd18e819ed8355e700177a543860120f4086b" => :sierra
+    sha256 "e818505723a34e425cd2e35acccd992f8f79287bfa77ec7bdda4e9df4083d5e2" => :x86_64_linux
   end
 
   depends_on "bison" => :build

--- a/tools/provision/formula/util-linux.rb
+++ b/tools/provision/formula/util-linux.rb
@@ -6,12 +6,12 @@ class UtilLinux < AbstractOsqueryFormula
   url "https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.xz"
   sha256 "0a818fcdede99aec43ffe6ca5b5388bff80d162f2f7bd4541dca94fecb87a290"
   head "https://github.com/karelzak/util-linux.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "c9d2ffdc06cedf460d4c9d3501ac0dac621326b442a23aaee20a82d976180275" => :x86_64_linux
+    sha256 "44b55c155b23c6f95e21b318a5a6ff59317ba3ce23e881647bc6736703d4c396" => :x86_64_linux
   end
 
   def install

--- a/tools/provision/formula/xz.rb
+++ b/tools/provision/formula/xz.rb
@@ -8,12 +8,12 @@ class Xz < AbstractOsqueryFormula
   url "https://fossies.org/linux/misc/xz-5.2.2.tar.gz"
   mirror "http://tukaani.org/xz/xz-5.2.2.tar.gz"
   sha256 "73df4d5d34f0468bd57d09f2d8af363e95ed6cc3a4a86129d2f2c366259902a2"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b7775a9d7f107466a61be4aa0f7b1cd909afc21f3c57b15f05641d0f0bacd802" => :x86_64_linux
+    sha256 "f472ad6242a1e6ed6ec8bede925096226d471ad3cb79529917f9ff0c15705186" => :x86_64_linux
   end
 
   option :universal
@@ -23,7 +23,9 @@ class Xz < AbstractOsqueryFormula
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+                          "--prefix=#{prefix}",
+                          "--disable-shared",
+                          "--enable-static"
     system "make", "install"
   end
 

--- a/tools/provision/formula/yara.rb
+++ b/tools/provision/formula/yara.rb
@@ -4,13 +4,13 @@ class Yara < AbstractOsqueryFormula
   desc "Malware identification and classification tool"
   homepage "https://github.com/VirusTotal/yara/"
   head "https://github.com/VirusTotal/yara.git"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "68e6811d60260a9a50ca03d0e465856ce4b1d7941178e1173b12f2d1615b6766" => :sierra
-    sha256 "86789b8d8cd613517c25d375d1b76e5ee0ac7ae6583a162efe4a6fdbc29897d6" => :x86_64_linux
+    sha256 "645665d4b083262f89895e2ba17702e40e5022dfcad2ef6b7599962a6232aaea" => :sierra
+    sha256 "dfab5e0b5061d3075a0d20ac7a9455196da4606233e8dca89206b8a23af15e64" => :x86_64_linux
   end
 
   stable do

--- a/tools/provision/formula/zlib-legacy.rb
+++ b/tools/provision/formula/zlib-legacy.rb
@@ -5,12 +5,12 @@ class ZlibLegacy < AbstractOsqueryFormula
   homepage "http://www.zlib.net/"
   url "https://github.com/madler/zlib/archive/v1.2.3.tar.gz"
   sha256 "2134178c123ea8252fd6afc9b794d9a2df480ccd030cc5db720a41883676fc2e"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "f37ddfc888ac2d3421c14f8b5ebc8aa24e114c42fb4d9951a79726257d139c59" => :x86_64_linux
+    sha256 "36d4b40c34bc526ec5cf7a8e07ba6ffb2d1fc601a8266d68a68384674f2a4e06" => :x86_64_linux
   end
 
   option :universal

--- a/tools/provision/formula/zzuf.rb
+++ b/tools/provision/formula/zzuf.rb
@@ -6,13 +6,13 @@ class Zzuf < AbstractOsqueryFormula
   url "https://github.com/theopolis/zzuf/archive/v0.15-osx-r2.tar.gz"
   sha256 "9f59bac21aef5408bbdaab0b2732ca5848dbd3e74297b66c34245bdbc04db86e"
   version "0.15-osx-r2"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "da9a3da97e8d2f884dddaa9e9dd219d43459850f88a283bfe78b5a8bb7b33655" => :sierra
-    sha256 "e3bf2204807277382cf513cfb9f640278071098e12cd64952686f564d0f0dbf4" => :x86_64_linux
+    sha256 "fd280466be13986efe1ec9280f18c180ae30b01b304ce88b1b679411a62afc4a" => :sierra
+    sha256 "0418ccf84f6548c2385363277e39e4b9d2855d7fd2745f279a709639f1a0e1e8" => :x86_64_linux
   end
 
   head do

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -268,7 +268,13 @@ function brew_bottle() {
   fi
 
   log "installing $HASH into $FORMULA_FILE"
-  sed -i '' "s/sha256 \"\\(.*\\)\" => :${SUFFIX}/sha256 \"${HASH}\" => :${SUFFIX}/g" $FORMULA_FILE
+  if [[ "$BREW_TYPE" = "linux" ]]; then
+    SED="sed -i "
+  else
+    SED="sed -i '' "
+  fi
+
+  $SED "s/sha256 \"\\(.*\\)\" => :${SUFFIX}/sha256 \"${HASH}\" => :${SUFFIX}/g" $FORMULA_FILE
 }
 
 function brew_postinstall() {


### PR DESCRIPTION
This is the second attempt at rebuilding all macOS and Linux dependencies after an upgrade of compiler flags and compiler infrastructure on Linux (LLVM version 4.0). It re-introduces the RPATH for dependency tools and remove more shared library builds.

It is intended to fix the `tools/analyze.sh` script too.