### PR TITLE
Adding EmPyre agent to osx-attacks

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -475,6 +475,13 @@
       "version": "1.4.5",
       "description" : "OSX/Proton bundled with a tampered version of handbrake: (https://objective-see.com/blog/blog_0x1D.html)",
       "value" : "Artifacts created by this malware"
+    },
+    "EmPyre_Agent": {
+      "query" : "select * from launchd where name = 'com.proxy.initialize.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "EmPyre post exploitation agent (https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/persistence/osx/launchdaemonexecutable.py)",
+      "value" : "Artifacts created by this malware"
     }
   }
 }


### PR DESCRIPTION
Adds launchd detection for the default plist name. More here: https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/persistence/osx/launchdaemonexecutable.py#L61