### PR TITLE
rocksdb: Flush all column families and set max files

### DIFF
--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -96,6 +96,9 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
    */
   void repairDB();
 
+  /// Flush memtables and trigger compaction.
+  void flush();
+
  private:
   /**
    * @brief Mark the RocksDB database as corrupted.


### PR DESCRIPTION
This addresses #3594.

We can try to force RocksDB to use a max of 256 files. We should also be `Flush`ing all of the column families on reset. This is a bug because we were not using the RocksDB API correctly. 