### PR TITLE
logger: Rename BufferedLogSink instance and other nits

### DIFF
--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -91,7 +91,7 @@ Status FirehoseLogForwarder::send(std::vector<std::string>& log_data,
     // processing. See http://goo.gl/Pz6XOj
     buffer[log.length()] = '\n';
     record.SetData(buffer);
-    records.push_back(std::move(record));
+    records.emplace_back(std::move(record));
   }
 
   Aws::Firehose::Model::PutRecordBatchRequest request;
@@ -113,7 +113,7 @@ Status FirehoseLogForwarder::send(std::vector<std::string>& log_data,
   }
 
   VLOG(1) << "Successfully sent " << result.GetRequestResponses().size()
-          << " logs to Firehose.";
+          << " logs to Firehose";
   return Status(0);
 }
 

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -120,7 +120,7 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
       entry.WithPartitionKey(record_partition_key)
           .WithData(Aws::Utils::ByteBuffer((unsigned char*)log.c_str(),
                                            log.length()));
-      entries.push_back(std::move(entry));
+      entries.emplace_back(std::move(entry));
       valid_log_data_indices.push_back(log_data_index);
 
       log_data_index++;

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -61,7 +61,7 @@ void BufferedLogForwarder::check() {
             std::string value;
             auto& target = isResultIndex(index) ? results : statuses;
             if (getDatabaseValue(kLogs, index, value)) {
-              target.push_back(std::move(value));
+              target.emplace_back(std::move(value));
             }
           }));
 

--- a/osquery/logger/plugins/tests/tls_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/tls_logger_tests.cpp
@@ -16,7 +16,7 @@
 #include "osquery/tests/test_additional_util.h"
 #include "osquery/tests/test_util.h"
 
-#include "osquery/logger/plugins/tls.h"
+#include "osquery/logger/plugins/tls_logger.h"
 
 namespace pt = boost::property_tree;
 

--- a/osquery/logger/plugins/tls_logger.cpp
+++ b/osquery/logger/plugins/tls_logger.cpp
@@ -19,7 +19,7 @@
 
 #include "osquery/config/parsers/decorators.h"
 #include "osquery/core/json.h"
-#include "osquery/logger/plugins/tls.h"
+#include "osquery/logger/plugins/tls_logger.h"
 
 namespace pt = boost::property_tree;
 

--- a/osquery/logger/plugins/tls_logger.h
+++ b/osquery/logger/plugins/tls_logger.h
@@ -56,7 +56,9 @@ class TLSLoggerPlugin : public LoggerPlugin {
   /// Setup node key and worker thread for sending logs.
   Status setUp() override;
 
-  bool usesLogStatus() override { return true; }
+  bool usesLogStatus() override {
+    return true;
+  }
 
  protected:
   /// Log a result string. This is the basic catch-all for snapshots and events.


### PR DESCRIPTION
This renames the `BufferedLogSink`'s `instance()` member to `get()` and removes the `static`/free method calling convention such that we can properly call some members `const`.

This applies some C++ modernization and potential performance improvements with moving rvalues (which seems to have been the intention). 