### PR TITLE
packs: Allow posix in pack platform selection

### DIFF
--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -256,6 +256,11 @@ bool Pack::checkPlatform(const std::string& platform) const {
     return true;
   }
 
+  auto posix_type = (platform.find("posix") != std::string::npos);
+  if (posix_type && isPlatform(PlatformType::TYPE_POSIX)) {
+    return true;
+  }
+
   return (platform.find(kSDKPlatform) != std::string::npos);
 }
 

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -95,6 +95,18 @@ TEST_F(PacksTests, test_check_platform) {
 
   fpack.platform_ = "bad_value";
   EXPECT_FALSE(fpack.checkPlatform());
+
+  fpack.platform_ = "posix";
+  if (isPlatform(PlatformType::TYPE_POSIX) ||
+      isPlatform(PlatformType::TYPE_LINUX) ||
+      isPlatform(PlatformType::TYPE_OSX) ||
+      isPlatform(PlatformType::TYPE_FREEBSD)) {
+    EXPECT_TRUE(fpack.checkPlatform());
+  }
+
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    EXPECT_FALSE(fpack.checkPlatform());
+  }
 }
 
 TEST_F(PacksTests, test_check_version) {

--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -203,7 +203,7 @@
     "rpm_packages": {
       "query" : "select * from rpm_packages;",
       "interval" : "86400",
-      "platform" : "redhat,centos",
+      "platform" : "linux",
       "version" : "1.4.5",
       "description" : "Retrieves all the installed RPM packages in the target Linux system.",
       "value" : "General security posture."

--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -96,7 +96,7 @@
     "deb_packages": {
       "query" : "select * from deb_packages;",
       "interval" : "86400",
-      "platform" : "ubuntu",
+      "platform" : "linux",
       "version" : "1.4.5",
       "description" : "Retrieves all the installed DEB packages in the target Linux system.",
       "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
@@ -104,7 +104,7 @@
     "apt_sources": {
       "query" : "select * from apt_sources;",
       "interval" : "86400",
-      "platform" : "ubuntu",
+      "platform" : "linux",
       "version" : "1.4.5",
       "description" : "Retrieves all the APT sources to install packages from in the target Linux system.",
       "value" : "In the future this may not have a lot of value as we expect to have installed only signed packages"
@@ -112,7 +112,7 @@
     "portage_packages": {
       "query" : "select * from portage_packages;",
       "interval" : "86400",
-      "platform" : "gentoo",
+      "platform" : "linux",
       "version" : "2.0.0",
       "description" : "Retrieves all the installed packages on the target Linux system.",
       "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
@@ -120,7 +120,7 @@
     "rpm_packages": {
       "query" : "select * from rpm_packages;",
       "interval" : "86400",
-      "platform" : "redhat,centos",
+      "platform" : "linux",
       "version" : "1.4.5",
       "description" : "Retrieves all the installed RPM packages in the target Linux system.",
       "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."


### PR DESCRIPTION
Fixes: #3216

The `posix` query select should be valid. Any specific version of Linux does not make sense so remove them from the included packs.