### PR TITLE
Minor static analysis fixes.

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -255,7 +255,7 @@ class DropPrivileges : private boost::noncopyable {
   gid_t* original_groups_{nullptr};
 
   /// The size of the original groups to backup when restoring privileges.
-  size_t group_size_{0};
+  int group_size_{0};
 
  private:
   FRIEND_TEST(PermissionsTests, test_explicit_drop);

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -225,9 +225,11 @@ Status Carver::carve(const boost::filesystem::path& path) {
   for (size_t i = 0; i < blkCount; i++) {
     inBuff.clear();
     auto bytesRead = src.read(inBuff.data(), FLAGS_carver_block_size);
-    auto bytesWritten = dst.write(inBuff.data(), bytesRead);
-    if (bytesWritten < 0) {
-      return Status(1, "Error writing bytes to tmp fs");
+    if (bytesRead > 0) {
+      auto bytesWritten = dst.write(inBuff.data(), bytesRead);
+      if (bytesWritten < 0) {
+        return Status(1, "Error writing bytes to tmp fs");
+      }
     }
   }
 

--- a/osquery/events/linux/audit.h
+++ b/osquery/events/linux/audit.h
@@ -276,7 +276,7 @@ class AuditEventPublisher
    * This contains the: pid, enabled, rate_limit, backlog_limit, lost, and
    * failure booleans and counts.
    */
-  struct audit_status status_;
+  struct audit_status status_ {};
 
   /**
    * @brief A counter of non-blocking netlink reads that contained no data.
@@ -291,7 +291,7 @@ class AuditEventPublisher
   bool control_{false};
 
   /// The last (most recent) audit reply.
-  struct audit_reply reply_;
+  struct audit_reply reply_ {};
 
   /// Track all rule data added by the publisher.
   std::vector<struct AuditRuleInternal> transient_rules_;

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -258,23 +258,27 @@ class LoggerDisabler : private boost::noncopyable {
 
 static void serializeIntermediateLog(const std::vector<StatusLogLine>& log,
                                      PluginRequest& request) {
-  pt::ptree tree;
-  for (const auto& log_item : log) {
-    pt::ptree child;
-    child.put("s", log_item.severity);
-    child.put("f", log_item.filename);
-    child.put("i", log_item.line);
-    child.put("m", log_item.message);
-    child.put("h", log_item.identifier);
-    child.put("c", log_item.calendar_time);
-    child.put("u", log_item.time);
-    tree.push_back(std::make_pair("", std::move(child)));
-  }
+  try {
+    pt::ptree tree;
+    for (const auto& log_item : log) {
+      pt::ptree child;
+      child.put("s", log_item.severity);
+      child.put("f", log_item.filename);
+      child.put("i", log_item.line);
+      child.put("m", log_item.message);
+      child.put("h", log_item.identifier);
+      child.put("c", log_item.calendar_time);
+      child.put("u", log_item.time);
+      tree.push_back(std::make_pair("", std::move(child)));
+    }
 
-  // Save the log as a request JSON string.
-  std::ostringstream output;
-  pt::write_json(output, tree, false);
-  request["log"] = output.str();
+    // Save the log as a request JSON string.
+    std::ostringstream output;
+    pt::write_json(output, tree, false);
+    request["log"] = output.str();
+  } catch (const pt::ptree_error& e) {
+    VLOG(1) << "Error serializing log entries: " << e.what();
+  }
 }
 
 static void deserializeIntermediateLog(const PluginRequest& request,

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -105,12 +105,11 @@ QueryData genPrometheusMetrics(QueryContext& context) {
   /* Below should be unreachable if there were no urls child node, but we set
    * handle with default value for consistency's sake and for added robustness.
    */
-  auto urls = config.get_child("urls", boost::property_tree::ptree());
+  auto urls = config.get_child("urls");
   if (urls.empty()) {
     return result;
   }
-  for (const auto& url :
-       config.get_child("urls", boost::property_tree::ptree())) {
+  for (const auto& url : config.get_child("urls")) {
     if (!url.first.empty()) {
       return result;
     }

--- a/osquery/tables/networking/posix/utils.cpp
+++ b/osquery/tables/networking/posix/utils.cpp
@@ -112,6 +112,10 @@ std::string macAsString(const struct ifaddrs* addr) {
   }
 
 #if defined(__linux__)
+  if (addr->ifa_name == nullptr) {
+    return blank_mac;
+  }
+
   struct ifreq ifr;
   ifr.ifr_addr.sa_family = AF_INET;
   memcpy(ifr.ifr_name, addr->ifa_name, IFNAMSIZ);


### PR DESCRIPTION
system.h: group_size_ can potentially be assigned negative value
carver.cpp: bytesRead can be negative. Check before calling write()
system.cpp: In rare cases (?) std::time can return -1. Fallback to 0 to avoid passing negative value to method that expect unsigned values
system.cpp: Check group_size_ before allocation memory
audit.h: Initialize status_ and reply_ fields
logger.cpp: Catch ptree error which can be thrown from put() and write_json
prometheus_metrics.cpp: Remove unnecessary default tree passed to get_child. count("urls") ensures that child tree exists
utils.cpp: Check addr->ifa_name for nullptr