### PR TITLE
sql: Handle potential LIKE and GLOB optimizations by increasing comparisons

### DIFF
--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -320,6 +320,16 @@ int xColumn(sqlite3_vtab_cursor* cur, sqlite3_context* ctx, int col) {
   return SQLITE_OK;
 }
 
+static inline bool sensibleComparison(ColumnType type, unsigned char op) {
+  if (type == TEXT_TYPE) {
+    if (op == GREATER_THAN || op == GREATER_THAN_OR_EQUALS || op == LESS_THAN ||
+        op == LESS_THAN_OR_EQUALS) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
   auto* pVtab = (VirtualTable*)tab;
   const auto& columns = pVtab->content->columns;
@@ -364,6 +374,11 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
         continue;
       }
       const auto& name = std::get<0>(columns[constraint_info.iColumn]);
+      const auto& type = std::get<1>(columns[constraint_info.iColumn]);
+      if (!sensibleComparison(type, constraint_info.op)) {
+        cost += 10;
+        continue;
+      }
 
       // Check if this constraint is on an index or required column.
       const auto& options = std::get<2>(columns[constraint_info.iColumn]);


### PR DESCRIPTION
This prevents LIKE and GLOB from being optimized into `> /EXPRESSION` and `<= /expression0`.

See #3579.