### PR TITLE
windows: Adding SKIP_TESTS check for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,8 +489,8 @@ if(WINDOWS)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static gtest/gmock library" FORCE)
 
   file(GLOB INCLUDE_DIRS LIST_DIRECTORIES true "${WINDOWS_DEP_DIR}/*/*/include")
-  include_directories(${INCLUDE_DIRS})
-  include_directories("${WINDOWS_DEP_DIR}/boost-msvc14/local")
+  include_directories(SYSTEM ${INCLUDE_DIRS})
+  include_directories(SYSTEM "${WINDOWS_DEP_DIR}/boost-msvc14/local")
 
   ## TODO(FIXME): temporary for now
   include_directories("${WINDOWS_DEP_DIR}/linenoise-ng/local/include/linenoise")

--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -1,15 +1,24 @@
+@echo off
 call "%VS140COMNTOOLS%vcvarsqueryregistry.bat" 64bit
 call "%VCINSTALLDIR%vcvarsall.bat" amd64
 
-mkdir .\build\windows10
+:: Suppress the error message generated if the directory already exists
+md .\build\windows10 2>NUL
 cd .\build\windows10
+
+:: Generate the osquery solution
 cmake ..\.. -G "Visual Studio 14 2015 Win64"
 
-for %%t in (shell,daemon,osquery_tests,osquery_additional_tests,osquery_tables_tests) do (
+for %%t in (shell,daemon) do (
   cmake --build . --target %%t --config Release -- /verbosity:minimal /maxcpucount
   if errorlevel 1 goto end
 )
 
+:: Build and run the tests for osquery if SKIP_TESTS isn't defined
+if defined SKIP_TESTS goto end
+for %%t in (osquery_tests,osquery_additional_tests,osquery_tables_tests) do (
+  cmake --build . --target %%t --config Release -- /verbosity:minimal /maxcpucount
+  if errorlevel 1 goto end
+)
 ctest --output-on-failure
-
 :end


### PR DESCRIPTION
Windows by default builds all unit tests. This PR adds a check for the environment variable `SKIP_TESTS` to speed up development builds.

Further, CMake by default adds header include directories without the `SYSTEM` declaration, meaning that during builds the third party header includes will be processed and errors/warnings will be generated on this code. This sets said `SYSTEM` declaration for third party header includes on Windows.