### PR TITLE
pidfile: Update pidfile to /var/run on Linux and fbsd

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -95,24 +95,28 @@
 #define OSQUERY_HOME "/etc/osquery"
 #define OSQUERY_DB_HOME "/var/osquery"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
+#define OSQUERY_PIDFILE "/var/run/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
+#define OSQUERY_PIDFILE OSQUERY_DB_HOME "\\"
 #define OSQUERY_LOG_HOME OSQUERY_HOME "\\log\\"
 #define OSQUERY_CERTS_HOME OSQUERY_HOME "\\certs\\"
 #elif defined(FREEBSD)
 #define OSQUERY_HOME "/var/db/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "/var/run/"
+#define OSQUERY_PIDFILE "/var/run/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/etc/ssl/"
 #else
 #define OSQUERY_HOME "/var/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
+#define OSQUERY_PIDFILE OSQUERY_DB_HOME "/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME OSQUERY_HOME "/certs/"
 #endif

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -61,7 +61,7 @@ DECLARE_uint64(alarm_timeout);
 /// The path to the pidfile for osqueryd
 CLI_FLAG(string,
          pidfile,
-         OSQUERY_DB_HOME "/osqueryd.pidfile",
+         OSQUERY_PIDFILE "osqueryd.pidfile",
          "Path to the daemon pidfile mutex");
 
 /// Should the daemon force unload previously-running osqueryd daemons.

--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -33,7 +33,8 @@ if [ -z $EXEC ]; then EXEC=/usr/bin/osqueryd; fi
 if [ -z $FLAGS_PATH ]; then FLAGS_PATH=/etc/osquery/osquery.flags; fi
 if [ -z $REAL_CONFIG_PATH ]; then REAL_CONFIG_PATH=/etc/osquery/osquery.conf; fi
 if [ -z $LOCKFILE ]; then LOCKFILE=/var/lock/osqueryd; fi
-if [ -z $PIDFILE ]; then PIDFILE=/var/run/osqueryd.pid; fi
+if [ -z $PIDFILE ]; then PIDFILE=/var/run/osqueryd.pidfile; fi
+if [ -z $OLD_PIDFILE ]; then OLD_PIDFILE=/var/run/osqueryd.pid; fi
 if [ -z $UID ]; then UID=$(id -u); fi
 
 if [ $UID -eq 0 ] && [ -e /etc/sysconfig/$PROG ]; then
@@ -51,6 +52,13 @@ if [ ! -e $FLAGS_PATH ] && [ ! -e $REAL_CONFIG_PATH ]; then
   RETVAL=1
 fi
 
+move_pidfile() {
+  if [ -f $OLD_PIDFILE ]; then
+    # Support for deprecated pidfile location.
+    mv $OLD_PIDFILE $PIDFILE
+  fi
+}
+
 ensure_root() {
   if [ $UID -ne 0 ] ; then
     echo "User has insufficient privilege."
@@ -60,6 +68,7 @@ ensure_root() {
 
 start() {
   ensure_root
+  move_pidfile
 
   ARGS=""
   if [ -f $PIDFILE ]; then
@@ -84,6 +93,7 @@ start() {
 
 stop() {
   ensure_root
+  move_pidfile
 
   if [ ! -f $PIDFILE ] ; then
     RETVAL=0

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -6,6 +6,7 @@ After=network.service syslog.service
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
+ExecStartPre=/bin/sh -c "if [ -f $OLD_PIDFILE ]; then mv $OLD_PIDFILE $PIDFILE; fi"
 ExecStart=/usr/bin/osqueryd \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE

--- a/tools/deployment/osqueryd.sysconfig
+++ b/tools/deployment/osqueryd.sysconfig
@@ -1,2 +1,4 @@
 FLAG_FILE="/etc/osquery/osquery.flags"
 CONFIG_FILE="/etc/osquery/osquery.conf"
+OLD_PIDFILE="/var/osquery/osqueryd.pidfile"
+PIDFILE="/var/run/osqueryd.pidfile"


### PR DESCRIPTION
This updates the `--pidfile` location to be `/var/run` (like it should), for Linux and FreeBSD.

It adds logic to the SystemD service unit to "migrate" the pidfile from the old location to the new. This allows a `systemctl status osqueryd` to behave normally if:
- `osqueryd` was started before this commit
- `osqueryd` was started after this commit

...and checked after this commit.

It adds logic to the upstart initscript to report the correct status for `osqueryd` started with init or SystemD:
- `/etc/init.d/osqueryd status`
- `systemctl status osqueryd`

...will both report the correct status for `osqueryd` started with SystemD before and after this commit. `systemctl` will NOT report the correct status for `osqueryd` started with an initscript before or after this commit.