### PR TITLE
deploy: Adding binary version and publisher information

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -292,11 +292,33 @@ if(NOT OSQUERY_BUILD_SDK_ONLY)
     set_target_properties(libosquery_additional_shared PROPERTIES OUTPUT_NAME osquery_additional)
   endif()
 
-  add_executable(daemon
+  set(DAEMON_SOURCE_FILES
     devtools/shell.cpp
     main/main.cpp
     main/${PROCESS_FAMILY}/main.cpp
   )
+  # Add the versioning information for Windows binaries
+  if(WINDOWS)
+    # The windows version resource requires a version string, as well
+    # as version components separated by a comma. First we replace the `-`
+    # values that may exist for commit hash versions, then we grab the
+    # major version components
+    string(REPLACE "-" "." OSQUERY_VER_TEMP "${OSQUERY_BUILD_VERSION}")
+    string(REPLACE "." ";" OSQUERY_VERSION_LIST "${OSQUERY_VER_TEMP}")
+    list(GET OSQUERY_VERSION_LIST 0 OSQUERY_PRODUCT_NUMBER)
+    list(GET OSQUERY_VERSION_LIST 1 OSQUERY_PRODUCT_VERSION)
+    list(GET OSQUERY_VERSION_LIST 2 OSQUERY_BUILD_NUMBER)
+
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/tools/version.rc.in
+      ${CMAKE_BINARY_DIR}/osquery/version.rc
+      @ONLY)
+    list(APPEND DAEMON_SOURCE_FILES ${CMAKE_BINARY_DIR}/osquery/version.rc)
+  endif()
+  add_executable(daemon
+    ${DAEMON_SOURCE_FILES}
+  )
+
   ADD_DEFAULT_LINKS(daemon TRUE)
   SET_OSQUERY_COMPILE(daemon "${CXX_COMPILE_FLAGS}")
   set_target_properties(daemon PROPERTIES OUTPUT_NAME osqueryd)

--- a/tools/version.rc.in
+++ b/tools/version.rc.in
@@ -1,0 +1,54 @@
+#include <windows.h>
+
+#define VER_FILEVERSION             @OSQUERY_PRODUCT_NUMBER@,@OSQUERY_PRODUCT_VERSION@,@OSQUERY_BUILD_NUMBER@,0
+#define VER_FILEVERSION_STR         "@OSQUERY_BUILD_VERSION@.0\0"
+
+#define VER_PRODUCTVERSION          @OSQUERY_PRODUCT_NUMBER@,@OSQUERY_PRODUCT_VERSION@,@OSQUERY_BUILD_NUMBER@,0
+#define VER_PRODUCTVERSION_STR      "@OSQUERY_BUILD_VERSION@\0"
+
+#define VER_COMPANYNAME_STR         "Facebook"
+#define VER_FILEDESCRIPTION_STR     "osquery daemon and shell"
+#define VER_INTERNALNAME_STR        "osquery"
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (c) 2014-present, Facebook, Inc. All rights reserved."
+#define VER_ORIGINALFILENAME_STR    "osqueryd.exe"
+#define VER_PRODUCTNAME_STR         "osquery"
+
+#ifndef DEBUG
+#define VER_DEBUG                   0
+#else
+#define VER_DEBUG                   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION    	VER_FILEVERSION
+PRODUCTVERSION 	VER_PRODUCTVERSION
+FILEFLAGSMASK  	VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+  FILEFLAGS 0x1L
+#else
+  FILEFLAGS 0x0L
+#endif
+FILEOS         	VOS__WINDOWS32
+FILETYPE       	VFT_APP
+FILESUBTYPE    	VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "CompanyName",      VER_COMPANYNAME_STR
+            VALUE "FileDescription",  VER_FILEDESCRIPTION_STR
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "InternalName",     VER_INTERNALNAME_STR
+            VALUE "LegalCopyright",   VER_LEGALCOPYRIGHT_STR
+            VALUE "OriginalFilename", VER_ORIGINALFILENAME_STR
+            VALUE "ProductName",      VER_PRODUCTNAME_STR
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1252
+    END
+END


### PR DESCRIPTION
As per the MSDN, Windows has the capability of bundling a versioning information resource with compiled binaries to offer publisher and version information to the operating system. This diff bundles said version resource so that we might gain additional information about the version of osquery running from various windows applications. In particular, the Windows Event Logs contain application logs about programs running on the system, and currently all of the values for osquery are blank and empty:

![binary_with_out_version](https://user-images.githubusercontent.com/1328916/29904426-a12acad0-8dbd-11e7-88ce-9e30547a48c4.PNG)

![error_with_out_version](https://user-images.githubusercontent.com/1328916/29904472-d0c32b8e-8dbd-11e7-875b-de0497f9bd37.PNG)

With this diff, we now have all of the fields filled out, so whenever the application crashes we'll be able to tell from Windows Event Logs the build version of the application:

![binary_with_version](https://user-images.githubusercontent.com/1328916/29904435-abaeec02-8dbd-11e7-9cd2-6397d76a293e.PNG)

![error_with_version](https://user-images.githubusercontent.com/1328916/29904482-e07d66e8-8dbd-11e7-9c21-b44eda60ac5d.PNG)

This data acts as something of a redundancy to the information you can obtain from chocolatey data, however if osquery is installed through other means than Chocolatey (an MSI perhaps), you can now see versioning information about osquery from the binary properties.

