### PR TITLE
Address YARA hardcoded home folder issue

### DIFF
--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -107,7 +107,7 @@ QueryData genYara(QueryContext& context) {
     // Check if this "ad-hoc" signature file has not been used/compiled.
     if (rules.count(file) == 0) {
       // If this is a relative path append the default yara search path.
-      auto path = (file[0] != '/') ? std::string("/etc/osquery/yara/") : "";
+      auto path = (file[0] != '/') ? kYARAHome : "";
       path += file;
 
       YR_RULES* tmp_rules = nullptr;

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -123,7 +123,7 @@ Status handleRuleFiles(const std::string& category,
     YR_RULES* tmp_rules = nullptr;
     auto rule = item.second.get("", "");
     if (rule[0] != '/') {
-      rule = std::string("/etc/osquery/yara/") + rule;
+      rule = kYARAHome + rule;
     }
 
     // First attempt to load the file, in case it is saved (pre-compiled)

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -20,6 +20,8 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
+const std::string kYARAHome{OSQUERY_HOME "/yara/"};
+
 void YARACompilerCallback(int error_level,
                           const char* file_name,
                           int line_number,


### PR DESCRIPTION
YARA had it's osquery folder hardcoded, this makes it consistent with osquery home.

Fix #3229 