### PR TITLE
Add mount to fsevents

### DIFF
--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -40,6 +40,7 @@ std::map<FSEventStreamEventFlags, std::string> kMaskActions = {
     {kFSEventStreamEventFlagItemModified, "UPDATED"},
     {kFSEventStreamEventFlagItemRenamed, "MOVED_TO"},
     {kFSEventStreamEventFlagMustScanSubDirs, "COLLISION_WITHIN"},
+    {kFSEventStreamEventFlagMount, "MOUNTED"},
     {kFSEventStreamEventFlagUnmount, "UNMOUNTED"},
     {kFSEventStreamEventFlagRootChanged, "ROOT_CHANGED"},
 };

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -62,7 +62,7 @@ void genInterfaceDetail(const WmiResultItem& adapter, QueryData& results) {
   WmiRequest irequest(query);
   if (irequest.getStatus().ok()) {
     auto& iresults = irequest.results();
-    if (iresults.size() == 0) {
+    if (iresults.empty()) {
       return;
     }
     iresults[0].GetLong("MTU", lPlaceHolder);


### PR DESCRIPTION
When testing FIM on APFS I noticed that we aren't capturing mount alerts even though we're capturing unmount. I figure that this was just overlooked (unmount was added in pull request #1197 and it's not mentioned why mount wasn't added) so this just adds it in.

Also fixing a small nit that should've been addressed in a commit yesterday.