### PR TITLE
worker: shutdown safely on Windows only if not worker

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -204,6 +204,9 @@ class Initializer : private boost::noncopyable {
 
   /// A platform specific callback to wait for shutdown.
   static std::function<void()> shutdown_;
+
+  /// Mutex to protect use of the shutdown callable.
+  Mutex shutdown_mutext_;
 };
 
 /**

--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -206,7 +206,7 @@ class Initializer : private boost::noncopyable {
   static std::function<void()> shutdown_;
 
   /// Mutex to protect use of the shutdown callable.
-  Mutex shutdown_mutext_;
+  static Mutex shutdown_mutex_;
 };
 
 /**

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -212,6 +212,7 @@ const std::string kBackupDefaultFlagfile{OSQUERY_HOME "/osquery.flags.default"};
 const size_t kDatabaseMaxRetryCount{25};
 const size_t kDatabaseRetryDelay{200};
 std::function<void()> Initializer::shutdown_{nullptr};
+Mutex Initializer::shutdown_mutex_;
 
 static inline void printUsage(const std::string& binary, ToolType tool) {
   // Parse help options before gflags. Only display osquery-related options.
@@ -570,7 +571,7 @@ void Initializer::initActivePlugin(const std::string& type,
 }
 
 void Initializer::installShutdown(std::function<void()>& handler) {
-  WriteLock lock(shutdown_mutext_);
+  WriteLock lock(shutdown_mutex_);
   shutdown_ = std::move(handler);
 }
 
@@ -673,7 +674,7 @@ void Initializer::start() const {
 
 void Initializer::waitForShutdown() {
   {
-    WriteLock lock(shutdown_mutext_);
+    WriteLock lock(shutdown_mutex_);
     if (shutdown_ != nullptr) {
       // Copy the callable, then remove it, prevent callable recursion.
       auto shutdown = shutdown_;


### PR DESCRIPTION
After merging the binaries together, the logic for handling shutdowns got a little muddled between the worker and the watcher. This adds an explicit clear on the pointer to the shutdown routine, as well as provides assurances that the watcher will be the only process to execute the shutdown logic. This partially addresses #3619 in that the service now correctly exits and does not emit any `ERROR` level logging, however the service still technically crashes as a dump is generated [at the destruction of the Dispatcher](https://github.com/facebook/osquery/blob/master/include/osquery/dispatcher.h#L205)

@theopolis hope you don't mind that I `cherry-picked` your commit <3