### PR TITLE
Separate preferences from plist and add user-concept

### DIFF
--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -504,7 +504,8 @@ static int xFilter(sqlite3_vtab_cursor* pVtabCursor,
         required_satisfied = true;
       }
 
-      if (!user_based_satisfied && constraint.first == "uid") {
+      if (!user_based_satisfied &&
+          (constraint.first == "uid" || constraint.first == "username")) {
         // UID was required and exists in the constraints.
         user_based_satisfied = true;
       }

--- a/osquery/tables/system/darwin/ad_config.cpp
+++ b/osquery/tables/system/darwin/ad_config.cpp
@@ -20,7 +20,7 @@ const std::string kADConfigPath =
     "Configurations/Active Directory/";
 
 void genADConfig(const std::string& path, QueryData& results) {
-  auto config = SQL::selectAllFrom("preferences", "path", EQUALS, path);
+  auto config = SQL::selectAllFrom("plist", "path", EQUALS, path);
   if (config.size() == 0) {
     // Fail if the file could not be plist-parsed.
     return;

--- a/osquery/tables/system/darwin/os_version.cpp
+++ b/osquery/tables/system/darwin/os_version.cpp
@@ -27,8 +27,7 @@ QueryData genOSVersion(QueryContext& context) {
   r["platform_like"] = "darwin";
 
   // The version path plist is parsed by the OS X tool: sw_vers.
-  auto sw_vers =
-      SQL::selectAllFrom("preferences", "path", EQUALS, kVersionPath);
+  auto sw_vers = SQL::selectAllFrom("plist", "path", EQUALS, kVersionPath);
   if (sw_vers.empty()) {
     return {r};
   }

--- a/osquery/tables/system/darwin/packages.cpp
+++ b/osquery/tables/system/darwin/packages.cpp
@@ -272,7 +272,7 @@ QueryData genPackageBOM(QueryContext& context) {
 }
 
 void genPackageReceipt(const std::string& path, QueryData& results) {
-  auto receipt = SQL::selectAllFrom("preferences", "path", EQUALS, path);
+  auto receipt = SQL::selectAllFrom("plist", "path", EQUALS, path);
   if (receipt.size() == 0) {
     // Fail if the file could not be plist-parsed.
     return;

--- a/specs/darwin/plist.table
+++ b/specs/darwin/plist.table
@@ -1,0 +1,13 @@
+table_name("plist")
+description("Read and parse a plist file.")
+schema([
+    Column("key", TEXT, "Preference top-level key"),
+    Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
+    Column("value", TEXT, "String value of most CF types"),
+    Column("path", TEXT, "(optional) read preferences from a plist",
+      required=True),
+])
+implementation("system/darwin/preferences@genOSXPlist")
+examples([
+  "select * from plist where path = '/Library/Preferences/loginwindow.plist'"
+])

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -3,13 +3,14 @@ description("OS X defaults and managed preferences.")
 schema([
     Column("domain", TEXT, "Application ID usually in com.name.product format",
       index=True),
-    Column("key", TEXT, "Preference top-level key"),
-    Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
+    Column("key", TEXT, "Preference top-level key", index=True),
+    Column("subkey", TEXT, "Intemediate key path, includes lists/dicts", index=True),
     Column("value", TEXT, "String value of most CF types"),
     Column("forced", INTEGER, "1 if the value is forced/managed, else 0"),
     Column("username", TEXT, "(optional) read preferences for a specific user",
       additional=True),
 ])
+attributes(user_data=True)
 implementation("system/darwin/preferences@genOSXDefaultPreferences")
 examples([
   "select * from preferences where domain = 'loginwindow'",

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -7,11 +7,10 @@ schema([
     Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),
     Column("forced", INTEGER, "1 if the value is forced/managed, else 0"),
-    Column("path", TEXT, "(optional) read preferences from a plist",
+    Column("username", TEXT, "(optional) read preferences for a specific user",
       additional=True),
 ])
-implementation("system/darwin/preferences@genOSXPreferences")
+implementation("system/darwin/preferences@genOSXDefaultPreferences")
 examples([
   "select * from preferences where domain = 'loginwindow'",
-  "select * from preferences where path = '/Library/Preferences/loginwindow.plist'"
 ])


### PR DESCRIPTION
This separates the overloaded use of the `preferences` table.

`preferences` acts like `defaults` on macOS. It is limited in that it cannot join users or report the system's defaults. In the current form it can also take any `path` input and report the flattened plist items.

This separates the defaults, keeping the functionality in `preferences` from the `plist` (a new table) functions.