### PR TITLE
windows: Updating windows system_info to return fqdn for hostname

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -272,6 +272,14 @@ class DropPrivileges : private boost::noncopyable {
 std::string getHostname();
 
 /**
+ * @brief Getter for a host's fully qualified domain name
+ *
+ * @return a string representation of the hosts fully qualified domain name
+ * if the host is joined to a domain, otherwise it simply returns the hostname
+ */
+std::string getFqdn();
+
+/**
  * @brief Generate a new generic UUID
  *
  * @return a string containing a random UUID

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -22,9 +22,9 @@ namespace tables {
 
 QueryData genSystemInfo(QueryContext& context) {
   Row r;
-  r["hostname"] = osquery::getHostname();
-  r["computer_name"] = r["hostname"];
-  r["local_hostname"] = r["hostname"];
+  r["hostname"] = osquery::getFqdn();
+  r["computer_name"] = osquery::getHostname();
+  r["local_hostname"] = r["computer_name"];
   getHostUUID(r["uuid"]);
 
   auto qd = SQL::selectAllFrom("cpuid");


### PR DESCRIPTION
The `hostname` column in the `system_info` table is currently only the generic system name. This changes the value to be the FQDN in the event the system is joined to a domain, and the generic hostname otherwise.