### PR TITLE
windows: Fixing INFO verbosity in drivers table and various resharper lints

### DIFF
--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -60,7 +60,8 @@ std::map<int, std::vector<FeatureDef>> kCPUFeatures{
 
 static inline void cpuid(size_t eax, size_t ecx, int regs[4]) {
 #if defined(WIN32)
-  __cpuidex((int*)regs, (int)eax, (int)ecx);
+  __cpuidex(
+      static_cast<int*>(regs), static_cast<int>(eax), static_cast<int>(ecx));
 #else
   asm volatile("cpuid"
                : "=a"(regs[0]), "=b"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
@@ -122,9 +123,12 @@ inline Status genStrings(QueryData& results) {
   cpuid(0x40000000, 0, regs);
   if (regs[0] && 0xFF000000 != 0) {
     std::stringstream hypervisor;
-    hypervisor << std::hex << std::setw(8) << std::setfill('0') << (int)regs[0];
-    hypervisor << std::hex << std::setw(8) << std::setfill('0') << (int)regs[1];
-    hypervisor << std::hex << std::setw(8) << std::setfill('0') << (int)regs[2];
+    hypervisor << std::hex << std::setw(8) << std::setfill('0')
+               << static_cast<int>(regs[0]);
+    hypervisor << std::hex << std::setw(8) << std::setfill('0')
+               << static_cast<int>(regs[1]);
+    hypervisor << std::hex << std::setw(8) << std::setfill('0')
+               << static_cast<int>(regs[2]);
 
     r["feature"] = "hypervisor_id";
     r["value"] = hypervisor.str();
@@ -137,10 +141,13 @@ inline Status genStrings(QueryData& results) {
   // Finally, check the processor serial number.
   std::stringstream serial;
   cpuid(1, 0, regs);
-  serial << std::hex << std::setw(8) << std::setfill('0') << (int)regs[0];
+  serial << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[0]);
   cpuid(3, 0, regs);
-  serial << std::hex << std::setw(8) << std::setfill('0') << (int)regs[0];
-  serial << std::hex << std::setw(8) << std::setfill('0') << (int)regs[3];
+  serial << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[0]);
+  serial << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[3]);
 
   r["feature"] = "serial";
   r["value"] = serial.str();
@@ -156,7 +163,7 @@ inline void genFamily(QueryData& results) {
   int regs[4] = {-1};
 
   cpuid(1, 0, regs);
-  int family = regs[0] & 0xf00;
+  auto family = regs[0] & 0xf00;
 
   std::stringstream family_string;
   family_string << std::hex << std::setw(4) << std::setfill('0') << family;
@@ -182,10 +189,10 @@ QueryData genCPUID(QueryContext& context) {
   genFamily(results);
 
   int regs[4] = {-1};
-  int feature_register = 0;
-  int feature_bit = 0;
+  auto feature_register = 0;
+  auto feature_bit = 0;
   for (const auto& feature_set : kCPUFeatures) {
-    int eax = feature_set.first;
+    auto eax = feature_set.first;
     cpuid(eax, 0, regs);
 
     for (const auto& feature : feature_set.second) {
@@ -219,10 +226,14 @@ QueryData genCPUID(QueryContext& context) {
 
     cpuid(0x12, 0, regs);
     std::stringstream sgx0;
-    sgx0 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[0];
-    sgx0 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[1];
-    sgx0 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[2];
-    sgx0 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[3];
+    sgx0 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[0]);
+    sgx0 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[1]);
+    sgx0 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[2]);
+    sgx0 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[3]);
     r["feature"] = "sgx0";
     r["value"] = sgx0.str();
     r["input_eax"] = std::to_string(0x12);
@@ -230,10 +241,14 @@ QueryData genCPUID(QueryContext& context) {
 
     cpuid(0x12, 1, regs);
     std::stringstream sgx1;
-    sgx1 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[0];
-    sgx1 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[1];
-    sgx1 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[2];
-    sgx1 << std::hex << std::setw(8) << std::setfill('0') << (int)regs[3];
+    sgx1 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[0]);
+    sgx1 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[1]);
+    sgx1 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[2]);
+    sgx1 << std::hex << std::setw(8) << std::setfill('0')
+         << static_cast<int>(regs[3]);
     r["feature"] = "sgx1";
     r["value"] = sgx1.str();
     r["input_eax"] = std::to_string(0x12) + ",1";
@@ -242,5 +257,5 @@ QueryData genCPUID(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/uptime.cpp
+++ b/osquery/tables/system/uptime.cpp
@@ -11,9 +11,9 @@
 #include <osquery/tables.h>
 
 #if defined(__APPLE__)
-#include <time.h>
 #include <errno.h>
 #include <sys/sysctl.h>
+#include <time.h>
 #elif defined(__linux__)
 #include <sys/sysinfo.h>
 #elif defined(WIN32)
@@ -46,7 +46,7 @@ long getUptime() {
 
   return sys_info.uptime;
 #elif defined(WIN32)
-  return (long)GetTickCount64() / 1000;
+  return static_cast<long>(GetTickCount64()) / 1000;
 #endif
 
   return -1;
@@ -68,5 +68,5 @@ QueryData genUptime(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/patches.cpp
+++ b/osquery/tables/system/windows/patches.cpp
@@ -8,11 +8,8 @@
  *
  */
 
-#include <osquery/sql.h>
-#include <osquery/system.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
@@ -22,7 +19,7 @@ QueryData genInstalledPatches(QueryContext& context) {
   QueryData results;
 
   WmiRequest wmiSystemReq("select * from Win32_QuickFixEngineering");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  auto& wmiResults = wmiSystemReq.results();
 
   if (wmiResults.size() != 0) {
     Row r;
@@ -43,5 +40,5 @@ QueryData genInstalledPatches(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -40,7 +40,6 @@ void genProcess(const WmiResultItem& result, QueryData& results_data) {
   long pid;
   long lPlaceHolder;
   std::string sPlaceHolder;
-  HANDLE hProcess = nullptr;
 
   /// Store current process pid for more efficient API use.
   auto currentPid = GetCurrentProcessId();
@@ -50,6 +49,7 @@ void genProcess(const WmiResultItem& result, QueryData& results_data) {
 
   long uid = -1;
   long gid = -1;
+  HANDLE hProcess = nullptr;
   if (pid == currentPid) {
     hProcess = GetCurrentProcess();
   } else {
@@ -127,7 +127,6 @@ void genProcess(const WmiResultItem& result, QueryData& results_data) {
 
   if (hProcess != nullptr) {
     CloseHandle(hProcess);
-    hProcess = nullptr;
   }
   if (tok != nullptr) {
     CloseHandle(tok);
@@ -177,5 +176,5 @@ QueryData genProcesses(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -8,16 +8,12 @@
  *
  */
 
-#include <string>
-
 #include <boost/regex.hpp>
 
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
-#include "osquery/core/windows/wmi.h"
 #include "osquery/tables/system/windows/registry.h"
 
 namespace osquery {
@@ -75,5 +71,5 @@ QueryData genPrograms(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -8,7 +8,6 @@
  *
  */
 
-#include <osquery/logger.h>
 #include <osquery/tables.h>
 
 #include "osquery/core/windows/wmi.h"
@@ -44,5 +43,5 @@ QueryData genPlatformInfo(QueryContext& context) {
   results.push_back(r);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -9,16 +9,10 @@
  */
 
 #include <sstream>
-#include <string>
 
-#include <stdlib.h>
-
-#include <osquery/core.h>
-#include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
@@ -29,9 +23,9 @@ QueryData genWmiCliConsumers(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM CommandLineEventConsumer";
 
-  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), static_cast<BSTR>(L"ROOT\\Subscription"));
   if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
+    auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 
@@ -46,5 +40,5 @@ QueryData genWmiCliConsumers(QueryContext& context) {
 
   return results_data;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -9,16 +9,10 @@
  */
 
 #include <sstream>
-#include <string>
 
-#include <stdlib.h>
-
-#include <osquery/core.h>
-#include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
@@ -29,9 +23,9 @@ QueryData genWmiFilters(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM __EventFilter";
 
-  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), static_cast<BSTR>(L"ROOT\\Subscription"));
   if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
+    auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 
@@ -46,5 +40,5 @@ QueryData genWmiFilters(QueryContext& context) {
 
   return results_data;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -9,16 +9,10 @@
  */
 
 #include <sstream>
-#include <string>
 
-#include <stdlib.h>
-
-#include <osquery/core.h>
-#include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
@@ -29,9 +23,9 @@ QueryData genFilterConsumer(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
-  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), static_cast<BSTR>(L"ROOT\\Subscription"));
   if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
+    auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 
@@ -45,5 +39,5 @@ QueryData genFilterConsumer(QueryContext& context) {
 
   return results_data;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -9,16 +9,10 @@
  */
 
 #include <sstream>
-#include <string>
 
-#include <stdlib.h>
-
-#include <osquery/core.h>
-#include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
@@ -29,9 +23,9 @@ QueryData genScriptConsumers(QueryContext& context) {
   std::stringstream ss;
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
-  WmiRequest request(ss.str(), (BSTR)L"ROOT\\Subscription");
+  WmiRequest request(ss.str(), static_cast<BSTR>(L"ROOT\\Subscription"));
   if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
+    auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 
@@ -47,5 +41,5 @@ QueryData genScriptConsumers(QueryContext& context) {
 
   return results_data;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
This fixes numerous resharper lint issues, but most importantly the `drivers` table was spewing the following message on query due to an incorrect return value check:
```
...
I0524 21:48:42.050192  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.054209  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.058182  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.062187  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.066190  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.072209  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.079238  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.087190  4468 drivers.cpp:60] QueryServiceConfig failed (122)
I0524 21:48:42.091190  4468 drivers.cpp:60] QueryServiceConfig failed (122)
...
```