### PR TITLE
<Vagrant/ubuntu: Add a dep for running make sysprep>

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -211,7 +211,7 @@ Vagrant.configure("2") do |config|
       if name.start_with?('ubuntu')
         build.vm.provision 'bootstrap', type: 'shell' do |s|
           s.inline = 'sudo apt-get update;'\
-                     'sudo apt-get install --yes git;'
+                     'sudo apt-get install --yes git realpath;'
         end
       end
     end


### PR DESCRIPTION
On Ubuntu14 make sysprep requires realpath to be isntalled to run.