### PR TITLE
[Tidy] Fix syscall deprecation on macOS

### DIFF
--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -89,11 +89,10 @@ int platformGetPid() {
 }
 
 int platformGetTid() {
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(FREEBSD)
   return std::hash<std::thread::id>()(std::this_thread::get_id());
-#elif !defined(FREEBSD)
+#else
   return (int)syscall(SYS_gettid);
 #endif
-  return 0;
 }
 }

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -89,7 +89,9 @@ int platformGetPid() {
 }
 
 int platformGetTid() {
-#if !defined(FREEBSD)
+#if defined(__APPLE__)
+  return std::hash<std::thread::id>()(std::this_thread::get_id());
+#elif !defined(FREEBSD)
   return (int)syscall(SYS_gettid);
 #endif
   return 0;


### PR DESCRIPTION
The syscall to get thread id is deprecated on macOS as of 10.12. This replaces the syscall with a std:: library call. I found this code mod in another project [here](https://github.com/gabime/spdlog/commit/b715378ff55eb40664d215e9264407b0310ec763#diff-075620b19501eee6536187116b2c8ff9R183) and discussion of it [here](https://github.com/gabime/spdlog/issues/74).