### PR TITLE
nits: Use char-overload for find

### DIFF
--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -200,7 +200,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
   // backing memory as modifiable.
   for (size_t i = 0; i < argc; i++) {
     std::string component(argv[i]);
-    if (component.find(" ") != std::string::npos) {
+    if (component.find(' ') != std::string::npos) {
       boost::replace_all(component, "\"", "\\\"");
       argv_stream << "\"" << component << "\" ";
     } else {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -221,8 +221,8 @@ std::vector<std::string> EventSubscriberPlugin::getIndexes(EventTime start,
     std::sort(indexes.begin(),
               indexes.end(),
               [](const std::string& left, const std::string& right) {
-                auto n1 = timeFromRecord(left.substr(left.find(".") + 1));
-                auto n2 = timeFromRecord(right.substr(right.find(".") + 1));
+                auto n1 = timeFromRecord(left.substr(left.find('.') + 1));
+                auto n2 = timeFromRecord(right.substr(right.find('.') + 1));
                 return n1 < n2;
               });
   }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -300,7 +300,7 @@ Status resolveFilePattern(const fs::path& fs_path,
 
 inline void replaceGlobWildcards(std::string& pattern, GlobLimits limits) {
   // Replace SQL-wildcard '%' with globbing wildcard '*'.
-  if (pattern.find("%") != std::string::npos) {
+  if (pattern.find('%') != std::string::npos) {
     boost::replace_all(pattern, "%", "*");
   }
 

--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -60,7 +60,7 @@ std::string TLSEnrollPlugin::enroll() {
   // If no node secret has been negotiated, try a TLS request.
   auto uri = "https://" + FLAGS_tls_hostname + FLAGS_enroll_tls_endpoint;
   if (FLAGS_tls_secret_always) {
-    uri += ((uri.find("?") != std::string::npos) ? "&" : "?") +
+    uri += ((uri.find('?') != std::string::npos) ? "&" : "?") +
            FLAGS_tls_enroll_override + "=" + getEnrollSecret();
   }
 

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -56,7 +56,7 @@ class TLSRequestHelper : private boost::noncopyable {
 
     // Some APIs may require persistent identification.
     if (FLAGS_tls_secret_always) {
-      uri += ((uri.find("?") != std::string::npos) ? "&" : "?") +
+      uri += ((uri.find('?') != std::string::npos) ? "&" : "?") +
              FLAGS_tls_enroll_override + "=" + getEnrollSecret();
     }
     return uri;

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -139,7 +139,7 @@ static void ip4StringToDecimalFunc(sqlite3_context* context,
 
   struct sockaddr sa;
   std::string address((char*)sqlite3_value_text(argv[0]));
-  if (address.find(":") != std::string::npos) {
+  if (address.find(':') != std::string::npos) {
     // Assume this is an IPv6 address.
     sqlite3_result_null(context);
   } else {

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -620,8 +620,8 @@ long diffNanos(const std::string& iso1, const std::string& iso2) {
     return 0L;
   }
 
-  std::size_t pos1 = iso1.find(".");
-  std::size_t pos2 = iso2.find(".");
+  std::size_t pos1 = iso1.find('.');
+  std::size_t pos2 = iso2.find('.');
   if (pos1 == std::string::npos || pos2 == std::string::npos) {
     VLOG(1) << "Failed to parse dates: " << iso1 << " and " << iso2;
     return 0L;

--- a/osquery/tables/events/darwin/process_file_events.cpp
+++ b/osquery/tables/events/darwin/process_file_events.cpp
@@ -54,7 +54,7 @@ void ProcessFileEventSubscriber::configure() {
               OSQUERY_FILE_ACTION_CLOSE_MODIFIED)};
       auto path = file;
       replaceGlobWildcards(path);
-      path = path.substr(0, path.find("*"));
+      path = path.substr(0, path.find('*'));
       strncpy(sub.path, path.c_str(), MAXPATHLEN);
       sc->category = category;
       VLOG(1) << "Added process file event listener to: " << path;

--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -140,7 +140,7 @@ QueryData genKernelInfo(QueryContext& context) {
       auto signature = stringFromCFString((CFStringRef)property);
       CFRelease(property);
 
-      r["version"] = signature.substr(22, signature.find(":") - 22);
+      r["version"] = signature.substr(22, signature.find(':') - 22);
     }
   }
 

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -139,8 +139,8 @@ void genOSXDomainPrefs(const CFStringRef& domain, QueryData& results) {
 
     // Interesting results/behavior from Microsoft products.
     r["key"] = stringFromCFString(key);
-    if (r.at("key").find(">") != std::string::npos ||
-        r.at("key").find("<") != std::string::npos || r.at("key").size() == 0) {
+    if (r.at("key").find('>') != std::string::npos ||
+        r.at("key").find('<') != std::string::npos || r.at("key").size() == 0) {
       continue;
     }
 

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -43,7 +43,7 @@ QueryData genShims(QueryContext& context) {
     QueryData regResults;
     sdb sdb;
     std::string subkey = rKey.at("path");
-    auto start = subkey.find("{");
+    auto start = subkey.find('{');
     if (start == std::string::npos) {
       continue;
     }


### PR DESCRIPTION
Use the single-character search overload of `std::string::find` as suggested via modernizers. 