### PR TITLE
Change make format to use dependency binary, not system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,7 +631,7 @@ add_custom_target(
 # make format
 add_custom_target(
   format
-  "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py" "-f"
+  "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/formatting/git-clang-format.py" "-f" "--binary" "${BUILD_DEPS}/bin/clang-format"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Formatting code staged code changes with clang-format" VERBATIM
 )


### PR DESCRIPTION
make format has been using the system installed clang-format, not the one installed by deps.
Adding the binary flag to point to our locally installed clang-format binary.