### PR TITLE
freebsd: Update Vagrantfile, config tests, and remove hidden visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,12 @@ if(POSIX)
     -pipe
     -fdata-sections
     -ffunction-sections
-    -fvisibility=hidden
-    -fvisibility-inlines-hidden
   )
   if(NOT FREEBSD)
     add_compile_options(
       -Werror=shadow
+      -fvisibility=hidden
+      -fvisibility-inlines-hidden
     )
   endif()
 elseif(WINDOWS)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,9 @@ targets = {
   "ubuntu16.10"  => {
     "box" => "bento/ubuntu-16.10"
   },
+  "ubuntu17.04"  => {
+    "box" => "wholebits/ubuntu17.04-64"
+  },
   "ubuntu14"  => {
     "box" => "ubuntu/trusty64"
   },
@@ -177,17 +180,33 @@ Vagrant.configure("2") do |config|
           ]
       end
 
-      if name == 'freebsd10'
+      if name.start_with?('freebsd')
         # configure the NICs
         build.vm.provider :virtualbox do |vb|
           vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
           vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
         end
         # Private network for NFS
-        build.vm.network :private_network, ip: "192.168.56.101"
-        build.vm.synced_folder ".", "/vagrant", type: "nfs"
-        build.vm.provision "shell",
-          inline: "pkg install -y gmake"
+        build.vm.network :private_network,
+          ip: "192.168.56.101", :mac => "5CA1AB1E0001"
+        build.vm.synced_folder ".", "/vagrant", type: "rsync",
+          rsync__exclude: [
+            "build",
+            ".git/objects",
+            ".git/modules/third-party/objects"
+          ]
+        build.vm.provision 'shell',
+          inline:
+            "sudo sed -i '' -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf;"\
+            "su -m root -c 'pkg update -f';"\
+            "sudo pkg install -y openjdk8 bash git gmake python ruby;"\
+            "sudo mount -t fdescfs fdesc /dev/fd;"\
+            "sudo mount -t procfs proc /proc;"\
+            "echo -e \""\
+              "fdesc   /dev/fd     fdescfs     rw  0   0\n"\
+              "proc    /proc       procfs      rw  0   0"\
+            "\" | sudo tee /etc/fstab;"\
+            "sudo ln -f `which bash` /bin"
       end
       if name.start_with?('ubuntu')
         build.vm.provision 'bootstrap', type: 'shell' do |s|

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -206,9 +206,11 @@ TEST_F(ConfigTests, test_pack_restrictions) {
 
   get().packs(([&results](std::shared_ptr<Pack>& pack) {
     if (results[pack->getName()]) {
-      EXPECT_TRUE(pack->shouldPackExecute());
+      EXPECT_TRUE(pack->shouldPackExecute())
+          << "Pack " << pack->getName() << " should have executed";
     } else {
-      EXPECT_FALSE(pack->shouldPackExecute());
+      EXPECT_FALSE(pack->shouldPackExecute())
+          << "Pack " << pack->getName() << " should not have executed";
     }
   }));
 }
@@ -260,7 +262,11 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
       ([&queries](const std::string&, const ScheduledQuery& query) {
         queries.push_back(query);
       }));
-  EXPECT_EQ(queries.size(), getUnrestrictedPack().get_child("queries").size());
+
+  auto expected_size = getUnrestrictedPack().get_child("queries").size();
+  EXPECT_EQ(queries.size(), expected_size)
+      << "The number of queries in the schedule (" << queries.size()
+      << ") should equal " << expected_size;
 }
 
 class TestConfigParserPlugin : public ConfigParserPlugin {


### PR DESCRIPTION
Fixes #3418.

It stinks we didn't catch the `-fvisibility=hidden` effecting FreeBSD earlier. I'm not sure why this causes the remote APIs to hang. FreeBSD is somewhat different that macOS/Linux in that most dependencies are available statically. If dynamic links, `asio`, `cpp-netlib` did not use these compile options, there will be undefined behavior.