### PR TITLE
tables: Implement shared folders table for Darwin

### DIFF
--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -26,7 +26,7 @@ Status genSharePointEntries(std::vector<NSDictionary *> &sharepoints) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory node: "
            << std::string([[err localizedDescription] UTF8String]);
-      return osquery::Status(1, [[err localizedDescription] UTF8String]);
+      return Status(1, [[err localizedDescription] UTF8String]);
     }
 
     ODQuery *q = [ODQuery queryWithNode:root
@@ -40,7 +40,7 @@ Status genSharePointEntries(std::vector<NSDictionary *> &sharepoints) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory query: "
            << std::string([[err localizedDescription] UTF8String]);
-      return osquery::Status(1, [[err localizedDescription] UTF8String]);
+      return Status(1, [[err localizedDescription] UTF8String]);
     }
 
     // Obtain the results synchronously, not good for very large sets.
@@ -48,7 +48,7 @@ Status genSharePointEntries(std::vector<NSDictionary *> &sharepoints) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory results: "
            << std::string([[err localizedDescription] UTF8String]);
-      return osquery::Status(1, [[err localizedDescription] UTF8String]);
+      return Status(1, [[err localizedDescription] UTF8String]);
     }
 
     for (ODRecord *re in od_results) {
@@ -56,13 +56,13 @@ Status genSharePointEntries(std::vector<NSDictionary *> &sharepoints) {
       if (err != nullptr) {
         TLOG << "Error with OpenDirectory attribute: "
              << std::string([[err localizedDescription] UTF8String]);
-        return osquery::Status(1, [[err localizedDescription] UTF8String]);
+        return Status(1, [[err localizedDescription] UTF8String]);
       } else {
         sharepoints.push_back(recordPath);
       }
     }
   }
-  return osquery::Status(0, "OK");
+  return Status(0, "OK");
 }
 
 QueryData genSharedFolders(QueryContext &context) {

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -7,13 +7,12 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+#import <OpenDirectory/OpenDirectory.h>
 
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-
-#import <OpenDirectory/OpenDirectory.h>
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#import <OpenDirectory/OpenDirectory.h>
+
+namespace osquery {
+namespace tables {
+
+void genSharePointEntries(NSMutableArray *sharepoints) {
+  @autoreleasepool {
+    ODSession *s = [ODSession defaultSession];
+    NSError *err = nullptr;
+    ODNode *root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+    if (err != nullptr) {
+      TLOG << "Error with OpenDirectory node: "
+           << std::string([[err localizedDescription] UTF8String]);
+      return;
+    }
+
+    ODQuery *q = [ODQuery queryWithNode:root
+                         forRecordTypes:kODRecordTypeSharePoints
+                              attribute:@"dsAttrTypeNative:directory_path"
+                              matchType:kODMatchEqualTo
+                            queryValues:nil
+                       returnAttributes:kODAttributeTypeNativeOnly
+                         maximumResults:0
+                                  error:&err];
+    if (err != nullptr) {
+      TLOG << "Error with OpenDirectory query: "
+           << std::string([[err localizedDescription] UTF8String]);
+      return;
+    }
+
+    // Obtain the results synchronously, not good for very large sets.
+    NSArray *od_results = [q resultsAllowingPartial:NO error:&err];
+    if (err != nullptr) {
+      TLOG << "Error with OpenDirectory results: "
+           << std::string([[err localizedDescription] UTF8String]);
+      return;
+    }
+
+    for (ODRecord *re in od_results) {
+      NSDictionary *recordPath = [re recordDetailsForAttributes:nil error:&err];
+      if (err != nullptr) {
+        TLOG << "Error with OpenDirectory attribute: "
+             << std::string([[err localizedDescription] UTF8String]);
+        return;
+      } else {
+        [sharepoints addObject: recordPath];
+      }
+    }
+  }
+}
+
+QueryData genSharedFolders(QueryContext &context) {
+  NSMutableArray *sharepoints = [[NSMutableArray alloc] init];
+  QueryData results;
+  genSharePointEntries(sharepoints);
+  for (id sharepoint in sharepoints) {
+    Row r;
+    r["name"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:smb_name"] lastObject] UTF8String];
+    r["path"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:directory_path"] lastObject] UTF8String];
+    results.push_back(r);
+  }
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -71,8 +71,10 @@ QueryData genSharedFolders(QueryContext &context) {
   genSharePointEntries(sharepoints);
   for (const auto &sharepoint : sharepoints) {
     Row r;
-    r["name"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:smb_name"] lastObject] UTF8String];
-    r["path"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:directory_path"] lastObject] UTF8String];
+    r["name"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:smb_name"]
+        lastObject] UTF8String];
+    r["path"] = [[[sharepoint valueForKey:@"dsAttrTypeNative:directory_path"]
+        lastObject] UTF8String];
     results.push_back(r);
   }
   return results;

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
+
 #import <OpenDirectory/OpenDirectory.h>
 
 #include <osquery/core.h>

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -60,8 +60,9 @@ QueryData genSharedFolders(QueryContext &context) {
       } else {
         auto nameValue = [[[recordPath valueForKey:@"dsAttrTypeNative:smb_name"]
             lastObject] UTF8String];
-        auto pathValue = [[[recordPath valueForKey:@"dsAttrTypeNative:directory_path"]
-            lastObject] UTF8String];
+        auto pathValue =
+            [[[recordPath valueForKey:@"dsAttrTypeNative:directory_path"]
+                lastObject] UTF8String];
         r["name"] = nameValue;
         r["path"] = pathValue;
         results.push_back(r);

--- a/specs/darwin/shared_folders.table
+++ b/specs/darwin/shared_folders.table
@@ -1,0 +1,7 @@
+table_name("shared_folders")
+description("Folders available to others via SMB or AFP.")
+schema([
+    Column("name", TEXT, "The shared name of the folder as it appears to other users"),
+    Column("path", TEXT, "Absolute path of shared folder on the local system")
+])
+implementation("shared_folders@genSharedFolders")


### PR DESCRIPTION
This pull request resolves #3393 by implementing a `shared_folders` table. 

## Overview

The shared table folder simply lists all folders marked as a "shared folder" via the properties GUI in Finder, the `dscl` binary, and the File sharing options under "Sharing" in System Preferences.

```
osquery> select * from shared_folders;
+------------------------------+-----------------------+
| name                         | path                  |
+------------------------------+-----------------------+
| Jason Meller’s Public Folder | /Users/jmeller/Public |
+------------------------------+-----------------------+
```

The table returns the folder's path and the name other users will see it when browsing it via SMB or AFP.

This table will return shared folders _regardless_ if file sharing is enabled or not. To check if file sharing is enabled, one could use the `sharing` table in PR #3509.

## Implementation info

Based on @groob's suggestion, I utilized the OpenDirectory API to query all records with the property of `kODRecordTypeSharePoints`. From there, we simply pass the two relevant attributes to osquery.