### PR TITLE
fix memory leak in Linux disk_encryption

### DIFF
--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -29,7 +29,7 @@ void genFDEStatusForBlockDevice(const std::string &name,
   r["name"] = name;
   r["uuid"] = uuid;
 
-  struct crypt_device *cd = nullptr;
+  struct crypt_device* cd = nullptr;
   struct crypt_active_device cad;
   crypt_status_info ci;
   std::string type;
@@ -52,14 +52,12 @@ void genFDEStatusForBlockDevice(const std::string &name,
 
     if (crypt_init < 0) {
       VLOG(1) << "Unable to initialize crypt device for " << name;
-      crypt_free(cd);
       break;
     }
 
     type = crypt_get_type(cd);
     if (crypt_get_active_device(cd, name.c_str(), &cad) < 0) {
       VLOG(1) << "Unable to get active device for " << name;
-      crypt_free(cd);
       break;
     }
     cipher = crypt_get_cipher(cd);
@@ -72,6 +70,9 @@ void genFDEStatusForBlockDevice(const std::string &name,
     r["encrypted"] = "0";
   }
 
+  if (cd != nullptr) {
+    crypt_free(cd);
+  }
   results.push_back(r);
 }
 


### PR DESCRIPTION
Before:
```
$ sudo ./tools/analysis/profile.py --leaks --restrict disk_encryption
Analyzing leaks in query: SELECT * FROM disk_encryption;
  possibly: 0 bytes in 0 blocks; definitely:  1,656 bytes in 1 blocks ; indirectly:  45 bytes in 3 blocks 
```

After:

```
$ sudo ./tools/analysis/profile.py --leaks --restrict disk_encryption
Analyzing leaks in query: SELECT * FROM disk_encryption;
  possibly: 0 bytes in 0 blocks; definitely: 0 bytes in 0 blocks; indirectly: 0 bytes in 0 blocks
```