### PR TITLE
deploy: removing extraneous verbosity from windows deployment scripts

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -72,7 +72,7 @@ Set-DenyWriteAcl $daemonFolder 'Add'
 
 if ($installService) {
   if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
-    Write-Debug '[+] Installing osquery daemon service.'
+    Write-Debug 'Installing osquery daemon service.'
     # If the 'install' parameter is passed, we create a Windows service with
     # the flag file in the default location in \ProgramData\osquery\
     New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
@@ -95,10 +95,4 @@ if (-not ($oldPath -imatch [regex]::escape($targetFolder))) {
     $newPath = $newPath + ';' + $targetFolder
   }
   [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
-}
-
-if (Test-Path $targetFolder) {
-  Write-Output "osquery was successfully installed to $targetFolder."
-} else {
-  Write-Output 'There was an error installing osquery.'
 }

--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -31,11 +31,6 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue)) {
 
 if (Test-Path $targetFolder) {
   Remove-Item -Force -Recurse $targetFolder
-  if (Test-Path $targetFolder) {
-    Write-Output 'osquery uninstallation was unsuccessful.'
-  } else {
-    Write-Output 'osquery was uninstalled successfully.'
-  }
 } else {
-  Write-Output 'osquery was not found on the system. Nothing to do.'
+  Write-Debug 'osquery was not found on the system. Nothing to do.'
 }


### PR DESCRIPTION
Some of our `Write-Output` messages during the chocolatey install are extraneous, or just flat out wrong. This removes those, and changes our `Write-Output`s to `Write-Debug` to ensure verbosity only shows up when needed/asked for.