### PR TITLE
Adding URL Search hooks to ie_extensions table

### DIFF
--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -37,11 +37,18 @@ const std::vector<std::string> kIEBrowserHelperKeys = {
     "MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Explor"
     "er\\Browser "
     "Helper Objects",
+    "HKEY_USERS\\%"
+    "\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Browser "
+    "Helper Objects",
+    "HKEY_USERS\\%"
+    "\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Explor"
+    "er\\Browser Helper Objects",
+    "HKEY_USERS\\%\\SOFTWARE\\Microsoft\\Internet Explorer\\URLSearchHooks",
 };
 
 static inline Status getBHOs(QueryData& results) {
-  SQL sql("SELECT name,path FROM registry WHERE type = 'subkey' AND (key = '" +
-          boost::join(kIEBrowserHelperKeys, "' OR key = '") + "')");
+  SQL sql("SELECT name,path FROM registry WHERE key LIKE '" +
+          boost::join(kIEBrowserHelperKeys, "' OR key LIKE '") + "'");
   if (!sql.ok()) {
     return sql.getStatus();
   }
@@ -50,7 +57,7 @@ static inline Status getBHOs(QueryData& results) {
     auto ret = getClassExecutables(cls.at("name"), executables);
     if (!ret.ok()) {
       LOG(WARNING) << "Failed to get class executables: " + ret.getMessage();
-      return ret;
+      continue;
     }
 
     std::string clsName;


### PR DESCRIPTION
Adding URL search hooks to the extensions table. Just a simple addition of a new key to query.

```
osquery> select * from ie_extensions;
+------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------+--------------------------------------------------------------+
| name                                           | registry_path
                                                        | version         | path                                                         |
+------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------+--------------------------------------------------------------+
C:\Program Files\Microsoft Office\root\Office16\GROOVEEX.DLL |
| Microsoft Url Search Hook                      | HKEY_USERS\S-1-5-19\SOFTWARE\Microsoft\Internet Explorer\URLSearchHooks\{CFBFAE00-17A6-11D0-99CB-00C04FD64497}                                                       | 11.0.14393.1358 | C:\Windows\System32\ieframe.dll                              |
| Microsoft Url Search Hook                      | HKEY_USERS\S-1-5-20\SOFTWARE\Microsoft\Internet Explorer\URLSearchHooks\{CFBFAE00-17A6-11D0-99CB-00C04FD64497}                                                       | 11.0.14393.1358 | C:\Windows\System32\ieframe.dll
```