### PR TITLE
linux usb_devices: add the class, subclass and protocol information

### DIFF
--- a/specs/posix/usb_devices.table
+++ b/specs/posix/usb_devices.table
@@ -8,6 +8,9 @@ schema([
     Column("model", TEXT, "USB Device model string"),
     Column("model_id", TEXT, "Hex encoded USB Device model identifier"),
     Column("serial", TEXT, "USB Device serial connection"),
+    Column("class", TEXT, "USB Device class"),
+    Column("subclass", TEXT, "USB Device subclass"),
+    Column("protocol", TEXT, "USB Device protocol"),
     Column("removable", INTEGER, "1 If USB device is removable else 0"),
 ])
 implementation("usb_devices@genUSBDevices")


### PR DESCRIPTION
This enables the `usb_devices` table to show as well the device class, device subclass and protocol as defined [there](http://www.usb.org/developers/defined_class) when the information is available.

## Before
```
osquery> select * from usb_devices;
+-------------+----------+------------------+-----------+--------------+----------+--------------+-----------+
| usb_address | usb_port | vendor           | vendor_id | model        | model_id | serial       | removable |
+-------------+----------+------------------+-----------+--------------+----------+--------------+-----------+
| 1           | 1        | Linux Foundation | 1d6b      | 1.1 root hub | 0001     | 0000:00:01.2 | -1        |
+-------------+----------+------------------+-----------+--------------+----------+--------------+-----------+
```
## After
```
osquery> select * from usb_devices;
+-------------+----------+------------------+-----------+--------------+----------+--------------+-------+----------+----------+-----------+
| usb_address | usb_port | vendor           | vendor_id | model        | model_id | serial       | class | subclass | protocol | removable |
+-------------+----------+------------------+-----------+--------------+----------+--------------+-------+----------+----------+-----------+
| 1           | 1        | Linux Foundation | 1d6b      | 1.1 root hub | 0001     | 0000:00:01.2 | 9     | 0        | 0        | -1        |
+-------------+----------+------------------+-----------+--------------+----------+--------------+-------+----------+----------+-----------+
```