### PR TITLE
Add Epoch marker to scheduled query log results

### DIFF
--- a/docs/wiki/deployment/anomaly-detection.md
+++ b/docs/wiki/deployment/anomaly-detection.md
@@ -34,7 +34,8 @@ Using the [log aggregation guide](log-aggregation.md), you will receive log line
     },
     "hostname":  "ted-osx.local",
     "calendarTime":  "Fri Nov  7 09:42:42 2014",
-    "unixTime":  1415382685
+    "unixTime":  1415382685,
+    "epoch": 314159265
 }
 ```
 

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -351,6 +351,9 @@ struct QueryLogItem {
   /// The time that the query was executed, seconds as UNIX time.
   size_t time{0};
 
+  /// The epoch at the time the query was executed
+  uint64_t epoch;
+
   /// The time that the query was executed, an ASCII string.
   std::string calendar_time;
 

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -677,6 +677,7 @@ void Config::purge() {
     if (last_executed < getUnixTime() - 592200) {
       // Query has not run in the last week, expire results and interval.
       deleteDatabaseValue(kQueries, saved_query);
+      deleteDatabaseValue(kQueries, saved_query + "epoch");
       deleteDatabaseValue(kPersistentSettings, "interval." + saved_query);
       deleteDatabaseValue(kPersistentSettings, "timestamp." + saved_query);
       VLOG(1) << "Expiring results for scheduled query: " << saved_query;

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -83,6 +83,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   runDecorators(DECORATE_INTERVAL, 60);
 
   QueryLogItem item;
+  item.epoch = 0L;
   getDecorations(item.decorations);
   ASSERT_EQ(item.decorations.size(), 2U);
   EXPECT_EQ(item.decorations.at("internal_60_test"), "test");
@@ -92,7 +93,8 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   std::string expected =
       "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"\","
       "\"hostIdentifier\":\"\",\"calendarTime\":\"\",\"unixTime\":\"0\","
-      "\"decorations\":{\"internal_60_test\":\"test\",\"one\":\"1\"}}\n";
+      "\"epoch\":\"0\",\"decorations\":{\"internal_60_test\":\"test\","
+      "\"one\":\"1\"}}\n";
   EXPECT_EQ(log_line, expected);
 
   // Now clear and run again.

--- a/osquery/database/benchmarks/database_benchmarks.cpp
+++ b/osquery/database/benchmarks/database_benchmarks.cpp
@@ -93,7 +93,7 @@ static void DATABASE_query_results(benchmark::State& state) {
   while (state.KeepRunning()) {
     DiffResults diff_results;
     auto dbq = Query("default", query);
-    dbq.addNewResults(qd, diff_results);
+    dbq.addNewResults(qd, 0, diff_results);
   }
 }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -274,6 +274,7 @@ inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
   tree.put<std::string>("hostIdentifier", item.identifier);
   tree.put<std::string>("calendarTime", item.calendar_time);
   tree.put<size_t>("unixTime", item.time);
+  tree.put<uint64_t>("epoch", item.epoch);
 
   // Append the decorations.
   if (item.decorations.size() > 0) {

--- a/osquery/database/query.h
+++ b/osquery/database/query.h
@@ -51,6 +51,16 @@ class Query {
   Status getPreviousQueryResults(QueryData& results);
 
   /**
+   * @brief Get the epoch associated with the previous query results
+   *
+   * This method retrieves the epoch associated with the results data that was
+   * was stored in rocksdb
+   *
+   * @return the epoch associated with the previous query results.
+   */
+  uint64_t getPreviousEpoch();
+
+  /**
    * @brief Get the names of all historical queries.
    *
    * If you'd like to perform some database maintenance, getStoredQueryNames()
@@ -82,11 +92,11 @@ class Query {
    * to the database using addNewResults.
    *
    * @param qd the QueryData object, which has the results of the query.
-   * @param unix_time the time that the query was executed.
+   * @param epoch the epoch associatted with QueryData
    *
    * @return the success or failure of the operation.
    */
-  Status addNewResults(const QueryData& qd);
+  Status addNewResults(const QueryData& qd, const uint64_t epoch);
 
   /**
    * @brief Add a new set of results to the persistent storage and get back
@@ -97,11 +107,13 @@ class Query {
    * indicating what rows in the query's results have changed.
    *
    * @param qd the QueryData object containing query results to store.
+   * @param epoch the epoch associated with QueryData
    * @param dr an output to a DiffResults object populated based on last run.
    *
    * @return the success or failure of the operation.
    */
   Status addNewResults(const QueryData& qd,
+                       const uint64_t epoch,
                        DiffResults& dr,
                        bool calculate_diff = true);
 

--- a/osquery/database/tests/query_tests.cpp
+++ b/osquery/database/tests/query_tests.cpp
@@ -33,7 +33,7 @@ TEST_F(QueryTests, test_add_and_get_current_results) {
   // Test adding a "current" set of results to a scheduled query instance.
   auto query = getOsqueryScheduledQuery();
   auto cf = Query("foobar", query);
-  auto status = cf.addNewResults(getTestDBExpectedResults());
+  auto status = cf.addNewResults(getTestDBExpectedResults(), 0);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(status.toString(), "OK");
 
@@ -47,7 +47,7 @@ TEST_F(QueryTests, test_add_and_get_current_results) {
 
     // Add the "current" results and output the differentials.
     DiffResults dr;
-    auto s = cf.addNewResults(result.second, dr, true);
+    auto s = cf.addNewResults(result.second, 0, dr, true);
     EXPECT_TRUE(s.ok());
 
     // Call the diffing utility directly.
@@ -105,14 +105,14 @@ TEST_F(QueryTests, test_query_name_updated) {
 
   DiffResults dr;
   auto results = getTestDBExpectedResults();
-  cf.addNewResults(results, dr);
+  cf.addNewResults(results, 0, dr);
   EXPECT_FALSE(cf.isNewQuery());
 
   query.query += " LIMIT 1";
   auto cf2 = Query("will_update_query", query);
   EXPECT_TRUE(cf2.isQueryNameInDatabase());
   EXPECT_TRUE(cf2.isNewQuery());
-  cf2.addNewResults(results, dr);
+  cf2.addNewResults(results, 0, dr);
   EXPECT_FALSE(cf2.isNewQuery());
 }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -32,6 +32,8 @@ FLAG(uint64,
      300,
      "Interval in seconds to reload database arenas");
 
+FLAG(uint64, schedule_epoch, 0, "Epoch for scheduled queries");
+
 HIDDEN_FLAG(bool, enable_monitor, true, "Enable the schedule monitor");
 
 HIDDEN_FLAG(bool,
@@ -89,6 +91,7 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   item.name = name;
   item.identifier = ident;
   item.time = osquery::getUnixTime();
+  item.epoch = FLAGS_schedule_epoch;
   item.calendar_time = osquery::getAsciiTime();
   getDecorations(item.decorations);
 
@@ -110,7 +113,7 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // We can then ask for a differential from the last time this named query
   // was executed by exact matching each row.
   if (!FLAGS_events_optimize || !sql.eventBased()) {
-    status = dbQuery.addNewResults(sql.rows(), diff_results);
+    status = dbQuery.addNewResults(sql.rows(), item.epoch, diff_results);
     if (!status.ok()) {
       std::string line =
           "Error adding new results to database: " + status.what();

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -144,6 +144,7 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   item.identifier = "test";
   item.time = 0;
   item.calendar_time = "test";
+  item.epoch = 0L;
 
   EXPECT_TRUE(logSnapshotQuery(item));
   auto snapshot_path = fs::path(FLAGS_logger_path) / "osqueryd.snapshots.log";
@@ -158,10 +159,10 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   std::string expected =
       "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"test\","
       "\"hostIdentifier\":\"test\","
-      "\"calendarTime\":\"test\",\"unixTime\":\"0\"}\n{\"snapshot\":\"\","
-      "\"action\":\"snapshot\","
+      "\"calendarTime\":\"test\",\"unixTime\":\"0\",\"epoch\":\"0\"}\n"
+      "{\"snapshot\":\"\",\"action\":\"snapshot\","
       "\"name\":\"test\",\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":\"0\"}\n";
+      "\"unixTime\":\"0\",\"epoch\":\"0\"}\n";
   EXPECT_EQ(content, expected);
 }
 }

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -330,6 +330,7 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   item.identifier = "unknown_test_host";
   item.time = 0;
   item.calendar_time = "no_time";
+  item.epoch = 0L;
   item.results.added.push_back({{"test_column", "test_value"}});
   logQueryLogItem(item);
   EXPECT_EQ(1U, LoggerTests::log_lines.size());
@@ -341,8 +342,8 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   // Make sure the JSON output does not have a newline.
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
-      "\"calendarTime\":\"no_time\",\"unixTime\":\"0\",\"columns\":{\"test_"
-      "column\":\"test_value\"},\"action\":\"added\"}";
+      "\"calendarTime\":\"no_time\",\"unixTime\":\"0\",\"epoch\":\"0\","
+      "\"columns\":{\"test_column\":\"test_value\"},\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }
 

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -322,11 +322,13 @@ std::pair<pt::ptree, QueryLogItem> getSerializedQueryLogItem() {
   i.calendar_time = "Mon Aug 25 12:10:57 2014";
   i.time = 1408993857;
   i.identifier = "foobaz";
+  i.epoch = 0L;
   root.add_child("diffResults", dr.first);
   root.put<std::string>("name", "foobar");
   root.put<std::string>("hostIdentifier", "foobaz");
   root.put<std::string>("calendarTime", "Mon Aug 25 12:10:57 2014");
   root.put<int>("unixTime", 1408993857);
+  root.put<uint64_t>("epoch", 0L);
   return std::make_pair(root, i);
 }
 


### PR DESCRIPTION
After initially returning all the results of a scheduled query, osquery subsequently returns incremental changes to the original result set on subsequent runs of the scheduled query.

It is useful for a backend to maintain a current full state of a machine based on the initial result set + incremental updates. 

However, because osquery can periodically delete its rocksdb local db (which is used to calculate the incrementals), or, in the face of backup/restores etc. on the host running osquery, the backend and osquery can fall out of sync on the current state.

This PR adds an epoch marker to scheduled queries. The marker provides a mechanism by which osquery and the backend can remain in sync wrt which "epoch" the scheduled query results belong to. If the backend falls out of sync for some reason, it can simply set a new epoch via the config flag, and cause osquery to get back in sync by resending the initial results (with the new epoch marker), and then resuming the incremental updates. 