### PR TITLE
Adds platform to enrollment request

### DIFF
--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -86,6 +86,8 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
   boost::property_tree::ptree params;
   params.put<std::string>(FLAGS_tls_enroll_override, getEnrollSecret());
   params.put<std::string>("host_identifier", getHostIdentifier());
+  params.put<std::string>("platform_type",
+      boost::lexical_cast<std::string>(static_cast<uint64_t>(kPlatformType)));
 
   auto request = Request<TLSTransport, JSONSerializer>(uri);
   request.setOption("hostname", FLAGS_tls_hostname);


### PR DESCRIPTION
Base10 encodes the integer representation of the platform type bitmask to enrollment requests. This will allow deployments to track what platform (windows/linux/mac os x/etc) each enrolled host is (or at least claims to be).

Tested this against modified and unmodified enrollment server and both worked fine. 