### PR TITLE
add LVM and parental contexts to block_devices and disk_encryption on Linux

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -67,7 +67,7 @@ if(LINUX)
   set(TABLE_PLATFORM "linux")
 
   ADD_OSQUERY_LINK_ADDITIONAL("libresolv.so")
-  ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup devmapper")
+  ADD_OSQUERY_LINK_ADDITIONAL("cryptsetup devmapper lvm2app lvm-internal daemonclient")
   ADD_OSQUERY_LINK_ADDITIONAL("gcrypt gpg-error")
   ADD_OSQUERY_LINK_ADDITIONAL("blkid")
   ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")

--- a/osquery/tables/system/linux/block_devices.cpp
+++ b/osquery/tables/system/linux/block_devices.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include <blkid/blkid.h>
 #include <libudev.h>
@@ -19,10 +20,52 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+extern "C" {
+#include <lvm2app.h>
+#include <sys/sysmacros.h>
+}
+
 namespace osquery {
 namespace tables {
 
-static void getBlockDevice(struct udev_device *dev, QueryData &results) {
+void populatePVChildren(lvm_t lvm,
+                        const std::string& devname,
+                        const std::string& pvid,
+                        std::map<std::string, std::string>& lvm_lv2pv) {
+  const auto pvid_copy = boost::erase_all_copy(pvid, "-");
+  const char* vg_name = lvm_vgname_from_pvid(lvm, pvid_copy.c_str());
+  if (vg_name == nullptr) {
+    return;
+  }
+
+  vg_t vg = lvm_vg_open(lvm, vg_name, "r", 0);
+  if (vg == nullptr) {
+    return;
+  }
+  struct dm_list* lvs = lvm_vg_list_lvs(vg);
+  if (lvs != nullptr) {
+    lv_list_t* lv = nullptr;
+    dm_list_iterate_items(lv, lvs) {
+      struct lvm_property_value kernel_major = lvm_lv_get_property(
+                                    lv->lv, "lv_kernel_major"),
+                                kernel_minor = lvm_lv_get_property(
+                                    lv->lv, "lv_kernel_minor");
+      const uint64_t major = kernel_major.value.integer,
+                     minor = kernel_minor.value.integer;
+      dev_t devno = makedev(major, minor);
+      char* const child_devname = blkid_devno_to_devname(devno);
+      if (child_devname != nullptr) {
+        lvm_lv2pv[child_devname] = devname;
+      }
+      free(child_devname);
+    }
+  }
+  lvm_vg_close(vg);
+}
+
+static void getBlockDevice(struct udev_device* dev,
+                           QueryData& results,
+                           std::map<std::string, std::string>& lvm_lv2pv) {
   Row r;
   const char *name = udev_device_get_devnode(dev);
   if (name == nullptr) {
@@ -37,6 +80,8 @@ static void getBlockDevice(struct udev_device *dev, QueryData &results) {
       udev_device_get_parent_with_subsystem_devtype(dev, "block", nullptr);
   if (subdev != nullptr) {
     r["parent"] = udev_device_get_devnode(subdev);
+  } else if (lvm_lv2pv.count(name)) {
+    r["parent"] = lvm_lv2pv[name];
   }
 
   const char *size = udev_device_get_sysattr_value(dev, "size");
@@ -80,6 +125,13 @@ static void getBlockDevice(struct udev_device *dev, QueryData &results) {
       if (!blkid_probe_lookup_value(pr, "LABEL", &blk_value, nullptr)) {
         r["label"] = blk_value;
       }
+      if (boost::algorithm::starts_with(r["type"], "LVM")) {
+        lvm_t lvm = lvm_init(nullptr);
+        if (lvm != nullptr) {
+          populatePVChildren(lvm, name, r["uuid"], lvm_lv2pv);
+          lvm_quit(lvm);
+        }
+      }
     }
     blkid_free_probe(pr);
   }
@@ -89,7 +141,7 @@ static void getBlockDevice(struct udev_device *dev, QueryData &results) {
 
 QueryData genBlockDevs(QueryContext &context) {
   if (getuid() || geteuid()) {
-    VLOG(1) << "Not running as root, some column data not available";
+    VLOG(1) << "Not running as root, LVM and other column data not available";
   }
 
   QueryData results;
@@ -103,13 +155,14 @@ QueryData genBlockDevs(QueryContext &context) {
   udev_enumerate_add_match_subsystem(enumerate, "block");
   udev_enumerate_scan_devices(enumerate);
 
+  std::map<std::string, std::string> lvm_lv2pv;
   struct udev_list_entry *devices, *dev_list_entry;
   devices = udev_enumerate_get_list_entry(enumerate);
   udev_list_entry_foreach(dev_list_entry, devices) {
     const char *path = udev_list_entry_get_name(dev_list_entry);
     struct udev_device *dev = udev_device_new_from_syspath(udev, path);
     if (path != nullptr && dev != nullptr) {
-      getBlockDevice(dev, results);
+      getBlockDevice(dev, results, lvm_lv2pv);
     }
     udev_device_unref(dev);
   }

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -29,7 +29,7 @@ void genFDEStatusForBlockDevice(const std::string &name,
   r["name"] = name;
   r["uuid"] = uuid;
 
-  struct crypt_device *cd = nullptr;
+  struct crypt_device* cd = nullptr;
   struct crypt_active_device cad;
   crypt_status_info ci;
   std::string type;
@@ -52,14 +52,12 @@ void genFDEStatusForBlockDevice(const std::string &name,
 
     if (crypt_init < 0) {
       VLOG(1) << "Unable to initialize crypt device for " << name;
-      crypt_free(cd);
       break;
     }
 
     type = crypt_get_type(cd);
     if (crypt_get_active_device(cd, name.c_str(), &cad) < 0) {
       VLOG(1) << "Unable to get active device for " << name;
-      crypt_free(cd);
       break;
     }
     cipher = crypt_get_cipher(cd);
@@ -72,6 +70,9 @@ void genFDEStatusForBlockDevice(const std::string &name,
     r["encrypted"] = "0";
   }
 
+  if (cd != nullptr) {
+    crypt_free(cd);
+  }
   results.push_back(r);
 }
 


### PR DESCRIPTION
Filling in the parent field in the `block_devices` table with the containing LVM physical volume allows `disk_encryption` rows to inherit encryption status from parents.

My lsblk + device map:

```
$ lsblk
NAME                     MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
nvme0n1                  259:0    0   477G  0 disk  
├─nvme0n1p3              259:3    0   476G  0 part  
│ └─nvme0n1p3_crypt      253:0    0   476G  0 crypt 
│   ├─xubuntu--vg-root   253:1    0 456.2G  0 lvm   /
│   └─xubuntu--vg-swap_1 253:2    0  19.8G  0 lvm   [SWAP]
[snip]

$ ls -l /dev/mapper/
total 0
crw------- 1 root root 10, 236 Aug 10 09:08 control
lrwxrwxrwx 1 root root       7 Aug 10 09:08 nvme0n1p3_crypt -> ../dm-0
lrwxrwxrwx 1 root root       7 Aug 10 09:08 xubuntu--vg-root -> ../dm-1
lrwxrwxrwx 1 root root       7 Aug 10 09:08 xubuntu--vg-swap_1 -> ../dm-2
```

before:

```
# osqueryi "select name, encrypted, type from disk_encryption where name not like '%loop%'"
+----------------+-----------+-----------------------+
| name           | encrypted | type                  |
+----------------+-----------+-----------------------+
| /dev/sdb       | 0         |                       |
| /dev/sda       | 0         |                       |
| /dev/nvme0n1   | 0         |                       |
| /dev/nvme0n1p1 | 0         |                       |
| /dev/nvme0n1p2 | 0         |                       |
| /dev/nvme0n1p3 | 0         |                       |
| /dev/dm-0      | 1         | LUKS1-aes-xts-plain64 |
| /dev/dm-1      | 0         |                       |
| /dev/dm-2      | 0         |                       |
+----------------+-----------+-----------------------+

```
after:

```
# ./build/xenial/osquery/osqueryi "select name, encrypted, type from disk_encryption where name not like '%loop%'"
  WARNING: Failed to connect to lvmetad. Falling back to device scanning.
+----------------+-----------+-----------------------+
| name           | encrypted | type                  |
+----------------+-----------+-----------------------+
| /dev/sdb       | 0         |                       |
| /dev/sda       | 0         |                       |
| /dev/nvme0n1   | 0         |                       |
| /dev/nvme0n1p1 | 0         |                       |
| /dev/nvme0n1p2 | 0         |                       |
| /dev/nvme0n1p3 | 0         |                       |
| /dev/dm-0      | 1         | LUKS1-aes-xts-plain64 |
| /dev/dm-1      | 1         | LUKS1-aes-xts-plain64 |
| /dev/dm-2      | 1         | LUKS1-aes-xts-plain64 |
+----------------+-----------+-----------------------+
```

As a side benefit, the changes to `disk_encryption` should also work for logical partitions that are inside of extended partitions.