### PR TITLE
deps: Add doxygen and valgrind and remove realpath requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ endif
 ifeq ($(DEBUG_SHARED_DIR),0)
 	DEBUG_DIR = $(shell ln -sf $(shell mktemp -d) build/debug_shared)
 endif
-	BUILD_DIR = $(shell realpath build/$(BUILD_NAME))$(DIR)
-	DEBUG_BUILD_DIR = $(shell realpath build/debug_$(BUILD_NAME))$(DEBUG_DIR)
+	BUILD_DIR = $(shell readlink --canonicalize build/$(BUILD_NAME))$(DIR)
+	DEBUG_BUILD_DIR = $(shell readlink --canonicalize build/debug_$(BUILD_NAME))$(DEBUG_DIR)
 ifneq (build/$(BUILD_NAME),$(BUILD_DIR))
 	LINK = " \-\> $(BUILD_DIR), $(DEBUG_BUILD_DIR)"
 endif

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -214,7 +214,7 @@ Vagrant.configure("2") do |config|
       if name.start_with?('ubuntu', 'debian')
         build.vm.provision 'bootstrap', type: 'shell' do |s|
           s.inline = 'sudo apt-get update;'\
-                     'sudo apt-get install --yes git realpath;'
+                     'sudo apt-get install --yes git;'
         end
       end
     end

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -127,7 +127,7 @@ function main() {
   platform OS
   distro $OS DISTRO
 
-  OUTPUT_PKG_PATH=`realpath "$BUILD_DIR"`/$PACKAGE_NAME$(get_pkg_suffix)
+  OUTPUT_PKG_PATH=`readlink --canonicalize "$BUILD_DIR"`/$PACKAGE_NAME$(get_pkg_suffix)
 
   rm -rf $WORKING_DIR
   rm -f $OUTPUT_PKG_PATH
@@ -281,7 +281,7 @@ function main() {
   fi
 
   PACKAGE_DEBUG_DEPENDENCIES=`echo "$PACKAGE_DEBUG_DEPENDENCIES"|tr '-' '_'`
-  OUTPUT_DEBUG_PKG_PATH=`realpath "$BUILD_DIR"`/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)
+  OUTPUT_DEBUG_PKG_PATH=`readlink --canonicalize "$BUILD_DIR"`/$PACKAGE_DEBUG_NAME$(get_pkg_suffix)
   if [[ "$BUILD_DEBUG_PKG" = "true" ]]; then
     rm -f $OUTPUT_DEBUG_PKG_PATH
     CMD="$FPM -s dir -t $PACKAGE_TYPE            \

--- a/tools/provision/amazon.sh
+++ b/tools/provision/amazon.sh
@@ -23,6 +23,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -19,4 +19,6 @@ function distro_main() {
   package bzip2
   package bison
   package flex
+  package doxygen
+  package valgrind
 }

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -23,6 +23,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -19,4 +19,6 @@ function distro_main() {
   package curl
   package bison
   package flex
+  package doxygen
+  package valgrind
 }

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -22,6 +22,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -44,4 +44,8 @@ function distro_main() {
   package yara
   package aws-sdk-cpp
   package lldpd
+
+  # For testing
+  package doxygen
+  package valgrind
 }

--- a/tools/provision/manjaro.sh
+++ b/tools/provision/manjaro.sh
@@ -19,4 +19,6 @@ function distro_main() {
   package bzip2
   package bison
   package flex
+  package doxygen
+  package valgrind
 }

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -22,6 +22,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -23,6 +23,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -22,6 +22,8 @@ function distro_main() {
   package gettext-devel
   package bison
   package flex
+  package doxygen
+  package valgrind
 
   package rpm-devel
   package rpm-build

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -21,8 +21,9 @@ function distro_main() {
   package bison
   package flex
   package bsdtar
-  package doxygen
   package realpath
+  package doxygen
+  package valgrind
 
   GEM=`which gem`
   do_sudo $GEM install fpm 


### PR DESCRIPTION
1. `realpath` is not needed when we can use `readlink --canonicalize`. This is more widely supported and allows use to use Vagrant out of the box on older RHEL and CentOS machines (if you're still custom-building on those).
2. The `make sysprep` command should install `doxygen` and `valgrind` for documentation generation and memory `--leaks` analysis.