### PR TITLE
config: Unify the config refresh logic

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -51,6 +51,14 @@ The **filesystem** config plugin's path to a JSON file.
 On OS X the default path is **/var/osquery/osquery.conf**.
 If you want to read from multiple configuration paths create a directory: **/etc/osquery/osquery.conf.d/**. All files within that optional directory will be read and merged in lexical order.
 
+`--config_refresh=0`
+
+An optional configuration refresh interval in seconds. By default a configuration is fetched only at osquery load. If the configuration should be auto-updated set a "refresh" time to a value in seconds greater than 0. If the configuration endpoint cannot be reached during runtime, the normal retry approach is applied (e.g., the **tls** config plugin will retry 3 times).
+
+`--config_accelerated_refresh=300`
+
+If a configuration refresh is used (`config_refresh > 0`) and the refresh attempt fails, the accelerated refresh will be used. This allows plugins like **tls** to fetch fresh data after having been offline for a while.
+
 `--config_check=false`
 
 Check the format of an osquery config and exit. Arbitrary config plugins may be used. osquery will return a non-0 exit if the parsing failed.
@@ -176,11 +184,6 @@ See the **tls**/[remote](../deployment/remote.md) plugin documentation. A very s
 `--config_tls_endpoint=""`
 
 The **tls** endpoint path, e.g.: **/api/v1/config** when using the **tls** config plugin. See the other **tls_** related CLI flags.
-
-`--config_tls_refresh=0`
-
-The configuration **tls** endpoint refresh interval. By default a configuration is fetched only at osquery load. If the configuration should be auto-updated set a "refresh" time to a value in seconds. This option enforces a minimum of 10 seconds. If the configuration endpoint cannot be reached during run, during an attempted refresh, the normal retry approach is applied.
-
 
 `--config_tls_max_attempts=3`
 

--- a/osquery/config/plugins/tests/tls_config_tests.cpp
+++ b/osquery/config/plugins/tests/tls_config_tests.cpp
@@ -20,7 +20,7 @@
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
-#include "osquery/config/plugins/tls.h"
+#include "osquery/config/plugins/tls_config.h"
 #include "osquery/core/conversions.h"
 #include "osquery/core/json.h"
 #include "osquery/dispatcher/scheduler.h"

--- a/osquery/config/plugins/tls_config.cpp
+++ b/osquery/config/plugins/tls_config.cpp
@@ -25,7 +25,7 @@
 #include "osquery/remote/serializers/json.h"
 #include "osquery/remote/utility.h"
 
-#include "osquery/config/plugins/tls.h"
+#include "osquery/config/plugins/tls_config.h"
 
 namespace pt = boost::property_tree;
 
@@ -42,26 +42,12 @@ CLI_FLAG(string,
          "",
          "TLS/HTTPS endpoint for config retrieval");
 
-/// Config polling/updating, only applies to TLS configurations.
-CLI_FLAG(uint64,
-         config_tls_refresh,
-         0,
-         "Optional interval in seconds to re-read configuration");
-
-/// How long to wait when config update fails
-CLI_FLAG(uint64,
-         config_tls_accelerated_refresh,
-         300,
-         "Interval to wait if reading a configuration fails");
-
 DECLARE_bool(tls_secret_always);
 DECLARE_string(tls_enroll_override);
 DECLARE_bool(tls_node_api);
 DECLARE_bool(enroll_always);
 
 REGISTER(TLSConfigPlugin, "config", "tls");
-
-std::atomic<size_t> TLSConfigPlugin::kCurrentDelay{0};
 
 Status TLSConfigPlugin::setUp() {
   if (FLAGS_enroll_always && !FLAGS_disable_enrollment) {
@@ -75,29 +61,11 @@ Status TLSConfigPlugin::setUp() {
   }
 
   uri_ = TLSRequestHelper::makeURI(FLAGS_config_tls_endpoint);
-
-  kCurrentDelay = FLAGS_config_tls_refresh;
-
   return Status(0, "OK");
-}
-
-void TLSConfigPlugin::updateDelayPeriod(bool success) {
-  if (success) {
-    if (kCurrentDelay != FLAGS_config_tls_refresh) {
-      VLOG(1) << "Normal configuration delay restored";
-      kCurrentDelay = FLAGS_config_tls_refresh;
-    }
-  } else {
-    if (kCurrentDelay == FLAGS_config_tls_refresh) {
-      VLOG(1) << "Using accelerated configuration delay";
-      kCurrentDelay = FLAGS_config_tls_accelerated_refresh;
-    }
-  }
 }
 
 Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
   std::string json;
-
   pt::ptree params;
   if (FLAGS_tls_node_api) {
     // The TLS node API morphs some verbs and variables.
@@ -106,7 +74,6 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
 
   auto s = TLSRequestHelper::go<JSONSerializer>(
       uri_, params, json, FLAGS_config_tls_max_attempts);
-
   if (s.ok()) {
     if (FLAGS_tls_node_api) {
       // The node API embeds configuration data (JSON escaped).
@@ -125,39 +92,7 @@ Status TLSConfigPlugin::genConfig(std::map<std::string, std::string>& config) {
       config["tls_plugin"] = json;
     }
   }
-  updateDelayPeriod(s.ok());
 
-  // If the initial configuration includes a non-0 refresh, start an additional
-  // service that sleeps and periodically regenerates the configuration.
-  if (!started_thread_ && FLAGS_config_tls_refresh >= 1) {
-    Dispatcher::addService(std::make_shared<TLSConfigRefreshRunner>());
-    started_thread_ = true;
-  }
   return s;
-}
-
-void TLSConfigRefreshRunner::start() {
-  while (!interrupted()) {
-    // Cool off and time wait the configured period.
-    // Apply this interruption initially as at t=0 the config was read.
-    pauseMilli(TLSConfigPlugin::kCurrentDelay * 1000);
-    // Since the pause occurs before the logic, we need to check for an
-    // interruption request.
-    if (interrupted()) {
-      return;
-    }
-
-    // Access the configuration.
-    auto plugin = RegistryFactory::get().plugin("config", "tls");
-    if (plugin != nullptr) {
-      auto config_plugin = std::dynamic_pointer_cast<ConfigPlugin>(plugin);
-
-      // The config instance knows the TLS plugin is selected.
-      std::map<std::string, std::string> config;
-      if (config_plugin->genConfig(config)) {
-        Config::get().update(config);
-      }
-    }
-  }
 }
 }

--- a/osquery/config/plugins/tls_config.h
+++ b/osquery/config/plugins/tls_config.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <vector>
-
 #include <osquery/config.h>
 #include <osquery/dispatcher.h>
 
@@ -24,7 +22,6 @@ class TLSConfigPlugin : public ConfigPlugin,
  public:
   Status setUp() override;
   Status genConfig(std::map<std::string, std::string>& config) override;
-  static std::atomic<size_t> kCurrentDelay;
 
  protected:
   /// Calculate the URL once and cache the result.
@@ -32,14 +29,5 @@ class TLSConfigPlugin : public ConfigPlugin,
 
  private:
   friend class TLSConfigTests;
-
-  void updateDelayPeriod(bool success);
-  bool started_thread_{false};
-};
-
-class TLSConfigRefreshRunner : public InternalRunnable {
- public:
-  /// A simple wait/interruptible lock.
-  void start();
 };
 }

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -22,17 +22,20 @@
 #include <osquery/system.h>
 
 #include "osquery/core/json.h"
+#include "osquery/core/process.h"
 #include "osquery/tests/test_util.h"
 
 namespace pt = boost::property_tree;
 
 namespace osquery {
 
+DECLARE_uint64(config_refresh);
+DECLARE_uint64(config_accelerated_refresh);
+
 // Blacklist testing methods, internal to config implementations.
 extern void restoreScheduleBlacklist(std::map<std::string, size_t>& blacklist);
 extern void saveScheduleBlacklist(
     const std::map<std::string, size_t>& blacklist);
-extern void stripConfigComments(std::string& json);
 
 class ConfigTests : public testing::Test {
  public:
@@ -70,6 +73,10 @@ class TestConfigPlugin : public ConfigPlugin {
 
   Status genConfig(std::map<std::string, std::string>& config) override {
     genConfigCount++;
+    if (fail) {
+      return Status(1);
+    }
+
     std::string content;
     auto s = readFile(kTestDataPath + "test_noninline_packs.conf", content);
     config["data"] = content;
@@ -87,14 +94,15 @@ class TestConfigPlugin : public ConfigPlugin {
   }
 
  public:
-  int genConfigCount{0};
-  int genPackCount{0};
+  std::atomic<size_t> genConfigCount{0};
+  std::atomic<size_t> genPackCount{0};
+  std::atomic<bool> fail{false};
 };
 
 TEST_F(ConfigTests, test_plugin) {
   auto& rf = RegistryFactory::get();
-  rf.registry("config")->add("test", std::make_shared<TestConfigPlugin>());
-
+  auto plugin = std::make_shared<TestConfigPlugin>();
+  rf.registry("config")->add("test", plugin);
   // Change the active config plugin.
   EXPECT_TRUE(rf.setActive("config", "test").ok());
 
@@ -103,6 +111,10 @@ TEST_F(ConfigTests, test_plugin) {
 
   EXPECT_EQ(status.ok(), true);
   EXPECT_EQ(status.toString(), "OK");
+
+  Registry::call("config", {{"action", "genConfig"}});
+  EXPECT_EQ(2U, plugin->genConfigCount);
+  rf.registry("config")->remove("test");
 }
 
 TEST_F(ConfigTests, test_invalid_content) {
@@ -165,13 +177,14 @@ TEST_F(ConfigTests, test_pack_noninline) {
   this->load();
   // Expect the test plugin to have recorded 1 pack.
   // This value is incremented when its genPack method is called.
-  EXPECT_EQ(plugin->genPackCount, 1);
+  EXPECT_EQ(plugin->genPackCount, 1U);
 
   int total_packs = 0;
   // Expect the config to have recorded a pack for the inline and non-inline.
   get().packs(
       [&total_packs](const std::shared_ptr<Pack>& pack) { total_packs++; });
   EXPECT_EQ(total_packs, 2);
+  rf.registry("config")->remove("test");
 }
 
 TEST_F(ConfigTests, test_pack_restrictions) {
@@ -300,6 +313,7 @@ TEST_F(ConfigTests, test_get_parser) {
 
   EXPECT_EQ(data.count("list"), 1U);
   EXPECT_EQ(data.count("dictionary"), 1U);
+  rf.registry("config_parser")->remove("test");
 }
 
 class PlaceboConfigParserPlugin : public ConfigParserPlugin {
@@ -333,6 +347,7 @@ TEST_F(ConfigTests, test_plugin_reconfigure) {
   auto placebo = std::static_pointer_cast<PlaceboConfigParserPlugin>(
       rf.plugin("config_parser", "placebo"));
   EXPECT_EQ(placebo->configures, 1U);
+  rf.registry("config_parser")->remove("placebo");
 }
 
 TEST_F(ConfigTests, test_pack_file_paths) {
@@ -366,5 +381,67 @@ TEST_F(ConfigTests, test_pack_file_paths) {
   get().update({{"data", "{}"}});
   get().files(fileCounter);
   EXPECT_EQ(count, 0U);
+}
+
+void waitForConfig(std::shared_ptr<TestConfigPlugin>& plugin, size_t count) {
+  // Max wait of 3 seconds.
+  size_t delay = 3000;
+  while (delay > 0) {
+    if (plugin->genConfigCount > count) {
+      break;
+    }
+    delay -= 20;
+    sleepFor(20);
+  }
+}
+
+TEST_F(ConfigTests, test_config_refresh) {
+  auto& rf = RegistryFactory::get();
+  auto refresh = FLAGS_config_refresh;
+  auto refresh_acceleratred = FLAGS_config_accelerated_refresh;
+
+  // Create and add a test plugin.
+  auto plugin = std::make_shared<TestConfigPlugin>();
+  EXPECT_TRUE(rf.registry("config")->add("test", plugin));
+  EXPECT_TRUE(rf.setActive("config", "test"));
+
+  // Expect the config to not contain a default refresh value.
+  ASSERT_EQ(0U, refresh);
+
+  // Set a config_refresh value to convince the Config to start the thread.
+  FLAGS_config_refresh = 2;
+  FLAGS_config_accelerated_refresh = 1;
+  get().refresh_runner_->mod_ = 10;
+  get().refresh();
+
+  // This refresh call with a refresh value > 0 will have started a refresh
+  // thread.
+  ASSERT_TRUE(get().started_thread_);
+
+  // The runner will wait at least one refresh-delay.
+  waitForConfig(plugin, 1);
+  ASSERT_GT(plugin->genConfigCount, 1U);
+
+  // Now make the configuration break.
+  plugin->fail = true;
+  auto count = static_cast<size_t>(plugin->genConfigCount);
+  waitForConfig(plugin, count + 1);
+  ASSERT_GT(plugin->genConfigCount, count + 1);
+  EXPECT_EQ(get().refresh_runner_->refresh(), 1U);
+
+  // Test that the normal acceleration is restored.
+  plugin->fail = false;
+  count = static_cast<size_t>(plugin->genConfigCount);
+  waitForConfig(plugin, count + 1);
+  ASSERT_GT(plugin->genConfigCount, count + 1);
+  EXPECT_EQ(get().refresh_runner_->refresh(), 2U);
+
+  // Stop the refresh runner thread.
+  Dispatcher::stopServices();
+  Dispatcher::joinServices();
+
+  FLAGS_config_refresh = refresh;
+  FLAGS_config_accelerated_refresh = refresh_acceleratred;
+  rf.registry("config")->remove("test");
 }
 }


### PR DESCRIPTION
There are two config "refresh" concepts in the codebase right now. One only applies to the TLS configuration plugin, the other applies to any plugin; they use (respectively):
* `--config_tls_refresh`
* `--config_refresh`

This PR deprecates the `*_tls_*` flags related to refreshing by assigning them as aliases. It moves the "accelerated" refresh concept used by the TLS plugin to the general concept. It also adds a test for configuration refreshing. This test has not been applied end-to-end to the TLS plugin.