### PR TITLE
virtual tables: Add optional --table_delay between scans

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -97,6 +97,10 @@ If this value is non-0 the watchdog level (`--watchdog_level`) for maximum susta
 
 Attempt to convert all UNIX calendar times to UTC.
 
+`--table_delay=0`
+
+Add a microsecond delay between multiple table calls (when a table is used in a JOIN). A `200` microsecond delay will trade about 20% additional time for a reduced 5% CPU utilization.
+
 **Windows Only**
 
 Windows builds include a `--install` and `--uninstall` that will create a Windows service using the `osqueryd.exe` binary and preserve an optional `--flagfile` if provided.

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -236,6 +236,10 @@ void SQLiteDBInstance::addAffectedTable(VirtualTableContent* table) {
   affected_tables_.insert(std::make_pair(table->name, table));
 }
 
+bool SQLiteDBInstance::tableCalled(VirtualTableContent* table) {
+  return (affected_tables_.count(table->name) > 0);
+}
+
 TableAttributes SQLiteDBInstance::getAttributes() const {
   const SQLiteDBInstance* rdbc = this;
   if (isPrimary() && !managed_) {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -68,6 +68,9 @@ class SQLiteDBInstance : private boost::noncopyable {
   /// Clear per-query state of a table affected by the use of this instance.
   void clearAffectedTables();
 
+  /// Check if a virtual table had been called already.
+  bool tableCalled(VirtualTableContent* table);
+
  private:
   /// Handle the primary/forwarding requests for table attribute accesses.
   TableAttributes getAttributes() const;


### PR DESCRIPTION
This adds an optional flag `--table_delay` that will sleep the process for a number of microseconds between multi-table calls.

With a `1000` microsecond delay:
```
Profiling query: select count(1) from file join hash using(path) where path like '/Users/reed/Downloads/%'
 D:3  C:2  M:0  F:0  U:3  manual (1/1): duration: 4.04213500023 cpu_time: 3.887093824 memory: 7528448 fds: 4 utilization: 85.8 
Profiling query: select count(1) from file join hash using(path) where path like '/Users/reed/Downloads/%'
 D:3  C:2  M:0  F:0  U:3  manual (1/1): duration: 4.54719901085 cpu_time: 4.030604288 memory: 7553024 fds: 4 utilization: 80.09 
```

Time increases from `4.05s` to `4.54` and utilization drops `5%`.