### PR TITLE
deps: Update cmake to version 3.9.1

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -398,7 +398,7 @@ function Main {
   $out = Install-ChocoPackage 'cppcheck'
   $out = Install-ChocoPackage '7zip.commandline'
   $out = Install-ChocoPackage 'vswhere'
-  $out = Install-ChocoPackage 'cmake.portable' '3.6.1'
+  $out = Install-ChocoPackage 'cmake.portable'
   $chocoParams = @("--params=`"/InstallDir:C:\tools\python2`"")
   $out = Install-ChocoPackage 'python2' '' ${chocoParams}
   # Convenience variable for accessing Python

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -70,11 +70,11 @@ function platform_linux_main() {
   # OpenSSL is needed for the final build.
   brew_tool osquery/osquery-local/libxml2
   brew_tool osquery/osquery-local/openssl
+  brew_tool osquery/osquery-local/cmake
 
   # Curl and Python are needed for LLVM mostly.
   brew_tool osquery/osquery-local/curl
   brew_tool osquery/osquery-local/python
-  brew_tool osquery/osquery-local/cmake --without-docs
 
   # Linux library secondary dependencies.
   brew_tool osquery/osquery-local/berkeley-db
@@ -109,7 +109,7 @@ function platform_darwin_main() {
   brew_tool pkg-config
   brew_tool makedepend
   brew_tool ninja
-  brew_tool osquery/osquery-local/cmake --without-docs
+  brew_tool osquery/osquery-local/cmake
   brew_tool clang-format
   brew_tool autoconf
   brew_tool automake

--- a/tools/provision/formula/cmake.rb
+++ b/tools/provision/formula/cmake.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Cmake < AbstractOsqueryFormula
   desc "Cross-platform make"
   homepage "https://www.cmake.org/"
-  url "https://cmake.org/files/v3.6/cmake-3.6.1.tar.gz"
-  sha256 "28ee98ec40427d41a45673847db7a905b59ce9243bb866eaf59dce0f58aaef11"
-  revision 101
+  url "https://cmake.org/files/v3.9/cmake-3.9.1.tar.gz"
+  sha256 "d768ee83d217f91bb597b3ca2ac663da7a8603c97e1f1a5184bc01e0ad2b12bb"
+  revision 100
 
   head "https://cmake.org/cmake.git"
 
@@ -16,14 +16,11 @@ class Cmake < AbstractOsqueryFormula
     sha256 "b7d652e5b9661321b797e20ad03c7474eea34618235149fc1a01c8c93b0bd61b" => :x86_64_linux
   end
 
-  option "without-docs", "Don't build man pages"
-  option "with-completion", "Install Bash completion (Has potential problems with system bash)"
-
-  depends_on "sphinx-doc" => :build if build.with? "docs"
-
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
   # For the GUI application please instead use `brew cask install cmake`.
+
+  patch :DATA
 
   def install
     args = %W[
@@ -35,35 +32,19 @@ class Cmake < AbstractOsqueryFormula
       --mandir=/share/man
       --system-zlib
       --system-bzip2
+      --system-liblzma
     ]
 
-    # https://github.com/Homebrew/legacy-homebrew/issues/45989
-    if MacOS.version <= :lion
-      args << "--no-system-curl"
-    else
-      args << "--system-curl"
-    end
-
-    if build.with? "docs"
-      # There is an existing issue around OS X & Python locale setting
-      # See https://bugs.python.org/issue18378#msg215215 for explanation
-      ENV["LC_ALL"] = "en_US.UTF-8"
-      args << "--sphinx-man" << "--sphinx-build=#{Formula["sphinx-doc"].opt_bin}/sphinx-build"
-    end
-
+    # Keep these for initial compiler detection
+    # This initial detection does not use LDFLAGS.
     ENV.append "CXXFLAGS", "-L#{legacy_prefix}/lib"
     ENV.append "CXXFLAGS", "-L#{default_prefix}/lib"
     ENV.append "CXXFLAGS", "-lrt -lpthread" if OS.linux?
+    ENV["LD_LIBRARY_PATH"] = default_prefix/"lib"
 
     system "./bootstrap", *args
     system "make"
     system "make", "install"
-
-    if build.with? "completion"
-      cd "Auxiliary/bash-completion/" do
-        bash_completion.install "ctest", "cmake", "cpack"
-      end
-    end
 
     elisp.install "Auxiliary/cmake-mode.el"
   end
@@ -73,3 +54,18 @@ class Cmake < AbstractOsqueryFormula
     system bin/"cmake", "."
   end
 end
+
+__END__
+diff --git a/Utilities/cmlibuv/CMakeLists.txt b/Utilities/cmlibuv/CMakeLists.txt
+index 4c8e228..9605d6a 100644
+--- a/Utilities/cmlibuv/CMakeLists.txt
++++ b/Utilities/cmlibuv/CMakeLists.txt
+@@ -175,7 +175,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+ endif()
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-  list(APPEND uv_libraries dl rt)
++  list(APPEND uv_libraries dl rt pthread)
+   list(APPEND uv_headers
+     include/uv-linux.h
+     )


### PR DESCRIPTION
This reduces the complexity of the `cmake` formula.

Version 3.9.1 will be needed for newer versions of xcode, see: https://gitlab.kitware.com/cmake/cmake/merge_requests/658
This tries to add a `-lto_library` as a link target, because of `-l...to...`.

Since `cmake` can bundle some of it's dependencies we can relax the requirements for our build list. The sooner we can build `cmake` the better.

The patch for `pthread` linking is applied because it's a "hidden" link dependency that the utility was expecting to get from `dl` or `rt`.