### PR TITLE
Fix error handling in AWS logger plugins

### DIFF
--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -100,6 +100,12 @@ Status FirehoseLogForwarder::send(std::vector<std::string>& log_data,
 
   Aws::Firehose::Model::PutRecordBatchOutcome outcome =
       client_->PutRecordBatch(request);
+
+  if (!outcome.IsSuccess()) {
+    LOG(ERROR) << "Firehose write failed: " << outcome.GetError().GetMessage();
+    return Status(1, outcome.GetError().GetMessage());
+  }
+
   Aws::Firehose::Model::PutRecordBatchResult result = outcome.GetResult();
   if (result.GetFailedPutCount() != 0) {
     for (const auto& record : result.GetRequestResponses()) {

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -132,6 +132,12 @@ Status KinesisLogForwarder::send(std::vector<std::string>& log_data,
 
     Aws::Kinesis::Model::PutRecordsOutcome outcome =
         client_->PutRecords(request);
+
+    if (!outcome.IsSuccess()) {
+      LOG(ERROR) << "Kinesis write failed: " << outcome.GetError().GetMessage();
+      return Status(1, outcome.GetError().GetMessage());
+    }
+
     Aws::Kinesis::Model::PutRecordsResult result = outcome.GetResult();
     VLOG(1) << "Successfully sent "
             << result.GetRecords().size() - result.GetFailedRecordCount()

--- a/osquery/logger/plugins/tests/aws_firehose_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_firehose_tests.cpp
@@ -54,7 +54,8 @@ TEST_F(FirehoseTests, test_send) {
   forwarder.client_ = client;
 
   std::vector<std::string> logs{"{\"foo\":\"bar\"}"};
-  Aws::Firehose::Model::PutRecordBatchOutcome outcome;
+  Aws::Firehose::Model::PutRecordBatchOutcome outcome(
+      Aws::Firehose::Model::PutRecordBatchResult{});
   outcome.GetResult().SetFailedPutCount(0);
   EXPECT_CALL(*client,
               PutRecordBatch(Property(

--- a/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_tests.cpp
@@ -56,7 +56,8 @@ TEST_F(KinesisTests, test_send) {
   forwarder.client_ = client;
 
   std::vector<std::string> logs{"{\"foo\":\"bar\"}"};
-  Aws::Kinesis::Model::PutRecordsOutcome outcome;
+  Aws::Kinesis::Model::PutRecordsOutcome outcome(
+      Aws::Kinesis::Model::PutRecordsResult{});
   outcome.GetResult().SetFailedRecordCount(0);
   EXPECT_CALL(
       *client,


### PR DESCRIPTION
The AWS plugins were correctly handling errors with individual records posting,
but did not handle an error for the overall request (such as an auth error). As
a result, when these errors occurred, osquery would print "Successfully sent 0
records to Kinesis." We now explicitly handle these errors.

Fixes #3310