### PR TITLE
deploy: adding sanity checks to deployment powershell scripts

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
@@ -7,16 +7,26 @@
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
 $serviceName = 'osqueryd'
-$progData =  [System.Environment]::GetEnvironmentVariable('ProgramData')
+$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
 $targetFolder = Join-Path $progData "osquery"
 $daemonFolder = Join-Path $targetFolder $serviceName
+$extensionsFolder = Join-Path $targetFolder 'extensions'
 
-# Before modifying we ensure to stop the service, if it exists
-if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and (Get-Service $serviceName).Status -eq 'Running') {
+# Ensure the service is stopped and processes are not running if exists.
+if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
+  (Get-Service $serviceName).Status -eq 'Running') {
   Stop-Service $serviceName
+  # If we find zombie processes, ensure they're termintated
+  $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
+  if ($proc -ne $null) {
+    Stop-Process -Force $proc -ErrorAction SilentlyContinue
+  }
 }
 
 # Lastly, ensure that the Deny Write ACLs have been removed before modifying
 if (Test-Path $daemonFolder) {
   Set-DenyWriteAcl $daemonFolder 'Remove'
+}
+if (Test-Path $extensionsFolder) {
+  Set-DenyWriteAcl $extensionsFolder 'Remove'
 }

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -8,23 +8,33 @@
 
 $serviceName = 'osqueryd'
 $serviceDescription = 'osquery daemon service'
-$progData =  [System.Environment]::GetEnvironmentVariable('ProgramData')
+$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
 $targetFolder = Join-Path $progData 'osquery'
 $daemonFolder = Join-Path $targetFolder 'osqueryd'
+$extensionsFolder = Join-Path $targetFolder 'extensions'
 $logFolder = Join-Path $targetFolder 'log'
 $targetDaemonBin = Join-Path $targetFolder 'osqueryd.exe'
 $destDaemonBin = Join-Path $daemonFolder 'osqueryd.exe'
 $packageParameters = $env:chocolateyPackageParameters
 $arguments = @{}
 
-# Before modifying we ensure to stop the service, if it exists
-if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and (Get-Service $serviceName).Status -eq 'Running') {
+# Ensure the service is stopped and processes are not running if exists.
+if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
+  (Get-Service $serviceName).Status -eq 'Running') {
   Stop-Service $serviceName
+  # If we find zombie processes, ensure they're termintated
+  $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
+  if ($proc -ne $null) {
+    Stop-Process -Force $proc -ErrorAction SilentlyContinue
+  }
 }
 
 # Lastly, ensure that the Deny Write ACLs have been removed before modifying
 if (Test-Path $daemonFolder) {
   Set-DenyWriteAcl $daemonFolder 'Remove'
+}
+if (Test-Path $extensionsFolder) {
+  Set-DenyWriteAcl $extensionsFolder 'Remove'
 }
 
 # Now parse the packageParameters using good old regular expression

--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -4,7 +4,7 @@
 #  This source code is licensed under the BSD-style license found in the
 #  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
-$progData =  [System.Environment]::GetEnvironmentVariable('ProgramData')
+$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
 $targetFolder = Join-Path $progData "osquery"
 $serviceName = 'osqueryd'
 
@@ -12,12 +12,19 @@ $serviceName = 'osqueryd'
 # we don't make use of our local vars, as Regex requires escaping the '\'
 $oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
 if ($oldPath -imatch [regex]::escape($targetFolder)) {
-  $newPath = $oldPath -replace [regex]::escape($targetFolder),$NULL
+  $newPath = $oldPath -replace [regex]::escape($targetFolder), $NULL
   [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
 }
 
 if ((Get-Service $serviceName -ErrorAction SilentlyContinue)) {
   Stop-Service $serviceName
+  
+  # If we find zombie processes, ensure they're termintated
+  $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
+  if ($proc -ne $null) {
+    Stop-Process -Force $proc -ErrorAction SilentlyContinue
+  }
+
   Set-Service $serviceName -startuptype 'manual'
   Get-CimInstance -ClassName Win32_Service -Filter "Name='osqueryd'" | Invoke-CimMethod -methodName Delete
 }


### PR DESCRIPTION
This updates the Powershell chocolatey deployment scripts to ensure the environment is sane before attempting an install, which should result in more robust installations and uninstallation on Windows systems.