### PR TITLE
rocksdb: Implement a 'backup' and recover feature for RocksDB

### DIFF
--- a/docs/wiki/deployment/debugging.md
+++ b/docs/wiki/deployment/debugging.md
@@ -121,6 +121,10 @@ $ sudo osqueryctl config-check || echo 'config has an error'
 
 The first `config-check` fails because it attempts to verify the sanity of the RocksDB directory while a daemon is running. The second attempt succeeds and should be the actual indicator!
 
+While not expected, the backing store may be corrupted by problems with the filesystem, incorrect shutdowns, or running out of disk space. If any corruption is detect via the startup sanity checks or during runtime osquery may backup the database and attempt a recovery. The most basic recovery is just to move the database content to the backup location and start 'fresh'.
+
+If your `--database_path` is `/var/osquery/osquery.db` then the backup is `/var/osquery/osquery.db.backup`. The database is always a folder and the backup location is the suffix ".backup" appended.
+
 ### Missing event subscribers
 
 If you see:

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -142,7 +142,7 @@ class DatabasePlugin : public Plugin {
 
  public:
   /// Database-specific workflow: reset the originally request instance.
-  virtual Status reset() final;
+  Status reset();
 
   /// Database-specific workflow: perform an initialize, then reset.
   bool checkDB();

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -203,7 +203,11 @@ Status resolveFilePattern(const boost::filesystem::path& pattern,
 void replaceGlobWildcards(std::string& pattern, GlobLimits limits = GLOB_ALL);
 
 /// Attempt to remove a directory path.
-Status remove(const boost::filesystem::path& path);
+Status removePath(const boost::filesystem::path& path);
+
+/// Move a file or directory to another path.
+Status movePath(const boost::filesystem::path& from,
+                const boost::filesystem::path& to);
 
 /**
  * @brief Check if an input path is a directory.

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -344,9 +344,7 @@ Status createPidFile() {
   }
 
   // Now the pidfile is either the wrong pid or the pid is not running.
-  try {
-    boost::filesystem::remove(pidfile_path);
-  } catch (const boost::filesystem::filesystem_error& /* e */) {
+  if (!removePath(pidfile_path)) {
     // Unable to remove old pidfile.
     LOG(WARNING) << "Unable to remove the osqueryd pidfile";
   }

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -8,19 +8,19 @@
  *
  */
 
-#include <mutex>
-
 #include <sys/stat.h>
 
 #include <rocksdb/db.h>
 #include <rocksdb/env.h>
 #include <rocksdb/options.h>
 
-#include <osquery/database.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
+#include "osquery/database/plugins/rocksdb.h"
 #include "osquery/filesystem/fileops.h"
+
+namespace fs = boost::filesystem;
 
 namespace osquery {
 
@@ -32,100 +32,13 @@ HIDDEN_FLAG(uint64, rocksdb_buffer_blocks, 256, "Write buffer blocks (4k)");
 
 DECLARE_string(database_path);
 
-class GlogRocksDBLogger : public rocksdb::Logger {
- public:
-  // We intend to override a virtual method that is overloaded.
-  using rocksdb::Logger::Logv;
-  void Logv(const char* format, va_list ap) override;
-};
-
-class RocksDBDatabasePlugin : public DatabasePlugin {
- public:
-  /// Data retrieval method.
-  Status get(const std::string& domain,
-             const std::string& key,
-             std::string& value) const override;
-
-  /// Data storage method.
-  Status put(const std::string& domain,
-             const std::string& key,
-             const std::string& value) override;
-
-  /// Data removal method.
-  Status remove(const std::string& domain, const std::string& k) override;
-
-  /// Data range removal method.
-  Status removeRange(const std::string& domain,
-                     const std::string& low,
-                     const std::string& high) override;
-
-  /// Key/index lookup method.
-  Status scan(const std::string& domain,
-              std::vector<std::string>& results,
-              const std::string& prefix,
-              size_t max = 0) const override;
-
- public:
-  /// Database workflow: open and setup.
-  Status setUp() override;
-
-  /// Database workflow: close and cleanup.
-  void tearDown() override {
-    close();
-  }
-
-  /// Need to tear down open resources,
-  virtual ~RocksDBDatabasePlugin() {
-    close();
-  }
-
- private:
-  /// Obtain a close lock and release resources.
-  void close();
-
-  /**
-   * @brief Private helper around accessing the column family handle for a
-   * specific column family, based on its name
-   */
-  rocksdb::ColumnFamilyHandle* getHandleForColumnFamily(
-      const std::string& cf) const;
-
-  /**
-   * @brief Helper method which can be used to get a raw pointer to the
-   * underlying RocksDB database handle
-   *
-   * @return a pointer to the underlying RocksDB database handle
-   */
-  rocksdb::DB* getDB() const;
-
-  /**
-   * @brief Helper method to repair a corrupted db. Best effort only.
-   *
-   * @return nothing.
-   */
-  void repairDB();
-
- private:
-  bool initialized_{false};
-
-  /// The database handle
-  rocksdb::DB* db_{nullptr};
-
-  /// RocksDB logger instance.
-  std::shared_ptr<GlogRocksDBLogger> logger_{nullptr};
-
-  /// Column family descriptors which are used to connect to RocksDB
-  std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
-
-  /// A vector of pointers to column family handles
-  std::vector<rocksdb::ColumnFamilyHandle*> handles_;
-
-  /// The RocksDB connection options that are used to connect to RocksDB
-  rocksdb::Options options_;
-
-  /// Deconstruction mutex.
-  Mutex close_mutex_;
-};
+/**
+ * @brief Track external systems marking the RocksDB database as corrupted.
+ *
+ * This can be set using the RocksDBDatabasePlugin's static methods.
+ * The two primary external systems are the RocksDB logger plugin and tests.
+ */
+std::atomic<bool> kRocksDBCorruptionIndicator{false};
 
 /// Backing-storage provider for osquery internal/core.
 REGISTER_INTERNAL(RocksDBDatabasePlugin, "database", "rocksdb");
@@ -151,6 +64,11 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
     // logger from trying to make a call back into RocksDB and causing a
     // deadlock.
     LOG(INFO) << "RocksDB: " << log_line;
+  }
+
+  // If the callback includes 'Corruption' then set the corruption indicator.
+  if (log_line.find("Corruption:") != std::string::npos) {
+    RocksDBDatabasePlugin::setCorrupted();
   }
 }
 
@@ -249,6 +167,10 @@ Status RocksDBDatabasePlugin::setUp() {
   return Status(0);
 }
 
+void RocksDBDatabasePlugin::tearDown() {
+  close();
+}
+
 void RocksDBDatabasePlugin::close() {
   WriteLock lock(close_mutex_);
   if (db_ != nullptr) {
@@ -263,21 +185,42 @@ void RocksDBDatabasePlugin::close() {
     delete db_;
     db_ = nullptr;
   }
+
+  if (isCorrupted()) {
+    repairDB();
+    setCorrupted(false);
+  }
+}
+
+bool RocksDBDatabasePlugin::isCorrupted() {
+  return kRocksDBCorruptionIndicator;
+}
+
+void RocksDBDatabasePlugin::setCorrupted(bool corrupted) {
+  kRocksDBCorruptionIndicator = corrupted;
 }
 
 void RocksDBDatabasePlugin::repairDB() {
-  // ROCKSDB_LITE does not have a RepairDB method. No option but to delete the
-  // corrupted DB
-  LOG(INFO) << "Deleting corrupted database files";
-  std::vector<std::string> file_names;
-  auto s = listFilesInDirectory(path_, file_names);
-  if (s.ok()) {
-    for (auto file : file_names) {
-      osquery::remove(file);
+  // Try to backup the existing database.
+  auto bpath = path_ + ".backup";
+  if (pathExists(bpath).ok()) {
+    if (!removePath(bpath).ok()) {
+      LOG(ERROR) << "Cannot remove previous RocksDB database backup: " << bpath;
+      return;
+    } else {
+      LOG(WARNING) << "Removed previous RocksDB database backup: " << bpath;
     }
-  } else {
-    LOG(INFO) << "Unable to list " << path_ << ": " << s.toString();
   }
+
+  if (movePath(path_, bpath).ok()) {
+    LOG(WARNING) << "Backing up RocksDB database: " << bpath;
+  } else {
+    LOG(ERROR) << "Cannot backup the RocksDB database: " << bpath;
+    return;
+  }
+
+  // ROCKSDB_LITE does not have a RepairDB method.
+  LOG(WARNING) << "Destroying RocksDB database due to corruption";
 }
 
 rocksdb::DB* RocksDBDatabasePlugin::getDB() const {
@@ -328,8 +271,6 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
   // Events should be fast, and do not need to force syncs.
   if (kEvents != domain) {
     options.sync = true;
-  } else {
-    options.disableWAL = true;
   }
   auto s = getDB()->Put(options, cfh, key, value);
   if (s.code() != 0 && s.IsIOError()) {

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <atomic>
+
+#include <rocksdb/db.h>
+
+#include <osquery/core.h>
+#include <osquery/database.h>
+
+namespace osquery {
+
+/**
+ * @brief This class is used to capture internal RocksDB messages.
+ *
+ * This can capture internal RocksDB warnings and errors.
+ * We can use them to check the status of the database and forward to the logger
+ * plugin so they are not lost to stderr.
+ */
+class GlogRocksDBLogger : public rocksdb::Logger {
+ public:
+  using rocksdb::Logger::Logv;
+
+  /// Capture log events from RocksDB, inspect, and potentially forward to Glog.
+  void Logv(const char* format, va_list ap) override;
+};
+
+class RocksDBDatabasePlugin : public DatabasePlugin {
+ public:
+  /// Data retrieval method.
+  Status get(const std::string& domain,
+             const std::string& key,
+             std::string& value) const override;
+
+  /// Data storage method.
+  Status put(const std::string& domain,
+             const std::string& key,
+             const std::string& value) override;
+
+  /// Data removal method.
+  Status remove(const std::string& domain, const std::string& k) override;
+
+  /// Data range removal method.
+  Status removeRange(const std::string& domain,
+                     const std::string& low,
+                     const std::string& high) override;
+
+  /// Key/index lookup method.
+  Status scan(const std::string& domain,
+              std::vector<std::string>& results,
+              const std::string& prefix,
+              size_t max = 0) const override;
+
+ public:
+  /// Database workflow: open and setup.
+  Status setUp() override;
+
+  /// Database workflow: close and cleanup.
+  void tearDown() override;
+
+  /// Need to tear down open resources,
+  virtual ~RocksDBDatabasePlugin() {
+    close();
+  }
+
+ private:
+  /// Obtain a close lock and release resources.
+  void close();
+
+  /**
+   * @brief Private helper around accessing the column family handle for a
+   * specific column family, based on its name
+   */
+  rocksdb::ColumnFamilyHandle* getHandleForColumnFamily(
+      const std::string& cf) const;
+
+  /**
+   * @brief Helper method which can be used to get a raw pointer to the
+   * underlying RocksDB database handle
+   *
+   * @return a pointer to the underlying RocksDB database handle
+   */
+  rocksdb::DB* getDB() const;
+
+  /**
+   * @brief Helper method to repair a corrupted db. Best effort only.
+   *
+   * @return nothing.
+   */
+  void repairDB();
+
+ private:
+  /**
+   * @brief Mark the RocksDB database as corrupted.
+   *
+   * This will set the global kCorruptionIndicator.
+   * This may be used from tests or from the RocksDB logger.
+   */
+  static void setCorrupted(bool corrupted = true);
+
+  /// Check if the RocksDB database as been marked corrupted.
+  static bool isCorrupted();
+
+ private:
+  bool initialized_{false};
+
+  /// The database handle
+  rocksdb::DB* db_{nullptr};
+
+  /// RocksDB logger instance.
+  std::shared_ptr<GlogRocksDBLogger> logger_{nullptr};
+
+  /// Column family descriptors which are used to connect to RocksDB
+  std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
+
+  /// A vector of pointers to column family handles
+  std::vector<rocksdb::ColumnFamilyHandle*> handles_;
+
+  /// The RocksDB connection options that are used to connect to RocksDB
+  rocksdb::Options options_;
+
+  /// Deconstruction mutex.
+  Mutex close_mutex_;
+
+ private:
+  friend class GlogRocksDBLogger;
+  FRIEND_TEST(RocksDBDatabasePluginTests, test_corruption);
+};
+} // namespace osquery

--- a/osquery/database/tests/plugin_tests.h
+++ b/osquery/database/tests/plugin_tests.h
@@ -12,10 +12,7 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/filesystem/operations.hpp>
-
 #include <osquery/database.h>
-#include <osquery/flags.h>
 
 #include "osquery/tests/test_util.h"
 
@@ -48,29 +45,11 @@
 
 namespace osquery {
 
-DECLARE_string(database_path);
-
 class DatabasePluginTests : public testing::Test {
  public:
-  void SetUp() override {
-    auto& rf = RegistryFactory::get();
-    existing_plugin_ = rf.getActive("database");
-    rf.plugin("database", existing_plugin_)->tearDown();
+  void SetUp() override;
 
-    setName(name());
-    path_ = FLAGS_database_path;
-    boost::filesystem::remove_all(path_);
-
-    auto plugin = rf.plugin("database", getName());
-    plugin_ = std::dynamic_pointer_cast<DatabasePlugin>(plugin);
-    plugin_->reset();
-  }
-
-  void TearDown() override {
-    auto& rf = RegistryFactory::get();
-    rf.plugin("database", name_)->tearDown();
-    rf.setActive("database", existing_plugin_);
-  }
+  void TearDown() override;
 
  protected:
   /// Path to testing database.
@@ -84,9 +63,11 @@ class DatabasePluginTests : public testing::Test {
   void setName(const std::string& name) {
     name_ = name;
   }
+
   const std::string& getName() {
     return name_;
   }
+
   std::shared_ptr<DatabasePlugin> getPlugin() {
     return plugin_;
   }

--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -44,8 +44,7 @@ class FSEventsTests : public testing::Test {
   }
 
   void TearDown() override {
-    remove(real_test_path);
-    fs::remove_all(real_test_dir);
+    removePath(real_test_dir);
   }
 
   void StartEventLoop() {

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -49,8 +49,7 @@ class INotifyTests : public testing::Test {
 
   void TearDown() override {
     // End the event loops, and join on the threads.
-    remove(real_test_path);
-    fs::remove_all(real_test_dir);
+    removePath(real_test_dir);
   }
 
   void StartEventLoop() {

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -242,7 +242,7 @@ bool ExtensionManagerHandler::exists(const std::string& name) {
 } // namespace extensions
 
 ExtensionRunnerCore::~ExtensionRunnerCore() {
-  remove(path_);
+  removePath(path_);
 }
 
 void ExtensionRunnerCore::stop() {
@@ -265,7 +265,7 @@ inline void removeStalePaths(const std::string& manager) {
   // Attempt to remove all stale extension sockets.
   resolveFilePattern(manager + ".*", paths);
   for (const auto& path : paths) {
-    remove(path);
+    removePath(path);
   }
 }
 

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -44,8 +44,8 @@ class ExtensionsTest : public testing::Test {
     socket_path += "testextmgr" + std::to_string(rand());
 
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
-      remove(socket_path);
-      if (pathExists(socket_path)) {
+      removePath(socket_path);
+      if (pathExists(socket_path).ok()) {
         throw std::domain_error("Cannot test sockets: " + socket_path);
       }
     }
@@ -56,7 +56,7 @@ class ExtensionsTest : public testing::Test {
     Dispatcher::joinServices();
 
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
-      remove(socket_path);
+      removePath(socket_path);
     }
   }
 

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -243,9 +243,26 @@ Status pathExists(const fs::path& path) {
   return Status(0, "1");
 }
 
-Status remove(const fs::path& path) {
-  auto status_code = std::remove(path.string().c_str());
-  return Status(status_code, "N/A");
+Status movePath(const fs::path& from, const fs::path& to) {
+  boost::system::error_code ec;
+  if (from.empty() || to.empty()) {
+    return Status(1, "Cannot copy empty paths");
+  }
+
+  fs::rename(from, to, ec);
+  if (ec.value() != errc::success) {
+    return Status(1, ec.message());
+  }
+  return Status(0);
+}
+
+Status removePath(const fs::path& path) {
+  boost::system::error_code ec;
+  auto removed_files = fs::remove_all(path, ec);
+  if (ec.value() != errc::success) {
+    return Status(1, ec.message());
+  }
+  return Status(0, std::to_string(removed_files));
 }
 
 static void genGlobs(std::string path,

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -345,7 +345,7 @@ Status socketExists(const fs::path& path, bool remove_socket) {
   if (pathExists(path).ok()) {
     if (!isWritable(path).ok()) {
       return Status(1, "Cannot write extension socket: " + path.string());
-    } else if (remove_socket && !osquery::remove(path).ok()) {
+    } else if (remove_socket && !removePath(path).ok()) {
       return Status(1, "Cannot remove extension socket: " + path.string());
     }
   } else {

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -84,7 +84,22 @@ TEST_F(FilesystemTests, test_read_file) {
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(content, "test123" + line_ending_);
 
-  osquery::remove(kTestWorkingDirectory + "fstests-file");
+  removePath(kTestWorkingDirectory + "fstests-file");
+}
+
+TEST_F(FilesystemTests, test_remove_path) {
+  fs::path test_dir(kTestWorkingDirectory + "rmdir");
+  fs::create_directories(test_dir);
+
+  fs::path test_file(kTestWorkingDirectory + "rmdir/rmfile");
+  writeTextFile(test_file, "testcontent");
+
+  ASSERT_TRUE(pathExists(test_file));
+
+  // Try to remove the directory.
+  EXPECT_TRUE(removePath(test_dir));
+  EXPECT_FALSE(pathExists(test_file));
+  EXPECT_FALSE(pathExists(test_dir));
 }
 
 TEST_F(FilesystemTests, test_write_file) {
@@ -94,19 +109,19 @@ TEST_F(FilesystemTests, test_write_file) {
   EXPECT_TRUE(writeTextFile(test_file, content).ok());
   ASSERT_TRUE(pathExists(test_file).ok());
   ASSERT_TRUE(isWritable(test_file).ok());
-  ASSERT_TRUE(osquery::remove(test_file).ok());
+  ASSERT_TRUE(removePath(test_file).ok());
 
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0400, true));
   ASSERT_TRUE(pathExists(test_file).ok());
   ASSERT_FALSE(isWritable(test_file).ok());
   ASSERT_TRUE(isReadable(test_file).ok());
-  ASSERT_TRUE(osquery::remove(test_file).ok());
+  ASSERT_TRUE(removePath(test_file).ok());
 
   EXPECT_TRUE(writeTextFile(test_file, content, (int)0000, true));
   ASSERT_TRUE(pathExists(test_file).ok());
   ASSERT_FALSE(isWritable(test_file).ok());
   ASSERT_FALSE(isReadable(test_file).ok());
-  ASSERT_TRUE(osquery::remove(test_file).ok());
+  ASSERT_TRUE(removePath(test_file).ok());
 }
 
 TEST_F(FilesystemTests, test_readwrite_file) {
@@ -123,7 +138,7 @@ TEST_F(FilesystemTests, test_readwrite_file) {
   EXPECT_TRUE(readFile(test_file, out_content).ok());
   EXPECT_EQ(filesize, out_content.size());
   EXPECT_EQ(in_content, out_content);
-  osquery::remove(test_file);
+  removePath(test_file);
 
   // Now try to write outside of a 4k chunk size.
   in_content = std::string(filesize + 1, 'A');
@@ -131,7 +146,7 @@ TEST_F(FilesystemTests, test_readwrite_file) {
   out_content.clear();
   readFile(test_file, out_content);
   EXPECT_EQ(in_content, out_content);
-  osquery::remove(test_file);
+  removePath(test_file);
 }
 
 TEST_F(FilesystemTests, test_read_limit) {

--- a/osquery/tables/yara/tests/yara_tests.cpp
+++ b/osquery/tables/yara/tests/yara_tests.cpp
@@ -24,14 +24,14 @@ const std::string alwaysFalse = "rule always_false { condition: false }";
 class YARATest : public testing::Test {
  protected:
   void SetUp() {
-    remove(ruleFile);
+    removePath(ruleFile);
     if (pathExists(ruleFile).ok()) {
       throw std::domain_error("Rule file exists.");
     }
   }
 
   void TearDown() {
-    remove(ruleFile);
+    removePath(ruleFile);
   }
 
   Row scanFile(const std::string& ruleContent) {


### PR DESCRIPTION
This tries to address: #3592.

First it renames: `osquery::remove` to `osquery::removePath` to differentiate from other similar method names (e.g., `std::remove`). `removePath` is then changed to use `boost::filesystem::remove_all`.

Second it adds a `movePath` that allows a file or directory to be moved to another location.

Use those two changes, this PR alters the behavior of the RocksDB database plugin's corruption and recovery behavior by first trying to move the existing corrupted database to `--database_path + ".backup"`. Then starting with a fresh DB at `--database_path`. The corruption detection logic is extended to include run-time detections. If a log-line is emitted indicating corruption then the next DB reset (default 5min) will perform the recovery.

There are several fixes included here to code structure that allow adding a test for the corruption recovery behavior.