### PR TITLE
virtual tables: Allow tables to use an 'extended' schema

### DIFF
--- a/docs/wiki/development/creating-tables.md
+++ b/docs/wiki/development/creating-tables.md
@@ -58,6 +58,30 @@ You may be wondering how osquery handles cross-platform support while still allo
 
 > NOTICE: the CMake build provides custom defines for each platform and platform version.
 
+**Specfile nuances**
+
+Each column in a **specfile** may have keyword arguments that effect how the SQLite behaves. If you require a column to be present in the `WHERE` predicate, like a `path` in the `file` table, then it must be reflected in the spec.
+
+- **required=True**: This will create a warning if the table is used and the column does not appear in the predicate.
+- **index=True**: This sets the `PRIMARY KEY` for the table, which helps the SQLite optimizer remove potential duplicates from complex `JOIN`s. If multiple columns have `index=True` then a primary key is created as the set of columns.
+- **additional=True**: This is weird, but use **additional** if the presence of the column in the predicate would somehow alter the logic in the table generator. This tells SQLite not to optimize out any use of this column in the predicate.
+- **hidden=True**: Sets the `HIDDEN` attribute for the column, so a `SELECT * FROM` will not include this column.
+
+The table may also set `attributes`:
+```python
+attributes(user_data=True)
+```
+
+There are several attributes that help with table documentation and optimization. These are keyword arguments in the `attributes` optional method.
+
+- **event_subscriber=True**: Indicates that the table is an abstraction on top of an event subscriber. The specfile for your subscriber must set this attribute.
+- **user_data=True**: This tells the caller that they should provide a `uid` in the query predicate. By default the table will inspect the current user's content, but may be asked to include results from others.
+- **cacheable=True**: The results from the table can be cached within the query schedule. If this table generates a lot of data it is best to cache the results so that queries needing access in the schedule with a shorter interval can simply copy the already generated structures.
+- **utility=True**: This table will be included in the osquery SDK, it is considered a core/non-platform specific utility.
+- **kernel_required=True**: This is rare, but tells the caller that results are only available if the osquery kernel extension is running.
+
+Specs may also include an **extended_schema** for a specific platform. They are the same as **schema** but the first argument is a function returning a bool. If true the columns are added and not marked hidden, otherwise they are all appended with `hidden=True`. This allows tables to keep a consistent set of columns and types while providing a good user experience for default selects.
+
 **Creating your implementation**
 
 As indicated in the spec file, our implementation will be in a function called `genTime`. Since this is a very general table and should compile on all supported operating systems we can place it in *osquery/tables/utility/time.cpp*. The directory *osquery/table/* contains the set of implementation categories. Each category *may* contain a platform-restricted directory. If a table requires a different implementation on different platform, use these subdirectories. Place implementations in the corresponding category using your best judgment. CMake will discover all files within the platform-related directory at build time.

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -15,6 +15,8 @@ schema([
     Column("idrops", BIGINT, "Input drops"),
     Column("odrops", BIGINT, "Output drops"),
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
+])
+extended_schema(WINDOWS, [
     Column("description", TEXT, "Short description of the object—a one-line string."),
     Column("manufacturer", TEXT, "Name of the network adapter's manufacturer."),
     Column("connection_id", TEXT, "Name of the network connection as it appears in the Network Connections Control Panel program."),

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -37,8 +37,6 @@ RESERVED = ["n", "index"]
 PLATFORM = platform()
 
 # Supported SQL types for spec
-
-
 class DataType(object):
     def __init__(self, affinity, cpp_type="std::string"):
         '''A column datatype is a pair of a SQL affinity to C++ type.'''
@@ -89,6 +87,26 @@ TABLE_ATTRIBUTES = {
     "utility": "UTILITY",
     "kernel_required": "KERNEL_REQUIRED",
 }
+
+
+def WINDOWS():
+    return PLATFORM in ['windows']
+
+
+def LINUX():
+    return PLATFORM in ['linux']
+
+
+def POSIX():
+    return PLATFORM in ['linux', 'darwin', 'freebsd']
+
+
+def DARWIN():
+    return PLATFORM in ['darwin']
+
+
+def FREEBSD():
+    return PLATFORM in ['freebsd']
 
 
 def to_camel_case(snake_case):
@@ -334,6 +352,19 @@ def schema(schema_list):
         if isinstance(it, ForeignKey):
             logging.debug("  - foreign_key: %s (%s)" % (it.column, it.table))
     table.schema = schema_list
+
+
+def extended_schema(check, schema_list):
+    """
+    define a comparator and a list of Columns objects.
+    """
+    logging.debug("- extended schema")
+    for it in schema_list:
+        if isinstance(it, Column):
+            logging.debug("  - column: %s (%s)" % (it.name, it.type))
+            if not check():
+                it.options['hidden'] = True
+            table.schema.append(it)
 
 
 def description(text):


### PR DESCRIPTION
This allows tables to extend their default schema with an `extended_schema`. The goal of the extended schema is to provide platform-specific columns without bloating the default-select case for the other platforms. The column types are still the same on all platforms, but marked `HIDDEN` for those not supported.