### PR TITLE
make_osx_package.sh: Add a way to include extra files in the package

### DIFF
--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -57,6 +57,7 @@ OSQUERY_TLS_CERT_CHAIN_BUILTIN_SRC="/usr/local/osquery/etc/openssl/cert.pem"
 OSQUERY_TLS_CERT_CHAIN_BUILTIN_DST="/private/var/osquery/certs/certs.pem"
 TLS_CERT_CHAIN_DST="/private/var/osquery/tls-server-certs.pem"
 FLAGFILE_DST="/private/var/osquery/osquery.flags"
+OSQUERY_PKG_INCLUDE_DIRS=()
 
 WORKING_DIR=/tmp/osquery_packaging
 INSTALL_PREFIX="$WORKING_DIR/prefix"
@@ -138,6 +139,9 @@ function parse_args() {
                               ;;
       -t | --cert-chain )     shift
                               TLS_CERT_CHAIN_SRC=$1
+                              ;;
+      -i | --include-dir )    shift
+                              OSQUERY_PKG_INCLUDE_DIRS[${#OSQUERY_PKG_INCLUDE_DIRS}]=$1
                               ;;
       -o | --output )         shift
                               OUTPUT_PKG_PATH=$1
@@ -236,8 +240,6 @@ function main() {
   fi
 
   # Copy extra files to the install prefix so that they get packaged too.
-  # To use, define the variable `OSQUERY_PKG_INCLUDE_DIRS` as a (bash) array
-  # containing directories to include in the built package.
   # NOTE: Files will be overwritten.
   for include_dir in ${OSQUERY_PKG_INCLUDE_DIRS[*]}; do
     log "adding $include_dir in the package prefix to be included in the package"

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -235,6 +235,15 @@ function main() {
     fi
   fi
 
+  # Copy extra files to the install prefix so that they get packaged too.
+  # To use, define the variable `OSQUERY_PKG_INCLUDE_DIRS` as a (bash) array
+  # containing directories to include in the built package.
+  # NOTE: Files will be overwritten.
+  for include_dir in ${OSQUERY_PKG_INCLUDE_DIRS[*]}; do
+    log "adding $include_dir in the package prefix to be included in the package"
+    cp -fR $include_dir/* $INSTALL_PREFIX/
+  done
+
   log "creating package"
   pkgbuild --root $INSTALL_PREFIX       \
            --scripts $SCRIPT_ROOT       \


### PR DESCRIPTION
We need to customize a little bit the package created by `make_osx_package.sh` to include extra files. With the current structure of the script, it is not possible to inject those files into the package creation steps; the [temporary directory gets deleted](https://github.com/facebook/osquery/blob/e0a24fb0/tools/deployment/make_osx_package.sh#L181-L182) and nothing else can be copied to it before [`pkgbuild` gets called](https://github.com/facebook/osquery/blob/e0a24fb0/tools/deployment/make_osx_package.sh#L239).

This PR adds a mechanism to add extra files and directory to the built package. It does so through the `OSQUERY_PKG_INCLUDE_DIRS` environment variable (bash array). A loop will copy the content of every entries of the variable in `$INSTALL_PREFIX/`, overwriting any collision. So for example if `OSQUERY_PKG_INCLUDE_DIRS=(dir1 dir2)` and those two directories have:
```
dir1
└── subdir
    └── sub
        └── sub
            └── testfile1.txt
dir2
└── subdir
    └── sub
        └── sub
            └── testfile2.txt

6 directories, 2 files
```
Then the package would install the two files `/subdir/sub/sub/testfile1.txt` and `/subdir/sub/sub/testfile2.txt`.

This allows us to, for example, add extra configuration files in `/private/var/osquery/osquery.conf.d/`, on top of the custom configuration `/private/var/osquery/osquery.conf` that gets used using the `-c`/`--config` script flag. We might also use it for other purposes, hence the usage of a bash array.

I haven't modified the Linux nor the Windows scripts though, I wanted to gather advice on this first.