### PR TITLE
Darwin: Add gatekeeper tables

### DIFF
--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -81,15 +81,16 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_status) {
-    if (row.find("key") != row.end() && row.find("value") != row.end()) {
-      if (row.at("key") == "enabled" && row.at("value") == "yes") {
-        r["assessments_enabled"] = INTEGER(1);
-        r["dev_id_enabled"] =
-            isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
-      } else {
-        r["assessments_enabled"] = INTEGER(0);
-        r["dev_id_enabled"] = INTEGER(0);
-      }
+    if (row.find("key") == row.end() || row.find("value") == row.end()) {
+      continue;
+    }
+    if (row.at("key") == "enabled" && row.at("value") == "yes") {
+      r["assessments_enabled"] = INTEGER(1);
+      r["dev_id_enabled"] =
+          isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
+    } else {
+      r["assessments_enabled"] = INTEGER(0);
+      r["dev_id_enabled"] = INTEGER(0);
     }
   }
 
@@ -100,10 +101,11 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_bundle) {
-    if (row.find("key") != row.end() && row.find("value") != row.end()) {
-      if (row.at("key") == "CFBundleShortVersionString") {
-        r["version"] = row.at("value");
-      }
+    if (row.find("key") == row.end() || row.find("value") == row.end()) {
+      continue;
+    }
+    if (row.at("key") == "CFBundleShortVersionString") {
+      r["version"] = row.at("value");
     }
   }
 
@@ -114,10 +116,11 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_opaque) {
-    if (row.find("key") != row.end() && row.find("value") != row.end()) {
-      if (row.at("key") == "CFBundleShortVersionString") {
-        r["opaque_version"] = row.at("value");
-      }
+    if (row.find("key") == row.end() || row.find("value") == row.end()) {
+      continue;
+    }
+    if (row.at("key") == "CFBundleShortVersionString") {
+      r["opaque_version"] = row.at("value");
     }
   }
   return {r};

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -78,12 +78,14 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_status) {
-    if (row.at("key") == "enabled" && row.at("value") == "yes" ) {
-      r["assessments_enabled"] = INTEGER(1);
-      r["dev_id_enabled"] = isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
-    } else {
-      r["assessments_enabled"] = INTEGER(0);
-      r["dev_id_enabled"] = INTEGER(0);
+    if ((row.find("key") == row.begin() || row.find("key") == row.end()) || (row.find("value") == row.begin() || row.find("value") == row.end())) {
+      if (row.at("key") == "enabled" && row.at("value") == "yes" ) {
+        r["assessments_enabled"] = INTEGER(1);
+        r["dev_id_enabled"] = isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
+      } else {
+        r["assessments_enabled"] = INTEGER(0);
+        r["dev_id_enabled"] = INTEGER(0);
+      }
     }
   }
 
@@ -94,8 +96,10 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_bundle) {
-    if (row.at("key") == "CFBundleShortVersionString") {
-      r["version"] = row.at("value");
+    if ((row.find("key") == row.begin() || row.find("key") == row.end()) || (row.find("value") == row.begin() || row.find("value") == row.end())) {
+      if (row.at("key") == "CFBundleShortVersionString") {
+        r["version"] = row.at("value");
+      }
     }
   }
 
@@ -113,7 +117,7 @@ QueryData genGateKeeper(QueryContext& context) {
   return {r};
 }
 
-void genGateKeeperApprovedAppRow(sqlite3_stmt* stmt, Row& r) {
+void genGateKeeperApprovedAppRow(sqlite3_stmt* const stmt, Row& r) {
   for (int i = 0; i < sqlite3_column_count(stmt); i++) {
     auto column_name = std::string(sqlite3_column_name(stmt, i));
     auto column_type = sqlite3_column_type(stmt, i);

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -60,7 +60,8 @@ bool isGateKeeperDevIdEnabled() {
       // Clean up.
       sqlite3_finalize(stmt);
       free(db);
-      return false; // return false if any rows say "disabled"
+      // return false if any rows say "disabled"
+      return false;
     }
   }
   sqlite3_finalize(stmt);

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -30,7 +30,8 @@ const std::string kGkeStatusPath = "/var/db/SystemPolicy-prefs.plist";
 
 const std::string kGkeBundlePath = "/var/db/gke.bundle/Contents/version.plist";
 
-const std::string kGkeOpaquePath = "/var/db/gkopaque.bundle/Contents/version.plist";
+const std::string kGkeOpaquePath =
+    "/var/db/gkopaque.bundle/Contents/version.plist";
 
 const std::string kPolicyDb = "/var/db/SystemPolicy";
 
@@ -50,7 +51,8 @@ bool isGateKeeperDevIdEnabled() {
     return false;
   }
 
-  std::string query = "SELECT disabled FROM authority WHERE label = 'Developer ID'";
+  std::string query =
+      "SELECT disabled FROM authority WHERE label = 'Developer ID'";
   sqlite3_stmt* stmt = nullptr;
   rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
 
@@ -80,9 +82,10 @@ QueryData genGateKeeper(QueryContext& context) {
 
   for (const auto& row : gke_status) {
     if (row.find("key") != row.end() && row.find("value") != row.end()) {
-      if (row.at("key") == "enabled" && row.at("value") == "yes" ) {
+      if (row.at("key") == "enabled" && row.at("value") == "yes") {
         r["assessments_enabled"] = INTEGER(1);
-        r["dev_id_enabled"] = isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
+        r["dev_id_enabled"] =
+            isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
       } else {
         r["assessments_enabled"] = INTEGER(0);
         r["dev_id_enabled"] = INTEGER(0);
@@ -155,7 +158,10 @@ QueryData genGateKeeperApprovedApps(QueryContext& context) {
     return results;
   }
 
-  const std::string query = "SELECT remarks as path, requirement, ctime, mtime from authority WHERE disabled = 0 AND JULIANDAY('now') < expires AND (flags & 1) = 0 AND label is NULL";
+  const std::string query =
+      "SELECT remarks as path, requirement, ctime, mtime from authority WHERE "
+      "disabled = 0 AND JULIANDAY('now') < expires AND (flags & 1) = 0 AND "
+      "label is NULL";
   sqlite3_stmt* stmt = nullptr;
   rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
   while ((sqlite3_step(stmt)) == SQLITE_ROW) {
@@ -170,5 +176,5 @@ QueryData genGateKeeperApprovedApps(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -151,6 +151,7 @@ QueryData genGateKeeperApprovedApps(QueryContext& context) {
     if (db != nullptr) {
       free(db);
     }
+    return results;
   }
 
   const std::string query = "SELECT remarks as path, requirement, ctime, mtime from authority WHERE disabled = 0 AND JULIANDAY('now') < expires AND (flags & 1) = 0 AND label is NULL";

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -78,7 +78,7 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_status) {
-    if ((row.find("key") == row.begin() || row.find("key") == row.end()) || (row.find("value") == row.begin() || row.find("value") == row.end())) {
+    if (row.find("key") != row.end() && row.find("value") != row.end()) {
       if (row.at("key") == "enabled" && row.at("value") == "yes" ) {
         r["assessments_enabled"] = INTEGER(1);
         r["dev_id_enabled"] = isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
@@ -96,7 +96,7 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_bundle) {
-    if ((row.find("key") == row.begin() || row.find("key") == row.end()) || (row.find("value") == row.begin() || row.find("value") == row.end())) {
+    if (row.find("key") != row.end() && row.find("value") != row.end()) {
       if (row.at("key") == "CFBundleShortVersionString") {
         r["version"] = row.at("value");
       }
@@ -110,8 +110,10 @@ QueryData genGateKeeper(QueryContext& context) {
   }
 
   for (const auto& row : gke_opaque) {
-    if (row.at("key") == "CFBundleShortVersionString") {
-      r["opaque_version"] = row.at("value");
+    if (row.find("key") != row.end() && row.find("value") != row.end()) {
+      if (row.at("key") == "CFBundleShortVersionString") {
+        r["opaque_version"] = row.at("value");
+      }
     }
   }
   return {r};

--- a/specs/darwin/gatekeeper.table
+++ b/specs/darwin/gatekeeper.table
@@ -7,3 +7,6 @@ schema([
     Column("opaque_version", TEXT, "Version of Gatekeeper's gkopaque.bundle"),
 ])
 implementation("gatekeeper@genGateKeeper")
+fuzz_paths([
+    "/var/db/SystemPolicy"
+])

--- a/specs/darwin/gatekeeper.table
+++ b/specs/darwin/gatekeeper.table
@@ -1,0 +1,9 @@
+table_name("gatekeeper")
+description("OS X Gatekeeper Details.")
+schema([
+    Column("assessments_enabled", INTEGER, "1 If a Gatekeeper is enabled else 0"),
+    Column("dev_id_enabled", INTEGER, "1 If a Gatekeeper allows execution from identified developers else 0"),
+    Column("version", TEXT, "Version of Gatekeeper's gke.bundle"),
+    Column("opaque_version", TEXT, "Version of Gatekeeper's gkopaque.bundle"),
+])
+implementation("gatekeeper@genGateKeeper")

--- a/specs/darwin/gatekeeper_approved_apps.table
+++ b/specs/darwin/gatekeeper_approved_apps.table
@@ -7,3 +7,6 @@ schema([
     Column("mtime", DOUBLE, "Last modification time"),
 ])
 implementation("gatekeeper@genGateKeeperApprovedApps")
+fuzz_paths([
+    "/var/db/SystemPolicy"
+])

--- a/specs/darwin/gatekeeper_approved_apps.table
+++ b/specs/darwin/gatekeeper_approved_apps.table
@@ -1,5 +1,5 @@
 table_name("gatekeeper_approved_apps")
-description("Gatekeeper apps a user allowed to run.")
+description("Gatekeeper apps a user has allowed to run.")
 schema([
     Column("path", TEXT, "Path of executable allowed to run"),
     Column("requirement", TEXT, "Code signing requirement language"),

--- a/specs/darwin/gatekeeper_approved_apps.table
+++ b/specs/darwin/gatekeeper_approved_apps.table
@@ -1,0 +1,9 @@
+table_name("gatekeeper_approved_apps")
+description("Gatekeeper apps a user allowed to run.")
+schema([
+    Column("path", TEXT, "Path of executable allowed to run"),
+    Column("requirement", TEXT, "Code signing requirement language"),
+    Column("ctime", DOUBLE, "Last change time"),
+    Column("mtime", DOUBLE, "Last modification time"),
+])
+implementation("gatekeeper@genGateKeeperApprovedApps")


### PR DESCRIPTION
This pull request adds two tables to instrument Apples macOS' app security subsystem called Gatekeeper.

## Gatekeeper Table
The first table is called `gatekeeper` it simply returns a single row with several columns that enumerate facts about the status of gatekeeper protection. This table can detect if gatekeeper is wholesale disabled or if it is enabled and if developer signed apps are allowed to run.

## Gatekeeper Approved Apps Table
The second table is called `gatekeeper_approved_apps`. This table enumerates all of the unsigned apps that have been explicitly whitelisted by a user. This list is populated when you attempt to run an app that is unsigned (or signed by an unknown key) and you explicitly allow it to run by going into the Security & Privacy settings of the System Preferences app.

## Rationale
Ensuring Gatekeeper is enabled is an important hygiene item for many mac admins. Also allowing osquery users to enumerate apps that an end-user had to explicitly whitelist to bypass Gatekeeper gives users of osquery a quick way to find suspicious and possibly malicious applications. On my own system it produced a litany of regretful decisions I have made.

## Technical Details
Apple stores details about the state of Gatekeeper in a series of plists (which live in `/var/db`) and a SQLite database. This PR accesses both sources of truth to enumerate both Gatekeeper tables.
