### PR TITLE
Changing init verbosity to honor verbose flag

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -640,7 +640,7 @@ void Initializer::start() const {
     if (tool_ == ToolType::DAEMON) {
       LOG(WARNING) << message;
     } else {
-      LOG(INFO) << message;
+      VLOG(1) << message;
     }
   }
 


### PR DESCRIPTION
Integration tests rely on a specific behavior. The initial verbosity log indicating the config file was unable to be found/read isn't honoring the `verbose` flag on Windows, so we make use of a macro that explicitly checks the `verbose` flag.