### PR TITLE
Load Averages on POSIX systems using getloadavg

### DIFF
--- a/osquery/tables/system/posix/load_average.cpp
+++ b/osquery/tables/system/posix/load_average.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <stdlib.h>
+
+#include "osquery/core/conversions.h"
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+QueryData genLoadAverage(QueryContext& context) {
+  QueryData results;
+
+  double loads[3];
+  std::vector<std::string> periods = {"1m", "5m", "15m"};
+  if (getloadavg(loads, 3) != -1) {
+    for (int i = 0; i < 3; i++) {
+      Row r;
+      r["period"] = periods[i];
+      r["average"] = std::to_string(loads[i]);
+      results.push_back(r);
+    }
+  };
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/posix/load_average.table
+++ b/specs/posix/load_average.table
@@ -1,0 +1,10 @@
+table_name("load_average")
+description("Displays information about the system wide load averages.")
+schema([
+    Column("period", TEXT, "Period over which the average is calculated."),
+    Column("average", TEXT, "Load average over the specified period."),
+])
+implementation("load_average@genLoadAverage")
+examples([
+  "select * from load_average;",
+])


### PR DESCRIPTION
Load Averages on POSIX systems using the `getloadavg` function from `stdlib.h`. This PR is not tested on machines other than a mac, but it should work! 😄 

Docs to `getloadavg`
Linux - http://man7.org/linux/man-pages/man3/getloadavg.3.html
FreeBSD - https://www.freebsd.org/cgi/man.cgi?query=getloadavg

Example output:
```
osquery> select * from load_average;
+-----------------+-----------------+------------------+
| load_average_1m | load_average_5m | load_average_15m |
+-----------------+-----------------+------------------+
| 1.901855        | 2.080078        | 2.167480         |
+-----------------+-----------------+------------------+
```