### PR TITLE
Fix an sqlite3 memory leak in quicklook_cache

### DIFF
--- a/osquery/tables/system/darwin/quicklook_cache.cpp
+++ b/osquery/tables/system/darwin/quicklook_cache.cpp
@@ -108,7 +108,7 @@ QueryData genQuicklookCache(QueryContext& context) {
       VLOG(1) << "Cannot open " << index << " read only: "
               << rc << " " << getStringForSQLiteReturnCode(rc);
       if (db != nullptr) {
-        free(db);
+        sqlite3_close(db);
       }
       continue;
     }
@@ -132,7 +132,7 @@ QueryData genQuicklookCache(QueryContext& context) {
 
     // Clean up.
     sqlite3_finalize(stmt);
-    free(db);
+    sqlite3_close(db);
   }
 
   return results;


### PR DESCRIPTION
Fixes a small memory leak in quicklook_cache. The SQLite database was being freed, but not closed causing some allocated resources to go out of scope.

Before:
```
Analyzing leaks in query: select * from quicklook_cache
  definitely:  63 leaks for 5984 total leaked bytes.
```
After:
```
Analyzing leaks in query: select * from quicklook_cache
  definitely: 0 leaks for 0 total leaked bytes.
```