### PR TITLE
packs: Update darwin's preferences table to plist

### DIFF
--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -24,7 +24,7 @@
       "value" : "Identify malware that uses this persistence mechanism to launch at a given interval"
     },
     "loginwindow1": {
-      "query" : "select key, subkey, value from preferences where path = '/Library/Preferences/com.apple.loginwindow.plist';",
+      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/com.apple.loginwindow.plist';",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -32,7 +32,7 @@
       "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
     },
     "loginwindow2": {
-      "query" : "select key, subkey, value from preferences where path = '/Library/Preferences/loginwindow.plist';",
+      "query" : "select key, subkey, value from plist where path = '/Library/Preferences/loginwindow.plist';",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -40,7 +40,7 @@
       "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
     },
     "loginwindow3": {
-      "query" : "select username, key, subkey, value from preferences p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.loginwindow.plist';",
+      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.loginwindow.plist';",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -48,7 +48,7 @@
       "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
     },
     "loginwindow4": {
-      "query" : "select username, key, subkey, value from preferences p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/loginwindow.plist';",
+      "query" : "select username, key, subkey, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/loginwindow.plist';",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -183,7 +183,7 @@
       "value" : "Identify actions taken. Useful for compromised hosts."
     },
     "recent_items": {
-      "query" : "select username, key, value from preferences p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.recentitems.plist';",
+      "query" : "select username, key, value from plist p, (select * from users where directory like '/Users/%') u where p.path = u.directory || '/Library/Preferences/com.apple.recentitems.plist';",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -303,7 +303,7 @@
       "value": "Artifact used by this malware"
     },
     "OSX_Pirrit": {
-      "query": "select * from preferences where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
+      "query": "select * from plist where path = '/Library/Preferences/com.common.plist' and key = 'net_pref';",
       "interval": "3600",
       "version": "1.4.5",
       "description": "(https://threatpost.com/mac-adware-osx-pirrit-unleashes-ad-overload-for-now/117273/)",

--- a/packs/vuln-management.conf
+++ b/packs/vuln-management.conf
@@ -126,7 +126,7 @@
       "value" : "This, with the help of vulnerability feed, can help tell if a vulnerable application is installed."
     },
     "unauthenticated_sparkle_feeds": {
-      "query" : "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, preferences p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join preferences p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
+      "query" : "select feeds.*, p2.value as sparkle_version from (select a.name as app_name, a.path as app_path, a.bundle_identifier as bundle_id, p.value as feed_url from (select name, path, bundle_identifier from apps) a, plist p where p.path = a.path || '/Contents/Info.plist' and p.key = 'SUFeedURL' and feed_url like 'http://%') feeds left outer join plist p2 on p2.path = app_path || '/Contents/Frameworks/Sparkle.framework/Resources/Info.plist' where (p2.key = 'CFBundleShortVersionString' OR coalesce(p2.key, '') = '');",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",


### PR DESCRIPTION
This updates several packs to use the new `plist` table. The `preferences` had overloaded capability to read a `.plist` but this feature has been removed from that table.