### PR TITLE
Some "make audit" output fixes.

### DIFF
--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -51,7 +51,7 @@ class Status {
    * Otherwise, it doesn't matter what the string is, as long as both the
    * setter and caller agree.
    */
-  Status(int c, std::string m) : code_(c), message_(m) {}
+  Status(int c, const std::string& m) : code_(c), message_(m) {}
 
  public:
   /**

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -783,6 +783,7 @@ class TablePlugin : public Plugin {
    * practice this does not perform well and is explicitly disabled.
    *
    * @param interval The interval this query expects the tables results.
+   * @param ctx The query context.
    * @return True if the cache contains fresh results, otherwise false.
    */
   bool isCached(size_t interval, const QueryContext& ctx) const;

--- a/osquery/sql/sqlite_math.cpp
+++ b/osquery/sql/sqlite_math.cpp
@@ -128,20 +128,16 @@ static void expFunc(sqlite3_context *context, int argc, sqlite3_value **argv) {
 static void powerFunc(sqlite3_context *context,
                       int argc,
                       sqlite3_value **argv) {
-  double r1 = 0.0;
-  double r2 = 0.0;
-  double val;
-
   assert(argc == 2);
 
   if (sqlite3_value_type(argv[0]) == SQLITE_NULL ||
       sqlite3_value_type(argv[1]) == SQLITE_NULL) {
     sqlite3_result_null(context);
   } else {
-    r1 = sqlite3_value_double(argv[0]);
-    r2 = sqlite3_value_double(argv[1]);
+    double r1 = sqlite3_value_double(argv[0]);
+    double r2 = sqlite3_value_double(argv[1]);
     errno = 0;
-    val = pow(r1, r2);
+    double val = pow(r1, r2);
     if (errno == 0) {
       sqlite3_result_double(context, val);
     } else {

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/asio.hpp>
 #include <boost/foreach.hpp>
@@ -266,7 +267,7 @@ std::string getValue(const pt::ptree& tree,
                      const std::set<std::string>& set,
                      const std::string& key) {
   std::string value = tree.get<std::string>(key, "");
-  if (value.find("sha256:") == 0) {
+  if (boost::starts_with(value, "sha256:")) {
     value.erase(0, 7);
   }
   if (set.empty()) {
@@ -274,7 +275,7 @@ std::string getValue(const pt::ptree& tree,
   }
 
   for (const auto& entry : set) {
-    if (value.find(entry) == 0) {
+    if (boost::starts_with(value, entry)) {
       return entry; // If entry from set is prefix of value from tree, return
     }
   }
@@ -378,7 +379,7 @@ QueryData genContainers(QueryContext& context) {
       }
     }
     r["image_id"] = container.get<std::string>("ImageID", "");
-    if (r["image_id"].find("sha256:") == 0) {
+    if (boost::starts_with(r["image_id"], "sha256:")) {
       r["image_id"].erase(0, 7);
     }
     r["image"] = container.get<std::string>("Image", "");
@@ -877,7 +878,7 @@ QueryData genImages(QueryContext& context) {
       const pt::ptree& node = entry.second;
       Row r;
       r["id"] = node.get<std::string>("Id", "");
-      if (r["id"].find("sha256:") == 0) {
+      if (boost::starts_with(r["id"], "sha256:")) {
         r["id"].erase(0, 7);
       }
       r["created"] = BIGINT(node.get<uint64_t>("Created", 0));

--- a/osquery/tables/system/linux/md_tables.cpp
+++ b/osquery/tables/system/linux/md_tables.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <numeric>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
 #include <osquery/core/conversions.h>
@@ -126,7 +127,7 @@ std::string MD::getPathByDevName(const std::string& name) {
     if (name.compare(
             strlen(devName) - name.length(), std::string::npos, devName) == 0) {
       devPath = devName;
-      if (devPath.find('/') != 0) {
+      if (!boost::starts_with(devPath, "/")) {
         devPath = "/dev/" + devPath;
       }
 

--- a/osquery/tables/system/linux/tests/md_tables_tests.cpp
+++ b/osquery/tables/system/linux/tests/md_tables_tests.cpp
@@ -59,7 +59,7 @@ mdu_disk_info_t getDiskInfo(
  */
 void GetDrivesForArrayTestHarness(std::string arrayName,
                                   int arrayRaidDisks,
-                                  std::string blkDevicePrefix,
+                                  const std::string& blkDevicePrefix,
                                   std::map<int, mdu_disk_info_t> targetDisks,
                                   QueryData& got) {
   MockMD md;

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -60,7 +60,7 @@ void enumerateTasksForFolder(std::string path, QueryData& results) {
   }
 
   ITaskFolder* pRootFolder = nullptr;
-  auto widePath = stringToWstring(path.c_str());
+  auto widePath = stringToWstring(path);
   ret = pService->GetFolder(BSTR(widePath.c_str()), &pRootFolder);
   pService->Release();
   if (FAILED(ret)) {


### PR DESCRIPTION
Fixed some cppcheck warnings:
* Inefficient usage of string::find() in condition (docker.cpp etc)
* Function parameter 'm' should be passed by reference (status.h)
* Passing the result of c_str() to a function that takes std::string as argument no. 1 is slow and redundant (scheduled_tasks.cpp)

Fixed "make docs" on Ubuntu. Was failing with following error:
osquery/include/osquery/tables.h:788: error: The following parameters of osquery::TablePlugin::isCached(size_t interval, const QueryContext &ctx) const are not documented:
  parameter 'ctx' (warning treated as error, aborting now)