### PR TITLE
aws: Restore exception error printing and upgrade to 1.1.5

### DIFF
--- a/osquery/logger/plugins/aws_util.cpp
+++ b/osquery/logger/plugins/aws_util.cpp
@@ -183,8 +183,9 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
 
     response->GetResponseBody() << resp.body();
 
-  } catch (const std::exception& /*e*/) {
-    LOG(ERROR) << "Exception making HTTP request to URL: " << url;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Exception making HTTP request to URL (" << url
+               << "): " << e.what();
     return nullptr;
   }
 

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -11,7 +11,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "ab2ad08c23fd765b02f1e961389b250f60e022e8d5ce94e822a998887e27286c" => :sierra
-    sha256 "0b2995f4546df02bcbebb8ea47f2cc276ecd1bcb0cb60787be02ff9a2748734b" => :x86_64_linux
+    sha256 "aa9b708a93f65447f79a80d04eb7edd496e63a8350a19ee2e585a3b8c69a0f1f" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class AwsSdkCpp < AbstractOsqueryFormula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/1.0.107.tar.gz"
-  sha256 "0560918ef2a4b660e49981378af42d999b91482a31e720be2d9c427f21ac8ad0"
-  revision 101
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.1.5.tar.gz"
+  sha256 "fc16f2fb45254acb2fcbabe13a97daceb1d920a6ac684ef5c601871a29dcb0cf"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -5,7 +5,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
   homepage "https://github.com/aws/aws-sdk-cpp"
   url "https://github.com/aws/aws-sdk-cpp/archive/1.1.5.tar.gz"
   sha256 "fc16f2fb45254acb2fcbabe13a97daceb1d920a6ac684ef5c601871a29dcb0cf"
-  revision 100
+  revision 101
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -31,6 +31,14 @@ class AwsSdkCpp < AbstractOsqueryFormula
       system "cmake", "..", *args
       system "make"
       system "make", "install"
+    end
+
+    # Move lib64/* to lib/ on Linuxbrew
+    lib64 = Pathname.new "#{lib}64"
+    if lib64.directory?
+      mkdir_p lib
+      system "mv #{lib64}/* #{lib}/"
+      rmdir lib64
     end
   end
 

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -10,7 +10,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "ab2ad08c23fd765b02f1e961389b250f60e022e8d5ce94e822a998887e27286c" => :sierra
+    sha256 "74639e0ab4b05e3e26356677d1ededbe221dbe3e18205fe9dfea53f43f67cf5f" => :sierra
     sha256 "aa9b708a93f65447f79a80d04eb7edd496e63a8350a19ee2e585a3b8c69a0f1f" => :x86_64_linux
   end
 


### PR DESCRIPTION
This restores the helpful error when connecting to AWS, which was removed in: #3343

The fix is upgrading the upstream AWS SDK to 1.1.5: https://github.com/aws/aws-sdk-cpp/releases/tag/1.1.5

Refer to #3437 on how not having this error printed causes issue for debugging.