### PR TITLE
dependencies: Adding build script for llvm-clang package for windows

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -284,13 +284,13 @@ function Install-ThirdParty {
     "aws-sdk-cpp.1.0.107-r1",
     "boost-msvc14.1.63.0-r2",
     "bzip2.1.0.6",
-    "clang-format.3.9.0",
     "cpp-netlib.0.12.0-r4",
     "doxygen.1.8.11",
     "gflags-dev.2.2.0-r1",
     "glog.0.3.4-r1",
     "libarchive.3.3.1-r1",
     "linenoise-ng.1.0.0-r1",
+    "llvm-clang.4.0.1",
     "openssl.1.0.2-k",
     "rocksdb.5.1.4-r1",
     "snappy-msvc.1.1.1.8",
@@ -308,11 +308,6 @@ function Install-ThirdParty {
       $packageData = $package -split '\.'
       $packageName = $packageData[0]
       $packageVersion = [string]::Join('.', $packageData[1..$packageData.length])
-
-      if (($packageName -eq "clang-format") -and (Test-Path env:OSQUERY_BUILD_HOST)) {
-        Write-Host "[*] Skipping $packageName $packageVersion on build hosts." -foregroundcolor Green
-        continue
-      }
 
       Write-Host " => Determining whether $packageName is already installed..." -foregroundcolor DarkYellow
       $isInstalled = Test-ChocoPackageInstalled $packageName $packageVersion

--- a/tools/provision/chocolatey/llvm-clang.ps1
+++ b/tools/provision/chocolatey/llvm-clang.ps1
@@ -1,0 +1,102 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+# Update-able metadata
+#
+# $version - The version of the software package to build
+# $chocoVersion - The chocolatey package version, used for incremental bumps
+#                 without changing the version of the software package
+$version = '4.0.1'
+$chocoVersion = '4.0.1'
+$packageName = 'llvm-clang'
+$projectSource = 'http://llvm.org/git/llvm.git'
+$packageSourceUrl = 'http://llvm.org/git/llvm.git'
+$packageDigest = '139BA95F9F88199CDC419A674F0A85DF3568367623486336843207A4982E36E9'
+$authors = 'llvm'
+$owners = 'llvm'
+$copyright = 'Copyright (c) 2003-2017 University of Illinois at Urbana-Champaign.'
+$license = "https://releases.llvm.org/$version/LICENSE.TXT"
+$url = "http://releases.llvm.org/$version/LLVM-$version-win64.exe"
+$parentPath = $(Split-Path -Parent $MyInvocation.MyCommand.Definition)
+
+$workingDir = Get-Location
+
+# Invoke our utilities file
+. $(Join-Path $parentPath "osquery_utils.ps1")
+
+# Invoke the MSVC developer tools/env
+Invoke-BatchFile "$env:VS140COMNTOOLS\..\..\vc\vcvarsall.bat" amd64
+
+# Time our execution
+$sw = [System.Diagnostics.StopWatch]::startnew()
+
+# Keep the location of build script, to bring with in the chocolatey package
+$buildScript = $MyInvocation.MyCommand.Definition
+
+# Create the choco build dir if needed
+$buildPath = Get-OsqueryBuildPath
+if ($buildPath -eq '') {
+  Write-Host '[-] Failed to find source root' -foregroundcolor red
+  exit
+}
+$chocoBuildPath = "$buildPath\chocolatey\$packageName"
+if (-not (Test-Path "$chocoBuildPath")) {
+  New-Item -Force -ItemType Directory -Path "$chocoBuildPath"
+}
+Set-Location $chocoBuildPath
+
+# Retreive the source
+if (-not (Test-Path "$packageName-$version.exe")) {
+  Invoke-WebRequest $url -OutFile "$packageName-$version.exe"
+  if ($(Get-FileHash -Algorithm sha256 "$packageName-$version.exe").Hash -ne `
+        $packageDigest) {
+    Write-Host '[-] Download of package failed! Check connection.' `
+               -foregroundcolor Red
+  }
+}
+
+# Extract the source
+$sourceDir = Join-Path $(Get-Location) "llvm-$version"
+if (-not (Test-Path $sourceDir)) {
+  $7z = (Get-Command '7z').Source
+  $7zargs = @(
+      'x',
+      "-ollvm-$version\local",
+      "$packageName-$version.exe"
+    )
+  Start-OsqueryProcess $7z $7zargs
+}
+Set-Location $sourceDir
+
+# Bundle the package into a chocolatey package
+Write-NuSpec `
+  $packageName `
+  $chocoVersion `
+  $authors `
+  $owners `
+  $projectSource `
+  $packageSourceUrl `
+  $copyright `
+  $license
+Copy-Item $buildScript $srcDir
+choco pack
+
+Write-Host "[*] Build took $($sw.ElapsedMilliseconds) ms" `
+  -ForegroundColor DarkGreen
+if (Test-Path "$packageName.$chocoVersion.nupkg") {
+  Write-Host `
+    "[+] Finished building $packageName v$chocoVersion." `
+    -ForegroundColor Green
+}
+else {
+  Write-Host `
+    "[-] Failed to build $packageName v$chocoVersion." `
+    -ForegroundColor Red
+}
+
+# Restore our working directory
+Set-Location $workingDir


### PR DESCRIPTION
This brings the clang compiler and utility binaries to Windows. Initially this will just be for leveraging the `clang-format` binary, however we'll make use of this soon to perform osquery builds using clang.

This should also address #3561