### PR TITLE
filesystem: Remove read_user_max flag

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -220,16 +220,6 @@ The URI path which will be used, in conjunction with `--tls_hostname`, to create
 
 The total number of attempts that will be made to the remote distributed query server if a request fails when using the **tls** distributed plugin.
 
-## Runtime flags
-
-`--read_max=52428800` (50MB)
-
-Maximum file read size. The daemon or shell will first 'stat' each file before reading. If the reported size is greater than `read_max` a "file too large" error will be returned.
-
-`--read_user_max=10485760` (10MB)
-
-Maximum non-super user read size. Similar to `--read_max` but applied to user-controlled (owned) files.
-
 ### osquery daemon runtime control flags
 
 `--schedule_splay_percent=10`
@@ -266,6 +256,10 @@ Limit the schedule, 0 for no limit. Optionally limit the `osqueryd`'s life by ad
 `--disable_tables=table_name1,table_name2`
 
 Comma-delimited list of table names to be disabled. This allows osquery to be launched without certain tables.
+
+`--read_max=52428800` (50MB)
+
+Maximum file read size. The daemon or shell will first 'stat' each file before reading. If the reported size is greater than `read_max` a "file too large" error will be returned.
 
 ### osquery events control flags
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -39,7 +39,6 @@ namespace errc = boost::system::errc;
 namespace osquery {
 
 FLAG(uint64, read_max, 50 * 1024 * 1024, "Maximum file read size");
-FLAG(uint64, read_user_max, 10 * 1024 * 1024, "Maximum non-su read size");
 
 /// See reference #1382 for reasons why someone would allow unsafe.
 HIDDEN_FLAG(bool, allow_unsafe, false, "Allow unsafe executable permissions");
@@ -109,15 +108,14 @@ Status readFile(const fs::path& path,
   }
 
   // Apply the max byte-read based on file/link target ownership.
-  off_t read_max =
-      static_cast<off_t>((handle.fd->isOwnerRoot().ok())
-                             ? FLAGS_read_max
-                             : std::min(FLAGS_read_max, FLAGS_read_user_max));
+  auto read_max = static_cast<off_t>(FLAGS_read_max);
   if (file_size > read_max) {
-    LOG(WARNING) << "Cannot read file that exceeds size limit: "
-                 << path.string();
-    VLOG(1) << "Cannot read " << path.string()
-            << " size exceeds limit: " << file_size << " > " << read_max;
+    if (!dry_run) {
+      LOG(WARNING) << "Cannot read file that exceeds size limit: "
+                   << path.string();
+      VLOG(1) << "Cannot read " << path.string()
+              << " size exceeds limit: " << file_size << " > " << read_max;
+    }
     return Status(1, "File exceeds read limits");
   }
 

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -31,7 +31,6 @@ namespace pt = boost::property_tree;
 namespace osquery {
 
 DECLARE_uint64(read_max);
-DECLARE_uint64(read_user_max);
 
 class FilesystemTests : public testing::Test {
  protected:
@@ -137,29 +136,20 @@ TEST_F(FilesystemTests, test_readwrite_file) {
 
 TEST_F(FilesystemTests, test_read_limit) {
   auto max = FLAGS_read_max;
-  auto user_max = FLAGS_read_user_max;
   FLAGS_read_max = 3;
   std::string content;
   auto status = readFile(kFakeDirectory + "/root.txt", content);
   EXPECT_FALSE(status.ok());
   FLAGS_read_max = max;
 
-  if (!isUserAdmin()) {
-    content.erase();
-    FLAGS_read_user_max = 2;
-    status = readFile(kFakeDirectory + "/root.txt", content);
-    EXPECT_FALSE(status.ok());
-    FLAGS_read_user_max = user_max;
+  // Make sure non-link files are still readable.
+  content.erase();
+  status = readFile(kFakeDirectory + "/root.txt", content);
+  EXPECT_TRUE(status.ok());
 
-    // Make sure non-link files are still readable.
-    content.erase();
-    status = readFile(kFakeDirectory + "/root.txt", content);
-    EXPECT_TRUE(status.ok());
-
-    // Any the links are readable too.
-    status = readFile(kFakeDirectory + "/root2.txt", content);
-    EXPECT_TRUE(status.ok());
-  }
+  // Any the links are readable too.
+  status = readFile(kFakeDirectory + "/root2.txt", content);
+  EXPECT_TRUE(status.ok());
 }
 
 TEST_F(FilesystemTests, test_list_files_missing_directory) {


### PR DESCRIPTION
The `--read_user_max` is confusing, let's remove it and only use the `--read_max` which is set to 50M by default.