### PR TITLE
deps: Update AWS-SDK 1.1.20 bottles

### DIFF
--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -10,8 +10,8 @@ class AwsSdkCpp < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "74639e0ab4b05e3e26356677d1ededbe221dbe3e18205fe9dfea53f43f67cf5f" => :sierra
-    sha256 "aa9b708a93f65447f79a80d04eb7edd496e63a8350a19ee2e585a3b8c69a0f1f" => :x86_64_linux
+    sha256 "68a77b8250e9408bc365c43a0701ff389f39db61ee1d7f876459501236004c44" => :sierra
+    sha256 "e89d2f3a6d190c2b8a02b61fa396588ec23c6fae0aad8307b1fb5d0bdeecae99" => :x86_64_linux
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This updates the bottle hashes for `aws-sdk-cpp` version `1.1.20`.