### PR TITLE
build: Set PATH_SET in the make defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ DEFINES := CTEST_OUTPUT_ON_FAILURE=1 \
 	LSAN_OPTIONS="detect_container_overflow=0 \
 	suppressions=${ANALYSIS}/lsan.supp" \
 	ASAN_OPTIONS="suppressions=${ANALYSIS}/asan.supp" \
-	TSAN_OPTIONS="suppressions=${ANALYSIS}/tsan.supp,second_deadlock_stack=1"
+	TSAN_OPTIONS="suppressions=${ANALYSIS}/tsan.supp,second_deadlock_stack=1" \
+	$(PATH_SET)
 
 
 .setup:


### PR DESCRIPTION
The `PATH_SET` variable should be included in the `make` `DEFINES` as that list of environment variables is passed to whatever is called after `cmake`.