### PR TITLE
Replace hardcoded paths throughout code base

### DIFF
--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -177,12 +177,20 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
     const std::string& args) {
   std::shared_ptr<PlatformProcess> process;
   std::string argv;
+  std::string osquery_path;
 
-  if (!isPlatform(PlatformType::TYPE_FREEBSD)) {
-    argv = "/usr/local/osquery/bin/python " + args;
+  boost::optional<std::string> osquery_path_option = getEnvVar("OSQUERY_DEPS");
+  if (osquery_path_option) {
+    osquery_path = *osquery_path_option;
   } else {
-    argv = "/usr/local/bin/python " + args;
+    if (!isPlatform(PlatformType::TYPE_FREEBSD)) {
+      osquery_path = "/usr/local/osquery";
+    } else {
+      osquery_path = "/usr/local";
+    }
   }
+
+  argv = osquery_path + "/bin/python " + args;
 
   int process_pid = ::fork();
   if (process_pid == 0) {

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -13,7 +13,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SOURCE_DIR="$SCRIPT_DIR/../.."
 BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build/linux"}
 
-export PATH="/usr/local/osquery/bin:/usr/local/bin:$PATH"
+OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
+
+export PATH="${OSQUERY_DEPS}/bin:/usr/local/bin:$PATH"
 source "$SOURCE_DIR/tools/lib.sh"
 
 PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`
@@ -37,14 +39,14 @@ SYSTEMD_SYSCONFIG_DST_DEB="/etc/default/osqueryd"
 CTL_SRC="$SCRIPT_DIR/osqueryctl"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/usr/share/osquery/packs/"
-LENSES_LICENSE="/usr/local/osquery/Cellar/augeas/*/COPYING"
-LENSES_SRC="/usr/local/osquery/share/augeas/lenses/dist"
+LENSES_LICENSE="${OSQUERY_DEPS}/Cellar/augeas/*/COPYING"
+LENSES_SRC="${OSQUERY_DEPS}/share/augeas/lenses/dist"
 LENSES_DST="/usr/share/osquery/lenses/"
 OSQUERY_POSTINSTALL=${OSQUERY_POSTINSTALL:-""}
 OSQUERY_PREUNINSTALL=${OSQUERY_PREUNINSTALL:-""}
 OSQUERY_CONFIG_SRC=${OSQUERY_CONFIG_SRC:-""}
 OSQUERY_TLS_CERT_CHAIN_SRC=${OSQUERY_TLS_CERT_CHAIN_SRC:-""}
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${OSQUERY_DEPS}/etc/openssl/cert.pem"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/usr/share/osquery/certs/certs.pem"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/usr/share/osquery/osquery.example.conf"

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -15,7 +15,7 @@ BUILD_DIR=${BUILD_DIR:="$SOURCE_DIR/build/linux"}
 
 OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
 
-export PATH="${OSQUERY_DEPS}/bin:/usr/local/bin:$PATH"
+export PATH="${OSQUERY_DEPS}/bin:$PATH"
 source "$SOURCE_DIR/tools/lib.sh"
 
 PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -24,7 +24,6 @@ fi
 
 OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
 
-export PATH="$PATH:/usr/local/bin"
 source "$SOURCE_DIR/tools/lib.sh"
 distro "darwin" BUILD_VERSION
 

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -22,6 +22,8 @@ else
   BUILD_DIR="${BUILD_DIR}darwin$BUILD_VERSION"
 fi
 
+OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
+
 export PATH="$PATH:/usr/local/bin"
 source "$SOURCE_DIR/tools/lib.sh"
 distro "darwin" BUILD_VERSION
@@ -44,8 +46,8 @@ NEWSYSLOG_SRC="$SCRIPT_DIR/$LD_IDENTIFIER.conf"
 NEWSYSLOG_DST="/private/var/osquery/$LD_IDENTIFIER.conf"
 PACKS_SRC="$SOURCE_DIR/packs"
 PACKS_DST="/private/var/osquery/packs/"
-LENSES_LICENSE="/usr/local/osquery/Cellar/augeas/*/COPYING"
-LENSES_SRC="/usr/local/osquery/share/augeas/lenses/dist"
+LENSES_LICENSE="${OSQUERY_DEPS}/Cellar/augeas/*/COPYING"
+LENSES_SRC="${OSQUERY_DEPS}/share/augeas/lenses/dist"
 LENSES_DST="/private/var/osquery/lenses/"
 OSQUERY_EXAMPLE_CONFIG_SRC="$SCRIPT_DIR/osquery.example.conf"
 OSQUERY_EXAMPLE_CONFIG_DST="/private/var/osquery/osquery.example.conf"
@@ -53,7 +55,7 @@ OSQUERY_CONFIG_SRC=""
 OSQUERY_CONFIG_DST="/private/var/osquery/osquery.conf"
 OSQUERY_DB_LOCATION="/private/var/osquery/osquery.db/"
 OSQUERY_LOG_DIR="/private/var/log/osquery/"
-OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
+OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="${OSQUERY_DEPS}/etc/openssl/cert.pem"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/private/var/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -29,7 +29,7 @@ import pexpect
 import timeout_decorator
 
 # While this path can be variable, in practice is lives statically.
-OSQUERY_DEPENDENCIES = "/usr/local/osquery"
+OSQUERY_DEPENDENCIES = os.getenv('OSQUERY_DEPS', "/usr/local/osquery")
 sys.path = [OSQUERY_DEPENDENCIES + "/lib/python2.7/site-packages"] + sys.path
 
 try:


### PR DESCRIPTION
Issue #3373 exposed a problem where the environment variable `OSQUERY_DEPS`, meant to control where to place osquery's build dependencies, is not always respected.

This makes using a non-default directory for the build dependencies (including a path which doesn't require root/sudo/admin access) unfeasible.

This pull request replaces the hard-coded path `/usr/local/osquery` with an attempt at accessing the `OSQUERY_DEPS` environment variable, defaulting to `/usr/local/osquery`. With these changes, it becomes possible to use `OSQUERY_DEPS` to place build dependencies in a user controlled directory.

The PR includes 6 commits (one per touched file) for easier review.

Note that this PR does not close #3373 completely since it doesn't fix:
1. Python needing to be recompiled when `OSQUERY_DEPS` is set;
1. libmagic formula needing a different mirror. See #3388 for that.