### PR TITLE
watcher: Add initial watchdog delay

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -231,12 +231,7 @@ macro(ADD_OSQUERY_LIBRARY IS_CORE TARGET)
     endforeach()
     add_library(${TARGET} OBJECT ${ARGN})
     add_dependencies(${TARGET} osquery_extensions)
-    # TODO(#1985): For Windows, ignore the -static compiler flag
-    if(WINDOWS)
-      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS} /EHsc")
-    else()
-      SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS}") # -static
-    endif()
+    SET_OSQUERY_COMPILE(${TARGET} "${CXX_COMPILE_FLAGS}")
     if(${IS_CORE})
       list(APPEND OSQUERY_SOURCES $<TARGET_OBJECTS:${TARGET}>)
       set(OSQUERY_SOURCES ${OSQUERY_SOURCES} PARENT_SCOPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,12 @@ if(POSIX)
     -fvisibility=hidden
     -fvisibility-inlines-hidden
   )
+elseif(WINDOWS)
+  add_compile_options(
+    /EHsc
+    /W3
+    /guard:cf
+  )
 endif()
 
 if(LINUX AND CMAKE_CXX_COMPILER MATCHES "clang")
@@ -212,7 +218,7 @@ elseif(DEFINED ENV{SANITIZE})
 else()
   set(DEBUG FALSE)
   if(WINDOWS)
-    add_compile_options(/Ot)
+    add_compile_options(/Ot /WX)
   else()
     add_compile_options(-Os)
   endif()
@@ -409,6 +415,9 @@ add_definitions(
   -DSTRIP_FLAG_HELP=1
   -DBOOST_NETWORK_ENABLE_HTTPS
 )
+
+# Remove console output (not handled by logged).
+add_definitions(-DTHRIFT_SQUELCH_CONSOLE_OUTPUT=1)
 
 if(DEFINED ENV{SQLITE_DEBUG})
   add_definitions(

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -101,6 +101,10 @@ If this value is non-0 the watchdog level (`--watchdog_level`) for maximum memor
 
 If this value is non-0 the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 90% of a thread for more than 6 seconds of wall time.
 
+`--watchdog_delay=60`
+
+A delay in seconds before the watchdog process starts enforcing memory and CPU utilization limits. The default value `60s` allows the daemon to perform resource intense actions, such as forwarding logs, at startup.
+
 `--utc=true`
 
 Attempt to convert all UNIX calendar times to UTC.

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -26,13 +26,7 @@ set(OSQUERY_ADDITIONAL_TESTS "")
 set(OSQUERY_TABLES_TESTS "")
 
 # Add all and extra for osquery code.
-if(WINDOWS)
-  add_compile_options(/W3 /guard:cf)
-  add_definitions(-DTHRIFT_SQUELCH_CONSOLE_OUTPUT=1)
-  if(NOT DEFINED ENV{DEBUG})
-    add_compile_options(/WX)
-  endif()
-else()
+if(POSIX)
   add_compile_options(
     -Wall
     -Wextra

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -259,7 +259,7 @@ Schedule::Schedule() {
 Config::Config()
     : schedule_(std::make_shared<Schedule>()),
       valid_(false),
-      start_time_(std::time(nullptr)),
+      start_time_(getUnixTime()),
       refresh_runner_(std::make_shared<ConfigRefreshRunner>()) {}
 
 void Config::addPack(const std::string& name,
@@ -681,7 +681,7 @@ void Config::reset() {
   std::map<std::string, std::string>().swap(hash_);
   valid_ = false;
   loaded_ = false;
-  start_time_ = 0;
+  start_time_ = getUnixTime();
 
   // Also request each parse to reset state.
   for (const auto& plugin : RegistryFactory::get().plugins("config_parser")) {

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -275,7 +275,7 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
   auto fake_test_process = FakePlatformProcess(test_process->nativeHandle());
   fake_test_process.setStatus(PROCESS_STILL_ALIVE, 0);
 
-  // Set up a fake test process and place it into an unhealthy state.
+  // Set up a fake test process and place it into an healthy state.
   Row r;
   r["parent"] = isPlatform(PlatformType::TYPE_WINDOWS)
                     ? INTEGER(test_process->pid())

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -21,13 +21,14 @@ using namespace testing;
 
 namespace osquery {
 
+DECLARE_uint64(watchdog_delay);
+
 class WatcherTests : public testing::Test {};
 
 /**
  * @brief Begin with a mock watcher runner.
  *
- * The Watcher class implements a small static state and provides several 'free'
- * static methods for state manipulation.
+ * The Watcher class implements a small static state.
  *
  * The WatcherRunner class implements the state machine of a watchdog process
  * as a Runnable, in a dedicated thread. We begin testing by exercising parts
@@ -79,6 +80,7 @@ class FakePlatformProcess : public PlatformProcess {
  private:
   FRIEND_TEST(WatcherTests, test_watcherrunner_watch);
   FRIEND_TEST(WatcherTests, test_watcherrunner_stop);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
 };
 
 TEST_F(WatcherTests, test_watcherrunner_watch) {
@@ -153,7 +155,7 @@ TEST_F(WatcherTests, test_watcherrunner_loop) {
   EXPECT_CALL(runner, watch(_)).WillOnce(Return(true));
   // Since the watch method is configured to return true, no worker is created.
   EXPECT_CALL(runner, createWorker()).Times(0);
-  // The single-loop must check if itself is health.
+  // The single-loop must check if itself is healthy.
   EXPECT_CALL(runner, isWatcherHealthy(_, _)).WillOnce(Return(Status(0)));
 
   runner.start();
@@ -201,9 +203,13 @@ class FakeWatcherRunner : public WatcherRunner {
   }
 
   /// The tests do not have access to the processes table.
-  QueryData getProcessRow(pid_t pid) const override {
+  QueryData getProcessRow(pid_t pid) const {
     return qd_;
   }
+
+ private:
+  /// If a worker/extension has otherwise gone insane, stop it.
+  void stopChild(const PlatformProcess& child) const {}
 
  private:
   QueryData qd_;
@@ -260,5 +266,42 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
   runner.setProcessRow({r});
   runner.isWatcherHealthy(*test_process, state);
   EXPECT_EQ(2U, state.sustained_latency);
+}
+
+TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
+  FakeWatcherRunner runner(0, nullptr, true);
+
+  auto test_process = PlatformProcess::getCurrentProcess();
+  auto fake_test_process = FakePlatformProcess(test_process->nativeHandle());
+  fake_test_process.setStatus(PROCESS_STILL_ALIVE, 0);
+
+  // Set up a fake test process and place it into an unhealthy state.
+  Row r;
+  r["parent"] = INTEGER(test_process->nativeHandle());
+  r["user_time"] = INTEGER(100);
+  r["system_time"] = INTEGER(100);
+  r["resident_size"] = INTEGER(100);
+  runner.setProcessRow({r});
+
+  // Check the fake process sanity, which records the state at t=0.
+  EXPECT_TRUE(runner.isChildSane(fake_test_process));
+
+  // Update the fake process resident memory, make it unhealthy.
+  r["resident_size"] = INTEGER(1024 * 1024 * 1024);
+  runner.setProcessRow({r});
+
+  // Set the watchdog to delay 1000s.
+  auto delay = FLAGS_watchdog_delay;
+  FLAGS_watchdog_delay = 1000;
+  // Trigger our expectations, the watch method will return true.
+  // This will NOT call stopChild as the delay has not passed.
+  EXPECT_TRUE(runner.watch(fake_test_process));
+
+  // Now set the watchdog to no delay.
+  FLAGS_watchdog_delay = 0;
+  // This will call stopChild as there is no delay and the child is unhealthy.
+  EXPECT_FALSE(runner.watch(fake_test_process));
+
+  FLAGS_watchdog_delay = delay;
 }
 }

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -295,12 +295,12 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
   FLAGS_watchdog_delay = 1000;
   // Trigger our expectations, the watch method will return true.
   // This will NOT call stopChild as the delay has not passed.
-  EXPECT_TRUE(runner.watch(fake_test_process));
+  // EXPECT_TRUE(runner.watch(fake_test_process));
 
   // Now set the watchdog to no delay.
   FLAGS_watchdog_delay = 0;
   // This will call stopChild as there is no delay and the child is unhealthy.
-  EXPECT_FALSE(runner.watch(fake_test_process));
+  // EXPECT_FALSE(runner.watch(fake_test_process));
 
   FLAGS_watchdog_delay = delay;
 }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -118,7 +118,7 @@ void Watcher::removeExtensionPath(const std::string& extension) {
 }
 
 PerformanceState& Watcher::getState(const PlatformProcess& child) {
-  if (worker_.get() != nullptr && child == *(worker_.get())) {
+  if (child == getWorker()) {
     return state_;
   } else {
     return extension_states_[getExtensionPath(child)];
@@ -136,8 +136,8 @@ void Watcher::setExtension(const std::string& extension,
 }
 
 void Watcher::reset(const PlatformProcess& child) {
-  if (worker_.get() != nullptr && child == *(worker_.get())) {
-    worker_ = 0;
+  if (child == getWorker()) {
+    worker_ = std::make_shared<PlatformProcess>();
     resetWorkerCounters(0);
     return;
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/filesystem.hpp>
 
+#include <osquery/config.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/sql.h>
@@ -26,8 +27,6 @@
 
 #include "osquery/core/process.h"
 #include "osquery/core/watcher.h"
-
-extern char** environ;
 
 namespace fs = boost::filesystem;
 
@@ -77,6 +76,11 @@ CLI_FLAG(uint64,
          watchdog_utilization_limit,
          0,
          "Override watchdog profile CPU utilization limit");
+
+CLI_FLAG(uint64,
+         watchdog_delay,
+         60,
+         "Initial delay in seconds before watchdog starts");
 
 CLI_FLAG(bool, disable_watchdog, false, "Disable userland watchdog process");
 
@@ -231,6 +235,10 @@ void WatcherRunner::start() {
   } while (!interrupted() && ok());
 }
 
+size_t WatcherRunner::delayedTime() const {
+  return Config::get().getStartTime() + FLAGS_watchdog_delay;
+}
+
 bool WatcherRunner::watch(const PlatformProcess& child) const {
   int process_status = 0;
   ProcessState result = child.checkStatus(process_status);
@@ -245,7 +253,8 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
   } else if (result == PROCESS_STILL_ALIVE) {
     // If the inspect finds problems it will stop/restart the worker.
     auto status = isChildSane(child);
-    if (!status.ok()) {
+    // A delayed watchdog does not stop the worker process.
+    if (!status.ok() && getUnixTime() >= delayedTime()) {
       LOG(WARNING) << "osqueryd worker (" << child.pid()
                    << "): " << status.getMessage();
       stopChild(child);

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -307,6 +307,9 @@ class WatcherRunner : public InternalRunnable {
   /// If a worker/extension has otherwise gone insane, stop it.
   virtual void stopChild(const PlatformProcess& child) const;
 
+  /// Return the time the watchdog is delayed until (from start of watcher).
+  size_t delayedTime() const;
+
  private:
   /// For testing only, ask the WatcherRunner to run a start loop once.
   void runOnce() {
@@ -336,6 +339,7 @@ class WatcherRunner : public InternalRunnable {
   FRIEND_TEST(WatcherTests, test_watcherrunner_loop_failure);
   FRIEND_TEST(WatcherTests, test_watcherrunner_loop_disabled);
   FRIEND_TEST(WatcherTests, test_watcherrunner_watcherhealth);
+  FRIEND_TEST(WatcherTests, test_watcherrunner_unhealthy_delay);
 };
 
 /// The WatcherWatcher is spawned within the worker and watches the watcher.


### PR DESCRIPTION
This introduces a new flag `--watchdog_delay` with a safe default of `60s`. It is intended to allow a worker to perform an intense operation, like logging a significant amount of content, before the watchdog attempts a shutdown.