### PR TITLE
Fix permissions tests running as root (Fix #3192)

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -101,11 +101,25 @@ Status writeTextFile(const boost::filesystem::path& path,
                      int permissions = 0660,
                      bool force_permissions = false);
 
-/// Check if a path is writable.
-Status isWritable(const boost::filesystem::path& path);
+/**
+ * @brief Check if a path is writable.
+ *
+ * @param path The path of the file that you would like to write.
+ * @param effective If you would like to check using effective UID
+ *
+ * @return A status returning if it's writable
+ */
+Status isWritable(const boost::filesystem::path& path, bool effective = false);
 
-/// Check if a path is readable.
-Status isReadable(const boost::filesystem::path& path);
+/**
+ * @brief Check if a path is readable.
+ *
+ * @param path The path of the file that you would like to read.
+ * @param effective If you would like to check using effective UID
+ *
+ * @return A status returning if it's readable
+ */
+Status isReadable(const boost::filesystem::path& path, bool effective = false);
 
 /**
  * @brief A helper to check if a path exists on disk or not.

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -7,7 +7,6 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -439,7 +438,6 @@ bool DropPrivileges::dropTo(uid_t uid, gid_t gid) {
     (void)setegid(getgid());
     return false;
   }
-
   // Privileges are now dropped to the requested user/group.
   to_user_ = uid;
   to_group_ = gid;

--- a/osquery/core/tests/posix/permissions_tests.cpp
+++ b/osquery/core/tests/posix/permissions_tests.cpp
@@ -9,7 +9,9 @@
  */
 
 #include <poll.h>
+#ifndef WIN32
 #include <pwd.h>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -91,13 +93,13 @@ TEST_F(PermissionsTests, test_path_drop) {
     EXPECT_TRUE(dropper->dropped_);
     EXPECT_EQ(dropper->to_user_, nobody->pw_uid);
 
+    // Dropping "up" to root should fail.
     // Even though this is possible and may make sense, it is confusing!
-    EXPECT_FALSE(dropper->dropTo(getuid(), getgid()));
+    EXPECT_FALSE(dropper->dropTo(0, 0));
 
     // Make sure the dropper worked!
     EXPECT_EQ(geteuid(), nobody->pw_uid);
   }
-
   // Now that the dropper is gone, the effective user/group should be restored.
   EXPECT_EQ(geteuid(), getuid());
   EXPECT_EQ(getegid(), getgid());

--- a/osquery/core/tests/posix/permissions_tests.cpp
+++ b/osquery/core/tests/posix/permissions_tests.cpp
@@ -100,6 +100,7 @@ TEST_F(PermissionsTests, test_path_drop) {
     // Make sure the dropper worked!
     EXPECT_EQ(geteuid(), nobody->pw_uid);
   }
+
   // Now that the dropper is gone, the effective user/group should be restored.
   EXPECT_EQ(geteuid(), getuid());
   EXPECT_EQ(getegid(), getgid());

--- a/osquery/core/tests/posix/permissions_tests.cpp
+++ b/osquery/core/tests/posix/permissions_tests.cpp
@@ -127,6 +127,26 @@ TEST_F(PermissionsTests, test_nobody_drop) {
   EXPECT_EQ(getegid(), getgid());
 }
 
+TEST_F(PermissionsTests, test_functional_drop) {
+  if (getuid() != 0) {
+    LOG(WARNING) << "Not root, skipping (explicit) deprivilege testing";
+    return;
+  }
+  std::string path(kTestWorkingDirectory + "fstests-file2");
+
+  {
+    PlatformFile fd(path, PF_CREATE_NEW | PF_WRITE);
+    EXPECT_TRUE(fd.isValid());
+    fd.write("somedata", 8);
+    ASSERT_TRUE(platformChmod(path, (int)0400));
+  }
+  {
+    AS_NOBODY(PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
+              EXPECT_FALSE(fd.isValid()););
+  }
+  fs::remove(path);
+}
+
 std::string kMultiThreadPermissionPath;
 
 class PermissionsRunnable : public InternalRunnable {

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -204,26 +204,31 @@ Status forensicReadFile(const fs::path& path,
   return readFile(path, content, 0, false, true, blocking);
 }
 
-Status isWritable(const fs::path& path) {
+Status isWritable(const fs::path& path, bool effective) {
   auto path_exists = pathExists(path);
   if (!path_exists.ok()) {
     return path_exists;
   }
-
-  if (platformAccess(path.string(), W_OK) == 0) {
+  if (effective) {
+    PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_WRITE);
+    return fd.isValid() ? Status(0) : Status(1);
+  } else if (platformAccess(path.string(), W_OK) == 0) {
     return Status(0, "OK");
   }
 
   return Status(1, "Path is not writable: " + path.string());
 }
 
-Status isReadable(const fs::path& path) {
+Status isReadable(const fs::path& path, bool effective) {
   auto path_exists = pathExists(path);
   if (!path_exists.ok()) {
     return path_exists;
   }
 
-  if (platformAccess(path.string(), R_OK) == 0) {
+  if (effective) {
+    PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_READ);
+    return fd.isValid() ? Status(0) : Status(1);
+  } else if (platformAccess(path.string(), R_OK) == 0) {
     return Status(0, "OK");
   }
 

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -389,14 +389,6 @@ TEST_F(FileOpsTests, test_chmod_no_exec) {
 TEST_F(FileOpsTests, test_chmod_no_read) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
-#ifndef WIN32
-  auto dropper = DropPrivileges::get();
-  if (getuid() == 0) {
-    auto nobody = getpwnam("nobody");
-    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-    EXPECT_EQ(getuid(), nobody->pw_uid);
-  }
-#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -407,8 +399,8 @@ TEST_F(FileOpsTests, test_chmod_no_read) {
   EXPECT_TRUE(platformChmod(path, S_IWUSR | S_IWOTH));
 
   {
-    PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
-    EXPECT_FALSE(fd.isValid());
+    AS_NOBODY(PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
+              EXPECT_FALSE(fd.isValid()););
   }
 
   {
@@ -420,14 +412,6 @@ TEST_F(FileOpsTests, test_chmod_no_read) {
 TEST_F(FileOpsTests, test_chmod_no_write) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
-#ifndef WIN32
-  auto dropper = DropPrivileges::get();
-  if (getuid() == 0) {
-    auto nobody = getpwnam("nobody");
-    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-    EXPECT_EQ(getuid(), nobody->pw_uid);
-  }
-#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -443,8 +427,8 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
   }
 
   {
-    PlatformFile fd(path, PF_OPEN_EXISTING | PF_WRITE);
-    EXPECT_FALSE(fd.isValid());
+    AS_NOBODY(PlatformFile fd(path, PF_OPEN_EXISTING | PF_WRITE);
+              EXPECT_FALSE(fd.isValid()););
   }
 }
 
@@ -454,15 +438,6 @@ TEST_F(FileOpsTests, test_access) {
 
   TempFile tmp_file;
   std::string path = tmp_file.path();
-
-#ifndef WIN32
-  auto dropper = DropPrivileges::get();
-  if (getuid() == 0) {
-    auto nobody = getpwnam("nobody");
-    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-    EXPECT_EQ(getuid(), nobody->pw_uid);
-  }
-#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -482,62 +457,62 @@ TEST_F(FileOpsTests, test_access) {
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR | S_IWUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
   EXPECT_EQ(0, platformAccess(path, R_OK | W_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
   EXPECT_EQ(0, platformAccess(path, R_OK));
   EXPECT_EQ(0, platformAccess(path, W_OK));
-  EXPECT_EQ(-1, platformAccess(path, X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR | S_IXUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
   EXPECT_EQ(0, platformAccess(path, R_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
   EXPECT_EQ(0, platformAccess(path, R_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IWUSR | S_IXUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
   EXPECT_EQ(0, platformAccess(path, W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
   EXPECT_EQ(0, platformAccess(path, W_OK));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
   EXPECT_EQ(0, platformAccess(path, R_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK));
-  EXPECT_EQ(-1, platformAccess(path, X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
 
   EXPECT_TRUE(platformChmod(path, S_IWUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
   EXPECT_EQ(0, platformAccess(path, W_OK));
-  EXPECT_EQ(-1, platformAccess(path, X_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
 
   EXPECT_TRUE(platformChmod(path, S_IXUSR));
 
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
-  EXPECT_EQ(-1, platformAccess(path, R_OK));
-  EXPECT_EQ(-1, platformAccess(path, W_OK));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
+  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   // Reset permissions
@@ -721,15 +696,6 @@ TEST_F(FileOpsTests, test_zero_permissions_file) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
 
-#ifndef WIN32
-  auto dropper = DropPrivileges::get();
-  if (getuid() == 0) {
-    auto nobody = getpwnam("nobody");
-    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-    EXPECT_EQ(getuid(), nobody->pw_uid);
-  }
-#endif
-
   const std::string expected_str = "0_permissions";
   const ssize_t expected_len = expected_str.size();
 
@@ -747,8 +713,8 @@ TEST_F(FileOpsTests, test_zero_permissions_file) {
 
   auto modes = {R_OK, W_OK, X_OK};
   for (auto& mode : modes) {
-    EXPECT_EQ(-1, platformAccess(path, mode));
+    AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, mode)));
   }
-  EXPECT_EQ(boost::none, platformFopen(path, "r"));
+  AS_NOBODY(EXPECT_EQ(boost::none, platformFopen(path, "r")));
 }
 }

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -434,10 +434,12 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
 }
 
 TEST_F(FileOpsTests, test_access) {
+#ifndef WIN32
   if (getuid() == 0) {
     LOG(WARNING) << "Access always succeeds as root; skipping";
     return;
   }
+#endif
   const int all_access = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP |
                          S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;
 
@@ -698,10 +700,12 @@ TEST_F(FileOpsTests, test_glob) {
 }
 
 TEST_F(FileOpsTests, test_zero_permissions_file) {
+#ifndef WIN32
   if (getuid() == 0) {
     LOG(WARNING) << "Access always succeeds as root; skipping";
     return;
   }
+#endif
   TempFile tmp_file;
   std::string path = tmp_file.path();
 

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -16,6 +16,7 @@
 #include <boost/filesystem.hpp>
 
 #include <osquery/core.h>
+#include <osquery/logger.h>
 
 #include "osquery/filesystem/fileops.h"
 #include "osquery/tests/test_util.h"
@@ -433,6 +434,10 @@ TEST_F(FileOpsTests, test_chmod_no_write) {
 }
 
 TEST_F(FileOpsTests, test_access) {
+  if (getuid() == 0) {
+    LOG(WARNING) << "Access always succeeds as root; skipping";
+    return;
+  }
   const int all_access = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP |
                          S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH;
 
@@ -457,62 +462,62 @@ TEST_F(FileOpsTests, test_access) {
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR | S_IWUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
   EXPECT_EQ(0, platformAccess(path, R_OK | W_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
   EXPECT_EQ(0, platformAccess(path, R_OK));
   EXPECT_EQ(0, platformAccess(path, W_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR | S_IXUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
   EXPECT_EQ(0, platformAccess(path, R_OK | X_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
   EXPECT_EQ(0, platformAccess(path, R_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
+  EXPECT_EQ(-1, platformAccess(path, W_OK));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IWUSR | S_IXUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
   EXPECT_EQ(0, platformAccess(path, W_OK | X_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK));
   EXPECT_EQ(0, platformAccess(path, W_OK));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IRUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
   EXPECT_EQ(0, platformAccess(path, R_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, W_OK));
+  EXPECT_EQ(-1, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IWUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK));
   EXPECT_EQ(0, platformAccess(path, W_OK));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, X_OK)));
+  EXPECT_EQ(-1, platformAccess(path, X_OK));
 
   EXPECT_TRUE(platformChmod(path, S_IXUSR));
 
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, R_OK)));
-  AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, W_OK)));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | W_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, W_OK | X_OK));
+  EXPECT_EQ(-1, platformAccess(path, R_OK));
+  EXPECT_EQ(-1, platformAccess(path, W_OK));
   EXPECT_EQ(0, platformAccess(path, X_OK));
 
   // Reset permissions
@@ -693,6 +698,10 @@ TEST_F(FileOpsTests, test_glob) {
 }
 
 TEST_F(FileOpsTests, test_zero_permissions_file) {
+  if (getuid() == 0) {
+    LOG(WARNING) << "Access always succeeds as root; skipping";
+    return;
+  }
   TempFile tmp_file;
   std::string path = tmp_file.path();
 
@@ -713,8 +722,8 @@ TEST_F(FileOpsTests, test_zero_permissions_file) {
 
   auto modes = {R_OK, W_OK, X_OK};
   for (auto& mode : modes) {
-    AS_NOBODY(EXPECT_EQ(-1, platformAccess(path, mode)));
+    EXPECT_EQ(-1, platformAccess(path, mode));
   }
-  AS_NOBODY(EXPECT_EQ(boost::none, platformFopen(path, "r")));
+  EXPECT_EQ(boost::none, platformFopen(path, "r"));
 }
 }

--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -7,6 +7,9 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+#ifndef WIN32
+#include <pwd.h>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -386,6 +389,14 @@ TEST_F(FileOpsTests, test_chmod_no_exec) {
 TEST_F(FileOpsTests, test_chmod_no_read) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
+#ifndef WIN32
+  auto dropper = DropPrivileges::get();
+  if (getuid() == 0) {
+    auto nobody = getpwnam("nobody");
+    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
+    EXPECT_EQ(getuid(), nobody->pw_uid);
+  }
+#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -409,6 +420,14 @@ TEST_F(FileOpsTests, test_chmod_no_read) {
 TEST_F(FileOpsTests, test_chmod_no_write) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
+#ifndef WIN32
+  auto dropper = DropPrivileges::get();
+  if (getuid() == 0) {
+    auto nobody = getpwnam("nobody");
+    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
+    EXPECT_EQ(getuid(), nobody->pw_uid);
+  }
+#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -435,6 +454,15 @@ TEST_F(FileOpsTests, test_access) {
 
   TempFile tmp_file;
   std::string path = tmp_file.path();
+
+#ifndef WIN32
+  auto dropper = DropPrivileges::get();
+  if (getuid() == 0) {
+    auto nobody = getpwnam("nobody");
+    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
+    EXPECT_EQ(getuid(), nobody->pw_uid);
+  }
+#endif
 
   {
     PlatformFile fd(path, PF_CREATE_ALWAYS | PF_WRITE);
@@ -692,6 +720,15 @@ TEST_F(FileOpsTests, test_glob) {
 TEST_F(FileOpsTests, test_zero_permissions_file) {
   TempFile tmp_file;
   std::string path = tmp_file.path();
+
+#ifndef WIN32
+  auto dropper = DropPrivileges::get();
+  if (getuid() == 0) {
+    auto nobody = getpwnam("nobody");
+    EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
+    EXPECT_EQ(getuid(), nobody->pw_uid);
+  }
+#endif
 
   const std::string expected_str = "0_permissions";
   const ssize_t expected_len = expected_str.size();

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -103,33 +103,13 @@ TEST_F(FilesystemTests, test_write_file) {
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0400, true));
   ASSERT_TRUE(pathExists(test_file).ok());
   ASSERT_TRUE(isReadable(test_file).ok());
-  {
-#ifndef WIN32
-    auto dropper = DropPrivileges::get();
-    if (getuid() == 0) {
-      auto nobody = getpwnam("nobody");
-      EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-      EXPECT_EQ(getuid(), nobody->pw_uid);
-    }
-#endif
-    ASSERT_FALSE(isWritable(test_file).ok());
-  }
+  AS_NOBODY(ASSERT_FALSE(isWritable(test_file).ok()));
   ASSERT_TRUE(osquery::remove(test_file).ok());
 
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0000, true));
   ASSERT_TRUE(pathExists(test_file).ok());
-  {
-#ifndef WIN32
-    auto dropper = DropPrivileges::get();
-    if (getuid() == 0) {
-      auto nobody = getpwnam("nobody");
-      EXPECT_TRUE(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));
-      EXPECT_EQ(getuid(), nobody->pw_uid);
-    }
-#endif
-    ASSERT_FALSE(isReadable(test_file).ok());
-    ASSERT_FALSE(isWritable(test_file).ok());
-  }
+  AS_NOBODY(ASSERT_FALSE(isReadable(test_file).ok()));
+  AS_NOBODY(ASSERT_FALSE(isWritable(test_file).ok()));
   ASSERT_TRUE(osquery::remove(test_file).ok());
 }
 

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -27,6 +27,7 @@
 #include <osquery/system.h>
 
 #include "osquery/core/process.h"
+#include "osquery/filesystem/fileops.h"
 #include "osquery/tests/test_util.h"
 
 namespace fs = boost::filesystem;
@@ -94,22 +95,23 @@ TEST_F(FilesystemTests, test_read_file) {
 TEST_F(FilesystemTests, test_write_file) {
   fs::path test_file(kTestWorkingDirectory + "fstests-file2");
   std::string content(2048, 'A');
-
   EXPECT_TRUE(writeTextFile(test_file, content).ok());
   ASSERT_TRUE(pathExists(test_file).ok());
-  ASSERT_TRUE(isWritable(test_file).ok());
+  ASSERT_TRUE(isWritable(test_file, true).ok());
   ASSERT_TRUE(osquery::remove(test_file).ok());
 
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0400, true));
+  ASSERT_TRUE(platformChmod(test_file.string(), (int)0400));
+
   ASSERT_TRUE(pathExists(test_file).ok());
   ASSERT_TRUE(isReadable(test_file).ok());
-  AS_NOBODY(ASSERT_FALSE(isWritable(test_file).ok()));
+  AS_NOBODY(ASSERT_FALSE(isWritable(test_file, true).ok()));
   ASSERT_TRUE(osquery::remove(test_file).ok());
 
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0000, true));
   ASSERT_TRUE(pathExists(test_file).ok());
-  AS_NOBODY(ASSERT_FALSE(isReadable(test_file).ok()));
-  AS_NOBODY(ASSERT_FALSE(isWritable(test_file).ok()));
+  AS_NOBODY(ASSERT_FALSE(isReadable(test_file, true).ok()));
+  AS_NOBODY(ASSERT_FALSE(isWritable(test_file, true).ok()));
   ASSERT_TRUE(osquery::remove(test_file).ok());
 }
 

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -8,6 +8,10 @@
  *
  */
 
+#ifndef WIN32
+#include <pwd.h>
+#endif
+
 #include <chrono>
 #include <deque>
 #include <random>

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -10,6 +10,10 @@
 
 #pragma once
 
+#ifndef WIN32
+#include <pwd.h>
+#endif
+
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,6 +25,20 @@
 #include <osquery/database.h>
 #include <osquery/events.h>
 #include <osquery/filesystem.h>
+
+#ifndef AS_NOBODY
+#ifndef WIN32
+#define AS_NOBODY(code)                                                        \
+  {                                                                            \
+    auto dropper = DropPrivileges::get();                                      \
+    auto nobody = getpwnam("nobody");                                          \
+    assert(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));                   \
+    code;                                                                      \
+  }
+#endif
+#else
+#define AS_NOBODY(code) code;
+#endif
 
 namespace pt = boost::property_tree;
 

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -25,7 +25,7 @@
 #include <osquery/database.h>
 #include <osquery/events.h>
 #include <osquery/filesystem.h>
-
+#ifndef WIN32
 #define AS_NOBODY(code)                                                        \
   {                                                                            \
     auto dropper = DropPrivileges::get();                                      \
@@ -33,6 +33,10 @@
     dropper->dropTo(nobody->pw_uid, nobody->pw_gid);                           \
     code;                                                                      \
   }
+#else
+#define AS_NOBODY(code)                                                        \
+  { code; }
+#endif
 
 namespace pt = boost::property_tree;
 

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -26,19 +26,13 @@
 #include <osquery/events.h>
 #include <osquery/filesystem.h>
 
-#ifndef AS_NOBODY
-#ifndef WIN32
 #define AS_NOBODY(code)                                                        \
   {                                                                            \
     auto dropper = DropPrivileges::get();                                      \
     auto nobody = getpwnam("nobody");                                          \
-    assert(dropper->dropTo(nobody->pw_uid, nobody->pw_gid));                   \
+    dropper->dropTo(nobody->pw_uid, nobody->pw_gid);                           \
     code;                                                                      \
   }
-#endif
-#else
-#define AS_NOBODY(code) code;
-#endif
 
 namespace pt = boost::property_tree;
 


### PR DESCRIPTION
On OSX when you run as root, it doesn't care about file permissions, it will always pass. This modifies the tests to take that into account.

I also added a new test for dropping permissions and checking that it cannot access files created with high permissions.