### PR TITLE
Rename new base64 functions to be like MySQL

### DIFF
--- a/osquery/sql/sqlite_encoding.cpp
+++ b/osquery/sql/sqlite_encoding.cpp
@@ -73,7 +73,7 @@ static void sqliteB64DecFunc(sqlite3_context* context,
 
 void registerEncodingExtensions(sqlite3* db) {
   sqlite3_create_function(db,
-                          "conditional_base64",
+                          "conditional_to_base64",
                           1,
                           SQLITE_UTF8,
                           nullptr,
@@ -81,7 +81,7 @@ void registerEncodingExtensions(sqlite3* db) {
                           nullptr,
                           nullptr);
   sqlite3_create_function(db,
-                          "base64",
+                          "to_base64",
                           1,
                           SQLITE_UTF8,
                           nullptr,
@@ -89,7 +89,7 @@ void registerEncodingExtensions(sqlite3* db) {
                           nullptr,
                           nullptr);
   sqlite3_create_function(db,
-                          "unbase64",
+                          "from_base64",
                           1,
                           SQLITE_UTF8,
                           nullptr,

--- a/osquery/sql/tests/sql_tests.cpp
+++ b/osquery/sql/tests/sql_tests.cpp
@@ -109,26 +109,26 @@ TEST_F(SQLTests, test_sql_escape) {
 
 TEST_F(SQLTests, test_sql_base64_encode) {
   QueryData d;
-  query("select base64('test') as test;", d);
+  query("select to_base64('test') as test;", d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "dGVzdA==");
 }
 
 TEST_F(SQLTests, test_sql_base64_decode) {
   QueryData d;
-  query("select unbase64('dGVzdA==') as test;", d);
+  query("select from_base64('dGVzdA==') as test;", d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "test");
 }
 
 TEST_F(SQLTests, test_sql_base64_conditional_encode) {
   QueryData d;
-  query("select conditional_base64('test') as test;", d);
+  query("select conditional_to_base64('test') as test;", d);
   EXPECT_EQ(d.size(), 1U);
   EXPECT_EQ(d[0]["test"], "test");
 
   QueryData d2;
-  query("select conditional_base64('悪因悪果') as test;", d2);
+  query("select conditional_to_base64('悪因悪果') as test;", d2);
   EXPECT_EQ(d2.size(), 1U);
   EXPECT_EQ(d2[0]["test"], "5oKq5Zug5oKq5p6c");
 }


### PR DESCRIPTION
It would be good if the base64 functions in osquery had the same names as MySQL before they become widely adopted.