### PR TITLE
build: Major change to building within shared folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ endif
 ifeq ($(FS_TYPE),nfs)
 	@echo "-- Requested build on shared (NFS) folder [Issue #3414]: using a temporary build directory"
 	@echo "-- Build directories: $(SOURCE_DIR)/build/{debug_}$(BUILD_NAME)$(LINK)"
+else
+	@mkdir -p $(BUILD_DIR)
+	@mkdir -p $(DEBUG_BUILD_DIR)
 endif
 
 	@mkdir -p build/docs

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -111,7 +111,7 @@ function build_target() {
   threads THREADS
 
   # Clean previous build artifacts.
-  $MAKE clean
+  $MAKE distclean
 
   # Build osquery.
   if [[ -z "$RUN_TARGET" ]]; then


### PR DESCRIPTION
This will be a work-in-progress until it's tested on several platforms.

The goal is to implement #3414 and allow easy building within shared-folders like `vboxsf` and `nfs`.