### PR TITLE
Fix memory leak in FreeBSD pkg_packages

### DIFF
--- a/osquery/tables/system/freebsd/pkg_packages.cpp
+++ b/osquery/tables/system/freebsd/pkg_packages.cpp
@@ -58,7 +58,7 @@ QueryData genPkgPackages(QueryContext& context) {
     VLOG(1) << "Cannot open pkgdb: " << rc << " "
             << getStringForSQLiteReturnCode(rc);
     if (db != nullptr) {
-      free(db);
+      sqlite3_close(db);
     }
   }
 
@@ -75,7 +75,7 @@ QueryData genPkgPackages(QueryContext& context) {
 
   // Clean up.
   sqlite3_finalize(stmt);
-  free(db);
+  sqlite3_close(db);
 
   return results;
 }


### PR DESCRIPTION
This should fix #3440. The SQLite database was being freed, but not closed causing some allocated resources to go out of scope.