### PR TITLE
Fixes from static code analysis

### DIFF
--- a/osquery/events/linux/audit.cpp
+++ b/osquery/events/linux/audit.cpp
@@ -77,7 +77,7 @@ class AuditConsumer : private boost::noncopyable {
   std::queue<AuditEventContextRef> queue_;
 
   /// An observed max-size of the queue.
-  size_t max_size_;
+  size_t max_size_ = 0;
 
   /// The queue-protecting Mutex.
   mutable Mutex mutex_;

--- a/osquery/filesystem/linux/mem.cpp
+++ b/osquery/filesystem/linux/mem.cpp
@@ -35,7 +35,7 @@ Status readMem(int fd, size_t base, size_t length, uint8_t* buffer) {
   // Read from raw memory until an unrecoverable read error or the all of the
   // requested bytes are read.
   size_t total_read = 0;
-  ssize_t bytes_read = 0;
+  ssize_t bytes_read = -1;
   while (total_read != length && bytes_read != 0) {
     bytes_read = read(fd, buffer + total_read, length - total_read);
     if (bytes_read == -1) {

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -65,16 +65,13 @@ Status procReadDescriptor(const std::string& process,
                           std::string& result) {
   auto link = kLinuxProcPath + "/" + process + "/fd/" + descriptor;
 
-  char result_path[PATH_MAX] = {0};
-  auto size = readlink(link.c_str(), result_path, sizeof(result_path) - 1);
-  if (size >= 0) {
+  char* result_path = realpath(link.c_str(), nullptr);
+  if (result_path != nullptr) {
     result = std::string(result_path);
+    free(result_path);
+    return Status(0, "OK");
   }
 
-  if (size >= 0) {
-    return Status(0, "OK");
-  } else {
-    return Status(1, "Could not read path");
-  }
+  return Status(1, "Could not read path");
 }
 }

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -9,6 +9,8 @@
  */
 #include <sstream>
 
+#include <boost/network/protocol/http/client.hpp>
+
 #include <osquery/config.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>

--- a/osquery/tables/applications/posix/prometheus_metrics.h
+++ b/osquery/tables/applications/posix/prometheus_metrics.h
@@ -14,8 +14,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/network/protocol/http/client.hpp>
-
 #include <osquery/tables.h>
 
 namespace osquery {

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -279,6 +279,7 @@ MultiHashes hashInode(TskFsFile* file) {
   // Set a maximum 'chunk' or block size to 1 page or the file size.
   TSK_OFF_T size = meta->getSize();
   if (size == 0) {
+    delete meta;
     return MultiHashes();
   }
 
@@ -308,7 +309,7 @@ MultiHashes hashInode(TskFsFile* file) {
   delete meta;
 
   // Convert the set of hashes into a device hashes transport.
-  MultiHashes dhs;
+  MultiHashes dhs = {};
   dhs.md5 = md5.digest();
   dhs.sha1 = sha1.digest();
   dhs.sha256 = sha256.digest();

--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -110,7 +110,7 @@ MultiHashes hashMultiFromFile(int mask, const std::string& path) {
                       }
                     }));
 
-  MultiHashes mh;
+  MultiHashes mh = {};
   if (!s.ok()) {
     return mh;
   }

--- a/osquery/tables/system/linux/md_tables.cpp
+++ b/osquery/tables/system/linux/md_tables.cpp
@@ -409,7 +409,7 @@ static inline bool handleMDStatuses(
 }
 
 MDDrive parseMDDrive(const std::string& name) {
-  MDDrive drive;
+  MDDrive drive = {};
   drive.name = name;
 
   auto start = name.find('[');
@@ -479,7 +479,6 @@ void MD::parseMDStat(const std::vector<std::string>& lines, MDStat& result) {
        * safety, we check if we at the end of the file. */
       if (n >= lines.size() - 1) {
         continue;
-        n += 1;
       }
       auto configline(split(lines[n + 1]));
 

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -55,14 +55,14 @@ inline std::string readProcLink(const std::string& attr,
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
 
-  std::string result;
-  char link_path[PATH_MAX] = {0};
-  auto bytes = readlink(attr_path.c_str(), link_path, sizeof(link_path) - 1);
-  if (bytes >= 0) {
-    result = std::string(link_path);
+  char* link_path = realpath(attr_path.c_str(), nullptr);
+  if (link_path != nullptr) {
+    std::string result = std::string(link_path);
+    free(link_path);
+    return result;
   }
 
-  return result;
+  return "";
 }
 
 // In the case where the linked binary path ends in " (deleted)", and a file


### PR DESCRIPTION
proc.cpp and processes.cpp, changed changed readlink() to realpath(). There was
no issue with the code, but it is easy to mis-use readlink. It can return
strings which are not null terminated in wrong arguments are passed.

Fixed 'meta' leak in sleuthkit.cpp#hashInode()

In sleuthkit.cpp, hash.cpp and md_tables.cpp structs were not properly
intialized. This can cause random values to be returned for primitive types
in the struct.

In audit.cpp initialize default value for max_size_.

In file_compression.cpp, handle -1 returned from read(). Also avoid divide
by zero if FLAGS_carver_block_size is accidentally set to 0.

while loop in mem.cpp#readMem never entered because bytes_read was initialized
to 0.