### PR TITLE
cpu_time table on darwin

### DIFF
--- a/osquery/tables/system/darwin/cpu_time.cpp
+++ b/osquery/tables/system/darwin/cpu_time.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*
+ *  Inspired from the psutil per_cpu_times function -
+ *  https://github.com/giampaolo/psutil/blob/ec1d35e41c288248818388830f0e4f98536b93e4/psutil/_psutil_osx.c#L739
+ */
+
+#include <mach/mach.h>
+#include <time.h>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+static inline long int ticks_to_usecs(int ticks) {
+  return static_cast<long int>(
+      (static_cast<double>(ticks) / CLOCKS_PER_SEC * 1000000));
+}
+
+QueryData genCpuTime(QueryContext& context) {
+  QueryData results;
+
+  natural_t processor_count;
+  processor_cpu_load_info_data_t* processor_times;
+  mach_port_t host = mach_host_self();
+  mach_msg_type_number_t processor_msg_count;
+
+  kern_return_t ret =
+      host_processor_info(host,
+                          PROCESSOR_CPU_LOAD_INFO,
+                          &processor_count,
+                          reinterpret_cast<processor_info_t*>(&processor_times),
+                          &processor_msg_count);
+
+  if (ret == KERN_SUCCESS) {
+    // Loop through the cores and add rows for each core.
+    for (unsigned int core = 0; core < processor_count; core++) {
+      Row r;
+      r["core"] = INTEGER(core);
+      r["user"] = BIGINT(
+          ticks_to_usecs(processor_times[core].cpu_ticks[CPU_STATE_USER]));
+      r["idle"] = BIGINT(
+          ticks_to_usecs(processor_times[core].cpu_ticks[CPU_STATE_IDLE]));
+      r["system"] = BIGINT(
+          ticks_to_usecs(processor_times[core].cpu_ticks[CPU_STATE_SYSTEM]));
+      r["nice"] = BIGINT(
+          ticks_to_usecs(processor_times[core].cpu_ticks[CPU_STATE_NICE]));
+
+      results.push_back(r);
+    }
+    vm_deallocate(
+        mach_task_self(),
+        reinterpret_cast<vm_address_t>(processor_times),
+        static_cast<vm_size_t>(processor_count * sizeof(*processor_times)));
+  }
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/posix/cpu_time.table
+++ b/specs/posix/cpu_time.table
@@ -13,7 +13,7 @@ schema([
     Column("guest", BIGINT, "Time spent running a virtual CPU for a guest OS under the control of the Linux kernel"),
     Column("guest_nice", BIGINT, "Time spent running a niced guest "),
 ])
-implementation("linux/cpu_time@genCpuTime")
+implementation("cpu_time@genCpuTime")
 fuzz_paths([
     "/proc/stat",
 ])


### PR DESCRIPTION
This PR adds support for the `cpu_time` table. It doesn't have all the information that is obtainable on ubuntu/centos but gets the basic user, idle and system time information that is found in `iostat`. This is done by a call to the `host_processor_info` function.