### PR TITLE
[RFC] Up the number of Vagrant vCPUs to 4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,7 +102,7 @@ Vagrant.configure("2") do |config|
     if ENV['OSQUERY_BUILD_CPUS']
       v.cpus = ENV['OSQUERY_BUILD_CPUS'].to_i
     else
-      v.cpus = 2
+      v.cpus = 4
     end
     v.memory = 4096
   end


### PR DESCRIPTION
The difference between 2 and 4 vCPUs I have found is enourmous, should we be thinking about upping this to decrease development time?