### PR TITLE
fim: Allow Linux publishers to be interrupted

### DIFF
--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -74,7 +74,7 @@ Status UdevEventPublisher::run() {
   fds[0].events = POLLIN;
 
   int selector = ::poll(fds, 1, 1000);
-  if (selector == -1) {
+  if (selector == -1 && errno != EINTR && errno != EAGAIN) {
     LOG(ERROR) << "Could not read udev monitor";
     return Status(1, "udev monitor failed.");
   }


### PR DESCRIPTION
The `::poll` calls in Linux event publishers may be interrupted by other threads. One example is when `rpm_packages` causes the process to drop privileges. The `errno` should be inspected in this case and the publisher thread be allowed to continue.