### PR TITLE
Custom directory flag for augeas lenses.

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -393,6 +393,12 @@ Path to the named pipe used for forwarding **rsyslog** events.
 
 Maximum number of logs to ingest per run (~200ms between runs). Use this as a fail-safe to prevent osquery from becoming overloaded when syslog is spammed.
 
+### Augeas
+
+`--augeas_lenses=/usr/share/osquery/lenses`
+
+Augeas lenses are bundled with osquery distributions. On Linux they are installed in /usr/share/osquery/lenses. On macOS lenses are installed in /private/var/osquery/lenses directory. Specify the path to the directory containing custom or different version lenses files.
+
 ### Shell-only flags
 
 Most of the shell flags are self-explanatory and are adapted from the SQLite shell. Refer to the shell's ".help" command for details and explanations.

--- a/docs/wiki/installation/install-linux.md
+++ b/docs/wiki/installation/install-linux.md
@@ -7,6 +7,7 @@ The default packages create the following structure:
 ```sh
 /etc/osquery/
 /usr/share/osquery/osquery.example.conf
+/usr/share/osquery/lenses/{*}.aug
 /usr/share/osquery/packs/{*}.conf
 /var/log/osquery/
 /usr/lib/osquery/

--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -13,6 +13,7 @@ The default package creates the following structure:
 /private/var/osquery/com.facebook.osqueryd.plist
 /private/var/osquery/osquery.example.conf
 /private/var/log/osquery/
+/private/var/osquery/lenses/{*}.aug
 /private/var/osquery/packs/{*}.conf
 /usr/local/lib/osquery/
 /usr/local/bin/osqueryctl

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -15,13 +15,25 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+namespace osquery {
+
+/**
+ * @brief Augeas lenses path.
+ *
+ * Directory that contains augeus lenses.
+ */
 #ifdef __APPLE__
-#define LENSES_PATH "/private/var/osquery/lenses"
+FLAG(string,
+     augeas_lenses,
+     "/private/var/osquery/lenses",
+     "Directory that contains augeas lenses files");
 #else
-#define LENSES_PATH "/usr/share/osquery/lenses"
+FLAG(string,
+     augeas_lenses,
+     "/usr/share/osquery/lenses",
+     "Directory that contains augeas lenses files");
 #endif
 
-namespace osquery {
 namespace tables {
 
 void reportAugeasError(augeas* aug) {
@@ -147,8 +159,8 @@ void matchAugeasPattern(augeas* aug,
 }
 
 QueryData genAugeas(QueryContext& context) {
-  augeas* aug =
-      aug_init(nullptr, LENSES_PATH, AUG_NO_ERR_CLOSE | AUG_ENABLE_SPAN);
+  augeas* aug = aug_init(
+      nullptr, FLAGS_augeas_lenses.c_str(), AUG_NO_ERR_CLOSE | AUG_ENABLE_SPAN);
 
   // Handle initialization errors.
   if (aug == nullptr) {


### PR DESCRIPTION
This provides ability for users to specify their own augeas lenses directory.

On OS X, docker top API is not honoring 'ps_args'. Added check to make results
have correct number of columns.

On Ubuntu 16.04, I am unable to 'make deps' without libyaml. pip install of
requirements.txt is failing to link. Complaining about missing libyaml.