### PR TITLE
format: Remove Cpp restriction

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 ---
-Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: true


### PR DESCRIPTION
If you try to run `make format_all` it will error on ObjC files on macOS. The clang-format documentation says that not including a `Language` stanza means the following rules are applied to all languages.

https://clang.llvm.org/docs/ClangFormatStyleOptions.html