### PR TITLE
windows: Multiple extensions now auto-load without error

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -360,14 +360,16 @@ Status WatcherRunner::isWatcherHealthy(const PlatformProcess& watcher,
 }
 
 QueryData WatcherRunner::getProcessRow(pid_t pid) const {
-#ifdef WIN32
-  pid = (pid == ULONG_MAX) ? -1 : pid;
-#endif
-
   // On Windows, pid_t = DWORD, which is unsigned. However invalidity
   // of processes is denoted by a pid_t of -1. We check for this
-  // by comparing the max value of DWORD, or ULONG_MAX
-  return SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(pid));
+  // by comparing the max value of DWORD, or ULONG_MAX, and then casting
+  // our query back to an int value, as ULONG_MAX causes boost exceptions
+  // as it's out of the range of an int.
+  int p = pid;
+#ifdef WIN32
+  p = (pid == ULONG_MAX) ? -1 : pid;
+#endif
+  return SQL::selectAllFrom("processes", "pid", EQUALS, INTEGER(p));
 }
 
 Status WatcherRunner::isChildSane(const PlatformProcess& child) const {

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include <chrono>
-
 #include <osquery/dispatcher.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include <chrono>
+#include <stdlib.h>
 #include <string>
 
 #include <osquery/core.h>
@@ -18,6 +20,8 @@
 #include "osquery/extensions/interface.h"
 
 using namespace osquery::extensions;
+
+using chrono_clock = std::chrono::high_resolution_clock;
 
 namespace osquery {
 namespace extensions {
@@ -126,8 +130,13 @@ void ExtensionManagerHandler::registerExtension(
     }
   }
 
+  // srand must be called in the active thread on Windows due to thread saftey
+  if (isPlatform(PlatformType::TYPE_WINDOWS)) {
+    std::srand(static_cast<unsigned int>(
+        chrono_clock::now().time_since_epoch().count()));
+  }
   // Every call to registerExtension is assigned a new RouteUUID.
-  RouteUUID uuid = (uint16_t)rand();
+  RouteUUID uuid = static_cast<uint16_t>(rand());
   VLOG(1) << "Registering extension (" << info.name << ", " << uuid
           << ", version=" << info.version << ", sdk=" << info.sdk_version
           << ")";


### PR DESCRIPTION
The `srand` function on Windows does not seed across multiple threads, and thus we make use of the Windows API `rand_s` function which leverages the native Windows OS crypto APIs to generate a cryptographically secure random number. This ensures that multiple extensions spawned have a unique uid value.

Furthermore, upon first launch of extensions an error occurs attempting to cast the Windows `ULONG_MAX` pid value to an integer due to `unsigned long` overflowing an `int` type. While this wasn't preventing extensions from spawning, it was causing errors on first launch. This diff also adds logic to finagle the pid value to a `-1` for "invalid" pids on Windows systems.

Some glorious testing follows:

```
C:\Users\thor\work\repos\osquery [win-extensions-triage-2]
λ  .\build\windows10\osquery\Release\osqueryi.exe --allow_unsafe --verbose
I0606 15:43:45.418145 11624 process_ops.cpp:162] Unable to find environment variable (0): OSQUERY_WORKER
I0606 15:43:45.420142 11624 init.cpp:383] osquery initialized [version=2.4.6-11-g912767a0]
I0606 15:43:45.421149 11624 process_ops.cpp:162] Unable to find environment variable (203): OSQUERY_WORKER
I0606 15:43:45.421149 11624 extensions.cpp:332] Found autoloadable extension: C:\ProgramData\osquery\extensions\external_extension_awesome.ext.exe
I0606 15:43:45.422147 11624 extensions.cpp:332] Found autoloadable extension: C:\ProgramData\osquery\extensions\external_extension_example2.ext.exe
I0606 15:43:45.423141  4620 interface.cpp:335] Extension manager service starting: \\.\pipe\shell.em
I0606 15:43:45.427141  2328 watcher.cpp:516] Created and monitoring extension child (8752): C:\ProgramData\osquery\extensions\external_extension_awesome.ext.exe
I0606 15:43:45.434136  2328 watcher.cpp:516] Created and monitoring extension child (13384): C:\ProgramData\osquery\extensions\external_extension_example2.ext.exe
I0606 15:43:45.452123  5340 init.cpp:386] osquery extension initialized [sdk=2.4.6]
I0606 15:43:45.453125  9504 init.cpp:386] osquery extension initialized [sdk=2.4.6]
I0606 15:43:45.457121  8684 interface.cpp:149] Registering extension (example2, 45971, version=0.0.1, sdk=2.4.6)
I0606 15:43:45.474113  8684 registry.cpp:344] Extension 45971 registered table plugin example2
I0606 15:43:45.474113  6332 interface.cpp:149] Registering extension (example, 1574, version=0.0.1, sdk=2.4.6)
I0606 15:43:45.475117 11624 process_ops.cpp:162] Unable to find environment variable (203): TERM
I0606 15:43:45.476126  5340 extensions.cpp:460] Extension (example2, 45971, 0.0.1, 2.4.6) registered
I0606 15:43:45.476126  6332 registry.cpp:344] Extension 1574 registered table plugin example
Using a I0606 15:43:45.476126  5016 interface.cpp:295] Extension service starting: \\.\pipe\shell.em.45971
virtual database. Need help, type '.help'
osquery> I0606 15:43:45.477110  5824 interface.cpp:295] Extension service starting: \\.\pipe\shell.em.1574
I0606 15:43:45.477110  9504 extensions.cpp:460] Extension (example, 1574, 0.0.1, 2.4.6) registered

osquery> select count(1) from example;
I0606 15:44:05.927495 11624 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0606 15:44:05.927495 11624 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
+----------+
| count(1) |
+----------+
| 1        |
+----------+
osquery> select count(1) from example2;
I0606 15:44:11.553737 11624 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
I0606 15:44:11.554745 11624 process_ops.cpp:162] Unable to find environment variable (203): ENHANCE
+----------+
| count(1) |
+----------+
| 182      |
+----------+
osquery>
```