### PR TITLE
Disallow the shadowing of local variables and fix existing shadows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ if(POSIX)
     -Wformat
     -Wformat-security
     -Werror=format-security
+    -Werror=shadow
     -Wabi-tag
     -fpermissive
     -fstack-protector-all

--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -150,14 +150,14 @@ QueryData genPlatformInfo(QueryContext& context) {
     std::vector<std::string> info_lines;
     iter_split(info_lines, info, boost::algorithm::first_finder("%0a"));
     for (const auto& line : info_lines) {
-      std::vector<std::string> details;
-      iter_split(details, line, boost::algorithm::first_finder(": "));
-      if (details.size() > 1) {
-        boost::trim(details[1]);
-        if (details[0].find("Revision") != std::string::npos) {
-          r["revision"] = details[1];
+      std::vector<std::string> details_vec;
+      iter_split(details_vec, line, boost::algorithm::first_finder(": "));
+      if (details_vec.size() > 1) {
+        boost::trim(details_vec[1]);
+        if (details_vec[0].find("Revision") != std::string::npos) {
+          r["revision"] = details_vec[1];
         }
-        extra_items.push_back(details[1]);
+        extra_items.push_back(details_vec[1]);
       }
     }
     r["extra"] = osquery::join(extra_items, "; ");

--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -710,21 +710,21 @@ QueryData genFanSpeedSensors(QueryContext &context) {
       std::stringstream key;
       key << boost::format(smcFanSpeedKey.first) % fanIdx;
 
-      QueryData key_data;
-      genSMCKey(key.str(), smc, key_data);
-      if (key_data.empty()) {
+      QueryData fan_data;
+      genSMCKey(key.str(), smc, fan_data);
+      if (fan_data.empty()) {
         continue;
       }
 
-      auto &smcRow = key_data.back();
-      if (smcRow["value"].empty()) {
+      auto& fdb = fan_data.back();
+      if (fdb["value"].empty()) {
         continue;
       }
 
       if (smcFanSpeedKey.second == "name") {
-        r[smcFanSpeedKey.second] = getFanName(smcRow["value"]);
+        r[smcFanSpeedKey.second] = getFanName(fdb["value"]);
       } else {
-        float fanSpeed = getConvertedValue(smcRow["type"], smcRow["value"]);
+        float fanSpeed = getConvertedValue(fdb["type"], fdb["value"]);
         r[smcFanSpeedKey.second] = INTEGER(fanSpeed);
       }
     }


### PR DESCRIPTION
I'd also like to add this as an error so that you cannot build when shadowing a local variable.