### PR TITLE
aws: Fix TSAN warning in request exception

### DIFF
--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -185,7 +185,8 @@ std::shared_ptr<Aws::Http::HttpResponse> NetlibHttpClient::MakeRequest(
 
     response->GetResponseBody() << resp.body();
 
-  } catch (const std::exception& e) {
+  } catch (std::exception e) {
+    /* NOTE: This exception must NOT be passed by reference. */
     LOG(ERROR) << "Exception making HTTP request to URL (" << url
                << "): " << e.what();
     return nullptr;


### PR DESCRIPTION
This fixes a TSAN warning (see: #3555) with `cpp-netlib` and `aws-sdk-cpp`.

We had fixes this once before, but also had removed valuable debug information. We choose to re-enable but forgot to test if copying the exception would be thread-safe: #3456.