### PR TITLE
Update column names, add process uid/gid, add switch to clear Audit config on startup.

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -493,7 +493,7 @@ bool AuditdNetlinkReader::deleteAuditRule(
 
   bool success = false;
 
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t retry = 0U; retry < 3U; retry++) {
     ssize_t bytes_sent;
 
     while (true) {

--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -31,6 +31,9 @@ enum class NetlinkStatus { ActiveMutable, ActiveImmutable, Disabled, Error };
 /// Subscription handle to be used with AuditNetlink::getEvents()
 using NetlinkSubscriptionHandle = std::uint32_t;
 
+/// Contains an audit_rule_data structure
+using AuditRuleDataObject = std::vector<std::uint8_t>;
+
 /// A single, prepared audit event record.
 struct AuditEventRecord final {
   /// Record type (i.e.: AUDIT_SYSCALL, AUDIT_PATH, ...)
@@ -100,6 +103,12 @@ class AuditdNetlink final : private boost::noncopyable {
 
   /// Configures the audit service and applies required rules
   bool configureAuditService() noexcept;
+
+  /// Clears out the audit configuration
+  bool clearAuditConfiguration() noexcept;
+
+  /// Deletes the given audit rule
+  bool deleteAuditRule(AuditRuleDataObject& rule_object);
 
   /// Removes the rules that we have applied
   void restoreAuditServiceConfiguration() noexcept;

--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -108,7 +108,7 @@ class AuditdNetlink final : private boost::noncopyable {
   bool clearAuditConfiguration() noexcept;
 
   /// Deletes the given audit rule
-  bool deleteAuditRule(AuditRuleDataObject& rule_object);
+  bool deleteAuditRule(const AuditRuleDataObject& rule_object);
 
   /// Removes the rules that we have applied
   void restoreAuditServiceConfiguration() noexcept;

--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -13,6 +13,7 @@
 #include <libaudit.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <future>
 #include <map>
 #include <memory>
@@ -123,11 +124,14 @@ class AuditdNetlink final : private boost::noncopyable {
   /// The thread that processes the audit events
   std::unique_ptr<std::thread> processing_thread_;
 
-  /// This queue contains unprocessed events
-  std::vector<AuditEventRecord> raw_queue;
+  /// This queue contains processed events
+  std::vector<AuditEventRecord> event_queue_;
 
-  /// Queue mutex.
-  std::mutex raw_queue_mutex;
+  /// Processed events queue mutex.
+  std::mutex event_queue_mutex_;
+
+  /// Processed events condition variable
+  std::condition_variable event_queue_cv_;
 };
 
 /// Handle quote and hex-encoded audit field content.

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -9,7 +9,6 @@
  */
 
 #include <array>
-#include <iostream>
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -89,7 +88,6 @@ Status AuditEventPublisher::run() {
     fire(event_context);
   }
 
-  std::cout << "AuditEventPublisher::run" << std::endl;
   return Status(0, "OK");
 }
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -178,6 +178,27 @@ void AuditEventPublisher::ProcessEvents(
       data.parent_process_id = static_cast<pid_t>(parent_process_id);
       audit_event.data = data;
 
+      std::uint64_t process_uid;
+      if (!GetIntegerFieldFromMap(
+              process_uid, audit_event_record.fields, "uid")) {
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process "
+                   "uid field is either missing or not valid.";
+
+        continue;
+      }
+
+      std::uint64_t process_gid;
+      if (!GetIntegerFieldFromMap(
+              process_gid, audit_event_record.fields, "gid")) {
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process "
+                   "gid field is either missing or not valid.";
+
+        continue;
+      }
+
+      data.process_uid = static_cast<uid_t>(process_uid);
+      data.process_gid = static_cast<gid_t>(process_gid);
+
       audit_event.record_list.push_back(audit_event_record);
       trace_context[audit_event_record.audit_id] = std::move(audit_event);
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <array>
+#include <iostream>
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
@@ -17,7 +18,13 @@
 #include "osquery/events/linux/auditeventpublisher.h"
 
 namespace osquery {
-DECLARE_bool(disable_audit);
+/// The audit subsystem may have a performance impact on the system.
+FLAG(bool,
+     disable_audit,
+     true,
+     "Disable receiving events from the audit subsystem");
+
+// External flags; they are used to determine whether we should run or not
 DECLARE_bool(audit_allow_fim_events);
 DECLARE_bool(audit_allow_process_events);
 DECLARE_bool(audit_allow_sockets);
@@ -43,6 +50,12 @@ Status AuditEventPublisher::setUp() {
     return Status(1, "Publisher disabled via configuration");
   }
 
+  if (executable_path_.empty()) {
+    char buffer[PATH_MAX] = {};
+    assert(readlink("/proc/self/exe", buffer, sizeof(buffer)) != -1);
+    executable_path_ = buffer;
+  }
+
   return Status(0, "OK");
 }
 
@@ -51,16 +64,15 @@ void AuditEventPublisher::configure() {
     return;
   }
 
-  if (audit_netlink_subscription_ == 0) {
-    audit_netlink_subscription_ = AuditdNetlink::get().subscribe();
-  }
+  audit_netlink_ = std::make_unique<AuditdNetlink>();
 }
 
 void AuditEventPublisher::tearDown() {
-  if (audit_netlink_subscription_ != 0) {
-    AuditdNetlink::get().unsubscribe(audit_netlink_subscription_);
-    audit_netlink_subscription_ = 0;
+  if (!IsPublisherEnabled()) {
+    return;
   }
+
+  audit_netlink_.reset();
 }
 
 Status AuditEventPublisher::run() {
@@ -68,9 +80,7 @@ Status AuditEventPublisher::run() {
     return Status(1, "Publisher disabled via configuration");
   }
 
-  // Request our event queue from the AuditdNetlink component
-  auto audit_event_record_queue =
-      AuditdNetlink::get().getEvents(audit_netlink_subscription_);
+  auto audit_event_record_queue = audit_netlink_->getEvents();
 
   auto event_context = createEventContext();
   ProcessEvents(event_context, audit_event_record_queue, audit_trace_context_);
@@ -79,6 +89,7 @@ Status AuditEventPublisher::run() {
     fire(event_context);
   }
 
+  std::cout << "AuditEventPublisher::run" << std::endl;
   return Status(0, "OK");
 }
 
@@ -86,12 +97,6 @@ void AuditEventPublisher::ProcessEvents(
     AuditEventContextRef event_context,
     const std::vector<AuditEventRecord>& record_list,
     AuditTraceContext& trace_context) noexcept {
-  if (executable_path_.empty()) {
-    char buffer[PATH_MAX] = {};
-    assert(readlink("/proc/self/exe", buffer, sizeof(buffer)) != -1);
-    executable_path_ = buffer;
-  }
-
   // Assemble each record into a AuditEvent object; multi-record events
   // are complete when we receive the terminator (AUDIT_EOE)
   for (const auto& audit_event_record : record_list) {
@@ -101,8 +106,8 @@ void AuditEventPublisher::ProcessEvents(
     // the second one is for syscalls
     if (audit_event_record.type >= AUDIT_FIRST_USER_MSG &&
         audit_event_record.type <= AUDIT_LAST_USER_MSG) {
-      UserAuditEventData data;
-      data.user_event_id = audit_event_record.type;
+      UserAuditEventData data = {};
+      data.user_event_id = static_cast<std::uint64_t>(audit_event_record.type);
 
       AuditEvent audit_event;
       audit_event.type = AuditEvent::Type::UserEvent;

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -116,7 +116,7 @@ void AuditEventPublisher::ProcessEvents(
 
     } else if (audit_event_record.type == AUDIT_SYSCALL) {
       if (audit_event_it != trace_context.end()) {
-        VLOG(1) << "Audit: Received a duplicated event.";
+        VLOG(1) << "Received a duplicated event.";
         trace_context.erase(audit_event_it);
       }
 
@@ -128,7 +128,7 @@ void AuditEventPublisher::ProcessEvents(
       std::string raw_executable_path;
       if (!GetStringFieldFromMap(
               raw_executable_path, audit_event_record.fields, "exe")) {
-        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The "
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The "
                    "executable path field is either missing or not valid.";
 
         continue;
@@ -143,7 +143,7 @@ void AuditEventPublisher::ProcessEvents(
 
       if (!GetIntegerFieldFromMap(
               data.syscall_number, audit_event_record.fields, "syscall")) {
-        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The "
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The "
                    "syscall field "
                    "is either missing or not valid.";
 
@@ -163,9 +163,8 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_id;
       if (!GetIntegerFieldFromMap(
               process_id, audit_event_record.fields, "pid")) {
-        VLOG(1)
-            << "Audit: Malformed AUDIT_SYSCALL record received. The process id "
-               "field is either missing or not valid.";
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process id "
+                   "field is either missing or not valid.";
 
         continue;
       }
@@ -173,7 +172,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t parent_process_id;
       if (!GetIntegerFieldFromMap(
               parent_process_id, audit_event_record.fields, "ppid")) {
-        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The parent "
+        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The parent "
                    "process id field is either missing or not valid.";
 
         continue;
@@ -186,7 +185,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_uid;
       if (!GetIntegerFieldFromMap(
               process_uid, audit_event_record.fields, "uid")) {
-        VLOG(1) << "Audit: Missing or invalid uid field in AUDIT_SYSCALL";
+        VLOG(1) << "Missing or invalid uid field in AUDIT_SYSCALL";
 
         continue;
       }
@@ -194,7 +193,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_gid;
       if (!GetIntegerFieldFromMap(
               process_gid, audit_event_record.fields, "gid")) {
-        VLOG(1) << "Audit: Missing or invalid gid field in AUDIT_SYSCALL";
+        VLOG(1) << "Missing or invalid gid field in AUDIT_SYSCALL";
 
         continue;
       }

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -181,8 +181,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_uid;
       if (!GetIntegerFieldFromMap(
               process_uid, audit_event_record.fields, "uid")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process "
-                   "uid field is either missing or not valid.";
+        VLOG(1) << "Missing or invalid uid field in AUDIT_SYSCALL";
 
         continue;
       }
@@ -190,8 +189,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_gid;
       if (!GetIntegerFieldFromMap(
               process_gid, audit_event_record.fields, "gid")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process "
-                   "gid field is either missing or not valid.";
+        VLOG(1) << "Missing or invalid gid field in AUDIT_SYSCALL";
 
         continue;
       }

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -113,7 +113,7 @@ void AuditEventPublisher::ProcessEvents(
 
     } else if (audit_event_record.type == AUDIT_SYSCALL) {
       if (audit_event_it != trace_context.end()) {
-        VLOG(1) << "Received a duplicated event.";
+        VLOG(1) << "Audit: Received a duplicated event.";
         trace_context.erase(audit_event_it);
       }
 
@@ -125,7 +125,7 @@ void AuditEventPublisher::ProcessEvents(
       std::string raw_executable_path;
       if (!GetStringFieldFromMap(
               raw_executable_path, audit_event_record.fields, "exe")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The "
+        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The "
                    "executable path field is either missing or not valid.";
 
         continue;
@@ -140,7 +140,8 @@ void AuditEventPublisher::ProcessEvents(
 
       if (!GetIntegerFieldFromMap(
               data.syscall_number, audit_event_record.fields, "syscall")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The syscall field "
+        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The "
+                   "syscall field "
                    "is either missing or not valid.";
 
         continue;
@@ -159,8 +160,9 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_id;
       if (!GetIntegerFieldFromMap(
               process_id, audit_event_record.fields, "pid")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The process id "
-                   "field is either missing or not valid.";
+        VLOG(1)
+            << "Audit: Malformed AUDIT_SYSCALL record received. The process id "
+               "field is either missing or not valid.";
 
         continue;
       }
@@ -168,7 +170,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t parent_process_id;
       if (!GetIntegerFieldFromMap(
               parent_process_id, audit_event_record.fields, "ppid")) {
-        VLOG(1) << "Malformed AUDIT_SYSCALL record received. The parent "
+        VLOG(1) << "Audit: Malformed AUDIT_SYSCALL record received. The parent "
                    "process id field is either missing or not valid.";
 
         continue;
@@ -181,7 +183,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_uid;
       if (!GetIntegerFieldFromMap(
               process_uid, audit_event_record.fields, "uid")) {
-        VLOG(1) << "Missing or invalid uid field in AUDIT_SYSCALL";
+        VLOG(1) << "Audit: Missing or invalid uid field in AUDIT_SYSCALL";
 
         continue;
       }
@@ -189,7 +191,7 @@ void AuditEventPublisher::ProcessEvents(
       std::uint64_t process_gid;
       if (!GetIntegerFieldFromMap(
               process_gid, audit_event_record.fields, "gid")) {
-        VLOG(1) << "Missing or invalid gid field in AUDIT_SYSCALL";
+        VLOG(1) << "Audit: Missing or invalid gid field in AUDIT_SYSCALL";
 
         continue;
       }

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -30,6 +30,10 @@ struct SyscallAuditEventData final {
 
   pid_t process_id;
   pid_t parent_process_id;
+
+  uid_t process_uid;
+  gid_t process_gid;
+
   std::string executable_path;
 };
 

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <memory>
 
 #include <boost/variant.hpp>
 
@@ -88,8 +89,8 @@ class AuditEventPublisher final
                             AuditTraceContext& trace_context) noexcept;
 
  private:
-  /// Audit netlink subscription handle
-  NetlinkSubscriptionHandle audit_netlink_subscription_{0};
+  /// Netlink reader
+  std::unique_ptr<AuditdNetlink> audit_netlink_;
 
   /// This is where audit records are assembled
   AuditTraceContext audit_trace_context_;

--- a/osquery/events/linux/tests/audit_tests.cpp
+++ b/osquery/events/linux/tests/audit_tests.cpp
@@ -66,7 +66,7 @@ TEST_F(AuditTests, test_handle_reply) {
   // Perform the parsing.
   AuditEventRecord audit_event_record = {};
   bool parser_status =
-      AuditdNetlink::ParseAuditReply(reply, audit_event_record);
+      AuditdNetlinkParser::ParseAuditReply(reply, audit_event_record);
   EXPECT_EQ(parser_status, true);
 
   free((char*)reply.message);

--- a/osquery/events/linux/tests/auditd_fim_tests.cpp
+++ b/osquery/events/linux/tests/auditd_fim_tests.cpp
@@ -75,7 +75,7 @@ TEST_F(AuditdFimTests, row_emission) {
     AuditEventRecord audit_event_record = {};
 
     bool parser_status =
-        AuditdNetlink::ParseAuditReply(reply, audit_event_record);
+        AuditdNetlinkParser::ParseAuditReply(reply, audit_event_record);
     EXPECT_EQ(parser_status, true);
 
     event_record_list.push_back(audit_event_record);

--- a/osquery/tables/events/linux/auditd_fim_events.cpp
+++ b/osquery/tables/events/linux/auditd_fim_events.cpp
@@ -345,6 +345,12 @@ bool EmitRowFromSyscallContext(
   row["ppid"] = std::to_string(
       static_cast<std::uint64_t>(syscall_context.parent_process_id));
 
+  row["uid"] =
+      std::to_string(static_cast<std::uint64_t>(syscall_context.process_uid));
+
+  row["gid"] =
+      std::to_string(static_cast<std::uint64_t>(syscall_context.process_gid));
+
   row["executable"] = syscall_context.executable_path;
   row["partial"] = (syscall_context.partial ? "true" : "false");
   row["cwd"] = syscall_context.cwd;
@@ -1189,6 +1195,8 @@ Status AuditdFimEventSubscriber::ProcessEvents(
     syscall_context.syscall_number = event_data.syscall_number;
     syscall_context.process_id = event_data.process_id;
     syscall_context.parent_process_id = event_data.parent_process_id;
+    syscall_context.process_uid = event_data.process_uid;
+    syscall_context.process_gid = event_data.process_gid;
     syscall_context.executable_path = event_data.executable_path;
 
     const AuditEventRecord* syscall_record = nullptr;

--- a/osquery/tables/events/linux/auditd_fim_events.cpp
+++ b/osquery/tables/events/linux/auditd_fim_events.cpp
@@ -270,8 +270,8 @@ bool EmitRowFromSyscallContext(
     const auto& data =
         boost::get<AuditdFimSrcDestData>(syscall_context.syscall_data);
 
-    row["path1"] = data.source;
-    row["path2"] = data.destination;
+    row["path"] = data.source;
+    row["dest_path"] = data.destination;
 
     is_write_operation = true;
     break;
@@ -314,7 +314,7 @@ bool EmitRowFromSyscallContext(
       row["operation"] = "close";
     }
 
-    row["path1"] = data.target;
+    row["path"] = data.target;
     break;
   }
 
@@ -326,9 +326,9 @@ bool EmitRowFromSyscallContext(
   }
 
   // Filter the events
-  bool include_event = L_IsPathIncluded(row["path1"]);
-  if (!include_event && row.find("path2") != row.end()) {
-    include_event = L_IsPathIncluded(row["path2"]);
+  bool include_event = L_IsPathIncluded(row["path"]);
+  if (!include_event && row.find("dest_path") != row.end()) {
+    include_event = L_IsPathIncluded(row["dest_path"]);
   }
 
   if (!include_event) {

--- a/osquery/tables/events/linux/auditd_fim_events.h
+++ b/osquery/tables/events/linux/auditd_fim_events.h
@@ -223,11 +223,17 @@ struct AuditdFimSyscallContext final {
   // A collection of all the AUDIT_PATH records we found
   std::unordered_map<std::size_t, AuditdFimPathRecordItem> path_record_map;
 
-  // The process id
+  /// The process id
   pid_t process_id;
 
-  // The parent process id
+  /// The parent process id
   pid_t parent_process_id;
+
+  /// The process uid
+  uid_t process_uid;
+
+  /// The process gid
+  gid_t process_gid;
 
   // Path of the executable that generated the event
   std::string executable_path;

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -111,9 +111,9 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     CopyFieldFromMap(row, syscall_event_record->fields, "gid", "0");
     CopyFieldFromMap(row, syscall_event_record->fields, "egid", "0");
 
-    GetStringFieldFromMap(row["path"], syscall_event_record->fields, "exe", "");
-    GetStringFieldFromMap(
-        row["cmdline"], syscall_event_record->fields, "comm", "");
+    std::string field_value;
+    GetStringFieldFromMap(field_value, syscall_event_record->fields, "exe", "");
+    row["path"] = DecodeAuditPathValues(field_value);
 
     auto qd = SQL::selectAllFrom("file", "path", EQUALS, row.at("path"));
     if (qd.size() == 1) {
@@ -130,6 +130,8 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     row["uptime"] = std::to_string(tables::getUptime());
 
     // build the command line from the AUDIT_EXECVE record
+    row["cmdline"] = "";
+
     for (const auto& arg : execve_event_record->fields) {
       if (arg.first == "argc") {
         continue;
@@ -140,7 +142,7 @@ Status AuditProcessEventSubscriber::ProcessEvents(
         row["cmdline"] += " ";
       }
 
-      row["cmdline"] += DecodeAuditPathValues(arg.second);
+      row["cmdline"] += arg.second; // DecodeAuditPathValues(arg.second);
     }
 
     // There may be a better way to calculate actual size from audit.

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -142,7 +142,7 @@ Status AuditProcessEventSubscriber::ProcessEvents(
         row["cmdline"] += " ";
       }
 
-      row["cmdline"] += arg.second; // DecodeAuditPathValues(arg.second);
+      row["cmdline"] += arg.second;
     }
 
     // There may be a better way to calculate actual size from audit.

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -159,7 +159,8 @@ Status SocketEventSubscriber::ProcessEvents(
     GetStringFieldFromMap(saddr, sockaddr_event_record->fields, "saddr");
     if (saddr.size() < 4 || saddr[0] == '1') {
       VLOG(1) << "Malformed syscall event. The AUDIT_SOCKADDR does not "
-                 "have a valid saddr field";
+                 "have a valid saddr field: \""
+              << saddr << "\"";
       continue;
     }
 

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -158,9 +158,7 @@ Status SocketEventSubscriber::ProcessEvents(
     std::string saddr;
     GetStringFieldFromMap(saddr, sockaddr_event_record->fields, "saddr");
     if (saddr.size() < 4 || saddr[0] == '1') {
-      VLOG(1) << "Malformed syscall event. The AUDIT_SOCKADDR does not "
-                 "have a valid saddr field: \""
-              << saddr << "\"";
+      VLOG(1) << "Invalid saddr field in AUDIT_SOCKADDR: \"" << saddr << "\"";
       continue;
     }
 

--- a/specs/posix/auditd_fim_events.table
+++ b/specs/posix/auditd_fim_events.table
@@ -10,6 +10,8 @@ schema([
     Column("cwd", TEXT, "The current working directory of the process"),
     Column("path", TEXT, "The path associated with the event"),
     Column("dest_path", TEXT, "The canonical path associated with the event"),
+    Column("uid", TEXT, "The uid of the process performing the action"),
+    Column("gid", TEXT, "The gid of the process performing the action"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])

--- a/specs/posix/auditd_fim_events.table
+++ b/specs/posix/auditd_fim_events.table
@@ -8,8 +8,8 @@ schema([
     Column("executable", TEXT, "The executable path"),
     Column("partial", TEXT, "True if this is a partial event (i.e.: this process existed before we started osquery)"),
     Column("cwd", TEXT, "The current working directory of the process"),
-    Column("path1", TEXT, "The path associated with the event"),
-    Column("path2", TEXT, "The canonical path associated with the event"),
+    Column("path", TEXT, "The path associated with the event"),
+    Column("dest_path", TEXT, "The canonical path associated with the event"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("eid", TEXT, "Event ID", hidden=True),
 ])


### PR DESCRIPTION
## auditd_fim_events table changes
- Added the process **uid** and **gid** columns.
- Renamed the **path1** column to **path**.
- Renamed the **path2** column to **dest_path**.

## socket_events table changes
- Print the **saddr** event field contents when the parser fails. The original function parsing the field has not been changed (this is straight from master); this may still come in handy when debugging.

## process_events table changes
- Use DecodeAuditPathValues to read path fields from the event records.

## AuditdNetlink changes
- Add support for clearing Audit rules when osquery starts ( #3468 ).
