### PR TITLE
Allow caching for tables with indexes and additionals

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -625,7 +625,7 @@ struct QueryContext : private only_movable {
                            std::set<std::string>& output)> predicate);
 
   /// Check if a table-defined index exists within the query cache.
-  bool isCached(const std::string& index) {
+  bool isCached(const std::string& index) const {
     return (table_->cache.count(index) != 0);
   }
 
@@ -785,7 +785,7 @@ class TablePlugin : public Plugin {
    * @param interval The interval this query expects the tables results.
    * @return True if the cache contains fresh results, otherwise false.
    */
-  bool isCached(size_t interval);
+  bool isCached(size_t interval, const QueryContext& ctx) const;
 
   /**
    * @brief Perform a database lookup of cached results and deserialize.
@@ -798,8 +798,17 @@ class TablePlugin : public Plugin {
    */
   QueryData getCache() const;
 
-  /// Similar to TablePlugin::getCache, if TablePlugin::generate is called.
-  void setCache(size_t step, size_t interval, const QueryData& results);
+  /**
+   * @brief Similar to getCache, stores the results from generate.
+   *
+   * Set will serialize and save the results as JSON to be retrieved later.
+   * It will inspect the query context, if any required/indexed/optimized or
+   * additional columns are used then the cache will not be saved.
+   */
+  void setCache(size_t step,
+                size_t interval,
+                const QueryContext& ctx,
+                const QueryData& results);
 
  private:
   /// The last time in seconds the table data results were saved to cache.
@@ -867,6 +876,7 @@ class TablePlugin : public Plugin {
   FRIEND_TEST(VirtualTableTests, test_tableplugin_columndefinition);
   FRIEND_TEST(VirtualTableTests, test_tableplugin_statement);
   FRIEND_TEST(VirtualTableTests, test_indexing_costs);
+  FRIEND_TEST(VirtualTableTests, test_table_results_cache);
   FRIEND_TEST(VirtualTableTests, test_yield_generator);
 };
 

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -169,8 +169,25 @@ PluginResponse TablePlugin::routeInfo() const {
   return response;
 }
 
-bool TablePlugin::isCached(size_t step) {
-  return (!FLAGS_disable_caching && step < last_cached_ + last_interval_);
+static bool cacheAllowed(const TableColumns& cols, const QueryContext& ctx) {
+  auto uncachable = ColumnOptions::INDEX | ColumnOptions::REQUIRED |
+                    ColumnOptions::ADDITIONAL | ColumnOptions::OPTIMIZED;
+  for (const auto& column : cols) {
+    auto opts = std::get<2>(column) & uncachable;
+    if (opts && ctx.constraints.at(std::get<0>(column)).exists()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool TablePlugin::isCached(size_t step, const QueryContext& ctx) const {
+  if (FLAGS_disable_caching) {
+    return false;
+  }
+
+  // Perform the step comparison first, because it's easy.
+  return (step < last_cached_ + last_interval_ && cacheAllowed(columns(), ctx));
 }
 
 QueryData TablePlugin::getCache() const {
@@ -185,10 +202,15 @@ QueryData TablePlugin::getCache() const {
 
 void TablePlugin::setCache(size_t step,
                            size_t interval,
+                           const QueryContext& ctx,
                            const QueryData& results) {
+  if (FLAGS_disable_caching || !cacheAllowed(columns(), ctx)) {
+    return;
+  }
+
   // Serialize QueryData and save to database.
   std::string content;
-  if (!FLAGS_disable_caching && serializeQueryDataJSON(results, content)) {
+  if (serializeQueryDataJSON(results, content)) {
     last_cached_ = step;
     last_interval_ = interval;
     setDatabaseValue(kQueries, "cache." + getName(), content);

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -133,10 +133,14 @@ class TestTablePlugin : public TablePlugin {
  public:
   void testSetCache(size_t step, size_t interval) {
     QueryData r;
-    setCache(step, interval, r);
+    QueryContext ctx;
+    setCache(step, interval, ctx, r);
   }
 
-  bool testIsCached(size_t interval) { return isCached(interval); }
+  bool testIsCached(size_t interval) {
+    QueryContext ctx;
+    return isCached(interval, ctx);
+  }
 };
 
 TEST_F(TablesTests, test_caching) {

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -29,6 +29,7 @@ schema([
     Column("threads", INTEGER, "Number of threads used by process"),
     Column("nice", INTEGER, "Process nice level (-20 to 20, default 0)"),
 ])
+attributes(cacheable=True)
 implementation("system/processes@genProcesses")
 examples([
   "select * from processes where pid = 1",

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -235,9 +235,6 @@ class TableState(Singleton):
         if "event_subscriber" in self.attributes:
             self.generator = True
         if "cacheable" in self.attributes:
-            if len(set(all_options).intersection(NON_CACHEABLE)) > 0:
-                print(lightred("Table cannot be marked cacheable: %s" % (path)))
-                exit(1)
             if self.generator:
                 print(lightred(
                     "Table cannot use a generator and be marked cacheable: %s" % (path)))

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -100,13 +100,13 @@ class {{table_name_cc}}TablePlugin : public TablePlugin {
 {% else %}\
   QueryData generate(QueryContext& context) override {
 {% if attributes.cacheable %}\
-    if (isCached(kCacheStep)) {
+    if (isCached(kCacheStep, context)) {
       return getCache();
     }
 {% endif %}\
     auto results = tables::{{function}}(context);
 {% if attributes.cacheable %}\
-    setCache(kCacheStep, kCacheInterval, results);
+    setCache(kCacheStep, kCacheInterval, context, results);
 {% endif %}
     return results;
   }


### PR DESCRIPTION
This should improve the performance of "stacked" scheduled queries against the `processes` table. This technique (improvement) can be applied to other tables later too.

The caching feature landed a while ago, but was never applied to tables that reacted programmatically to predicate constraints. 