### PR TITLE
Add support for hardware_serial

### DIFF
--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -53,6 +53,14 @@ QueryData genSystemInfo(QueryContext& context) {
     r["hardware_vendor"] = "-1";
     r["hardware_model"] = "-1";
   }
+  
+  WmiRequest wmiBiosReq("select * from Win32_Bios");
+  std::vector<WmiResultItem>& wmiBiosResults = wmiBiosReq.results();
+  if (wmiBiosResults.size() != 0) {
+	  wmiBiosResults[0].GetString("SerialNumber", r["hardware_serial"]);
+  } else {
+	  r["hardware_serial"] = "-1";
+  }
 
   SYSTEM_INFO systemInfo;
   GetSystemInfo(&systemInfo);
@@ -77,7 +85,6 @@ QueryData genSystemInfo(QueryContext& context) {
 
   r["cpu_subtype"] = "-1";
   r["hardware_version"] = "-1";
-  r["hardware_serial"] = "-1";
   return {r};
 }
 }


### PR DESCRIPTION
Adding support for hardware_serial to system_info.cpp

Reads serial number from the BIOs and returns -1 if i cannot be found.

Note:
Submitting on behalf of Google which has signed a CLA for this project.
dyl@google.com