### PR TITLE
windows: Fixing watcher respawn logic for killed worker processes

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -266,6 +266,7 @@ bool WatcherRunner::watch(const PlatformProcess& child) const {
   if (result == PROCESS_EXITED) {
     // If the worker process existed, store the exit code.
     Watcher::get().worker_status_ = process_status;
+    return false;
   }
 
   return true;


### PR DESCRIPTION
Currently if the osquery worker process dies on Windows, the exit code is stashed but the work process is never respawned, thus the watcher hangs indefinitely until the service restarts. This returns the correct code to re-spawn work processes.