### PR TITLE
carver: gating carver code in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,13 @@ endif()
 if(DEFINED ENV{SKIP_YARA})
   set(SKIP_YARA TRUE)
 endif()
+if(DEFINED ENV{SKIP_CARVER})
+  set(SKIP_CARVER TRUE)
+  # To remove references to carve functionality in sqlite helper functions
+  add_definitions(
+    -DSKIP_CARVER=1
+  )
+endif()
 
 # Similar to the feature skips, there are default-build skips.
 if(DEFINED ENV{SKIP_TESTS})

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -73,7 +73,9 @@ add_subdirectory(logger)
 add_subdirectory(registry)
 add_subdirectory(sql)
 add_subdirectory(remote)
-add_subdirectory(carver)
+if(NOT SKIP_CARVER)
+  add_subdirectory(carver)
+endif()
 
 # Add externals directory from parent
 add_subdirectory("${CMAKE_SOURCE_DIR}/external" "${CMAKE_BINARY_DIR}/external")

--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -2,26 +2,24 @@ ADD_OSQUERY_LIBRARY_CORE(osquery_sql
   sql.cpp
 )
 
-if(FREEBSD)
-  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
-    sqlite_util.cpp
-    sqlite_math.cpp
-    sqlite_hashing.cpp
-    sqlite_operations.cpp
-    sqlite_encoding.cpp
-    virtual_table.cpp
-  )
-else()
-  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
-    sqlite_util.cpp
-    sqlite_math.cpp
-    sqlite_string.cpp
-    sqlite_hashing.cpp
-    sqlite_operations.cpp
-    sqlite_encoding.cpp
-    virtual_table.cpp
-  )
+set(OSQUERY_SQL_INTERNAL
+  "sqlite_util.cpp"
+  "sqlite_math.cpp"
+  "sqlite_hashing.cpp"
+  "sqlite_encoding.cpp"
+  "virtual_table.cpp"
+)
+
+if(NOT FREEBSD)
+  list(APPEND OSQUERY_SQL_INTERNAL "sqlite_string.cpp")
 endif()
+if(NOT SKIP_CARVER)
+  list(APPEND OSQUERY_SQL_INTERNAL "sqlite_operations.cpp")
+endif()
+
+ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
+  ${OSQUERY_SQL_INTERNAL}
+)
 
 file(GLOB OSQUERY_SQL_TESTS "tests/*.cpp")
 ADD_OSQUERY_TEST_ADDITIONAL(${OSQUERY_SQL_TESTS})

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -221,8 +221,10 @@ static inline void openOptimized(sqlite3*& db) {
 #if !defined(FREEBSD)
   registerStringExtensions(db);
 #endif
-  registerHashingExtensions(db);
+#if !defined(SKIP_CARVER)
   registerOperationExtensions(db);
+#endif
+  registerHashingExtensions(db);
   registerEncodingExtensions(db);
 }
 

--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -9,10 +9,13 @@
 set(TABLE_CATEGORIES
   "applications"
   "events"
-  "forensic"
   "networking"
   "system"
 )
+
+if(NOT SKIP_CARVER)
+  list(APPEND TABLE_CATEGORIES "forensic")
+endif()
 
 # Apple/Darwin specific and applicable tables.
 if(APPLE)


### PR DESCRIPTION
In certain circumstances, one may wish to completely remove the carver code in it's entirety from the code base. To do so, one can use the `SKIP_CARVER=1` environment variable along with adding the `carves` table to the `specs/blacklist`.