### PR TITLE
watcher: Rename instance to get for consistency

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -121,7 +121,7 @@ static inline bool hasWorkerVariable() {
 volatile std::sig_atomic_t kHandledSignal{0};
 
 static inline bool isWatcher() {
-  return (osquery::Watcher::getWorker().isValid());
+  return (osquery::Watcher::get().getWorker().isValid());
 }
 
 void signalHandler(int num) {
@@ -155,7 +155,7 @@ void signalHandler(int num) {
       // The watcher waits for the worker to die.
       if (isWatcher()) {
         // Bind the fate of the worker to this watcher.
-        osquery::Watcher::bindFates();
+        osquery::Watcher::get().bindFates();
       } else {
         // Otherwise the worker or non-watched process joins.
         // Stop thrift services/clients/and their thread pools.
@@ -465,7 +465,7 @@ void Initializer::initWatcher() const {
 
   // Add a watcher service thread to start/watch an optional worker and list
   // of optional extensions from the autoload paths.
-  if (Watcher::hasManagedExtensions() || !FLAGS_disable_watchdog) {
+  if (Watcher::get().hasManagedExtensions() || !FLAGS_disable_watchdog) {
     Dispatcher::addService(std::make_shared<WatcherRunner>(
         *argc_, *argv_, !FLAGS_disable_watchdog));
   }
@@ -483,8 +483,8 @@ void Initializer::waitForWatcher() const {
     auto retcode = 0;
     if (kHandledSignal > 0) {
       retcode = 128 + kHandledSignal;
-    } else if (Watcher::getWorkerStatus() >= 0) {
-      retcode = Watcher::getWorkerStatus();
+    } else if (Watcher::get().getWorkerStatus() >= 0) {
+      retcode = Watcher::get().getWorkerStatus();
     } else {
       retcode = EXIT_FAILURE;
     }
@@ -540,7 +540,7 @@ void Initializer::initActivePlugin(const std::string& type,
       return rs;
     }
 
-    if (!Watcher::hasManagedExtensions()) {
+    if (!Watcher::get().hasManagedExtensions()) {
       // The plugin must be local, and is not active, problem.
       stop = true;
     }
@@ -559,7 +559,7 @@ void Initializer::start() const {
   // If the shell or daemon does not need extensions and it will exit quickly,
   // prefer to disable the extension manager.
   if ((FLAGS_config_check || FLAGS_config_dump) &&
-      !Watcher::hasManagedExtensions()) {
+      !Watcher::get().hasManagedExtensions()) {
     FLAGS_disable_extensions = true;
   }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -82,17 +82,16 @@ CLI_FLAG(bool, disable_watchdog, false, "Disable userland watchdog process");
 
 void Watcher::resetWorkerCounters(size_t respawn_time) {
   // Reset the monitoring counters for the watcher.
-  auto& state = instance().state_;
-  state.sustained_latency = 0;
-  state.user_time = 0;
-  state.system_time = 0;
-  state.last_respawn_time = respawn_time;
+  state_.sustained_latency = 0;
+  state_.user_time = 0;
+  state_.system_time = 0;
+  state_.last_respawn_time = respawn_time;
 }
 
 void Watcher::resetExtensionCounters(const std::string& extension,
                                      size_t respawn_time) {
-  WatcherLocker locker;
-  auto& state = instance().extension_states_[extension];
+  WatcherExtensionsLocker locker;
+  auto& state = get().extension_states_[extension];
   state.sustained_latency = 0;
   state.user_time = 0;
   state.system_time = 0;
@@ -109,34 +108,32 @@ std::string Watcher::getExtensionPath(const PlatformProcess& child) {
 }
 
 void Watcher::removeExtensionPath(const std::string& extension) {
-  WatcherLocker locker;
-  auto& self = instance();
-  self.extensions_.erase(extension);
-  self.extension_states_.erase(extension);
+  WatcherExtensionsLocker locker;
+  extensions_.erase(extension);
+  extension_states_.erase(extension);
 }
 
 PerformanceState& Watcher::getState(const PlatformProcess& child) {
-  auto& self = instance();
-  if (child == *self.worker_) {
-    return self.state_;
+  if (child == *worker_) {
+    return state_;
   } else {
-    return self.extension_states_[getExtensionPath(child)];
+    return extension_states_[getExtensionPath(child)];
   }
 }
 
 PerformanceState& Watcher::getState(const std::string& extension) {
-  return instance().extension_states_[extension];
+  return extension_states_[extension];
 }
 
 void Watcher::setExtension(const std::string& extension,
                            const std::shared_ptr<PlatformProcess>& child) {
-  WatcherLocker locker;
-  instance().extensions_[extension] = child;
+  WatcherExtensionsLocker locker;
+  extensions_[extension] = child;
 }
 
 void Watcher::reset(const PlatformProcess& child) {
-  if (child == *instance().worker_) {
-    instance().worker_ = 0;
+  if (child == *worker_) {
+    worker_ = 0;
     resetWorkerCounters(0);
     return;
   }
@@ -155,8 +152,8 @@ void Watcher::addExtensionPath(const std::string& path) {
   resetExtensionCounters(path, 0);
 }
 
-bool Watcher::hasManagedExtensions() {
-  if (instance().extensions_.size() > 0) {
+bool Watcher::hasManagedExtensions() const {
+  if (!extensions_.empty()) {
     return true;
   }
 
@@ -167,27 +164,28 @@ bool Watcher::hasManagedExtensions() {
   return getEnvVar("OSQUERY_EXTENSIONS").is_initialized();
 }
 
-bool WatcherRunner::ok() {
+bool WatcherRunner::ok() const {
   // Inspect the exit code, on success or catastrophic, end the watcher.
-  auto status = Watcher::getWorkerStatus();
+  auto status = Watcher::get().getWorkerStatus();
   if (status == EXIT_SUCCESS || status == EXIT_CATASTROPHIC) {
     return false;
   }
   // Watcher is OK to run if a worker or at least one extension exists.
-  return (Watcher::getWorker().isValid() || Watcher::hasManagedExtensions());
+  return (Watcher::get().getWorker().isValid() ||
+          Watcher::get().hasManagedExtensions());
 }
 
 void WatcherRunner::start() {
   // Set worker performance counters to an initial state.
-  Watcher::resetWorkerCounters(0);
+  Watcher::get().resetWorkerCounters(0);
   // Hold the current process (watcher) for inspection too.
   auto watcher = PlatformProcess::getCurrentProcess();
   PerformanceState watcher_state;
 
   // Enter the watch loop.
   do {
-    if (use_worker_ && !watch(Watcher::getWorker())) {
-      if (Watcher::fatesBound()) {
+    if (use_worker_ && !watch(Watcher::get().getWorker())) {
+      if (Watcher::get().fatesBound()) {
         // A signal has interrupted the watcher.
         break;
       }
@@ -196,7 +194,7 @@ void WatcherRunner::start() {
     }
 
     // Loop over every managed extension and check sanity.
-    for (const auto& extension : Watcher::extensions()) {
+    for (const auto& extension : Watcher::get().extensions()) {
       auto s = isChildSane(*extension.second);
       if (!s.ok()) {
         // The extension manager also watches for extension-related failures.
@@ -210,7 +208,7 @@ void WatcherRunner::start() {
     // If any extension creations failed, stop managing them.
     for (auto& extension : extension_restarts_) {
       if (extension.second > 3) {
-        Watcher::removeExtensionPath(extension.first);
+        Watcher::get().removeExtensionPath(extension.first);
         extension.second = 0;
       }
     }
@@ -236,7 +234,7 @@ void WatcherRunner::start() {
 bool WatcherRunner::watch(const PlatformProcess& child) const {
   int process_status = 0;
   ProcessState result = child.checkStatus(process_status);
-  if (Watcher::fatesBound()) {
+  if (Watcher::get().fatesBound()) {
     // A signal was handled while the watcher was watching.
     return false;
   }
@@ -258,7 +256,7 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
 
   if (result == PROCESS_EXITED) {
     // If the worker process existed, store the exit code.
-    Watcher::instance().worker_status_ = process_status;
+    Watcher::get().worker_status_ = process_status;
   }
 
   return true;
@@ -381,8 +379,8 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
   PerformanceChange change;
   {
-    WatcherLocker locker;
-    auto& state = Watcher::getState(child);
+    WatcherExtensionsLocker locker;
+    auto& state = Watcher::get().getState(child);
     change = getChange(rows[0], state);
   }
 
@@ -390,7 +388,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
   // child. It's possible for the child to die, and its pid reused.
   if (change.parent != PlatformProcess::getCurrentProcess()->pid()) {
     // The child's parent is not the watcher.
-    Watcher::reset(child);
+    Watcher::get().reset(child);
     // Do not stop or call the child insane, since it is not our child.
     return Status(0);
   }
@@ -406,7 +404,7 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 
   // The worker is sane, no action needed.
   // Attempt to flush status logs to the well-behaved worker.
-  if (use_worker_ && child.pid() == Watcher::getWorker().pid()) {
+  if (use_worker_ && child.pid() == Watcher::get().getWorker().pid()) {
     relayStatusLogs();
   }
 
@@ -414,18 +412,19 @@ Status WatcherRunner::isChildSane(const PlatformProcess& child) const {
 }
 
 void WatcherRunner::createWorker() {
+  auto& watcher = Watcher::get();
+
   {
-    WatcherLocker locker;
-    if (Watcher::getState(Watcher::getWorker()).last_respawn_time >
+    WatcherExtensionsLocker locker;
+    if (watcher.getState(watcher.getWorker()).last_respawn_time >
         getUnixTime() - getWorkerLimit(WatchdogLimitType::RESPAWN_LIMIT)) {
       LOG(WARNING) << "osqueryd worker respawning too quickly: "
-                   << Watcher::workerRestartCount() << " times";
-      Watcher::workerRestarted();
+                   << watcher.workerRestartCount() << " times";
+      watcher.workerRestarted();
       // The configured automatic delay.
       size_t delay = getWorkerLimit(WatchdogLimitType::RESPAWN_DELAY) * 1000;
       // Exponential back off for quickly-respawning clients.
-      delay +=
-          static_cast<size_t>(pow(2, Watcher::workerRestartCount())) * 1000;
+      delay += static_cast<size_t>(pow(2, watcher.workerRestartCount())) * 1000;
       pauseMilli(delay);
     }
   }
@@ -444,7 +443,7 @@ void WatcherRunner::createWorker() {
 
   // Set an environment signaling to potential plugin-dependent workers to wait
   // for extensions to broadcast.
-  if (Watcher::hasManagedExtensions()) {
+  if (watcher.hasManagedExtensions()) {
     setEnvVar("OSQUERY_EXTENSIONS", "true");
   }
 
@@ -468,16 +467,18 @@ void WatcherRunner::createWorker() {
     return;
   }
 
-  Watcher::setWorker(worker);
-  Watcher::resetWorkerCounters(getUnixTime());
+  watcher.setWorker(worker);
+  watcher.resetWorkerCounters(getUnixTime());
   VLOG(1) << "osqueryd watcher (" << PlatformProcess::getCurrentProcess()->pid()
           << ") executing worker (" << worker->pid() << ")";
 }
 
 void WatcherRunner::createExtension(const std::string& extension) {
+  auto& watcher = Watcher::get();
+
   {
-    WatcherLocker locker;
-    if (Watcher::getState(extension).last_respawn_time >
+    WatcherExtensionsLocker locker;
+    if (watcher.getState(extension).last_respawn_time >
         getUnixTime() - getWorkerLimit(WatchdogLimitType::RESPAWN_LIMIT)) {
       LOG(WARNING) << "Extension respawning too quickly: " << extension;
       // Unlike a worker, if an extension respawns to quickly we give up.
@@ -508,8 +509,8 @@ void WatcherRunner::createExtension(const std::string& extension) {
     Initializer::shutdown(EXIT_FAILURE);
   }
 
-  Watcher::setExtension(extension, ext_process);
-  Watcher::resetExtensionCounters(extension, getUnixTime());
+  watcher.setExtension(extension, ext_process);
+  watcher.resetExtensionCounters(extension, getUnixTime());
   VLOG(1) << "Created and monitoring extension child (" << ext_process->pid()
           << "): " << extension;
 }

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -96,76 +96,76 @@ struct PerformanceState {
 class Watcher : private boost::noncopyable {
  public:
   /// Instance accessor
-  static Watcher& instance() {
+  static Watcher& get() {
     static Watcher instance;
     return instance;
   }
 
   /// Reset counters after a worker exits.
-  static void resetWorkerCounters(size_t respawn_time);
+  void resetWorkerCounters(size_t respawn_time);
 
   /// Reset counters for an extension path.
-  static void resetExtensionCounters(const std::string& extension,
-                                     size_t respawn_time);
+  void resetExtensionCounters(const std::string& extension,
+                              size_t respawn_time);
 
   /// Lock access to extensions.
-  static void lock() {
-    instance().lock_.lock();
+  void lock() {
+    get().lock_.lock();
   }
 
   /// Unlock access to extensions.
-  static void unlock() {
-    instance().lock_.unlock();
+  void unlock() {
+    get().lock_.unlock();
   }
 
   /// Accessor for autoloadable extension paths.
-  static const ExtensionMap& extensions() {
-    return instance().extensions_;
+  const ExtensionMap& extensions() const {
+    return extensions_;
   }
 
   /// Lookup extension path from pid.
-  static std::string getExtensionPath(const PlatformProcess& child);
+  std::string getExtensionPath(const PlatformProcess& child);
 
   /// Remove an autoloadable extension path.
-  static void removeExtensionPath(const std::string& extension);
+  void removeExtensionPath(const std::string& extension);
 
   /// Add extensions autoloadable paths.
-  static void addExtensionPath(const std::string& path);
+  void addExtensionPath(const std::string& path);
 
   /// Get state information for a worker or extension child.
-  static PerformanceState& getState(const PlatformProcess& child);
-  static PerformanceState& getState(const std::string& extension);
+  PerformanceState& getState(const PlatformProcess& child);
+  PerformanceState& getState(const std::string& extension);
 
   /// Accessor for the worker process.
-  static PlatformProcess& getWorker() {
-    return *instance().worker_;
+  PlatformProcess& getWorker() {
+    return *worker_;
   }
 
   /// Setter for worker process.
-  static void setWorker(const std::shared_ptr<PlatformProcess>& child) {
-    instance().worker_ = child;
+  void setWorker(const std::shared_ptr<PlatformProcess>& child) {
+    worker_ = child;
   }
 
   /// Setter for an extension process.
-  static void setExtension(const std::string& extension,
-                           const std::shared_ptr<PlatformProcess>& child);
+  void setExtension(const std::string& extension,
+                    const std::shared_ptr<PlatformProcess>& child);
 
   /// Reset pid and performance counters for a worker or extension process.
-  static void reset(const PlatformProcess& child);
+  void reset(const PlatformProcess& child);
 
   /// Count the number of worker restarts.
-  static size_t workerRestartCount() {
-    return instance().worker_restarts_;
+  size_t workerRestartCount() const {
+    return worker_restarts_;
   }
 
   /// Become responsible for the worker's fate, but do not guarantee its safety.
-  static void bindFates() {
-    instance().restart_worker_ = false;
+  void bindFates() {
+    restart_worker_ = false;
   }
 
   /// Check if the worker and watcher's fates are bound.
-  static bool fatesBound() {
-    return !instance().restart_worker_;
+  bool fatesBound() const {
+    return !restart_worker_;
   }
 
   /**
@@ -175,11 +175,11 @@ class Watcher : private boost::noncopyable {
    * broadcast from potentially-loaded extensions. If no extensions are loaded
    * and an active (selected at command line) plugin is missing, fail quickly.
    */
-  static bool hasManagedExtensions();
+  bool hasManagedExtensions() const;
 
   /// Check the status of the last worker.
-  static int getWorkerStatus() {
-    return instance().worker_status_;
+  int getWorkerStatus() const {
+    return worker_status_;
   }
 
  private:
@@ -195,8 +195,8 @@ class Watcher : private boost::noncopyable {
 
  private:
   /// Inform the watcher that the worker restarted without cause.
-  static void workerRestarted() {
-    instance().worker_restarts_++;
+  void workerRestarted() {
+    worker_restarts_++;
   }
 
  private:
@@ -243,16 +243,16 @@ class Watcher : private boost::noncopyable {
  * extensions or autoloadable extension paths a Watcher may be monitoring.
  * A signal or WatcherRunner thread may stop or start extensions.
  */
-class WatcherLocker {
+class WatcherExtensionsLocker {
  public:
   /// Construct and gain watcher lock.
-  WatcherLocker() {
-    Watcher::lock();
+  WatcherExtensionsLocker() {
+    Watcher::get().lock();
   }
 
   /// Destruct and release watcher lock.
-  ~WatcherLocker() {
-    Watcher::unlock();
+  ~WatcherExtensionsLocker() {
+    Watcher::get().unlock();
   }
 };
 
@@ -282,7 +282,7 @@ class WatcherRunner : public InternalRunnable {
   void start();
 
   /// Boilerplate function to sleep for some configured latency
-  bool ok();
+  bool ok() const;
 
   /// Begin the worker-watcher process.
   virtual bool watch(const PlatformProcess& child) const;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -337,7 +337,7 @@ Status loadExtensions(const std::string& loadfile) {
   if (!FLAGS_extension.empty()) {
     // This is a shell-only development flag for quickly loading/using a single
     // extension. It bypasses the safety check.
-    Watcher::addExtensionPath(FLAGS_extension);
+    Watcher::get().addExtensionPath(FLAGS_extension);
   }
 
   std::string autoload_paths;
@@ -364,7 +364,7 @@ Status loadExtensions(const std::string& loadfile) {
   for (const auto& binary : autoload_binaries) {
     // After the path is sanitized the watcher becomes responsible for
     // forking and executing the extension binary.
-    Watcher::addExtensionPath(binary);
+    Watcher::get().addExtensionPath(binary);
   }
   return Status(0, "OK");
 }

--- a/osquery/main/shell.cpp
+++ b/osquery/main/shell.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     osquery::FLAGS_disable_events = true;
     osquery::FLAGS_disable_caching = true;
     // The shell may have loaded table extensions, if not, disable the manager.
-    if (!osquery::Watcher::hasManagedExtensions()) {
+    if (!osquery::Watcher::get().hasManagedExtensions()) {
       osquery::FLAGS_disable_extensions = true;
     }
   }


### PR DESCRIPTION
This is mostly code-cleanup: renaming singleton access method to `get()`. I say *mostly* because it allows us to correctly label member functions with `const` since they are no longer all static.