### PR TITLE
Fix C99 array errors by moving array to the heap

### DIFF
--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -140,13 +140,17 @@ QueryData genKnownWifiNetworks(QueryContext& context) {
     }
   } else if (CFGetTypeID(networks) == CFDictionaryGetTypeID()) {
     auto count = CFDictionaryGetCount((CFDictionaryRef)networks);
-    const void* keys[count];
-    const void* values[count];
-    CFDictionaryGetKeysAndValues((CFDictionaryRef)networks, keys, values);
+    auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
+    auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
 
-    for (CFIndex i = 0; i < count; i++) {
-      parseNetworks((CFDictionaryRef)values[i], results);
+    if (keys != nullptr && values != nullptr) {
+      CFDictionaryGetKeysAndValues((CFDictionaryRef)networks, keys, values);
+      for (CFIndex i = 0; i < count; i++) {
+        parseNetworks((CFDictionaryRef)values[i], results);
+      }
     }
+    free(keys);
+    free(values);
   }
   return results;
 }


### PR DESCRIPTION
osquery's build (especially tidy) was complainging the dynamically sized stack arrays are a C99 feature. This diff makes the compiler happy by moving them to heap with a malloc.

After they are used, the memory is freed. No exceptions should be raised or caught, and there are no other code paths so this memory should always be freed here. Also tested with ASAN and there were no memory errors announced.