### PR TITLE
Improve query profiler

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
     if not args.force and not os.path.exists(args.shell):
         print("Cannot find --shell: %s" % (args.shell))
         exit(1)
-    if args.config is None and not os.path.exists(args.tables):
+    if args.tables is None and not os.path.exists(args.tables):
         print("Cannot find --tables: %s" % (args.tables))
         exit(1)
 
@@ -340,6 +340,10 @@ if __name__ == "__main__":
             print("Cannot find --config: %s" % (args.config))
             exit(1)
         queries = utils.queries_from_config(args.config)
+        # Search queries in subdirectory ".d" based on the config filename
+        if os.path.isdir(args.config + ".d"):
+            for config_file in os.listdir(args.config + ".d"):
+                queries.update(utils.queries_from_config(os.path.join(args.config + ".d", config_file)))
     elif args.query is not None:
         queries["manual"] = args.query
     elif args.force:

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
     if not args.force and not os.path.exists(args.shell):
         print("Cannot find --shell: %s" % (args.shell))
         exit(1)
-    if args.tables is None and not os.path.exists(args.tables):
+    if args.config is None and not os.path.exists(args.tables):
         print("Cannot find --tables: %s" % (args.tables))
         exit(1)
 

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -97,15 +97,15 @@ def queries_from_config(config_path):
         for keys,values in config["packs"].iteritems():
             # Check if it is an internal pack definition
             if type(values) is dict:
-                for queryname,query in values["queries"].iteritems():
-                    queries["pack_"+queryname] = query["query"]
+                for queryname, query in values["queries"].iteritems():
+                    queries["pack_" + queryname] = query["query"]
             else:
                 with open(values) as fp:
                     packfile = fp.read()
-                    packcontent = rmcomment.sub('',packfile)
+                    packcontent = rmcomment.sub('', packfile)
                     packqueries = json.loads(packcontent)
-                    for queryname,query in packqueries["queries"].iteritems():
-                        queries["pack_"+queryname] = query["query"]
+                    for queryname, query in packqueries["queries"].iteritems():
+                        queries["pack_" + queryname] = query["query"]
 
     return queries
 

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -95,18 +95,18 @@ def queries_from_config(config_path):
             queries[name] = details["query"]
     if "packs" in config:
         for keys,values in config["packs"].iteritems():
-            with open(values) as fp:
-                packfile = fp.read()
-                packcontent = rmcomment.sub('',packfile)
-                packqueries = json.loads(packcontent)
-                for queryname,query in packqueries["queries"].iteritems():
+            # Check if it is an internal pack definition
+            if type(values) is dict:
+                for queryname,query in values["queries"].iteritems():
                     queries["pack_"+queryname] = query["query"]
+            else:
+                with open(values) as fp:
+                    packfile = fp.read()
+                    packcontent = rmcomment.sub('',packfile)
+                    packqueries = json.loads(packcontent)
+                    for queryname,query in packqueries["queries"].iteritems():
+                        queries["pack_"+queryname] = query["query"]
 
-
-        pass
-    if len(queries) == 0:
-        print("Could not find a schedule/queries in config: %s" % config_path)
-        exit(0)
     return queries
 
 


### PR DESCRIPTION
- Bugfix on tables path verification
- Search under <config file path>.d directory if exists in order to parse all sub configuration files
- In pack definition, check if it is an internal one and parse it