### PR TITLE
Updating shell_history in IR pack to include all users

### DIFF
--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -176,7 +176,7 @@
       "value" : "Scope for lateral movement. Potential exfiltration locations. Potential dormant backdoors."
     },
     "shell_history": {
-      "query" : "select * from shell_history;",
+      "query" : "select * from users join shell_history using (uid);",
       "interval" : "86400",
       "version" : "1.4.5",
       "description" : "Retrieves the command history, per user, by parsing the shell history files.",


### PR DESCRIPTION
The current pack query throws the following error:

```
sudo su - root
Password:
~ root# osqueryi
I0809 12:09:06.350368 2952184640 options.cpp:63] Verbose logging enabled by config option
I0809 12:09:06.413350 2952184640 events.cpp:707] Subscriber expiration is too low: hardware_events
Using a virtual database. Need help, type '.help'
osquery> select * from shell_history;
W0809 12:09:11.895354 2952184640 virtual_table.cpp:516] The shell_history table returns data based on the current user by default, consider JOINing against the users table
W0809 12:09:11.895416 2952184640 virtual_table.cpp:531] Please see the table documentation: https://osquery.io/docs/#shell_history
```

This PR will grab shell_history for all users on the system.

Per conversation in osquery slack: https://osquery.slack.com/archives/C08V7KTJB/p1502300873164900