### PR TITLE
watcher: Do not initialize the config in watcher

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,9 @@
+{
+  "ignore_dirs": [
+    "build",
+  ],
+  "content_hash_warming": true,
+  "content_hash_max_items": 333333,
+  "hint_num_files_per_dir": 8,
+  "fsevents_latency": 0.05
+}

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -154,9 +154,10 @@ class Config : private boost::noncopyable {
   }
 
   /// Get start time of config.
-  size_t getStartTime() const {
-    return start_time_;
-  }
+  static size_t getStartTime();
+
+  /// Set the start time if the config.
+  static void setStartTime(size_t st);
 
   /**
    * @brief Add a pack to the osquery schedule
@@ -362,9 +363,6 @@ class Config : private boost::noncopyable {
 
   /// Try if the configuration has started an auto-refresh thread.
   bool started_thread_{false};
-
-  /// A UNIX timestamp recorded when the config started.
-  size_t start_time_{0};
 
  private:
   /// Hold a reference to the refresh runner to update the acceleration.

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -170,9 +170,6 @@ class Initializer : private boost::noncopyable {
   /// This pauses the watchdog process until the watcher thread stops.
   void waitForWatcher() const;
 
-  /// Run the daemon: distributed, and scheduler.
-  void runDaemon() const;
-
  private:
   /// Set and wait for an active plugin optionally broadcasted.
   void initActivePlugin(const std::string& type, const std::string& name) const;

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -167,7 +167,11 @@ class Initializer : private boost::noncopyable {
   /// Initialize the osquery watcher, optionally spawn a worker.
   void initWatcher() const;
 
+  /// This pauses the watchdog process until the watcher thread stops.
   void waitForWatcher() const;
+
+  /// Run the daemon: distributed, and scheduler.
+  void runDaemon() const;
 
  private:
   /// Set and wait for an active plugin optionally broadcasted.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -41,6 +41,8 @@
 
 #include "osquery/core/process.h"
 #include "osquery/core/watcher.h"
+#include "osquery/dispatcher/distributed.h"
+#include "osquery/dispatcher/scheduler.h"
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -275,6 +277,8 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
       binary_((tool == ToolType::DAEMON) ? "osqueryd" : "osqueryi") {
   std::srand(static_cast<unsigned int>(
       chrono_clock::now().time_since_epoch().count()));
+  // The config holds the initialization time for easy access.
+  Config::setStartTime(getUnixTime());
 
   // Initialize registries and plugins
   registryAndPluginInit();
@@ -306,6 +310,7 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
                {"Stderr log level threshold", false, false, true, false});
 
   // osquery implements a custom help/usage output.
+  bool default_flags = true;
   for (int i = 1; i < *argc_; i++) {
     auto help = std::string((*argv_)[i]);
     if ((help == "--help" || help == "-help" || help == "--h" ||
@@ -313,6 +318,9 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
         tool != ToolType::TEST) {
       printUsage(binary_, tool_);
       shutdown();
+    }
+    if (help.find("--flagfile") == 0) {
+      default_flags = false;
     }
   }
 
@@ -324,11 +332,12 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
     FLAGS_disable_events = true;
   }
 
-  bool default_flags = false;
-  if (FLAGS_flagfile.empty() && isReadable(kDefaultFlagfile)) {
+  if (default_flags && isReadable(kDefaultFlagfile)) {
     // No flagfile was set (daemons and services always set a flagfile).
-    default_flags = true;
     FLAGS_flagfile = kDefaultFlagfile;
+  } else {
+    // No flagfile was set, but no default flags exist.
+    default_flags = false;
   }
 
   // Set version string from CMake build
@@ -459,6 +468,12 @@ void Initializer::initShell() const {
 }
 
 void Initializer::initWatcher() const {
+  // The watcher should not log into or use a persistent database.
+  FLAGS_disable_database = true;
+  FLAGS_disable_logging = true;
+  DatabasePlugin::setAllowOpen(true);
+  DatabasePlugin::initPlugin();
+
   // The watcher takes a list of paths to autoload extensions from.
   // The loadExtensions call will populate the watcher's list of extensions.
   osquery::loadExtensions();
@@ -490,6 +505,24 @@ void Initializer::waitForWatcher() const {
     }
     requestShutdown(retcode);
   }
+}
+
+void Initializer::runDaemon() const {
+  if (!FLAGS_disable_watchdog && !isWorker()) {
+    return;
+  }
+
+  // Finish the Initializer's setup.
+  start();
+
+  // Conditionally begin the distributed query service
+  auto s = osquery::startDistributed();
+  if (!s.ok()) {
+    VLOG(1) << "Not starting the distributed query service: " << s.toString();
+  }
+
+  // Begin the schedule runloop.
+  osquery::startScheduler();
 }
 
 void Initializer::initWorker(const std::string& name) const {
@@ -590,7 +623,13 @@ void Initializer::start() const {
   // Bind to an extensions socket and wait for registry additions.
   // After starting the extension manager, osquery MUST shutdown using the
   // internal 'shutdown' method.
-  osquery::startExtensionManager();
+  auto s = osquery::startExtensionManager();
+  if (!s.ok()) {
+    auto severity = (Watcher::get().hasManagedExtensions()) ? google::GLOG_ERROR
+                                                            : google::GLOG_INFO;
+    google::LogMessage(__FILE__, __LINE__, severity).stream()
+        << "Cannot start extension manager: " + s.getMessage();
+  }
 
   // Then set the config plugin, which uses a single/active plugin.
   initActivePlugin("config", FLAGS_config_plugin);
@@ -600,7 +639,7 @@ void Initializer::start() const {
 
   if (FLAGS_config_check) {
     // The initiator requested an initialization and config check.
-    auto s = Config::get().load();
+    s = Config::get().load();
     if (!s.ok()) {
       std::cerr << "Error reading config: " << s.toString() << "\n";
     }
@@ -615,7 +654,7 @@ void Initializer::start() const {
   }
 
   // Load the osquery config using the default/active config plugin.
-  auto s = Config::get().load();
+  s = Config::get().load();
   if (!s.ok()) {
     auto message = "Error reading config: " + s.toString();
     if (tool_ == ToolType::DAEMON) {

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -41,8 +41,6 @@
 
 #include "osquery/core/process.h"
 #include "osquery/core/watcher.h"
-#include "osquery/dispatcher/distributed.h"
-#include "osquery/dispatcher/scheduler.h"
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -505,24 +503,6 @@ void Initializer::waitForWatcher() const {
     }
     requestShutdown(retcode);
   }
-}
-
-void Initializer::runDaemon() const {
-  if (!FLAGS_disable_watchdog && !isWorker()) {
-    return;
-  }
-
-  // Finish the Initializer's setup.
-  start();
-
-  // Conditionally begin the distributed query service
-  auto s = osquery::startDistributed();
-  if (!s.ok()) {
-    VLOG(1) << "Not starting the distributed query service: " << s.toString();
-  }
-
-  // Begin the schedule runloop.
-  osquery::startScheduler();
 }
 
 void Initializer::initWorker(const std::string& name) const {

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -236,7 +236,7 @@ void WatcherRunner::start() {
 }
 
 size_t WatcherRunner::delayedTime() const {
-  return Config::get().getStartTime() + FLAGS_watchdog_delay;
+  return Config::getStartTime() + FLAGS_watchdog_delay;
 }
 
 bool WatcherRunner::watch(const PlatformProcess& child) const {

--- a/osquery/main/posix/daemon.cpp
+++ b/osquery/main/posix/daemon.cpp
@@ -9,12 +9,7 @@
  */
 
 #include <osquery/core.h>
-#include <osquery/flags.h>
-#include <osquery/logger.h>
 #include <osquery/system.h>
-
-#include "osquery/dispatcher/distributed.h"
-#include "osquery/dispatcher/scheduler.h"
 
 const std::string kWatcherWorkerName = "osqueryd: worker";
 
@@ -30,16 +25,7 @@ int main(int argc, char* argv[]) {
   runner.initWorkerWatcher(kWatcherWorkerName);
 
   // Start osquery work.
-  runner.start();
-
-  // Conditionally begin the distributed query service
-  auto s = osquery::startDistributed();
-  if (!s.ok()) {
-    VLOG(1) << "Not starting the distributed query service: " << s.toString();
-  }
-
-  // Begin the schedule runloop.
-  osquery::startScheduler();
+  runner.runDaemon();
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();

--- a/osquery/main/windows/daemon.cpp
+++ b/osquery/main/windows/daemon.cpp
@@ -20,6 +20,8 @@
 #include <osquery/system.h>
 
 #include "osquery/core/watcher.h"
+#include "osquery/dispatcher/distributed.h"
+#include "osquery/dispatcher/scheduler.h"
 
 DECLARE_string(flagfile);
 
@@ -328,7 +330,16 @@ void daemonEntry(int argc, char* argv[]) {
   }
 
   // Start osquery work.
-  runner.runDaemon();
+  runner.start();
+
+  // Conditionally begin the distributed query service.
+  auto s = osquery::startDistributed();
+  if (!s.ok()) {
+    VLOG(1) << "Not starting the distributed query service: " << s.toString();
+  }
+
+  // Begin the schedule runloop.
+  osquery::startScheduler();
 
   // kStopEvent is nullptr if not run from the service control manager
   if (kStopEvent != nullptr) {

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -210,7 +210,7 @@ QueryData genOsqueryInfo(QueryContext& context) {
       (pingExtension(FLAGS_extensions_socket).ok()) ? "active" : "inactive";
   r["build_platform"] = STR(OSQUERY_BUILD_PLATFORM);
   r["build_distro"] = STR(OSQUERY_BUILD_DISTRO);
-  r["start_time"] = INTEGER(Config::get().getStartTime());
+  r["start_time"] = INTEGER(Config::getStartTime());
   if (Initializer::isWorker()) {
     r["watcher"] = INTEGER(PlatformProcess::getLauncherProcess()->pid());
   } else {


### PR DESCRIPTION
This should fix an error in the watchdog, where an exception is thrown when attempting to use the database. Previously we used the `Config`, and on initialization it constructed a `Schedule`, which attempted to look up the last-failed query from the database.