### PR TITLE
Fixed the macOS build steps' order

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -25,8 +25,8 @@ The complete installation/build steps are as follows:
 
 ```sh
 $ git clone https://github.com/facebook/osquery.git
-$ # make sysprep
 $ cd osquery
+$ # make sysprep
 $ make deps
 $ make
 ```


### PR DESCRIPTION
The developer should first change directory to the osquery project's directory and then run the make command