### PR TITLE
[Tidy] Fix all C99 warnings

### DIFF
--- a/osquery/tables/networking/darwin/tests/wifi_tests.mm
+++ b/osquery/tables/networking/darwin/tests/wifi_tests.mm
@@ -37,11 +37,9 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   QueryData results;
   auto count = CFDictionaryGetCount(networks);
   ASSERT_EQ((long)count, 2);
-  auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
-  auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
-  ASSERT_NE(keys, nullptr);
-  ASSERT_NE(values, nullptr);
-  CFDictionaryGetKeysAndValues(networks, keys, values);
+  std::vector<const void *> keys(count);
+  std::vector<const void *> values(count);
+  CFDictionaryGetKeysAndValues(networks, keys.data(), values.data());
 
   for (CFIndex i = 0; i < count; i++) {
     parseNetworks((CFDictionaryRef)values[i], results);
@@ -82,8 +80,6 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   for (const auto& column : expected2) {
     EXPECT_EQ(results.back()[column.first], column.second);
   }
-  free(keys);
-  free(values);
 }
 
 TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {

--- a/osquery/tables/networking/darwin/tests/wifi_tests.mm
+++ b/osquery/tables/networking/darwin/tests/wifi_tests.mm
@@ -37,8 +37,10 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   QueryData results;
   auto count = CFDictionaryGetCount(networks);
   ASSERT_EQ((long)count, 2);
-  const void* keys[count];
-  const void* values[count];
+  auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
+  auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
+  ASSERT_NE(keys, nullptr);
+  ASSERT_NE(values, nullptr);
   CFDictionaryGetKeysAndValues(networks, keys, values);
 
   for (CFIndex i = 0; i < count; i++) {
@@ -80,6 +82,8 @@ TEST_F(WifiNetworksTest, test_parse_wifi_networks) {
   for (const auto& column : expected2) {
     EXPECT_EQ(results.back()[column.first], column.second);
   }
+  free(keys);
+  free(values);
 }
 
 TEST_F(WifiNetworksTest, test_parse_legacy_wifi_networks) {

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -140,17 +140,13 @@ QueryData genKnownWifiNetworks(QueryContext& context) {
     }
   } else if (CFGetTypeID(networks) == CFDictionaryGetTypeID()) {
     auto count = CFDictionaryGetCount((CFDictionaryRef)networks);
-    auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
-    auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
-
-    if (keys != nullptr && values != nullptr) {
-      CFDictionaryGetKeysAndValues((CFDictionaryRef)networks, keys, values);
-      for (CFIndex i = 0; i < count; i++) {
-        parseNetworks((CFDictionaryRef)values[i], results);
-      }
+    std::vector<const void *> keys(count);
+    std::vector<const void *> values(count);
+    CFDictionaryGetKeysAndValues((CFDictionaryRef)networks, keys.data(),
+                                 values.data());
+    for (CFIndex i = 0; i < count; i++) {
+      parseNetworks((CFDictionaryRef)values[i], results);
     }
-    free(keys);
-    free(values);
   }
   return results;
 }

--- a/osquery/tables/system/darwin/authorizations.mm
+++ b/osquery/tables/system/darwin/authorizations.mm
@@ -131,11 +131,13 @@ QueryData genAuthorizations(QueryContext &context) {
       }
 
       CFIndex count = CFDictionaryGetCount(rightSet);
-      const void *keys[count];
-      const void *values[count];
+      auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
+      auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
       CFDictionaryGetKeysAndValues(rightSet, keys, values);
       if ((const void *)keys == nullptr || (const void *)values == nullptr) {
         CFRelease(rightSet);
+        free(keys);
+        free(values);
         continue;
       }
 
@@ -159,10 +161,11 @@ QueryData genAuthorizations(QueryContext &context) {
       }
 
       results.push_back(r);
-
       if (rightSet != nullptr) {
         CFRelease(rightSet);
       }
+      free(keys);
+      free(values);
     }
 
     return results;

--- a/osquery/tables/system/darwin/authorizations.mm
+++ b/osquery/tables/system/darwin/authorizations.mm
@@ -131,13 +131,11 @@ QueryData genAuthorizations(QueryContext &context) {
       }
 
       CFIndex count = CFDictionaryGetCount(rightSet);
-      auto keys = static_cast<const void **>(malloc(sizeof(void *) * count));
-      auto values = static_cast<const void **>(malloc(sizeof(void *) * count));
-      CFDictionaryGetKeysAndValues(rightSet, keys, values);
-      if ((const void *)keys == nullptr || (const void *)values == nullptr) {
+      std::vector<const void *> keys(count);
+      std::vector<const void *> values(count);
+      CFDictionaryGetKeysAndValues(rightSet, keys.data(), values.data());
+      if (keys.data() == nullptr || values.data() == nullptr) {
         CFRelease(rightSet);
-        free(keys);
-        free(values);
         continue;
       }
 
@@ -164,8 +162,6 @@ QueryData genAuthorizations(QueryContext &context) {
       if (rightSet != nullptr) {
         CFRelease(rightSet);
       }
-      free(keys);
-      free(values);
     }
 
     return results;

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -68,12 +68,10 @@ Status parseKeychainItemACLEntry(SecACLRef acl,
   OSStatus os_status;
 
   uint32 acl_tag_size = 64;
-  CSSM_ACL_AUTHORIZATION_TAG* tags = static_cast<CSSM_ACL_AUTHORIZATION_TAG*>(
-      malloc(sizeof(CSSM_ACL_AUTHORIZATION_TAG) * acl_tag_size));
+  std::vector<CSSM_ACL_AUTHORIZATION_TAG> tags(acl_tag_size);
   OSQUERY_USE_DEPRECATED(
-      os_status = SecACLGetAuthorizations(acl, tags, &acl_tag_size););
+      os_status = SecACLGetAuthorizations(acl, tags.data(), &acl_tag_size););
   if (os_status != noErr) {
-    free(tags);
     return Status(os_status, "Could not get ACL authorizations");
   }
 
@@ -83,7 +81,6 @@ Status parseKeychainItemACLEntry(SecACLRef acl,
       acl_data.authorizations.push_back(kACLAuthorizationTags.at(tag));
     }
   }
-  free(tags);
   CFStringRef description = nullptr;
   CSSM_ACL_KEYCHAIN_PROMPT_SELECTOR prompt_selector = {};
   CFArrayRef application_list = nullptr;

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -68,10 +68,12 @@ Status parseKeychainItemACLEntry(SecACLRef acl,
   OSStatus os_status;
 
   uint32 acl_tag_size = 64;
-  CSSM_ACL_AUTHORIZATION_TAG tags[acl_tag_size];
+  CSSM_ACL_AUTHORIZATION_TAG* tags = static_cast<CSSM_ACL_AUTHORIZATION_TAG*>(
+      malloc(sizeof(CSSM_ACL_AUTHORIZATION_TAG) * acl_tag_size));
   OSQUERY_USE_DEPRECATED(
       os_status = SecACLGetAuthorizations(acl, tags, &acl_tag_size););
   if (os_status != noErr) {
+    free(tags);
     return Status(os_status, "Could not get ACL authorizations");
   }
 
@@ -81,7 +83,7 @@ Status parseKeychainItemACLEntry(SecACLRef acl,
       acl_data.authorizations.push_back(kACLAuthorizationTags.at(tag));
     }
   }
-
+  free(tags);
   CFStringRef description = nullptr;
   CSSM_ACL_KEYCHAIN_PROMPT_SELECTOR prompt_selector = {};
   CFArrayRef application_list = nullptr;

--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -162,18 +162,24 @@ void genOpenDescriptors(int pid, descriptor_type type, QueryData& results) {
   }
 
   // Allocate structs for each descriptor.
-  proc_fdinfo fds[bufsize / PROC_PIDLISTFD_SIZE];
+  proc_fdinfo* fds = static_cast<proc_fdinfo*>(
+      malloc(sizeof(proc_fdinfo) * (bufsize / PROC_PIDLISTFD_SIZE)));
+  if (fds == nullptr) {
+    return;
+  }
+  // proc_fdinfo fds[bufsize / PROC_PIDLISTFD_SIZE];
   proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds, bufsize);
 
-  for (auto fd_info : fds) {
+  for (size_t i = 0; i < bufsize / PROC_PIDLISTFD_SIZE; ++i) {
     if (type == DESCRIPTORS_TYPE_VNODE &&
-        fd_info.proc_fdtype == PROX_FDTYPE_VNODE) {
-      genFileDescriptor(pid, fd_info.proc_fd, results);
+        fds[i].proc_fdtype == PROX_FDTYPE_VNODE) {
+      genFileDescriptor(pid, fds[i].proc_fd, results);
     } else if (type == DESCRIPTORS_TYPE_SOCKET &&
-               fd_info.proc_fdtype == PROX_FDTYPE_SOCKET) {
-      genSocketDescriptor(pid, fd_info.proc_fd, results);
+               fds[i].proc_fdtype == PROX_FDTYPE_SOCKET) {
+      genSocketDescriptor(pid, fds[i].proc_fd, results);
     }
   }
+  free(fds);
 }
 
 QueryData genOpenSockets(QueryContext& context) {


### PR DESCRIPTION
In an effort to cleanup the osquery code base, warnings are being addressed. This diff fixes all C99 warnings about allocating dynamic arrays on the stack.