### PR TITLE
EC2 instance metadata implementation.

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -438,6 +438,10 @@ Example:
 SELECT * FROM kernel_hashes WHERE kernel_binary NOT LIKE "%apple%";
 ```
 
+### EC2
+
+There are two tables that provide EC2 instance related information. On non-EC2 instances these tables return empty results. `ec2_instance_metadata` table contains instance meta data information. `ec2_instance_tags` returns tags for the EC2 instance osquery is running on. Retrieving tags for EC2 instance requires authentication and appropriate permission. There are multiple ways credentials can be provided to osquery. See [AWS logging configuration](../deployment/aws-logging.md#configuration) for configuring credentials. AWS region (`--aws_region`) argument is not required and will be ignored by `ec2_instance_tags` implementation. The credentials configured should have permission to perform `ec2:DescribeTags` action.
+
 ### Decorator queries
 
 Decorator queries exist in osquery versions 1.7.3+ and are used to add additional "decorations" to results and snapshot logs. There are three types of decorator queries based on when and how you want the decoration data.

--- a/osquery/tables/cloud/ec2_instance_metadata.cpp
+++ b/osquery/tables/cloud/ec2_instance_metadata.cpp
@@ -1,0 +1,289 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <string>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/network/protocol/http/client.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+namespace pt = boost::property_tree;
+namespace http = boost::network::http;
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Super class for EC2 metadata accessors
+ */
+class Ec2MetaData {
+ protected:
+  /**
+   * @brief Meta data URL suffix
+   */
+  const std::string url_suffix_;
+
+  /**
+   * @brief Get metadata using HTTP.
+   *
+   * @return HTTP body.
+   */
+  std::string doGet() const;
+
+  /**
+   * @brief Extract relevant data from return API call, pure virtual
+   *
+   * @param http_body content of the http response body
+   * @param r The row to which the value need to be added
+   */
+  virtual void extractResult(const std::string& http_body, Row& r) const = 0;
+
+ public:
+  Ec2MetaData(const std::string urlSuffix)
+      : url_suffix_(std::move(urlSuffix)) {}
+
+  virtual ~Ec2MetaData() {}
+
+  /**
+   * @brief HTTP get and extract data
+   *
+   * @param r The row to which the value need to be added
+   */
+  void get(Row& r) const {
+    const std::string http_body = doGet();
+    extractResult(http_body, r);
+  }
+};
+
+/**
+ * @brief handle all data not requiring parsing
+ */
+class SimpleEc2MetaData : public Ec2MetaData {
+ protected:
+  /**
+   * @brief SQL type for the value
+   */
+  const ColumnType sql_type_;
+
+  /**
+   * @brief SQL column name
+   */
+  const std::string column_name_;
+
+  virtual void extractResult(const std::string& http_body,
+                             Row& r) const override;
+
+ public:
+  SimpleEc2MetaData(const ColumnType sqlType,
+                    const std::string columnName,
+                    const std::string urlSuffix)
+      : Ec2MetaData(urlSuffix),
+        sql_type_(std::move(sqlType)),
+        column_name_(std::move(columnName)) {}
+
+  virtual ~SimpleEc2MetaData() {}
+};
+
+/**
+ * @brief Handle IAM parsing
+ */
+class JSONEc2MetaData : public Ec2MetaData {
+ protected:
+  /**
+   * @brief SQL column names
+   */
+  const std::vector<std::string> column_names_;
+
+  /**
+   * @brief JSON key names
+   */
+  const std::vector<std::string> key_names_;
+
+  virtual void extractResult(const std::string& http_body,
+                             Row& r) const override;
+
+ public:
+  JSONEc2MetaData(const std::vector<std::string> columnNames,
+                  const std::vector<std::string> keyNames,
+                  const std::string urlSuffix)
+      : Ec2MetaData(urlSuffix),
+        column_names_(std::move(columnNames)),
+        key_names_(std::move(keyNames)) {}
+
+  virtual ~JSONEc2MetaData() {}
+};
+
+std::string Ec2MetaData::doGet() const {
+  const static std::string ec2_metadata_url{"http://169.254.169.254/latest/"};
+
+  http::client::request req(ec2_metadata_url + url_suffix_);
+  http::client::options options;
+  options.timeout(3);
+  http::client client(options);
+
+  try {
+    http::client::response res = client.get(req);
+    boost::uint16_t http_status_code = res.status();
+
+    // Silently ignore 404
+    if (http_status_code == 404) {
+      return "";
+    }
+
+    // Log "hard" errors
+    if (http_status_code != 200) {
+      VLOG(1) << "Unexpected HTTP response for: " << url_suffix_
+              << " Status: " << http_status_code;
+      return "";
+    }
+
+    return res.body();
+  } catch (std::system_error& e) {
+    VLOG(1) << "Request for " << url_suffix_ << " failed: " << e.what();
+  }
+
+  return "";
+}
+
+void setRowField(const ColumnType sql_type,
+                 const std::string& column_name,
+                 const std::string& value,
+                 Row& r) {
+  switch (sql_type) {
+  case TEXT_TYPE: {
+    std::string field_value{value};
+    // Remove trailing new line, if any
+    field_value.erase(std::remove(field_value.begin(), field_value.end(), '\n'),
+                      field_value.end());
+    // Join multi-line values
+    boost::replace_all(field_value, "\n", ",");
+    r[column_name] = field_value;
+    break;
+  }
+  case INTEGER_TYPE: {
+    r[column_name] = value.empty() ? INTEGER(0) : INTEGER(value);
+    break;
+  }
+  default:
+    VLOG(1) << "Unknown field type " << sql_type << " for: " << column_name;
+  }
+}
+
+void SimpleEc2MetaData::extractResult(const std::string& http_body,
+                                      Row& r) const {
+  return setRowField(sql_type_, column_name_, http_body, r);
+}
+
+void JSONEc2MetaData::extractResult(const std::string& http_body,
+                                    Row& r) const {
+  try {
+    std::stringstream json_stream;
+    json_stream << http_body;
+    pt::ptree tree;
+    pt::read_json(json_stream, tree);
+    for (size_t i = 0; i < column_names_.size(); i++) {
+      setRowField(TEXT_TYPE,
+                  column_names_[i],
+                  tree.get<std::string>(key_names_[i], ""),
+                  r);
+    }
+  } catch (const pt::json_parser::json_parser_error& e) {
+    VLOG(1) << "Could not parse JSON from " << url_suffix_ << ": " << e.what();
+  }
+}
+
+static bool isEc2Instance() {
+  static std::atomic<bool> checked(false);
+  static std::atomic<bool> is_ec2_instance(false);
+  if (checked) {
+    return is_ec2_instance; // Return if already checked
+  }
+
+  static std::once_flag once_flag;
+  std::call_once(once_flag, []() {
+    if (checked) {
+      return;
+    }
+
+    checked = true;
+    http::client::request req("http://169.254.169.254");
+    http::client::options options;
+    options.timeout(3);
+    http::client client(options);
+
+    try {
+      http::client::response res = client.get(req);
+      if (res.status() == 200) {
+        is_ec2_instance = true;
+      }
+    } catch (const std::system_error& e) {
+      // Assume that this is not EC2 instance
+      VLOG(1) << "Error checking if this is EC2 instance: " << e.what();
+    }
+  });
+
+  return is_ec2_instance;
+}
+
+QueryData genEc2Metadata(QueryContext& context) {
+  QueryData results;
+  if (!isEc2Instance()) {
+    return results;
+  }
+
+  const static std::vector<std::shared_ptr<Ec2MetaData>> fields(
+      {std::make_shared<JSONEc2MetaData>(
+           JSONEc2MetaData(std::vector<std::string>({"instance_id",
+                                                     "instance_type",
+                                                     "local_ipv4",
+                                                     "availability_zone",
+                                                     "region",
+                                                     "account_id",
+                                                     "architecture",
+                                                     "ami_id"}),
+                           std::vector<std::string>({"instanceId",
+                                                     "instanceType",
+                                                     "privateIp",
+                                                     "availabilityZone",
+                                                     "region",
+                                                     "accountId",
+                                                     "architecture",
+                                                     "imageId"}),
+                           "dynamic/instance-identity/document")),
+       std::make_shared<JSONEc2MetaData>(
+           JSONEc2MetaData(std::vector<std::string>({"iam_arn"}),
+                           std::vector<std::string>({"InstanceProfileArn"}),
+                           "meta-data/iam/info")),
+       std::make_shared<SimpleEc2MetaData>(
+           SimpleEc2MetaData(TEXT_TYPE, "mac", "meta-data/mac")),
+       std::make_shared<SimpleEc2MetaData>(SimpleEc2MetaData(
+           TEXT_TYPE, "local_hostname", "meta-data/local-hostname")),
+       std::make_shared<SimpleEc2MetaData>(SimpleEc2MetaData(
+           TEXT_TYPE, "ssh_public_key", "meta-data/public-keys/0/openssh-key")),
+       std::make_shared<SimpleEc2MetaData>(SimpleEc2MetaData(
+           TEXT_TYPE, "reservation_id", "meta-data/reservation-id")),
+       std::make_shared<SimpleEc2MetaData>(SimpleEc2MetaData(
+           TEXT_TYPE, "security_groups", "meta-data/security-groups"))});
+
+  Row r;
+  for (const auto& it : fields) {
+    it->get(r);
+  }
+
+  results.push_back(r);
+  return results;
+}
+}
+}

--- a/specs/linux/ec2_instance_metadata.table
+++ b/specs/linux/ec2_instance_metadata.table
@@ -1,0 +1,23 @@
+table_name("ec2_instance_metadata")
+description("EC2 instance metadata.")
+schema([
+    Column("instance_id", TEXT, "EC2 instance ID", index=True),
+    Column("instance_type", TEXT, "EC2 instance type"),
+    Column("architecture", TEXT, "Hardware architecture of this EC2 instance"),
+    Column("region", TEXT, "AWS region in which this instance launched"),
+    Column("availability_zone", TEXT, "Availability zone in which this instance launched"),
+    Column("local_hostname", TEXT, "Private IPv4 DNS hostname of the first interface of this instance"),
+    Column("local_ipv4", TEXT, "Private IPv4 address of the first interface of this instance"),
+    Column("mac", TEXT, "MAC address for the first network interface of this EC2 instance"),
+    Column("security_groups", TEXT, "Comma separated list of security group names"),
+    Column("iam_arn", TEXT, "If there is an IAM role associated with the instance, contains instance profile ARN"),
+    Column("ami_id", TEXT, "AMI ID used to launch this EC2 instance"),
+    Column("reservation_id", TEXT, "ID of the reservation"),
+    Column("account_id", TEXT, "AWS account ID which owns this EC2 instance"),
+    Column("ssh_public_key", TEXT, "SSH public key. Only available if supplied at instance launch time")
+])
+attributes(cacheable=True)
+implementation("cloud/ec2_metadata@genEc2Metadata")
+examples([
+    "select * from ec2_instance_metadata"
+])


### PR DESCRIPTION
This is based on https://github.com/facebook/osquery/pull/2853
I made some optimizations and cleanup.

When queried on non-EC2 instance, this table responds with no results
in 3 seconds. Subsequent queries are immediately returned.

On EC2 instance, each query makes 7 round trips to meta-data servers.

Original pull request had copyright claim by jfdive with BSD license.
I changed it to standard Facebook copyright.