### PR TITLE
tables: adding chocolatey packages virtual table

### DIFF
--- a/osquery/tables/system/windows/chocolatey_packages.cpp
+++ b/osquery/tables/system/windows/chocolatey_packages.cpp
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) 2014-present, Facebook, Inc.
+*  All rights reserved.
+*
+*  This source code is licensed under the BSD-style license found in the
+*  LICENSE file in the root directory of this source tree. An additional grant
+*  of patent rights can be found in the PATENTS file in the same directory.
+*
+*/
+
+#include <boost/filesystem.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/process.h"
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+Status genPackage(fs::path nuspec, Row& r) {
+  std::string content;
+  if (!readFile(nuspec, content).ok()) {
+    return Status(1, "Failed to read nuspec:" + nuspec.string());
+  }
+
+  std::stringstream ss;
+  ss << content;
+  pt::ptree propTree;
+  read_xml(ss, propTree);
+
+  r["name"] = propTree.get("package.metadata.id", "");
+  r["version"] = propTree.get("package.metadata.version", "");
+  r["summary"] = propTree.get("package.metadata.summary", "");
+  r["author"] = propTree.get("package.metadata.authors", "");
+  r["license"] = propTree.get("package.metadata.licenseUrl", "");
+  r["path"] = nuspec.string();
+
+  return Status();
+}
+
+QueryData genChocolateyPackages(QueryContext& context) {
+  QueryData results;
+
+  auto chocoEnvInstall = getEnvVar("ChocolateyInstall");
+
+  fs::path chocoInstallPath;
+  if (chocoEnvInstall.is_initialized()) {
+    chocoInstallPath = fs::path(*chocoEnvInstall);
+  }
+
+  if (chocoInstallPath.empty()) {
+    LOG(WARNING) << "Did not find chocolatey path environment variable.";
+    return results;
+  }
+
+  auto nuspecPattern = chocoInstallPath / "lib/%/%.nuspec";
+  std::vector<std::string> manifests;
+  resolveFilePattern(nuspecPattern, manifests, GLOB_FILES);
+
+  for (const auto& pkg : manifests) {
+    Row r;
+    auto s = genPackage(pkg, r);
+    if (!s.ok()) {
+      VLOG(1) << "Failed to parse " << pkg << " with " << s.getMessage();
+    }
+    results.push_back(r);
+  }
+
+  return results;
+}
+}
+}

--- a/specs/windows/chocolatey_packages.table
+++ b/specs/windows/chocolatey_packages.table
@@ -1,0 +1,11 @@
+table_name("chocolatey_packages")
+description("Chocolatey packages installed in a system.")
+schema([
+    Column("name", TEXT, "Package display name"),
+    Column("version", TEXT, "Package-supplied version"),
+    Column("summary", TEXT, "Package-supplied summary"),
+    Column("author", TEXT, "Optional package author"),
+    Column("license", TEXT, "License under which package is launched"),
+    Column("path", TEXT, "Path at which this package resides")
+])
+implementation("system/windows/chocolatey_packages@genChocolateyPackages")


### PR DESCRIPTION
This brings a new virtual table to Windows, `chocolatey_packages`!  Similar to the python packages table, this lists out all packages which have been installed via chocolatey on a system. It relies on the chocolatey environment variable `ChocolateyInstall` to provide the table with the installation path, after which it pareses the packages `.nuspec`s for information.
```
osquery> .mode line
osquery> select * from chocolatey_packages limit 10;
   name = 7zip.commandline
version = 16.02.0.20170209
summary = 7-Zip is a file archiver with a high compression ratio.
 author = Igor Pavlov
license = http://www.7-zip.org/license.txt
   path = C:\ProgramData\chocolatey\lib\7zip.commandline\7zip.commandline.nuspec

   name = 7zip.portable
version = 16.04
summary = 7-Zip is a file archiver with a high compression ratio.
 author = Igor Pavlov
license = http://www.7-zip.org/license.txt
   path = C:\ProgramData\chocolatey\lib\7zip.portable\7zip.portable.nuspec

   name = aws-sdk-cpp
version = 1.0.107-r1
summary = aws-sdk-cpp
 author = Amazon
license = https://github.com/aws/aws-sdk-cpp/blob/master/LICENSE
   path = C:\ProgramData\chocolatey\lib\aws-sdk-cpp\aws-sdk-cpp.nuspec

   name = boost-msvc14
version = 1.63.0-r2
summary = boost-msvc14
 author = boost-msvc14
license = http://www.boost.org/users/license.html
   path = C:\ProgramData\chocolatey\lib\boost-msvc14\boost-msvc14.nuspec

   name = bzip2
version = 1.0.6
summary = bzip2 libraries and binaries
 author = bzip2
license = http://www.bzip.org/index.html
   path = C:\ProgramData\chocolatey\lib\bzip2\bzip2.nuspec

   name = chocolatey-core.extension
version = 1.3.1
summary = Helper functions extending core choco functionality
 author = chocolatey
license = https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/LICENSE.md
   path = C:\ProgramData\chocolatey\lib\chocolatey-core.extension\chocolatey-core.extension.nuspec

   name = chocolatey-windowsupdate.extension
version = 1.0.2
summary = Helper functions useful for developing packages for Windows updates (KBs).
 author = Jakub Bere┼╝a┼äski
license = https://cdn.rawgit.com/jberezanski/ChocolateyPackages/8086c84fed16d4150a50ba1e97fd6b75e3c4f511/LICENSE
   path = C:\ProgramData\chocolatey\lib\chocolatey-windowsupdate.extension\chocolatey-windowsupdate.extension.nuspec

   name = cmake.portable
version = 3.6.1
summary = Cross-platform, open-source build system including CMake, CTest, CPack, and CMake-GUI
 author = Andy Cedilnik, Bill Hoffman, Brad King, Ken Martin, Alexander Neundorf
license = http://www.cmake.org/licensing/
   path = C:\ProgramData\chocolatey\lib\cmake.portable\cmake.portable.nuspec

   name = cpp-netlib
version = 0.12.0-r4
summary = cpp-netlib
 author = cpp-netlib
license = https://github.com/cpp-netlib/cpp-netlib/blob/master/LICENSE_1_0.txt
   path = C:\ProgramData\chocolatey\lib\cpp-netlib\cpp-netlib.nuspec

   name = cppcheck
version = 1.79.0
summary = A tool for static C/C++ code analysis
 author = The CPPCheck Team
license = http://www.gnu.org/copyleft/gpl.html
   path = C:\ProgramData\chocolatey\lib\cppcheck\cppcheck.nuspec
```