### PR TITLE
sanitizers: Skip several tests that fail custom alloc checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ elseif(WINDOWS)
   add_definitions(-DBOOST_ALL_NO_LIB)
 endif()
 
+set(TEST_ARGS "")
 if(LINUX AND CMAKE_CXX_COMPILER MATCHES "clang")
   # Use the LLVM versions of ar and ranlib to support LTO builds
   find_program(LLVMRANLIB_EXECUTABLE "llvm-ranlib" ENV PATH)
@@ -221,6 +222,19 @@ elseif(DEFINED ENV{SANITIZE})
       # LSAN is not available on OS X 10.12.
       add_compile_options(-fsanitize=leak)
     endif()
+  endif()
+
+  if(LINUX)
+    # Tests that fail TSAN Checks.
+    set(SANITIZE_SKIP_TEST
+      ProcessTests.test_launchExtension
+      BufferedLogForwarderTests.test_index
+      CarverTests.test_carve_files_locally
+      FileEventsTableTests.*
+      YARATest.*
+    )
+    string(REPLACE ";" ":" TEST_ARGS "${SANITIZE_SKIP_TEST}")
+    set(TEST_ARGS "--gtest_filter=-${TEST_ARGS}")
   endif()
 else()
   set(DEBUG FALSE)

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -358,7 +358,7 @@ if(NOT SKIP_TESTS)
   ADD_DEFAULT_LINKS(osquery_tests FALSE)
   target_link_libraries(osquery_tests gtest gmock libosquery_testing)
   SET_OSQUERY_COMPILE(osquery_tests "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")
-  add_test(osquery_tests osquery_tests)
+  add_test(osquery_tests osquery_tests ${TEST_ARGS})
 
   # osquery kernel tests.
   if(NOT ${OSQUERY_BUILD_SDK_ONLY} AND NOT WINDOWS)
@@ -397,14 +397,14 @@ if(NOT SKIP_TESTS)
     ADD_DEFAULT_LINKS(osquery_additional_tests TRUE)
     target_link_libraries(osquery_additional_tests gtest gmock libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_additional_tests "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")
-    add_test(osquery_additional_tests osquery_additional_tests)
+    add_test(osquery_additional_tests osquery_additional_tests ${TEST_ARGS})
 
     # osquery tables set of unit tests (extracted for organization).
     add_executable(osquery_tables_tests main/tests.cpp ${OSQUERY_TABLES_TESTS})
     ADD_DEFAULT_LINKS(osquery_tables_tests TRUE)
     target_link_libraries(osquery_tables_tests gtest gmock libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_tables_tests "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")
-    add_test(osquery_tables_tests osquery_tables_tests)
+    add_test(osquery_tables_tests osquery_tables_tests ${TEST_ARGS})
   endif()
 
   # Build the example extension with the SDK.

--- a/tools/tests/CMakeLists.txt
+++ b/tools/tests/CMakeLists.txt
@@ -1,10 +1,26 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
 # List of python modules containing unittests
-ADD_OSQUERY_PYTHON_TEST(test_osqueryi test_osqueryi.py)
+if(NOT DEFINED ENV{SANITIZE})
+  # Linenoise's input buffer fails TSAN checks.
+  ADD_OSQUERY_PYTHON_TEST(test_osqueryi test_osqueryi.py)
+endif()
+
 ADD_OSQUERY_PYTHON_TEST(test_osqueryd test_osqueryd.py)
 if(NOT WINDOWS)
-  ADD_OSQUERY_PYTHON_TEST(test_extensions test_extensions.py)
   ADD_OSQUERY_PYTHON_TEST(test_additional test_additional.py)
-  ADD_OSQUERY_PYTHON_TEST(test_example_queries test_example_queries.py)
+
+  if(NOT DEFINED ENV{SANITIZE})
+    # Too many FATAL's: failed to intercept strlen
+    ADD_OSQUERY_PYTHON_TEST(test_extensions test_extensions.py)
+    # The 'magic' table fails TSAN checks.
+    ADD_OSQUERY_PYTHON_TEST(test_example_queries test_example_queries.py)
+  endif()
 endif()
 
 # If the build hosts are building release packages


### PR DESCRIPTION
This PR makes me cry a little but IMO it is a good compensation for valuable sanitizer warning that are eaten by difficult-to-fix custom allocator problems. My suspicion is that static linking 20+ MB of content causes systemic issues. I've at least not been able to track down why random alignment problems occur with sanitizer tests.

