### PR TITLE
deps: Fix rapidjson bottle root_url

### DIFF
--- a/tools/provision/formula/rapidjson.rb
+++ b/tools/provision/formula/rapidjson.rb
@@ -8,6 +8,7 @@ class Rapidjson < AbstractOsqueryFormula
   head "https://github.com/miloyip/rapidjson.git"
 
   bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "8725e7b2e737904b7d72cfd9d844341310e42221d8c9c7df96d8380414bfc503" => :sierra
     sha256 "928f6189837de2419d4936340e9b29394454fb2ec65b1deac2923fb2155ad584" => :x86_64_linux


### PR DESCRIPTION
The `rapidjson` bottle was trying to download it's bottle from Homebrew's binary storage. This would always fail due to (1) missing version and (2) a bad compile hash.