### PR TITLE
leaks: Return 1 if profile detects any leaks in tables

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -122,7 +122,7 @@ def profile_leaks(shell, queries, count=1, rounds=1, supp_file=None):
                 if key == "indirectly":
                     output = utils.yellow(output)
                     report[name] = "WARNING"
-            else:
+            elif name not in report.keys():
                 report[name] = "SAFE"
             display.append("%s: %s" % (key, output))
         print("  %s" % "; ".join(display))
@@ -343,7 +343,8 @@ if __name__ == "__main__":
         # Search queries in subdirectory ".d" based on the config filename
         if os.path.isdir(args.config + ".d"):
             for config_file in os.listdir(args.config + ".d"):
-                queries.update(utils.queries_from_config(os.path.join(args.config + ".d", config_file)))
+                queries.update(utils.queries_from_config(os.path.join(
+                    args.config + ".d", config_file)))
     elif args.query is not None:
         queries["manual"] = args.query
     elif args.force:
@@ -375,3 +376,9 @@ if __name__ == "__main__":
             else:
                 fh.write(json.dumps(summary(results), indent=1))
         print("Wrote output summary: %s" % args.output)
+
+    if args.leaks:
+        for name in results.keys():
+            if results[name] != "SAFE":
+                sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
The `./tools/analysis/profile.py` can use `--leaks` to auto-find an `osqueryi` shell from the build directory and begin running each table: `select * from TABLE`. If any leaks are detected it will complete the execution and return 1, otherwise 0.