### PR TITLE
deps: Add bottle for macOS for bison

### DIFF
--- a/tools/provision/formula/bison.rb
+++ b/tools/provision/formula/bison.rb
@@ -8,11 +8,9 @@ class Bison < AbstractOsqueryFormula
   sha256 "b67fd2daae7a64b5ba862c66c07c1addb9e6b1b05c5f2049392cfd8a2172952e"
 
   bottle do
-    sha256 "609cc77d6ef01c5a7afc2f96b8a27fb7fcb639b3f6192f6e0f8d2f7623cc141e" => :sierra
-    sha256 "17488b69156f6fc91dd438c54920751399c23745f330487abd54c4cbcb49ff6a" => :el_capitan
-    sha256 "0a6b72564c1602a033d814b68939bf2732f21cfdc06196c29da19c79faba669f" => :yosemite
-    sha256 "a3146ea90c2e4ee5d5626154b3446c7c5aea748b9239beac6ac2c26e753c830e" => :mavericks
-    sha256 "1ac1b43ae92fea5b04f663197309ce8b788061d31f09ba14e97dd4d5d1183d62" => :mountain_lion
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "9b4094197f711a8d2942b55efdf3b42b245353cb521a282f555799dee2a53911" => :sierra
   end
 
   # Fix crash from usage of %n in dynamic format strings on High Sierra


### PR DESCRIPTION
Update the bottle hashes for `bison`, macOS is the only platform using a local-bison build.