### PR TITLE
Change 'libmagic' bottle's URL to a different mirror

### DIFF
--- a/tools/provision/formula/libmagic.rb
+++ b/tools/provision/formula/libmagic.rb
@@ -3,7 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libmagic < AbstractOsqueryFormula
   desc "Implementation of the file(1) command"
   homepage "https://www.darwinsys.com/file/"
-  url "https://fossies.org/linux/misc/file-5.29.tar.gz"
+  url "https://distfiles.macports.org/file/file-5.29.tar.gz"
   sha256 "ea661277cd39bf8f063d3a83ee875432cc3680494169f952787e002bdd3884c0"
   revision 101
 


### PR DESCRIPTION
As reported in https://github.com/facebook/osquery/issues/3373#issuecomment-305894590
the URL for libmagic formula's `file-5.29.tar.gz` is broken (404).

The version could be bumped to 5.31 (the version in the original URL). Instead, this PR changes the URL
to use a different mirror (macports.org instead of fossies.org).