### PR TITLE
freebsd: Some refactoring to processes table

### DIFF
--- a/osquery/tables/system/freebsd/procstat.cpp
+++ b/osquery/tables/system/freebsd/procstat.cpp
@@ -14,6 +14,7 @@
 #include <sys/user.h>
 #include <sys/sysctl.h>
 #include <sys/queue.h>
+
 #include <libprocstat.h>
 
 #include <osquery/tables.h>
@@ -22,23 +23,10 @@
 namespace osquery {
 namespace tables {
 
-/**
- * A helper function to retrieve processes using libprocstat(3). It is the
- * responsibility of the caller to call procstat_freeprocs() and
- * procstat_close() when done.
- *
- * Returns the number of processes in the "procs" list. On failure, returns 0
- * and sets pstat and procs to NULL.
- *
- * Errors are not well exposed in some of the calls in libprocstat(3). This is
- * a bit of a bummer as libkvm(3) is much better in that respect but I would
- * rather use libprocstat(3) as it provides a nicer abstraction.
- */
 unsigned int getProcesses(QueryContext& context,
                           struct procstat** pstat,
                           struct kinfo_proc** procs) {
   std::set<std::string> pids;
-  unsigned int cnt = 0;
 
   *pstat = procstat_open_sysctl();
   if (*pstat == nullptr) {
@@ -46,6 +34,7 @@ unsigned int getProcesses(QueryContext& context,
     return 0;
   }
 
+  unsigned int cnt = 0;
   if (context.constraints["pid"].exists(EQUALS)) {
     pids = context.constraints["pid"].getAll(EQUALS);
 
@@ -55,7 +44,7 @@ unsigned int getProcesses(QueryContext& context,
     for (const auto& pid : pids) {
       *procs = procstat_getprocs(*pstat, KERN_PROC_PID, std::stoi(pid), &cnt);
       if (*procs == nullptr) {
-        TLOG << "Problem retrieving processes.";
+        TLOG << "Problem retrieving processes";
         procstat_close(*pstat);
         *pstat = nullptr;
         return 0;
@@ -65,7 +54,7 @@ unsigned int getProcesses(QueryContext& context,
     // Get all PIDS.
     *procs = procstat_getprocs(*pstat, KERN_PROC_PROC, 0, &cnt);
     if (*procs == nullptr) {
-      TLOG << "Problem retrieving processes.";
+      TLOG << "Problem retrieving processes";
       procstat_close(*pstat);
       *pstat = nullptr;
       return 0;
@@ -75,9 +64,6 @@ unsigned int getProcesses(QueryContext& context,
   return cnt;
 }
 
-/**
- * Helper function to cleanup the libprocstat(3) pointers used.
- */
 void procstatCleanup(struct procstat* pstat, struct kinfo_proc* procs) {
   if (procs != nullptr) {
     procstat_freeprocs(pstat, procs);
@@ -87,6 +73,5 @@ void procstatCleanup(struct procstat* pstat, struct kinfo_proc* procs) {
     procstat_close(pstat);
   }
 }
-
 }
 }

--- a/osquery/tables/system/freebsd/procstat.h
+++ b/osquery/tables/system/freebsd/procstat.h
@@ -12,6 +12,7 @@
 
 #include <sys/queue.h>
 #include <sys/user.h>
+
 #include <libprocstat.h>
 
 #include <osquery/tables.h>
@@ -19,11 +20,23 @@
 namespace osquery {
 namespace tables {
 
+/**
+ * A helper function to retrieve processes using libprocstat(3). It is the
+ * responsibility of the caller to call procstat_freeprocs() and
+ * procstat_close() when done.
+ *
+ * Returns the number of processes in the "procs" list. On failure, returns 0
+ * and sets pstat and procs to NULL.
+ *
+ * Errors are not well exposed in some of the calls in libprocstat(3). This is
+ * a bit of a bummer as libkvm(3) is much better in that respect but I would
+ * rather use libprocstat(3) as it provides a nicer abstraction.
+ */
 unsigned int getProcesses(QueryContext& context,
                           struct procstat** pstat,
                           struct kinfo_proc** procs);
 
+/// Helper function to cleanup the libprocstat(3) pointers used.
 void procstatCleanup(struct procstat* pstat, struct kinfo_proc* procs);
-
 }
 }


### PR DESCRIPTION
I find that some of the process structures on Linux and macOS are esoteric enough that in edge-cases return `nullptr`s for paths/directories/etc.

This attempts to add additional checking to these structures.