### PR TITLE
Inotify: re-implemented remove/add subscription and remove/add monito…

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -361,6 +361,9 @@ class EventPublisherPlugin : public Plugin,
   virtual void fireCallback(const SubscriptionRef& sub,
                             const EventContextRef& ec) const = 0;
 
+  /// A lock for subscription manipulation.
+  Mutex subscription_lock_;
+
   /// The EventPublisher will keep track of Subscription%s that contain callins.
   SubscriptionVector subscriptions_;
 
@@ -377,9 +380,6 @@ class EventPublisherPlugin : public Plugin,
 
   /// A lock for incrementing the next EventContextID.
   Mutex ec_id_lock_;
-
-  /// A lock for subscription manipulation.
-  Mutex subscription_lock_;
 
   /// A helper count of event publisher runloop iterations.
   std::atomic<size_t> restart_count_{0};
@@ -1072,8 +1072,11 @@ class EventSubscriber : public EventSubscriberPlugin {
       // EventSubscriber and a single parameter placeholder (the EventContext).
       auto cb = std::bind(base_entry, sub, _1, _2);
       // Add a subscription using the callable and SubscriptionContext.
-      EventFactory::addSubscription(sub->getType(), sub->getName(), sc, cb);
-      subscription_count_++;
+      Status stat = EventFactory::addSubscription(sub->getType(),
+                                                    sub->getName(), sc, cb);
+      if (stat.ok()) {
+        subscription_count_++;
+      }
     }
   }
 

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -1072,8 +1072,8 @@ class EventSubscriber : public EventSubscriberPlugin {
       // EventSubscriber and a single parameter placeholder (the EventContext).
       auto cb = std::bind(base_entry, sub, _1, _2);
       // Add a subscription using the callable and SubscriptionContext.
-      Status stat = EventFactory::addSubscription(sub->getType(),
-                                                    sub->getName(), sc, cb);
+      Status stat =
+          EventFactory::addSubscription(sub->getType(), sub->getName(), sc, cb);
       if (stat.ok()) {
         subscription_count_++;
       }

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -26,9 +26,12 @@ namespace fs = boost::filesystem;
 
 namespace osquery {
 
-static const int kINotifyMLatency = 200;
-static const uint32_t kINotifyBufferSize =
-    (10 * ((sizeof(struct inotify_event)) + NAME_MAX + 1));
+//static const int kINotifyMLatency = 200;
+static const int kINotifyMaxEvents = 512;
+static const uint32_t kINotifyEventSize = sizeof(struct inotify_event)
+                                        + (NAME_MAX + 1);
+static const uint32_t kINotifyBufferSize = (kINotifyMaxEvents *
+                                                      kINotifyEventSize);
 
 std::map<int, std::string> kMaskActions = {
     {IN_ACCESS, "ACCESSED"},
@@ -66,11 +69,11 @@ Status INotifyEventPublisher::setUp() {
 
 bool INotifyEventPublisher::monitorSubscription(
     INotifySubscriptionContextRef& sc, bool add_watch) {
-  sc->discovered_ = sc->path;
+  std::string discovered = sc->path;
   if (sc->path.find("**") != std::string::npos) {
     sc->recursive = true;
-    sc->discovered_ = sc->path.substr(0, sc->path.find("**"));
-    sc->path = sc->discovered_;
+    discovered = sc->path.substr(0, sc->path.find("**"));
+    sc->path = discovered;
   }
 
   if (sc->path.find('*') != std::string::npos) {
@@ -78,27 +81,27 @@ bool INotifyEventPublisher::monitorSubscription(
     // directory instead. Apply a fnmatch on fired events to filter leafs.
     auto fullpath = fs::path(sc->path);
     if (fullpath.filename().string().find('*') != std::string::npos) {
-      sc->discovered_ = fullpath.parent_path().string() + '/';
+      discovered = fullpath.parent_path().string() + '/';
     }
 
-    if (sc->discovered_.find('*') != std::string::npos) {
+    if (discovered.find('*') != std::string::npos) {
       // If a wildcard exists within the tree (stem), resolve at configure
       // time and monitor each path.
       std::vector<std::string> paths;
-      resolveFilePattern(sc->discovered_, paths);
-      for (const auto& _path : paths) {
-        addMonitor(_path, sc->mask, sc->recursive, add_watch);
-      }
+      resolveFilePattern(discovered, paths);
       sc->recursive_match = sc->recursive;
+      for (const auto& _path : paths) {
+        addMonitor(_path, sc, sc->mask, sc->recursive, add_watch);
+      }
       return true;
     }
   }
 
-  if (isDirectory(sc->discovered_) && sc->discovered_.back() != '/') {
+  if (isDirectory(discovered) && discovered.back() != '/') {
     sc->path += '/';
-    sc->discovered_ += '/';
+    discovered += '/';
   }
-  return addMonitor(sc->discovered_, sc->mask, sc->recursive, add_watch);
+  return addMonitor(discovered, sc, sc->mask, sc->recursive, add_watch);
 }
 
 void INotifyEventPublisher::configure() {
@@ -107,14 +110,43 @@ void INotifyEventPublisher::configure() {
     return;
   }
 
+  SubscriptionVector delete_subscriptions;
+  {
+    WriteLock lock(subscription_lock_);
+    auto end =
+    std::remove_if(subscriptions_.begin(),
+                   subscriptions_.end(),
+                 [&delete_subscriptions](const SubscriptionRef& subscription) {
+                   auto inotify_sc =
+                                getSubscriptionContext(subscription->context);
+                   if (inotify_sc->mark_for_deletion == true) {
+                     delete_subscriptions.push_back(subscription);
+                     return true;
+                   }
+                   return false;
+                 });
+    subscriptions_.erase(end, subscriptions_.end());
+  }
+
+  for (auto& sub : delete_subscriptions) {
+    auto ino_sc = getSubscriptionContext(sub->context);
+    for (const auto& path : ino_sc->descriptor_paths_) {
+      removeMonitor(path.first, true, true);
+    }
+    ino_sc->descriptor_paths_.clear();
+  }
+
+  delete_subscriptions.clear();
+
   for (auto& sub : subscriptions_) {
     // Anytime a configure is called, try to monitor all subscriptions.
     // Configure is called as a response to removing/adding subscriptions.
     // This means recalculating all monitored paths.
     auto sc = getSubscriptionContext(sub->context);
-    if (sc->discovered_.size() > 0) {
+    if (sc->use_count_) {
       continue;
     }
+
     monitorSubscription(sc);
   }
 }
@@ -125,18 +157,6 @@ void INotifyEventPublisher::tearDown() {
   }
   inotify_handle_ = -1;
 
-  auto descriptors = descriptors_;
-  for (const auto& desc : descriptors) {
-    removeMonitor(desc, false);
-  }
-
-  {
-    // Then remove all path/descriptor mappings.
-    WriteLock lock(path_mutex_);
-    path_descriptors_.clear();
-    descriptor_paths_.clear();
-  }
-
   WriteLock lock(scratch_mutex_);
   if (scratch_ != nullptr) {
     free(scratch_);
@@ -144,18 +164,17 @@ void INotifyEventPublisher::tearDown() {
   }
 }
 
-Status INotifyEventPublisher::restartMonitoring() {
-  if (last_restart_ != 0 && getUnixTime() - last_restart_ < 10) {
-    return Status(1, "Overflow");
+void INotifyEventPublisher::handleOverflow() {
+  if (inotify_events_ < kINotifyMaxEvents) {
+    VLOG(1) << "inotify was overflown, increasing scratch buffer.";
+    // Exponential increment.
+    inotify_events_ = inotify_events_ * 2;
+  } else if (last_overflow_ != -1 && getUnixTime() - last_overflow_ < 60) {
+    return;
+  } else {
+    VLOG(1) << "inotify was overflown, continuing...";
+    last_overflow_ = getUnixTime();
   }
-  last_restart_ = getUnixTime();
-
-  tearDown();
-  setUp();
-
-  // Reconfigure ourself, the subscribers will not reconfigure.
-  configure();
-  return Status(0, "OK");
 }
 
 Status INotifyEventPublisher::run() {
@@ -163,9 +182,12 @@ Status INotifyEventPublisher::run() {
   fds[0].fd = getHandle();
   fds[0].events = POLLIN;
   int selector = ::poll(fds, 1, 1000);
-  if (selector == -1 && errno != EINTR && errno != EAGAIN) {
+  if (selector == -1) {
+    if (errno == EINTR) {
+      return Status(0, "inotify poll interrupted");
+    }
     LOG(WARNING) << "Could not read inotify handle";
-    return restartMonitoring();
+    return Status(1, "inotify poll failed");
   }
 
   if (selector == 0) {
@@ -178,7 +200,8 @@ Status INotifyEventPublisher::run() {
   }
 
   WriteLock lock(scratch_mutex_);
-  ssize_t record_num = ::read(getHandle(), scratch_, kINotifyBufferSize);
+  ssize_t record_num = ::read(getHandle(), scratch_, 
+                                         inotify_events_ * kINotifyEventSize);
   if (record_num == 0 || record_num == -1) {
     return Status(1, "INotify read failed");
   }
@@ -187,11 +210,9 @@ Status INotifyEventPublisher::run() {
     // Cast the inotify struct, make shared pointer, and append to contexts.
     auto event = reinterpret_cast<struct inotify_event*>(p);
     if (event->mask & IN_Q_OVERFLOW) {
-      // The inotify queue was overflown (remove all paths).
-      return restartMonitoring();
-    }
-
-    if (event->mask & IN_IGNORED) {
+      // The inotify queue was overflown (try to recieve more events from OS).
+      handleOverflow();
+    } else if (event->mask & IN_IGNORED) {
       // This inotify watch was removed.
       removeMonitor(event->wd, false);
     } else if (event->mask & IN_MOVE_SELF) {
@@ -210,7 +231,7 @@ Status INotifyEventPublisher::run() {
     p += (sizeof(struct inotify_event)) + event->len;
   }
 
-  pauseMilli(kINotifyMLatency);
+  //pauseMilli(kINotifyMLatency);
   return Status(0, "OK");
 }
 
@@ -223,11 +244,12 @@ INotifyEventContextRef INotifyEventPublisher::createEventContextFrom(
   // Get the pathname the watch fired on.
   {
     WriteLock lock(path_mutex_);
-    if (descriptor_paths_.find(event->wd) == descriptor_paths_.end()) {
+    if (descriptor_inosubctx_.find(event->wd) == descriptor_inosubctx_.end()) {
       // return a blank event context if we can't find the paths for the event
       return ec;
     } else {
-      ec->path = descriptor_paths_.at(event->wd);
+      auto isc = descriptor_inosubctx_.at(event->wd);
+      ec->path = isc->descriptor_paths_.at(event->wd);
     }
   }
 
@@ -270,18 +292,22 @@ bool INotifyEventPublisher::shouldFire(const INotifySubscriptionContextRef& sc,
 
   // inotify will not monitor recursively, new directories need watches.
   if (sc->recursive && ec->action == "CREATED" && isDirectory(ec->path)) {
-    const_cast<INotifyEventPublisher*>(this)->addMonitor(
-        ec->path + '/', sc->mask, true);
+    const_cast<INotifyEventPublisher*>(this)
+        ->addMonitor(ec->path + '/',
+                     const_cast<INotifySubscriptionContextRef&>(sc),
+                     sc->mask, true);
   }
 
   return true;
 }
 
 bool INotifyEventPublisher::addMonitor(const std::string& path,
+                                       INotifySubscriptionContextRef& isc,
                                        uint32_t mask,
                                        bool recursive,
                                        bool add_watch) {
-  if (!isPathMonitored(path)) {
+  {
+    WriteLock lock(path_mutex_);
     int watch = ::inotify_add_watch(
         getHandle(), path.c_str(), ((mask == 0) ? kFileDefaultMasks : mask));
     if (add_watch && watch == -1) {
@@ -289,15 +315,25 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
       return false;
     }
 
-    {
-      WriteLock lock(path_mutex_);
-      // Keep a list of the watch descriptors
-      descriptors_.push_back(watch);
+    if (descriptor_inosubctx_.find(watch) != descriptor_inosubctx_.end()) {
+      auto ino_sc = descriptor_inosubctx_.at(watch);
+      if (inotify_sanity_check) {
+        std::string watched_path = ino_sc->descriptor_paths_[watch];
+        path_descriptors_.erase(watched_path);
+      }
+      ino_sc->descriptor_paths_.erase(watch);
+      descriptor_inosubctx_.erase(watch);
+      --ino_sc->use_count_;
+    }
+
+    // Keep a map of (descriptor -> path)
+    isc->descriptor_paths_[watch] = path;
+    descriptor_inosubctx_[watch] = isc;
+    if (inotify_sanity_check) {
       // Keep a map of the path -> watch descriptor
       path_descriptors_[path] = watch;
-      // Keep a map of the opposite (descriptor -> path)
-      descriptor_paths_[watch] = path;
     }
+    ++isc->use_count_;
   }
 
   if (recursive && isDirectory(path).ok()) {
@@ -308,57 +344,75 @@ bool INotifyEventPublisher::addMonitor(const std::string& path,
     boost::system::error_code ec;
     for (const auto& child : children) {
       auto canonicalized = fs::canonical(child, ec).string() + '/';
-      addMonitor(canonicalized, mask, false);
+      addMonitor(canonicalized, isc, mask, false);
     }
   }
 
   return true;
 }
 
-bool INotifyEventPublisher::removeMonitor(const std::string& path, bool force) {
+bool INotifyEventPublisher::removeMonitor(int watch,
+                                          bool force,
+                                          bool batch_del) {
   {
     WriteLock lock(path_mutex_);
-    // If force then remove from INotify, otherwise cleanup file descriptors.
-    if (path_descriptors_.find(path) == path_descriptors_.end()) {
+    if (descriptor_inosubctx_.find(watch) == descriptor_inosubctx_.end()) {
       return false;
     }
-  }
 
-  int watch = 0;
-  {
-    WriteLock lock(path_mutex_);
-    watch = path_descriptors_[path];
-    path_descriptors_.erase(path);
-    descriptor_paths_.erase(watch);
+    auto isc = descriptor_inosubctx_.at(watch);
+    descriptor_inosubctx_.erase(watch);
 
-    auto position = std::find(descriptors_.begin(), descriptors_.end(), watch);
-    descriptors_.erase(position);
+    if (inotify_sanity_check) {
+      std::string watched_path = isc->descriptor_paths_[watch];
+      path_descriptors_.erase(watched_path);
+    }
+
+    if (!batch_del) {
+      isc->descriptor_paths_.erase(watch);
+      --isc->use_count_;
+    }
   }
 
   if (force) {
     ::inotify_rm_watch(getHandle(), watch);
   }
+
   return true;
 }
 
-bool INotifyEventPublisher::removeMonitor(int watch, bool force) {
-  std::string path;
-  {
-    WriteLock lock(path_mutex_);
-    if (descriptor_paths_.find(watch) == descriptor_paths_.end()) {
-      return false;
-    }
-    path = descriptor_paths_[watch];
-  }
-  return removeMonitor(path, force);
+void INotifyEventPublisher::removeSubscriptions(const std::string& subscriber) {
+  WriteLock lock(subscription_lock_);
+  std::for_each(
+             subscriptions_.begin(),
+             subscriptions_.end(),
+             [&subscriber](const SubscriptionRef& sub) {
+               if (sub->subscriber_name == subscriber) {
+                 getSubscriptionContext(sub->context)->mark_for_deletion = true;
+               }
+             });
+
 }
 
-void INotifyEventPublisher::removeSubscriptions(const std::string& subscriber) {
-  auto paths = descriptor_paths_;
-  for (const auto& path : paths) {
-    removeMonitor(path.first, true);
+Status INotifyEventPublisher::addSubscription(
+    const SubscriptionRef& subscription) {
+  WriteLock lock(subscription_lock_);
+  auto received_inotify_sc = getSubscriptionContext(subscription->context);
+  for (auto& sub: subscriptions_) {
+    auto inotify_sc = getSubscriptionContext(sub->context);
+    if (*received_inotify_sc == *inotify_sc) {
+      if (inotify_sc->mark_for_deletion) {
+        inotify_sc->mark_for_deletion = false;
+        return Status(0);
+      }
+      //Returing non zero signals EventSubscriber::subscribe
+      //dont bumpup subscription_count_.
+      return Status(1);
+    }
   }
-  EventPublisherPlugin::removeSubscriptions(subscriber);
+
+  subscriptions_.push_back(subscription);
+  return Status(0);
 }
 
 bool INotifyEventPublisher::isPathMonitored(const std::string& path) const {

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -88,9 +88,9 @@ struct INotifySubscriptionContext : public SubscriptionContext {
   friend class INotifyEventPublisher;
 };
 
-///Overloaded '==' operator, to check if two inotify subscriptions are same.
-inline bool operator ==(const INotifySubscriptionContext& lsc,
-                        const INotifySubscriptionContext& rsc) {
+/// Overloaded '==' operator, to check if two inotify subscriptions are same.
+inline bool operator==(const INotifySubscriptionContext& lsc,
+                       const INotifySubscriptionContext& rsc) {
   return ((lsc.category == rsc.category) && (lsc.opath == rsc.opath));
 }
 
@@ -136,8 +136,8 @@ class INotifyEventPublisher
 
  public:
   //@param unit_test publisher is instantiated for unit test.
-  INotifyEventPublisher(bool unit_test = false): inotify_sanity_check(unit_test) {
-  }
+  INotifyEventPublisher(bool unit_test = false)
+      : inotify_sanity_check(unit_test) {}
 
   virtual ~INotifyEventPublisher() {
     tearDown();
@@ -158,7 +158,7 @@ class INotifyEventPublisher
   /// Mark for delete, subscriptions.
   void removeSubscriptions(const std::string& subscriber) override;
 
-  ///Only add the subscription, if it not already part of subscription list.
+  /// Only add the subscription, if it not already part of subscription list.
   Status addSubscription(const SubscriptionRef& subscription) override;
 
  private:
@@ -171,7 +171,7 @@ class INotifyEventPublisher
     return inotify_handle_ > 0;
   }
 
-  /// Check all added Subscription%s for a path. 
+  /// Check all added Subscription%s for a path.
   /// Used for sanity check from unit test(s).
   bool isPathMonitored(const std::string& path) const;
 
@@ -221,7 +221,7 @@ class INotifyEventPublisher
   /// If we overflow, try to read more events from OS at time.
   void handleOverflow();
 
-  /// Map of watched path string to inotify watch file descriptor. 
+  /// Map of watched path string to inotify watch file descriptor.
   /// Used for sanity check from unit test(s).
   PathDescriptorMap path_descriptors_;
 
@@ -234,10 +234,10 @@ class INotifyEventPublisher
   /// Time in seconds of the last inotify overflow.
   std::atomic<int> last_overflow_{-1};
 
-  ///Tracks how many events to be received from OS.
-  std::atomic<int> inotify_events_{16};
+  /// Tracks how many events to be received from OS.
+  size_t inotify_events_{16};
 
-  ///Enable for sanity check from unit test(s).
+  /// Enable for sanity check from unit test(s).
   bool inotify_sanity_check{false};
 
   /**

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -25,6 +25,10 @@ extern std::map<int, std::string> kMaskActions;
 extern const uint32_t kFileDefaultMasks;
 extern const uint32_t kFileAccessMasks;
 
+// INotifySubscriptionContext containers
+using PathDescriptorMap = std::map<std::string, int>;
+using DescriptorPathMap = std::map<int, std::string>;
+
 /**
  * @brief Subscription details for INotifyEventPublisher events.
  *
@@ -40,6 +44,9 @@ struct INotifySubscriptionContext : public SubscriptionContext {
   /// Subscription the following filesystem path.
   std::string path;
 
+  /// original path, read from config
+  std::string opath;
+
   /// Limit the `inotify` actions to the subscription mask (if not 0).
   uint32_t mask{0};
 
@@ -48,6 +55,9 @@ struct INotifySubscriptionContext : public SubscriptionContext {
 
   /// Save the category this path originated form within the config.
   std::string category;
+
+  /// Lazy deletion of a subscription.
+  bool mark_for_deletion{false};
 
   /**
    * @brief Helper method to map a string action to `inotify` action mask bit.
@@ -65,15 +75,24 @@ struct INotifySubscriptionContext : public SubscriptionContext {
   }
 
  private:
-  /// During configure the INotify publisher may modify/optimize the paths.
-  std::string discovered_;
+  /// Actual number of paths being tracked under this subscription context.
+  std::atomic<unsigned int> use_count_{0};
 
   /// A configure-time pattern was expanded to match absolute paths.
   bool recursive_match{false};
 
+  /// Map of inotify watch file descriptor to watched path string.
+  DescriptorPathMap descriptor_paths_;
+
  private:
   friend class INotifyEventPublisher;
 };
+
+///Overloaded '==' operator, to check if two inotify subscriptions are same.
+inline bool operator ==(const INotifySubscriptionContext& lsc,
+                        const INotifySubscriptionContext& rsc) {
+  return ((lsc.category == rsc.category) && (lsc.opath == rsc.opath));
+}
 
 /**
  * @brief Event details for INotifyEventPublisher events.
@@ -96,10 +115,8 @@ using INotifyEventContextRef = std::shared_ptr<INotifyEventContext>;
 using INotifySubscriptionContextRef =
     std::shared_ptr<INotifySubscriptionContext>;
 
-// Publisher containers
-using DescriptorVector = std::vector<int>;
-using PathDescriptorMap = std::map<std::string, int>;
-using DescriptorPathMap = std::map<int, std::string>;
+// Publisher container
+using DescriptorINotifySubCtxMap = std::map<int, INotifySubscriptionContextRef>;
 
 /**
  * @brief A Linux `inotify` EventPublisher.
@@ -118,6 +135,10 @@ class INotifyEventPublisher
   DECLARE_PUBLISHER("inotify");
 
  public:
+  //@param unit_test publisher is instantiated for unit test.
+  INotifyEventPublisher(bool unit_test = false): inotify_sanity_check(unit_test) {
+  }
+
   virtual ~INotifyEventPublisher() {
     tearDown();
   }
@@ -134,8 +155,11 @@ class INotifyEventPublisher
   /// The calling for beginning the thread's run loop.
   Status run() override;
 
-  /// Remove all monitors and subscriptions.
+  /// Mark for delete, subscriptions.
   void removeSubscriptions(const std::string& subscriber) override;
+
+  ///Only add the subscription, if it not already part of subscription list.
+  Status addSubscription(const SubscriptionRef& subscription) override;
 
  private:
   /// Helper/specialized event context creation.
@@ -147,7 +171,8 @@ class INotifyEventPublisher
     return inotify_handle_ > 0;
   }
 
-  /// Check all added Subscription%s for a path.
+  /// Check all added Subscription%s for a path. 
+  /// Used for sanity check from unit test(s).
   bool isPathMonitored(const std::string& path) const;
 
   /**
@@ -161,11 +186,13 @@ class INotifyEventPublisher
    * recursively and add monitors to them.
    *
    * @param path complete (non-glob) canonical path to monitor.
+   * @param subscription context tracking the path.
    * @param recursive perform a single recursive search of subdirectories.
    * @param add_watch (testing only) should an inotify watch be created.
    * @return success if the inotify watch was created.
    */
   bool addMonitor(const std::string& path,
+                  INotifySubscriptionContextRef& isc,
                   uint32_t mask,
                   bool recursive,
                   bool add_watch = true);
@@ -175,8 +202,7 @@ class INotifyEventPublisher
                            bool add_watch = true);
 
   /// Remove an INotify watch (monitor) from our tracking.
-  bool removeMonitor(const std::string& path, bool force = false);
-  bool removeMonitor(int watch, bool force = false);
+  bool removeMonitor(int watch, bool force = false, bool batch_del = false);
 
   /// Given a SubscriptionContext and INotifyEventContext match path and action.
   bool shouldFire(const INotifySubscriptionContextRef& mc,
@@ -189,26 +215,30 @@ class INotifyEventPublisher
 
   /// Get the number of actual INotify active descriptors.
   size_t numDescriptors() const {
-    return descriptors_.size();
+    return descriptor_inosubctx_.size();
   }
 
-  /// If we overflow, try and restart the monitor
-  Status restartMonitoring();
+  /// If we overflow, try to read more events from OS at time.
+  void handleOverflow();
 
-  // Consider an event queue if separating buffering from firing/servicing.
-  DescriptorVector descriptors_;
-
-  /// Map of watched path string to inotify watch file descriptor.
+  /// Map of watched path string to inotify watch file descriptor. 
+  /// Used for sanity check from unit test(s).
   PathDescriptorMap path_descriptors_;
 
-  /// Map of inotify watch file descriptor to watched path string.
-  DescriptorPathMap descriptor_paths_;
+  /// Map of inotify watch file descriptor to subscription context.
+  DescriptorINotifySubCtxMap descriptor_inosubctx_;
 
   /// The inotify file descriptor handle.
   std::atomic<int> inotify_handle_{-1};
 
-  /// Time in seconds of the last inotify restart.
-  std::atomic<int> last_restart_{-1};
+  /// Time in seconds of the last inotify overflow.
+  std::atomic<int> last_overflow_{-1};
+
+  ///Tracks how many events to be received from OS.
+  std::atomic<int> inotify_events_{16};
+
+  ///Enable for sanity check from unit test(s).
+  bool inotify_sanity_check{false};
 
   /**
    * @brief Scratch space for reading INotify responses.

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -69,7 +69,7 @@ void FileEventSubscriber::configure() {
       auto sc = createSubscriptionContext();
       // Use the filesystem globbing pattern to determine recursiveness.
       sc->recursive = 0;
-      sc->path = file;
+      sc->opath = sc->path = file;
       sc->mask = kFileDefaultMasks;
       if (accesses.count(category) > 0) {
         sc->mask |= kFileAccessMasks;


### PR DESCRIPTION
Issues it addresses -

1. This patch protects against event loss in the case of, if config changes and path is still being monitored in the new config.
   checkin covered under "config: Only reconfigure if content changes (#3356)" protects if config does not change.

2. This patch also tries not to restart the monitoring in case of overflow but to refresh the cache(during addMonitor) and increase the rate of reading events from OS.

3. In the present logic if overflow happens it restarts monitoring but while doing so code does not reset discovered_ variable which means it practically stops monitoring after restartMonitoring.

4. In the case of overflow present code calls restartMonitoring(), which is called under WriteLock(scratch_mutex_), which calls tearDown and it also uses WriteLock(scratch_mutex_).
   I believe this leads to deadlock.

5. In the case of poll is interrupted by a signal and control reaches  "if (!(fds[0].revents & POLLIN))" it is unspecified what will be result of this "if" control statement.

6. one more motivation for this change is a comment at "osquery/tables/events/linux/file_events.cpp:59"
which says - "Clear all monitors from INotify. There may be a better way to find the set intersection/difference."
