### PR TITLE
deploy: Change OLD_PIDFILE for systemd to be LOCAL_PIDFILE

### DIFF
--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -119,10 +119,7 @@ restart() {
 }
 
 status() {
-  if [ ! -f $PIDFILE ] ; then
-    echo "$PROG is not running. no pidfile found."
-    RETVAL=7
-  else
+  if [ -f $PIDFILE ]; then
     PID=$(cat $PIDFILE)
     PROCNAME=$(ps -p $PID -o comm\=)
     if [ "$PROCNAME" = "$PROG" ]; then
@@ -133,6 +130,20 @@ status() {
       echo "$PROG is not running but a stale pidfile was found."
       RETVAL=7
     fi
+  elif [ -f $OLD_PIDFILE ]; then
+    PID=$(cat $OLD_PIDFILE)
+    PROCNAME=$(ps -p $PID -o comm\=)
+    if [ "$PROCNAME" = "$PROG" ]; then
+      echo "$PROG is already running (old pidfile): $PID"
+      RETVAL=0
+    else
+      # osqueryd pidfile exists but it's not running
+      echo "$PROG is not running but a stale old pidfile was found."
+      RETVAL=7
+    fi
+  else
+    echo "$PROG is not running. no pidfile found."
+    RETVAL=7
   fi
 }
 

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -6,7 +6,7 @@ After=network.service syslog.service
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
-ExecStartPre=/bin/sh -c "if [ -f $OLD_PIDFILE ]; then mv $OLD_PIDFILE $PIDFILE; fi"
+ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"
 ExecStart=/usr/bin/osqueryd \
   --flagfile $FLAG_FILE \
   --config_path $CONFIG_FILE

--- a/tools/deployment/osqueryd.sysconfig
+++ b/tools/deployment/osqueryd.sysconfig
@@ -1,4 +1,4 @@
 FLAG_FILE="/etc/osquery/osquery.flags"
 CONFIG_FILE="/etc/osquery/osquery.conf"
-OLD_PIDFILE="/var/osquery/osqueryd.pidfile"
+LOCAL_PIDFILE="/var/osquery/osqueryd.pidfile"
 PIDFILE="/var/run/osqueryd.pidfile"


### PR DESCRIPTION
The `OLD_PIDFILE` defined in the sysconfig would override the `initd` `OLD_PIDFILE` default. These are two different settings so they should be named differently in their defaults.