### PR TITLE
Check number of columns returned from 'docker top'.

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -544,6 +544,11 @@ QueryData genContainerProcesses(QueryContext& context) {
           vector.push_back(v.second.data());
         }
 
+        // On OS X, ps_args are not being honored. Check number of columns
+        if (vector.size() != 21) {
+          continue;
+        }
+
         Row r;
         r["id"] = id;
         r["pid"] = BIGINT(vector.at(0));


### PR DESCRIPTION
On OS X, ps_args are for some reason ignored.