### PR TITLE
General code cleanup for the config

### DIFF
--- a/osquery/config/plugins/tests/tls_config_tests.cpp
+++ b/osquery/config/plugins/tests/tls_config_tests.cpp
@@ -80,9 +80,8 @@ TEST_F(TLSConfigTests, test_retrieve_config) {
   Config c;
   c.load();
 
-  const auto& hashes = c.hash_;
   EXPECT_EQ("d9b4a05d914c81a1ed4ce129928e2d9a0309c753",
-            hashes.at("tls_plugin"));
+            c.getHash("tls_plugin"));
 
   // Configure the plugin to use the node API.
   Flag::updateValue("tls_node_api", "1");


### PR DESCRIPTION
This contains config testing and compiling improvements. The goal is to make implementation files that include `config.h` compile faster.