### PR TITLE
carver: adding dynamic block retry

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -278,7 +278,7 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   auto contRequest = Request<TLSTransport, JSONSerializer>(contUri_);
 
   std::set<std::pair<unsigned int, unsigned int>> carveBlocks;
-  for (auto i = 0; i < blkCount; i++) {
+  for (unsigned int i = 0; i < blkCount; i++) {
     // Map the carve data as (Block ID, Number of POST attempts)
     carveBlocks.insert(std::make_pair(i, 0));
   }

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -56,6 +56,12 @@ CLI_FLAG(uint32,
          8192,
          "Size of blocks used for POSTing data back to remote endpoints");
 
+/// Size of blocks used for POSTing data back to remote endpoints
+CLI_FLAG(uint32,
+         carver_max_block_retries,
+         3,
+         "Maximum number of times to attempt POSTing a block before giving up");
+
 CLI_FLAG(bool,
          disable_carver,
          true,
@@ -270,31 +276,50 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   }
 
   auto contRequest = Request<TLSTransport, JSONSerializer>(contUri_);
-  for (size_t i = 0; i < blkCount; i++) {
-    std::vector<char> block(FLAGS_carver_block_size, 0);
-    auto r = pFile.read(block.data(), FLAGS_carver_block_size);
 
-    if (r != FLAGS_carver_block_size && r > 0) {
-      // resize the buffer to size we read as last block is likely smaller
-      block.resize(r);
-    }
-
-    pt::ptree params;
-    params.put<size_t>("block_id", i);
-    params.put<std::string>("session_id", session_id);
-    params.put<std::string>("request_id", requestId_);
-    params.put<std::string>(
-        "data", base64Encode(std::string(block.begin(), block.end())));
-
-    // TODO: Error sending files.
-    status = contRequest.call(params);
-    if (!status.ok()) {
-      VLOG(1) << "Post of carved block " << i
-              << " failed: " << status.getMessage();
-      continue;
-    }
+  std::set<std::pair<unsigned int, unsigned int>> carveBlocks;
+  for (auto i = 0; i < blkCount; i++) {
+    // Map the carve data as (Block ID, Number of POST attempts)
+    carveBlocks.insert(std::make_pair(i, 0));
   }
 
+  while (!carveBlocks.empty()) {
+    for (auto cit = carveBlocks.begin(); cit != carveBlocks.end();) {
+      std::vector<char> block(FLAGS_carver_block_size, 0);
+      pFile.seek(cit->first * FLAGS_carver_block_size, PF_SEEK_BEGIN);
+      auto r = pFile.read(block.data(), FLAGS_carver_block_size);
+      if (r != FLAGS_carver_block_size && r > 0) {
+        // resize the buffer to size we read as last block is likely smaller
+        block.resize(r);
+      }
+      pt::ptree params;
+      params.put<size_t>("block_id", cit->first);
+      params.put<std::string>("session_id", session_id);
+      params.put<std::string>("request_id", requestId_);
+      params.put<std::string>(
+          "data", base64Encode(std::string(block.begin(), block.end())));
+
+      status = contRequest.call(params);
+      if (!status.ok()) {
+        // If the POST fails back off and retry later
+        const_cast<std::pair<unsigned int, unsigned int>&>(*cit).second++;
+        if (cit->second >= FLAGS_carver_max_block_retries) {
+          // The POST failed and exceeded our retry threshold
+          updateCarveValue(carveGuid_, "status", "FAILED");
+          return Status(1,
+                        "POST of block " + std::to_string(cit->first) +
+                            " failed " + std::to_string(cit->first) +
+                            " times with error: " + status.getMessage());
+        }
+        // Back off of POSTing and retry later.
+        pauseMilli(100 * cit->second + 1);
+        ++cit;
+      } else {
+        // The POST succeeded, remove the block from our list
+        cit = carveBlocks.erase(cit);
+      }
+    }
+  }
   updateCarveValue(carveGuid_, "status", "SUCCESS");
   return Status(0, "Ok");
 };

--- a/osquery/carver/carver.h
+++ b/osquery/carver/carver.h
@@ -142,6 +142,9 @@ class Carver : public InternalRunnable {
  private:
   friend class CarverTests;
   FRIEND_TEST(CarverTests, test_carve_files_locally);
+  FRIEND_TEST(CarverTests, test_compression);
+  FRIEND_TEST(CarverTests, test_decompression);
+  FRIEND_TEST(CarverTests, test_full_carve);
 };
 
 /**

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -130,4 +130,4 @@ Status Query::addNewResults(const QueryData& current_qd,
   }
   return Status(0, "OK");
 }
-}
+} // namespace osquery

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -130,4 +130,4 @@ TEST_F(QueryTests, test_get_stored_query_names) {
   auto in_vector = std::find(names.begin(), names.end(), "foobar");
   EXPECT_NE(in_vector, names.end());
 }
-}
+} // namespace osquery

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -20,6 +20,7 @@ import random
 import ssl
 import string
 import sys
+import tempfile
 import thread
 import threading
 
@@ -99,7 +100,7 @@ ENROLL_RESPONSE = {
 }
 
 RECEIVED_REQUESTS = []
-FILE_CARVE_DIR = '/tmp/'
+FILE_CARVE_DIR = tempfile.gettempdir()
 FILE_CARVE_MAP = {}
 
 def debug(response):
@@ -135,7 +136,7 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
         self._set_headers()
         content_len = int(self.headers.getheader('content-length', 0))
         request = json.loads(self.rfile.read(content_len))
-        
+
         # This contains a base64 encoded block of a file printing to the screen
         # slows down carving and makes scroll back a pain
         if (self.path != "/carve_block"):
@@ -247,7 +248,7 @@ class RealSimpleHandler(BaseHTTPRequestHandler):
         # Do we still need more blocks
         if len(FILE_CARVE_MAP[request['session_id']]['blocks_received']) < FILE_CARVE_MAP[request['session_id']]['block_count']:
             return
-        out_file_name = FILE_CARVE_DIR+FILE_CARVE_MAP[request['session_id']]['carve_guid']
+        out_file_name = os.path.join(FILE_CARVE_DIR, FILE_CARVE_MAP[request['session_id']]['carve_guid'])
         # Check the first four bytes for the zstd header.
         if (base64.standard_b64decode(FILE_CARVE_MAP[request['session_id']]['blocks_received'][0])[0:4] == b'\x28\xB5\x2F\xFD'):
             out_file_name +=  '.zst'


### PR DESCRIPTION
This updates the carver block POST logic to retry POSTing blocks that fail up to `carver_max_block_retries=3` times. We still need integration tests for the carver logic, which I have en-route, but I'm not sure I'll have them done and ready before we tag a new release. Below is a sample of testing the carves with our setup:
```
/tmp ❯ unzip 10000000_226051611257155_5300564889708789760_n.zip
Archive:  10000000_226051611257155_5300564889708789760_n.zip
[10000000_226051611257155_5300564889708789760_n.zip] s2AGDs password:
  inflating: s2AGDs
/tmp ❯ tar -xvf s2AGDs
x big3.bin
/tmp ❯ shasum -a big3.bin
Value "big3.bin" invalid for option a (number expected)
Type shasum -h for help
/tmp ❯ shasum -a 256 big3.bin                                                                                                                 

19637a00559c22bac79a282e00c8c877a03a2fe2bdc79dc7209f15bd4e291e1f  big3.bin
/tmp ❯ shasum -a 256 ~/Downloads/big3.bin
19637a00559c22bac79a282e00c8c877a03a2fe2bdc79dc7209f15bd4e291e1f  /Users/thor/Downloads/big3.bin
```