### PR TITLE
docs: Remove 'modules' from documentation

### DIFF
--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -11,7 +11,6 @@ This is pretty simple! Just append `--verbose` as a switch.
 ```
 $ osqueryi --verbose
 I0412 08:04:56.012428 3056837568 init.cpp:380] osquery initialized [version=2.4.0]
-I0412 08:04:56.013499 3056837568 extensions.cpp:308] Could not autoload modules: Failed reading: /var/osquery/modules.load
 I0412 08:04:56.014837 168243200 interface.cpp:317] Extension manager service starting: /Users/$USER/.osquery/shell.em
 I0412 08:04:56.015383 3056837568 init.cpp:615] Error reading config: config file does not exist: /var/osquery/osquery.conf
 Using a virtual database. Need help, type '.help'
@@ -35,7 +34,6 @@ $ osqueryd --ephemeral --database_path /tmp/osquery.db --verbose
 I0412 08:03:59.664191 3056837568 init.cpp:380] osquery initialized [version=2.4.0]
 I0412 08:03:59.666533 196194304 watcher.cpp:465] osqueryd watcher (35549) executing worker (35550)
 I0412 08:03:59.688765 3056837568 init.cpp:377] osquery worker initialized [watcher=35549]
-I0412 08:03:59.689954 3056837568 extensions.cpp:308] Could not autoload modules: Failed reading: /var/osquery/modules.load
 I0412 08:03:59.690062 3056837568 rocksdb.cpp:205] Opening RocksDB handle: /tmp/osquery.db
 ```
 

--- a/docs/wiki/deployment/extensions.md
+++ b/docs/wiki/deployment/extensions.md
@@ -46,16 +46,4 @@ $ cat /etc/osquery/osquery.flags
 --logger_plugin=scribe
 ```
 
-## Modules
-
-The osquery extensions concept builds on the platform's concept of a "registry" of plugin types and plugins therein. The registry maintains a lookup of each plugin and its origin, internal or a transient UUID assigned to an extension. osquery supports extensions as dynamic loadable objects too. 
-
-The CLI flag(s):
-
-```sh
---modules_autoload=/etc/osquery/modules.load
-```
-
-work the same as extensions, each path is evaluated for safe permission and ownership, and `dlopen`ed when an osquery process starts. There is example code for writing a loaded module in the [`osquery/examples`](https://github.com/facebook/osquery/tree/master/osquery/examples) folder. If you are building extensions using the osquery build process a module may be a better option.
-
 

--- a/docs/wiki/development/osquery-sdk.md
+++ b/docs/wiki/development/osquery-sdk.md
@@ -125,8 +125,8 @@ $ ./build/darwin/osquery/osqueryi --extension ./build/darwin/osquery/example_ext
 
 Your "external" extension, in the sense that the code is developed and contained somewhere external from the osquery repository, can be built semi-automatically.
 
-1. Symlink your external extension directory (modules work too) into `./external`.
-2. Make sure the symlink contains either `extension_` or `module_` as a prefix.
+1. Symlink your external extension directory into `./external`.
+2. Make sure the symlink contains `extension_` as a prefix.
 3. Run `make externals`.
 
 This will find and compile all `.*\.{cpp,c,mm}` files within your external directory. If you need something more complicated add a `CMakeLists.txt` to your directory and add your targets to the `externals` target.

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -135,10 +135,6 @@ osqueryd may depend on a config plugin from an extension. If the requested confi
 Seconds delay between extension connectivity checks.
 Extensions are loaded as processes. They are expected to start a thrift service thread. The osqueryd process will continue to check this API. If an extension process is incorrectly stopped, osqueryd will detect the connectivity failure and unregister the extension.
 
-`--modules_autoload=/etc/osquery/modules.load`
-
-Optional path to a list of autoloaded library module-based extensions. Modules are similar to extensions but are loaded as shared libraries. They are less flexible and should be built using the same GCC runtime and developer dependency library versions as osqueryd. See the extensions [deployment](../deployment/extensions.md) page for more details on extension module autoloading.
-
 `--extensions_require=custom1,custom1`
 
 Optional comma-delimited set of extension names to require before **osqueryi** or **osqueryd** will start. The tool will fail if the extension has not started according to the interval and timeout.


### PR DESCRIPTION
The 'modules' feature has been removed with LLVM 4.0, remove the documentation references.