### PR TITLE
tsan: Address failures and findings in LLVM 4.0

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -743,11 +743,11 @@ void Config::hashSource(const std::string& source, const std::string& content) {
 }
 
 Status Config::genHash(std::string& hash) {
+  WriteLock lock(config_hash_mutex_);
   if (!valid_) {
     return Status(1, "Current config is not valid");
   }
 
-  WriteLock lock(config_hash_mutex_);
   std::vector<char> buffer;
   buffer.reserve(hash_.size() * 32);
   auto add = [&buffer](const std::string& text) {

--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -183,9 +183,8 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
 
     response->GetResponseBody() << resp.body();
 
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Exception making HTTP request to URL (" << url
-               << "): " << e.what();
+  } catch (const std::exception& /*e*/) {
+    LOG(ERROR) << "Exception making HTTP request to URL: " << url;
     return nullptr;
   }
 

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -44,7 +44,9 @@ class MockKinesisClient : public Aws::Kinesis::KinesisClient {
 
 class KinesisTests : public testing::Test {
  public:
-  void SetUp() override { initAwsSdk(); }
+  void SetUp() override {
+    initAwsSdk();
+  }
 };
 
 TEST_F(KinesisTests, test_send) {

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -118,5 +118,5 @@ TEST_F(FileEventsTableTests, test_configure_subscriptions) {
     EXPECT_EQ(row2.at("subscriptions"), "0");
   }
 }
-#endif
+#endif /* WIN32 */
 }


### PR DESCRIPTION
This attempts to fix TSAN internal errors:
```
FATAL: ThreadSanitizer CHECK failed
```

And new findings from LLVM 4.0 on Linux.