### PR TITLE
events: Sane defaults for expiration and max

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -274,7 +274,7 @@ Maximum file read size. The daemon or shell will first 'stat' each file before r
 
 Disable osquery Operating System [eventing publish subscribe](../development/pubsub-framework.md) APIs. This will implicitly disable several tables that report based on logged events.
 
-`--events_expiry=86000`
+`--events_expiry=3600`
 
 Timeout to expire [eventing publish subscribe](../development/pubsub-framework.md) results from the backing-store. This expiration is only applied when results are queried. For example, if `--events_expiry=1` then events will only practically exist for a single select from the subscriber. If no select occurs then events will be saved in the backing store indefinitely.
 
@@ -282,9 +282,9 @@ Timeout to expire [eventing publish subscribe](../development/pubsub-framework.m
 
 Since event rows are only "added" it does not make sense to emit "removed" results. An optimization can occur within the osquery daemon's query schedule. Every time the select query runs on a subscriber the current time is saved. Subsequent selects will use the previously saved time as the lower bound. This optimization is removed if any constraints on the "time" column are included.
 
-`--events_max=1000`
+`--events_max=50000`
 
-Maximum number of events to buffer in the backing store while waiting for a query to 'drain' or trigger an expiration. If the expiration (`events_expiry`) is set to 1 day, this max value indicates that only 1000 events will be stored before dropping each day. In this case the limiting time is almost always the scheduled query. If a scheduled query that select from events-based tables occurs sooner than the expiration time that interval becomes the limit.
+Maximum number of events to buffer in the backing store while waiting for a query to 'drain' or trigger an expiration. If the expiration (`events_expiry`) is set to 1 hour, this max value indicates that only 50000 events will be stored before dropping each hour. In this case the limiting time is almost always the scheduled query. If a scheduled query that select from events-based tables occurs sooner than the expiration time that interval becomes the limit.
 
 **Windows Only**
 

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -43,14 +43,11 @@ FLAG(bool,
 
 // Access this flag through EventSubscriberPlugin::getEventsExpiry to allow for
 // overriding in subclasses
-FLAG(uint64,
-     events_expiry,
-     86000,
-     "Timeout to expire event subscriber results");
+FLAG(uint64, events_expiry, 3600, "Timeout to expire event subscriber results");
 
 // Access this flag through EventSubscriberPlugin::getEventsMax to allow for
 // overriding in subclasses
-FLAG(uint64, events_max, 1000, "Maximum number of events per type to buffer");
+FLAG(uint64, events_max, 50000, "Maximum number of events per type to buffer");
 
 static inline EventTime timeFromRecord(const std::string& record) {
   // Convert a stored index "as string bytes" to a time value.


### PR DESCRIPTION
See https://community.uptycs.com/osquery-fim-reliability/ for more details.

Several folks have suggested that the `events_max` default should be near 50k. The expiration is suggested to be `1` for best performance, yet we set the default to "near 1 day". The safe default was suggested to be an hour.