### PR TITLE
Add collisions to the interface_details table

### DIFF
--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -91,6 +91,7 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["oerrors"] = BIGINT_FROM_UINT32(ifd->tx_errors);
     r["idrops"] = BIGINT_FROM_UINT32(ifd->rx_dropped);
     r["odrops"] = BIGINT_FROM_UINT32(ifd->tx_dropped);
+    r["collisions"] = BIGINT_FROM_UINT32(ifd->collisions);
     // Get Linux physical properties for the AF_PACKET entry.
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd >= 0) {
@@ -127,6 +128,7 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["oerrors"] = BIGINT_FROM_UINT32(ifd->ifi_oerrors);
     r["idrops"] = BIGINT_FROM_UINT32(ifd->ifi_iqdrops);
     r["odrops"] = INTEGER(0);
+    r["collisions"] = BIGINT_FROM_UINT32(ifd->ifi_collisions);
     r["last_change"] = BIGINT_FROM_UINT32(ifd->ifi_lastchange.tv_sec);
 #endif
   }

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -15,6 +15,7 @@ schema([
     Column("oerrors", BIGINT, "Output errors"),
     Column("idrops", BIGINT, "Input drops"),
     Column("odrops", BIGINT, "Output drops"),
+    Column("collisions", BIGINT, "Packet Collisions detected"),
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
 ])
 extended_schema(WINDOWS, [


### PR DESCRIPTION
This data is available in both Linux and OSX from the [rtnl_link_stats](https://chromium.googlesource.com/native_client/linux-headers-for-nacl/+/2dc04f8190a54defc0d59e693fa6cff3e8a916a9/include/linux/if_link.h) and [if_data](https://developer.apple.com/documentation/kernel/if_data).

```
osquery> select interface, collisions from interface_details;
+-----------+------------+
| interface | collisions |
+-----------+------------+
| lo0       | 0          |
| gif0      | 0          |
| stf0      | 0          |
| en0       | 0          |
| en2       | 0          |
| en4       | 0          |
| en1       | 0          |
| en3       | 0          |
| bridge0   | 0          |
| p2p0      | 0          |
| awdl0     | 0          |
| utun0     | 0          |
| en6       | 0          |
| fw0       | 0          |
| en8       | 0          |
+-----------+------------+
```