### PR TITLE
tables: Add device_firmware to darwin

### DIFF
--- a/specs/darwin/device_firmware.table
+++ b/specs/darwin/device_firmware.table
@@ -1,0 +1,8 @@
+table_name("device_firmware")
+description("A best-effort list of discovered firmware versions.")
+schema([
+    Column("type", TEXT, "Type of device"),
+    Column("device", TEXT, "The device name", index=True),
+    Column("version", TEXT, "Firmware version"),
+])
+implementation("device_firmware@genDeviceFirmware")


### PR DESCRIPTION
This adds `device_firmware`, a general table for listing device firmware versions. Feel free to extend this and add platform firmware.

```
./build/darwin/osquery/osqueryi -A device_firmware            
+-------------+--------------------------------------+-----------------------------------------+
| type        | device                               | version                                 |
+-------------+--------------------------------------+-----------------------------------------+
| IOPCIDevice | AppleS3XController                   | 14.17.01                                |
| IOPCIDevice | AirPort_Brcm4360                     | Broadcom BCM43xx 1.0 (7.21.171.130.1a1) |
| IOResources | IOBluetoothHCIController             | v48 c4227                               |
|             | AppleBroadcomBluetoothHostController | v48 c4227                               |
+-------------+--------------------------------------+-----------------------------------------+
```