### PR TITLE
config: Rename getInstance to get for consistency

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -37,7 +37,7 @@ extern const std::string kExecutingQuery;
  * @brief The programmatic representation of osquery's configuration
  *
  * @code{.cpp}
- *   auto c = Config::getInstance();
+ *   auto c = Config::get();
  *   // use methods in osquery::Config on `c`
  * @endcode
  */
@@ -46,10 +46,9 @@ class Config : private boost::noncopyable {
   Config();
 
  public:
-  /// Get a singleton instance of the Config class
-  static Config& getInstance() {
-    static Config cfg;
-    return cfg;
+  static Config& get() {
+    static Config instance;
+    return instance;
   };
 
   /**
@@ -163,7 +162,7 @@ class Config : private boost::noncopyable {
    *
    * @code{.cpp}
    *   std::map<std::string, ScheduledQuery> queries;
-   *   Config::getInstance().scheduledQueries(
+   *   Config::get().scheduledQueries(
    *      ([&queries](const std::string& name, const ScheduledQuery& query) {
    *        queries[name] = query;
    *      }));
@@ -182,7 +181,7 @@ class Config : private boost::noncopyable {
    *
    * @code{.cpp}
    *   std::map<std::string, std::vector<std::string>> file_map;
-   *   Config::getInstance().files(
+   *   Config::get().files(
    *      ([&file_map](const std::string& category,
    *                   const std::vector<std::string>& files) {
    *        file_map[category] = files;
@@ -202,7 +201,7 @@ class Config : private boost::noncopyable {
    * QueryPerformance struct, if it exists.
    *
    * @code{.cpp}
-   *   Config::getInstance().getPerformanceStats(
+   *   Config::get().getPerformanceStats(
    *     "my_awesome_query",
    *     [](const QueryPerformance& query) {
    *       // use "query" here

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -137,8 +137,7 @@ class Schedule : private boost::noncopyable {
   void remove(const std::string& pack, const std::string& source) {
     packs_.remove_if([pack, source](PackRef& p) {
       if (p->getName() == pack && (p->getSource() == source || source == "")) {
-        Config::getInstance().removeFiles(source + FLAGS_pack_delimiter +
-                                          p->getName());
+        Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
         return true;
       }
       return false;
@@ -149,8 +148,7 @@ class Schedule : private boost::noncopyable {
   void removeAll(const std::string& source) {
     packs_.remove_if(([source](PackRef& p) {
       if (p->getSource() == source) {
-        Config::getInstance().removeFiles(source + FLAGS_pack_delimiter +
-                                          p->getName());
+        Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
         return true;
       }
       return false;
@@ -814,8 +812,7 @@ Status ConfigPlugin::call(const PluginRequest& request,
     if (request.count("source") == 0 || request.count("data") == 0) {
       return Status(1, "Missing source or data");
     }
-    return Config::getInstance().update(
-        {{request.at("source"), request.at("data")}});
+    return Config::get().update({{request.at("source"), request.at("data")}});
   }
   return Status(1, "Config plugin action unknown: " + request.at("action"));
 }
@@ -839,7 +836,7 @@ void ConfigRefreshRunner::start() {
     }
 
     VLOG(1) << "Refreshing configuration state";
-    Config::getInstance().refresh();
+    Config::get().refresh();
   }
 }
 }

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -66,7 +66,7 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     }
   }
 
-  Config::getInstance().removeFiles(source);
+  Config::get().removeFiles(source);
   for (const auto& category : data_.get_child("file_paths")) {
     for (const auto& path : category.second) {
       auto pattern = path.second.get_value<std::string>("");
@@ -74,7 +74,7 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
         continue;
       }
       replaceGlobWildcards(pattern);
-      Config::getInstance().addFile(source, category.first, pattern);
+      Config::get().addFile(source, category.first, pattern);
     }
   }
 

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -30,7 +30,7 @@ class DecoratorsConfigParserPluginTests : public testing::Test {
 
     // Construct a config map, the typical output from `Config::genConfig`.
     config_data_["awesome"] = content_;
-    Config::getInstance().reset();
+    Config::get().reset();
     clearDecorations("awesome");
 
     // Backup the current decorator status.
@@ -39,7 +39,7 @@ class DecoratorsConfigParserPluginTests : public testing::Test {
   }
 
   void TearDown() override {
-    Config::getInstance().reset();
+    Config::get().reset();
     FLAGS_disable_decorators = decorator_status_;
   }
 
@@ -51,7 +51,7 @@ class DecoratorsConfigParserPluginTests : public testing::Test {
 
 TEST_F(DecoratorsConfigParserPluginTests, test_decorators_list) {
   // Assume the decorators are disabled.
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
   auto parser = Config::getParser("decorators");
   EXPECT_NE(parser, nullptr);
 
@@ -65,7 +65,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_load) {
   // Re-enable the decorators, then update the config.
   // The 'load' decorator set should run every time the config is updated.
   FLAGS_disable_decorators = false;
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
 
   QueryLogItem item;
   getDecorations(item.decorations);
@@ -76,7 +76,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_load) {
 TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   // Prevent loads from executing.
   FLAGS_disable_decorators = true;
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
 
   // Mimic the schedule's execution.
   FLAGS_disable_decorators = false;
@@ -110,7 +110,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_load_top_level) {
   FLAGS_disable_decorators = false;
   // enable top level decorations for the test
   FLAGS_decorations_top_level = true;
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
 
   // make sure decorations object still exists
   QueryLogItem item;

--- a/osquery/config/parsers/tests/events_tests.cpp
+++ b/osquery/config/parsers/tests/events_tests.cpp
@@ -22,7 +22,7 @@ class EventsConfigParserPluginTests : public testing::Test {};
 
 TEST_F(EventsConfigParserPluginTests, test_get_event) {
   // Reset the schedule in case other tests were modifying.
-  auto& c = Config::getInstance();
+  auto& c = Config::get();
   c.reset();
 
   // Generate content to update/add to the config.
@@ -38,7 +38,7 @@ TEST_F(EventsConfigParserPluginTests, test_get_event) {
   EXPECT_EQ(s.toString(), "OK");
 
   // Retrieve a basic events parser.
-  auto plugin = Config::getInstance().getParser("events");
+  auto plugin = Config::get().getParser("events");
   EXPECT_TRUE(plugin != nullptr);
   const auto& data = plugin->getData();
 

--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -25,16 +25,16 @@ class FilePathsConfigParserPluginTests : public testing::Test {
 
     // Construct a config map, the typical output from `Config::genConfig`.
     config_data_["awesome"] = content_;
-    Config::getInstance().reset();
+    Config::get().reset();
   }
 
   void TearDown() override {
-    Config::getInstance().reset();
+    Config::get().reset();
   }
 
   size_t numFiles() {
     size_t count = 0;
-    Config::getInstance().files(([&count](
+    Config::get().files(([&count](
         const std::string&, const std::vector<std::string>&) { count++; }));
     return count;
   }
@@ -52,8 +52,8 @@ TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
       "/dev", "/dev/zero", "/dev/null", "/dev/random"};
   std::vector<std::string> values;
 
-  Config::getInstance().update(config_data_);
-  Config::getInstance().files(([&categories, &values](
+  Config::get().update(config_data_);
+  Config::get().files(([&categories, &values](
       const std::string& category, const std::vector<std::string>& files) {
     categories.push_back(category);
     for (const auto& file : files) {
@@ -66,22 +66,22 @@ TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
 }
 
 TEST_F(FilePathsConfigParserPluginTests, test_get_file_accesses) {
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
   auto parser = Config::getParser("file_paths");
   auto& accesses = parser->getData().get_child("file_accesses");
   EXPECT_EQ(accesses.size(), 2U);
 }
 
 TEST_F(FilePathsConfigParserPluginTests, test_remove_source) {
-  Config::getInstance().update(config_data_);
-  Config::getInstance().removeFiles("awesome");
+  Config::get().update(config_data_);
+  Config::get().removeFiles("awesome");
   // Expect the pack's set to persist.
   // Do not call removeFiles, instead only update the pack/config content.
   EXPECT_EQ(numFiles(), 1U);
 
   // This will clear all source data for 'awesome'.
   config_data_["awesome"] = "";
-  Config::getInstance().update(config_data_);
+  Config::get().update(config_data_);
   EXPECT_EQ(numFiles(), 0U);
 }
 }

--- a/osquery/config/plugins/tests/tls_config_tests.cpp
+++ b/osquery/config/plugins/tests/tls_config_tests.cpp
@@ -103,13 +103,13 @@ TEST_F(TLSConfigTests, test_runner_and_scheduler) {
   Registry::get().setActive("config", "tls");
 
   // Seed our instance config with a schedule.
-  Config::getInstance().load();
+  Config::get().load();
 
   // Start a scheduler runner for 3 seconds.
   auto t = static_cast<unsigned long int>(getUnixTime());
   Dispatcher::addService(std::make_shared<SchedulerRunner>(t + 1, 1));
   // Reload our instance config.
-  Config::getInstance().load();
+  Config::get().load();
   Dispatcher::joinServices();
 }
 

--- a/osquery/config/plugins/tls_config.cpp
+++ b/osquery/config/plugins/tls_config.cpp
@@ -155,7 +155,7 @@ void TLSConfigRefreshRunner::start() {
       // The config instance knows the TLS plugin is selected.
       std::map<std::string, std::string> config;
       if (config_plugin->genConfig(config)) {
-        Config::getInstance().update(config);
+        Config::get().update(config);
       }
     }
   }

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -37,7 +37,7 @@ extern void stripConfigComments(std::string& json);
 class ConfigTests : public testing::Test {
  public:
   ConfigTests() {
-    Config::getInstance().reset();
+    Config::get().reset();
   }
 
  protected:
@@ -51,13 +51,13 @@ class ConfigTests : public testing::Test {
 
  protected:
   Status load() {
-    return Config::getInstance().load();
+    return Config::get().load();
   }
   void setLoaded() {
-    Config::getInstance().loaded_ = true;
+    Config::get().loaded_ = true;
   }
   Config& get() {
-    return Config::getInstance();
+    return Config::get();
   }
 };
 

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -600,7 +600,7 @@ void Initializer::start() const {
 
   if (FLAGS_config_check) {
     // The initiator requested an initialization and config check.
-    auto s = Config::getInstance().load();
+    auto s = Config::get().load();
     if (!s.ok()) {
       std::cerr << "Error reading config: " << s.toString() << "\n";
     }
@@ -615,7 +615,7 @@ void Initializer::start() const {
   }
 
   // Load the osquery config using the default/active config plugin.
-  auto s = Config::getInstance().load();
+  auto s = Config::get().load();
   if (!s.ok()) {
     auto message = "Error reading config: " + s.toString();
     if (tool_ == ToolType::DAEMON) {

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1627,7 +1627,7 @@ int runPack(struct callback_data* data) {
   int rc = 0;
 
   // Check every pack for a name matching the requested --pack flag.
-  Config::getInstance().packs([data, &rc](std::shared_ptr<Pack>& pack) {
+  Config::get().packs([data, &rc](std::shared_ptr<Pack>& pack) {
     if (pack->getName() != FLAGS_pack) {
       return;
     }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -47,7 +47,7 @@ SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
   auto pid = std::to_string(PlatformProcess::getCurrentProcess()->pid());
   auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   auto t0 = getUnixTime();
-  Config::getInstance().recordQueryStart(name);
+  Config::get().recordQueryStart(name);
   SQLInternal sql(query.query);
   // Snapshot the performance after, and compare.
   auto t1 = getUnixTime();
@@ -63,8 +63,7 @@ SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
       }
     }
     // Always called while processes table is working.
-    Config::getInstance().recordQueryPerformance(
-        name, t1 - t0, size, r0[0], r1[0]);
+    Config::get().recordQueryPerformance(name, t1 - t0, size, r0[0], r1[0]);
   }
   return sql;
 }
@@ -149,7 +148,7 @@ void SchedulerRunner::start() {
   // Start the counter at the second.
   auto i = osquery::getUnixTime();
   for (; (timeout_ == 0) || (i <= timeout_); ++i) {
-    Config::getInstance().scheduledQueries(
+    Config::get().scheduledQueries(
         ([&i](const std::string& name, const ScheduledQuery& query) {
           if (query.splayed_interval > 0 && i % query.splayed_interval == 0) {
             TablePlugin::kCacheInterval = query.splayed_interval;

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -26,12 +26,12 @@ class SchedulerTests : public testing::Test {
   void SetUp() override {
     logging_ = FLAGS_disable_logging;
     FLAGS_disable_logging = true;
-    Config::getInstance().reset();
+    Config::get().reset();
   }
 
   void TearDown() override {
     FLAGS_disable_logging = logging_;
-    Config::getInstance().reset();
+    Config::get().reset();
   }
 
  private:
@@ -56,7 +56,7 @@ TEST_F(SchedulerTests, test_monitor) {
 
   // Ask the config instance for the monitored performance.
   QueryPerformance perf;
-  Config::getInstance().getPerformanceStats(
+  Config::get().getPerformanceStats(
       name, ([&perf](const QueryPerformance& r) { perf = r; }));
   // Make sure it was recorded query ran.
   // There is no pack for this query within the config, that is fine as these
@@ -89,7 +89,7 @@ TEST_F(SchedulerTests, test_config_results_purge) {
   // We do not need "THE" config instance.
   // We only need to trigger a 'purge' event, this occurs when configuration
   // content is updated by a plugin or on load.
-  Config::getInstance().purge();
+  Config::get().purge();
 
   // Nothing should have been purged.
   {
@@ -116,7 +116,7 @@ TEST_F(SchedulerTests, test_config_results_purge) {
       kPersistentSettings, "timestamp.test_query", std::to_string(query_time));
 
   // Trigger another purge.
-  Config::getInstance().purge();
+  Config::get().purge();
   // Now ALL 'test_query' related storage will have been purged.
   {
     std::string content;
@@ -159,7 +159,7 @@ TEST_F(SchedulerTests, test_scheduler) {
       "}"
       "}"
       "}";
-  Config::getInstance().update({{"data", config}});
+  Config::get().update({{"data", config}});
 
   // Run the scheduler for 1 second with a second interval.
   SchedulerRunner runner(static_cast<unsigned long int>(now + 1), 1);

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -91,7 +91,7 @@ class BenchmarkEventSubscriber
 
 static void EVENTS_subscribe_fire(benchmark::State& state) {
   // Setup the event config parser plugin.
-  auto plugin = Config::getInstance().getParser("events");
+  auto plugin = Config::get().getParser("events");
   plugin->setUp();
 
   // Register a publisher.

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -667,7 +667,7 @@ void EventFactory::configUpdate() {
   // Scan the schedule for queries that touch "_events" tables.
   // We will count the queries
   std::map<std::string, SubscriberExpirationDetails> subscriber_details;
-  Config::getInstance().scheduledQueries([&subscriber_details](
+  Config::get().scheduledQueries([&subscriber_details](
       const std::string& name, const ScheduledQuery& query) {
     std::vector<std::string> tables;
     // Convert query string into a list of virtual tables effected.
@@ -856,7 +856,7 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
     return Status(1, "Subscribers must have set a name");
   }
 
-  auto plugin = Config::getInstance().getParser("events");
+  auto plugin = Config::get().getParser("events");
   if (plugin != nullptr && plugin.get() != nullptr) {
     const auto& data = plugin->getData();
     // First perform explicit enabling.

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -451,12 +451,12 @@ TEST_F(EventsTests, test_event_subscriber_configure) {
   // Assure we start from a base state.
   EXPECT_EQ(sub->timesConfigured, 0U);
   // Force the config into a loaded state.
-  Config::getInstance().loaded_ = true;
-  Config::getInstance().update({{"data", "{}"}});
+  Config::get().loaded_ = true;
+  Config::get().update({{"data", "{}"}});
   EXPECT_EQ(sub->timesConfigured, 1U);
 
   // Now update the config to contain sets of scheduled queries.
-  Config::getInstance().update(
+  Config::get().update(
       {{"data",
         "{\"schedule\": {\"1\": {\"query\": \"select * from fake_events\", "
         "\"interval\": 10}, \"2\":{\"query\": \"select * from time, "
@@ -471,7 +471,7 @@ TEST_F(EventsTests, test_event_subscriber_configure) {
   rf.registry("event_subscriber")->remove(sub->getName());
 
   // Final check to make sure updates are not effecting this subscriber.
-  Config::getInstance().update({{"data", "{}"}});
+  Config::get().update({{"data", "{}"}});
   EXPECT_EQ(sub->timesConfigured, 2U);
 }
 

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -63,8 +63,8 @@ void FileEventSubscriber::configure() {
   // There may be a better way to find the set intersection/difference.
   removeSubscriptions();
 
-  Config::getInstance().files([this](const std::string& category,
-                                     const std::vector<std::string>& files) {
+  Config::get().files([this](const std::string& category,
+                             const std::vector<std::string>& files) {
     for (const auto& file : files) {
       VLOG(1) << "Added file event listener to: " << file;
       auto sc = createSubscriptionContext();

--- a/osquery/tables/events/darwin/process_events.cpp
+++ b/osquery/tables/events/darwin/process_events.cpp
@@ -75,7 +75,7 @@ Status ProcessEventSubscriber::Callback(
     bool use_whitelist = false;
     pt::ptree whitelist;
 
-    auto plugin = Config::getInstance().getParser("events");
+    auto plugin = Config::get().getParser("events");
     if (plugin == nullptr || plugin.get() == nullptr) {
       LOG(ERROR) << "Could not load events config parser";
     } else {

--- a/osquery/tables/events/darwin/process_file_events.cpp
+++ b/osquery/tables/events/darwin/process_file_events.cpp
@@ -43,8 +43,8 @@ void ProcessFileEventSubscriber::configure() {
   // There may be a better way to find the set intersection/difference.
   removeSubscriptions();
 
-  Config::getInstance().files([this](const std::string &category,
-                                     const std::vector<std::string> &files) {
+  Config::get().files([this](const std::string& category,
+                             const std::vector<std::string>& files) {
     for (const auto &file : files) {
       auto sc = createSubscriptionContext();
       sc->event_type = OSQUERY_FILE_EVENT;

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -62,8 +62,8 @@ void FileEventSubscriber::configure() {
 
   auto parser = Config::getParser("file_paths");
   auto& accesses = parser->getData().get_child("file_accesses");
-  Config::getInstance().files([this, &accesses](
-      const std::string& category, const std::vector<std::string>& files) {
+  Config::get().files([this, &accesses](const std::string& category,
+                                        const std::vector<std::string>& files) {
     for (const auto& file : files) {
       VLOG(1) << "Added file event listener to: " << file;
       auto sc = createSubscriptionContext();

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -30,7 +30,7 @@ class FileEventSubscriber;
 class FileEventsTableTests : public testing::Test {
  public:
   void SetUp() override {
-    Config::getInstance().reset();
+    Config::get().reset();
 
     // Promote registry access exceptions when testing tables and SQL.
     exceptions_ = FLAGS_registry_exceptions;
@@ -46,7 +46,7 @@ class FileEventsTableTests : public testing::Test {
 
  protected:
   Status load() {
-    return Config::getInstance().load();
+    return Config::get().load();
   }
 
  private:
@@ -110,7 +110,7 @@ TEST_F(FileEventsTableTests, test_configure_subscriptions) {
   }
 
   // The most important part, make sure a reconfigure removes the subscriptions.
-  Config::getInstance().update({{"data", "{}"}});
+  Config::get().update({{"data", "{}"}});
 
   {
     SQL results(q);

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -98,8 +98,8 @@ void YARAEventSubscriber::configure() {
   // But the subscriber must duplicate the set of subscriptions such that the
   // publisher's 'fire'-matching logic routes related events to our callback.
   std::map<std::string, std::vector<std::string>> file_map;
-  Config::getInstance().files([&file_map](
-      const std::string& category, const std::vector<std::string>& files) {
+  Config::get().files([&file_map](const std::string& category,
+                                  const std::vector<std::string>& files) {
     file_map[category] = files;
   });
 


### PR DESCRIPTION
The `Registry` APIs use `get()` for their singleton access. This moves the `Config` singleton to the same name.