### PR TITLE
logger: Use a mutex to protect buffered counts

### DIFF
--- a/osquery/logger/plugins/buffered.h
+++ b/osquery/logger/plugins/buffered.h
@@ -202,6 +202,9 @@ class BufferedLogForwarder : public InternalRunnable {
   std::atomic<size_t> log_index_{0};
 
   /// Stores the count of buffered logs
-  std::atomic<size_t> buffer_count_{0};
+  size_t buffer_count_{0};
+
+  /// Protects the count of buffered logs
+  RecursiveMutex count_mutex_;
 };
 }


### PR DESCRIPTION
I tested this with `SANITIZE_THREAD=1` and `make sanitize` on Linux. The goal is to protect the internal memory for `buffer_count_` but also the logic that increments and decrements. It seems to be rolling over and to protect the check and edit we switch the atomic to a mutex over the critical section.