### PR TITLE
A fix for Mac OSX process start_time

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -313,14 +313,18 @@ QueryData genProcesses(QueryContext& context) {
       // Convert the time in CPU ticks since boot to seconds.
       // This is relative to time not-sleeping since boot.
 
+      //
       auto uptime = tables::getUptime();
       uint64_t absoluteTime = mach_absolute_time();
 
-      auto multiply = static_cast<double>(time_base.numer) / static_cast<double>(time_base.denom);
-      auto diff = static_cast<long>((rusage_info_data.ri_proc_start_abstime - absoluteTime));
+      auto multiply = static_cast<double>(time_base.numer) /
+                      static_cast<double>(time_base.denom);
+      auto diff = static_cast<long>(
+          (rusage_info_data.ri_proc_start_abstime - absoluteTime));
 
       // This is a negative value
-      auto seconds_since_launch = static_cast<long>((diff * multiply) / START_TIME_RATIO);
+      auto seconds_since_launch =
+          static_cast<long>((diff * multiply) / START_TIME_RATIO);
 
       // Get the start_time since the computer started
       r["start_time"] = TEXT(uptime + seconds_since_launch);

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -324,10 +324,8 @@ QueryData genProcesses(QueryContext& context) {
       // This is a negative value
       auto seconds_since_launch =
           static_cast<long>((diff * multiply) / START_TIME_RATIO);
-
       // Get the start_time since the computer started
       r["start_time"] = TEXT(uptime + seconds_since_launch);
-
     } else {
       r["wired_size"] = "-1";
       r["resident_size"] = "-1";

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -313,7 +313,6 @@ QueryData genProcesses(QueryContext& context) {
       // Convert the time in CPU ticks since boot to seconds.
       // This is relative to time not-sleeping since boot.
 
-      //
       auto uptime = tables::getUptime();
       uint64_t absoluteTime = mach_absolute_time();
 

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -313,14 +313,14 @@ QueryData genProcesses(QueryContext& context) {
       // Convert the time in CPU ticks since boot to seconds.
       // This is relative to time not-sleeping since boot.
 
-      long uptime = tables::getUptime();
+      auto uptime = tables::getUptime();
       uint64_t absoluteTime = mach_absolute_time();
 
-      double multiply = (double) time_base.numer / (double) time_base.denom;
-      long diff = ((rusage_info_data.ri_proc_start_abstime - absoluteTime));
+      auto multiply = static_cast<double>(time_base.numer) / static_cast<double>(time_base.denom);
+      auto diff = static_cast<long>((rusage_info_data.ri_proc_start_abstime - absoluteTime));
 
       // This is a negative value
-      long seconds_since_launch = (long) ((diff * multiply) / START_TIME_RATIO);
+      auto seconds_since_launch = static_cast<long>((diff * multiply) / START_TIME_RATIO);
 
       // Get the start_time since the computer started
       r["start_time"] = TEXT(uptime + seconds_since_launch);


### PR DESCRIPTION
This hopefully (works for me at least) fixes the issue presented in ticket #3495. Needs to be tested on older OSX builds.