### PR TITLE
[Tidy] Fix four character literal warning

### DIFF
--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -204,7 +204,8 @@ Status genKeychainACLAppsForEntry(SecKeychainRef keychain,
   case kSecGenericPasswordItemClass:
     item_id = CSSM_DL_DB_RECORD_GENERIC_PASSWORD;
     break;
-  case 'ashp':
+  // ashp case
+  case 0x61736870:
     item_id = CSSM_DL_DB_RECORD_APPLESHARE_PASSWORD;
     break;
   default:


### PR DESCRIPTION
Using a four character literal as an int causes clang to issue a warning. This replaces the string literal with a numerical hex representation and a comment noting what it was before.