### PR TITLE
virtual tables: Build Linux cpu_time on FreeBSD

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -76,35 +76,46 @@ if(POSIX)
 endif()
 
 # For each general category, add the C++ files in the base.
-foreach(CAT ${TABLE_CATEGORIES})
-  file(GLOB OSQUERY_${CAT}_TABLES
-    "${CAT}/*.[cpm]*"
-    "${CAT}/${TABLE_PLATFORM}/*.[cpm]*"
+foreach(CATEGORY ${TABLE_CATEGORIES})
+  file(GLOB OSQUERY_${CATEGORY}_TABLES
+    "${CATEGORY}/*.[cpm]*"
+    "${CATEGORY}/${TABLE_PLATFORM}/*.[cpm]*"
   )
-  if(OSQUERY_${CAT}_TABLES)
+  if(OSQUERY_${CATEGORY}_TABLES)
     ADD_OSQUERY_LIBRARY_ADDITIONAL(
-      osquery_${CAT}_tables
-      ${OSQUERY_${CAT}_TABLES}
+      osquery_${CATEGORY}_tables
+      ${OSQUERY_${CATEGORY}_TABLES}
     )
   endif()
 
   # POSIX tables.
   if(POSIX)
-    file(GLOB OSQUERY_${CAT}_POSIX_TABLES "${CAT}/posix/*.[cpm]*")
-    if(OSQUERY_${CAT}_POSIX_TABLES)
+    file(GLOB OSQUERY_${CATEGORY}_POSIX_TABLES "${CATEGORY}/posix/*.[cpm]*")
+    if(OSQUERY_${CATEGORY}_POSIX_TABLES)
       ADD_OSQUERY_LIBRARY_ADDITIONAL(
-        osquery_${CAT}_posix_tables
-        ${OSQUERY_${CAT}_POSIX_TABLES}
+        osquery_${CATEGORY}_posix_tables
+        ${OSQUERY_${CATEGORY}_POSIX_TABLES}
+      )
+    endif()
+  endif()
+
+  # Table implementations shared by FreeBSD and Linux
+  if(FREEBSD OR LINUX)
+    file(GLOB OSQUERY_${CATEGORY}_FREENUX_TABLES "${CATEGORY}/freenux/*.[cpm]*")
+    if(OSQUERY_${CATEGORY}_FREENUX_TABLES)
+      ADD_OSQUERY_LIBRARY_ADDITIONAL(
+        osquery_${CATEGORY}_freenux_tables
+        ${OSQUERY_${CATEGORY}_FREENUX_TABLES}
       )
     endif()
   endif()
 
   # Add the table tests.
-  file(GLOB OSQUERY_${CAT}_TABLES_TESTS
-    "${CAT}/tests/*.[cpm]*"
-    "${CAT}/${TABLE_PLATFORM}/tests/*.[cpm]*"
+  file(GLOB OSQUERY_${CATEGORY}_TABLES_TESTS
+    "${CATEGORY}/tests/*.[cpm]*"
+    "${CATEGORY}/${TABLE_PLATFORM}/tests/*.[cpm]*"
   )
-  ADD_OSQUERY_TABLE_TEST(${OSQUERY_${CAT}_TABLES_TESTS})
+  ADD_OSQUERY_TABLE_TEST(${OSQUERY_${CATEGORY}_TABLES_TESTS})
 endforeach()
 
 file(GLOB OSQUERY_UTILITY_TABLES "utility/*.cpp")

--- a/osquery/tables/system/freenux/cpu_time.cpp
+++ b/osquery/tables/system/freenux/cpu_time.cpp
@@ -20,8 +20,7 @@ namespace tables {
 
 const std::string kProcStat = "/proc/stat";
 
-std::vector<std::string> procFromFile(const std::string &path) {
-
+std::vector<std::string> procFromFile(const std::string& path) {
   if (!isReadable(path).ok()) {
     return {};
   }
@@ -33,7 +32,7 @@ std::vector<std::string> procFromFile(const std::string &path) {
 
   auto lines = split(content, "\n");
   std::vector<std::string> proc_lines;
-  for (auto &line : lines) {
+  for (auto& line : lines) {
     boost::trim(line);
     if (boost::starts_with(line, "cpu")) {
       proc_lines.push_back(line);
@@ -49,8 +48,7 @@ std::vector<std::string> procFromFile(const std::string &path) {
   return proc_lines;
 }
 
-static void genCpuTimeLine(const std::string &line, QueryData &results) {
-
+static void genCpuTimeLine(const std::string& line, QueryData& results) {
   auto words = osquery::split(line, " ");
   auto num_words = words.size();
 
@@ -81,11 +79,11 @@ static void genCpuTimeLine(const std::string &line, QueryData &results) {
   results.push_back(r);
 }
 
-QueryData genCpuTime(QueryContext &context) {
+QueryData genCpuTime(QueryContext& context) {
   QueryData results;
 
   auto proc_lines = procFromFile(kProcStat);
-  for (const auto &line : proc_lines) {
+  for (const auto& line : proc_lines) {
     genCpuTimeLine(line, results);
   }
 


### PR DESCRIPTION
This introduces a new table category (implementation only for now) called `freenux`, an invented term for the repo meaning tables that build on both FreeBSD and Linux. Because "linbsd" didn't sound very nice.

The first table sharing an implementation is `cpu_time`, which already exists in the `posix` set of specfiles.