### PR TITLE
deps: Fix Linux build-world and link math for cryptsetup

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -20,7 +20,7 @@ LINUXBREW_REPO="https://github.com/Linuxbrew/brew"
 # Set the SHA1 commit hashes for the pinned homebrew Taps.
 # Pinning allows determinism for bottle availability, expect to update often.
 HOMEBREW_CORE="941ca36839ea354031846d73ad538e1e44e673f4"
-LINUXBREW_CORE="abc5c5782c5850f2deff1f3d463945f90f2feaac"
+LINUXBREW_CORE="f54281a496bb7d3dd2f46b2f3067193d05f5013b"
 HOMEBREW_BREW="ac2cbd2137006ebfe84d8584ccdcb5d78c1130d9"
 LINUXBREW_BREW="20bcce2c176469cec271b46d523eef1510217436"
 

--- a/tools/provision/formula/libcryptsetup.rb
+++ b/tools/provision/formula/libcryptsetup.rb
@@ -4,7 +4,7 @@ class Libcryptsetup < AbstractOsqueryFormula
   desc "Open source disk encryption libraries"
   homepage "https://gitlab.com/cryptsetup/cryptsetup"
   url "https://osquery-packages.s3.amazonaws.com/deps/cryptsetup-1.6.7.tar.gz"
-  revision 101
+  revision 102
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -13,6 +13,8 @@ class Libcryptsetup < AbstractOsqueryFormula
   end
 
   def install
+    ENV.append "LDFLAGS", "-lm"
+
     args = [
       "--disable-selinux",
       "--disable-udev",


### PR DESCRIPTION
This revers the `homebrew-core` tap back to `binutils` version 2.28, see #3533.

It also links `-lm` for `libcryptsetup`. It seems this is needed with the recent changes to devmapper.