### PR TITLE
tables: Adding list indexing to darwin plist table

### DIFF
--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -245,7 +245,12 @@ void genOSXPlistPrefValue(const pt::ptree& tree,
     if (r["subkey"].size() > 0) {
       r["subkey"] += "/";
     }
-    r["subkey"] += item.first;
+
+    if (item.first.size() == 0) {
+      r["subkey"] += item.second.get("Name", "");
+    } else {
+      r["subkey"] += item.first;
+    }
     genOSXPlistPrefValue(item.second, r, results);
   }
 }

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -231,6 +231,7 @@ QueryData genOSXDefaultPreferences(QueryContext& context) {
 
 void genOSXPlistPrefValue(const pt::ptree& tree,
                           const Row& base,
+                          unsigned int level,
                           QueryData& results) {
   if (tree.empty()) {
     Row r = base;
@@ -244,14 +245,13 @@ void genOSXPlistPrefValue(const pt::ptree& tree,
     Row r = base;
     if (r["subkey"].size() > 0) {
       r["subkey"] += "/";
+      if (item.first.size() == 0) {
+        r["subkey"] += std::to_string(level++);
+      }
     }
 
-    if (item.first.size() == 0) {
-      r["subkey"] += item.second.get("Name", "");
-    } else {
-      r["subkey"] += item.first;
-    }
-    genOSXPlistPrefValue(item.second, r, results);
+    r["subkey"] += item.first;
+    genOSXPlistPrefValue(item.second, r, level, results);
   }
 }
 
@@ -294,7 +294,7 @@ QueryData genOSXPlist(QueryContext& context) {
       r["path"] = path;
       r["key"] = item.first;
       r["subkey"] = "";
-      genOSXPlistPrefValue(item.second, r, results);
+      genOSXPlistPrefValue(item.second, r, 0, results);
     }
   }
 


### PR DESCRIPTION
This addresses #3544

Some plists might have sublists, and it seemed that while we were processing these correctly it may be the case that the plist subitems don't have a label as it's enumerating list values. This makes an attempt to grab the `Name` field if it exists, and use this as the Label for list objects. This is particularly useful in the case of the MobileMeAccounts plist file.