### PR TITLE
audit: Isolate the audit consumer logic into a thread

### DIFF
--- a/osquery/events/linux/audit.cpp
+++ b/osquery/events/linux/audit.cpp
@@ -10,11 +10,14 @@
 
 #include <poll.h>
 
+#include <queue>
+
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/utility/string_ref.hpp>
 
+#include <osquery/dispatcher.h>
 #include <osquery/filesystem.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -39,6 +42,8 @@ FLAG(bool,
      false,
      "Allow the audit publisher to change auditing configuration");
 
+HIDDEN_FLAG(uint64, audit_queue_size, 8192 * 4, "Size of the userland queue");
+
 HIDDEN_FLAG(bool, audit_debug, false, "Debug Linux audit messages");
 
 REGISTER(AuditEventPublisher, "event_publisher", "audit");
@@ -47,6 +52,46 @@ enum AuditStatus {
   AUDIT_DISABLED = 0,
   AUDIT_ENABLED = 1,
   AUDIT_IMMUTABLE = 2,
+};
+
+class AuditConsumer : private boost::noncopyable {
+ public:
+  static AuditConsumer& get() {
+    static AuditConsumer instance;
+    return instance;
+  }
+
+  /// Add and copy an audit reply into the queue.
+  void push(AuditEventContextRef& reply);
+
+  /// Inspect the front of the queue, usually to move the content.
+  AuditEventContextRef& peek();
+
+  size_t size() const;
+
+  /// Remove the front element.
+  void pop();
+
+ private:
+  /// The managed thread-unsafe queue.
+  std::queue<AuditEventContextRef> queue_;
+
+  /// An observed max-size of the queue.
+  size_t max_size_;
+
+  /// The queue-protecting Mutex.
+  mutable Mutex mutex_;
+};
+
+class AuditConsumerRunner : public InternalRunnable {
+ public:
+  AuditConsumerRunner(AuditEventPublisher* publisher) : publisher_(publisher) {}
+
+  /// Thread entrypoint.
+  void start() override;
+
+ private:
+  AuditEventPublisher* publisher_;
 };
 
 void AuditAssembler::start(size_t capacity,
@@ -187,6 +232,8 @@ Status AuditEventPublisher::setUp() {
     // Request only the highest priority of audit status messages.
     set_aumessage_mode(MSG_QUIET, DBG_NO);
   }
+
+  Dispatcher::addService(std::make_shared<AuditConsumerRunner>(this));
   return Status(0, "OK");
 }
 
@@ -474,6 +521,60 @@ static inline int safe_audit_get_reply(int fd, struct audit_reply* rep) {
   return len;
 }
 
+void AuditConsumer::push(AuditEventContextRef& reply) {
+  auto& self = get();
+  WriteLock lock(self.mutex_);
+
+  if (self.queue_.size() > FLAGS_audit_queue_size) {
+    // The userland queue is filled, drop.
+    return;
+  }
+  self.queue_.push(reply);
+}
+
+AuditEventContextRef& AuditConsumer::peek() {
+  ReadLock lock(get().mutex_);
+
+  return get().queue_.front();
+}
+
+void AuditConsumer::pop() {
+  auto& self = get();
+  WriteLock lock(self.mutex_);
+
+  self.queue_.pop();
+
+  if (self.queue_.size() > self.max_size_) {
+    self.max_size_ = self.queue_.size();
+  } else if (self.queue_.empty() && self.max_size_ > 100) {
+    std::queue<AuditEventContextRef> empty;
+    std::swap(empty, self.queue_);
+    self.max_size_ = 0;
+  }
+}
+
+size_t AuditConsumer::size() const {
+  ReadLock lock(get().mutex_);
+
+  return get().queue_.size();
+}
+
+void AuditConsumerRunner::start() {
+  while (!interrupted()) {
+    size_t events = AuditConsumer::get().size();
+    for (size_t i = 0; i < events; i++) {
+      // Build the event context from the reply type and parse the message.
+      publisher_->fire(AuditConsumer::get().peek());
+      AuditConsumer::get().pop();
+    }
+
+    if (!interrupted() && events == 0) {
+      // Only pause if there were no events to process.
+      pauseMilli(1000);
+    }
+  }
+}
+
 Status AuditEventPublisher::run() {
   if (!FLAGS_disable_audit && (count_ == 0 || count_++ % 10 == 0)) {
     // Request an update to the audit status.
@@ -523,17 +624,20 @@ Status AuditEventPublisher::run() {
       handle_reply = true;
     case AUDIT_EOE: // 1320 (multi-record event).
       break;
+    case AUDIT_FIRST_SELINUX ... AUDIT_LAST_SELINUX:
+      break;
+    case AUDIT_FIRST_USER_MSG2 ... AUDIT_LAST_USER_MSG2:
+      break;
     default:
       // All other cases, pass to reply.
-      handle_reply = true;
+      handle_reply = false;
     }
 
     // Replies are 'handled' as potential events for several audit types.
     if (handle_reply) {
       auto ec = createEventContext();
-      // Build the event context from the reply type and parse the message.
       if (handleAuditReply(reply_, ec)) {
-        fire(ec);
+        AuditConsumer::get().push(ec);
       }
     }
   });

--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -211,6 +211,9 @@ struct AuditEventContext : public EventContext {
 using AuditEventContextRef = std::shared_ptr<AuditEventContext>;
 using AuditSubscriptionContextRef = std::shared_ptr<AuditSubscriptionContext>;
 
+/// This is a dispatched service that handles published audit replies.
+class AuditConsumerRunner;
+
 class AuditEventPublisher
     : public EventPublisher<AuditSubscriptionContext, AuditEventContext> {
   DECLARE_PUBLISHER("audit");
@@ -292,6 +295,9 @@ class AuditEventPublisher
 
   /// Track all rule data added by the publisher.
   std::vector<struct AuditRuleInternal> transient_rules_;
+
+ private:
+  friend class AuditConsumerRunner;
 };
 
 /**


### PR DESCRIPTION
This "isolates" the audit consumer logic (well, most of) into a single consumer thread. It tries to be smart about the size of the queue used to buffer audit replies. If there are too many replies then it drops instead of consuming too much memory. If the queue size was ever > 100 then the queue container is replaced.

After several performance tests (system stress at 11), this will peak RSS at 50M. The success rate is poor, but comparable to previous implementations.