### PR TITLE
Adding bison data folder to system chocolatey path

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -385,6 +385,7 @@ function Main {
   $chocoPath = $oldPath = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall', 'Machine')
   if (Test-Path (Join-Path $chocoPath 'lib\winflexbison\tools\')) {
     Copy-Item (Join-Path $chocoPath 'lib\winflexbison\tools\win_bison.exe') (Join-Path $chocoPath 'bin\bison.exe')
+    Copy-Item -Recurse (Join-Path $chocoPath 'lib\winflexbison\tools\data') (Join-Path $chocoPath 'bin\data')
     Copy-Item (Join-Path $chocoPath 'lib\winflexbison\tools\win_flex.exe') (Join-Path $chocoPath 'bin\flex.exe')
   }
   $out = Install-ChocoPackage 'cppcheck'


### PR DESCRIPTION
Bison installed via chocolatey on windows relies on a folder called `data` residing in the same path as the binary. This brings said path into the same location where we drop bison for usage.