### PR TITLE
rocksdb: Use normal RocksDB (no lite)

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -133,10 +133,8 @@ endif()
 
 if(APPLE OR LINUX)
   ADD_OSQUERY_LINK_CORE("libdl")
-  ADD_OSQUERY_LINK_ADDITIONAL("rocksdb_lite")
 elseif(FREEBSD)
   ADD_OSQUERY_LINK_CORE("icuuc")
-  ADD_OSQUERY_LINK_ADDITIONAL("rocksdb-lite")
 endif()
 
 if(POSIX)
@@ -145,6 +143,7 @@ if(POSIX)
   ADD_OSQUERY_LINK_CORE("boost_thread")
   ADD_OSQUERY_LINK_CORE("boost_context")
   ADD_OSQUERY_LINK_ADDITIONAL("boost_regex")
+  ADD_OSQUERY_LINK_ADDITIONAL("rocksdb")
 endif()
 
 if(LINUX OR FREEBSD)

--- a/osquery/database/CMakeLists.txt
+++ b/osquery/database/CMakeLists.txt
@@ -10,9 +10,6 @@ ADD_OSQUERY_LIBRARY(TRUE osquery_database
   plugins/ephemeral.cpp
 )
 
-# Optionally (but by default), add the RocksDB database plugin.
-add_definitions(-DROCKSDB_LITE=1)
-
 # Begin with just the SQLite database plugin.
 set(OSQUERY_DATABASE_PLUGINS
   plugins/sqlite.cpp

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -26,8 +26,6 @@ namespace osquery {
  */
 class GlogRocksDBLogger : public rocksdb::Logger {
  public:
-  using rocksdb::Logger::Logv;
-
   /// Capture log events from RocksDB, inspect, and potentially forward to Glog.
   void Logv(const char* format, va_list ap) override;
 };
@@ -106,7 +104,7 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
    * This will set the global kCorruptionIndicator.
    * This may be used from tests or from the RocksDB logger.
    */
-  static void setCorrupted(bool corrupted = true);
+  static void setCorrupted(bool corrupted = true, bool force = false);
 
   /// Check if the RocksDB database as been marked corrupted.
   static bool isCorrupted();

--- a/osquery/database/plugins/tests/rocksdb_tests.cpp
+++ b/osquery/database/plugins/tests/rocksdb_tests.cpp
@@ -41,18 +41,21 @@ TEST_F(RocksDBDatabasePluginTests, test_corruption) {
   ASSERT_FALSE(pathExists(path_ + ".backup"));
 
   // Mark the database as corrupted
-  RocksDBDatabasePlugin::setCorrupted();
-  printf("set corrupt\n");
+  RocksDBDatabasePlugin::setCorrupted(true, true);
   resetDatabase();
-  printf("did reset\n");
-
   EXPECT_TRUE(pathExists(path_ + ".backup"));
 
   // Remove the backup and expect another reload to not create one.
   removePath(path_ + ".backup");
   ASSERT_FALSE(pathExists(path_ + ".backup"));
 
+  // Resetting will have cleared the corruption indicators.
   resetDatabase();
   EXPECT_FALSE(pathExists(path_ + ".backup"));
+
+  // A non-forced corrupted call will use the internal Repair APIs.
+  RocksDBDatabasePlugin::setCorrupted();
+  resetDatabase();
+  ASSERT_FALSE(pathExists(path_ + ".backup"));
 }
 }

--- a/tools/provision/formula/rocksdb.rb
+++ b/tools/provision/formula/rocksdb.rb
@@ -3,9 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Rocksdb < AbstractOsqueryFormula
   desc "Persistent key-value store for fast storage environments"
   homepage "http://rocksdb.org"
-  url "https://github.com/facebook/rocksdb/archive/rocksdb-5.7.2.tar.gz"
-  sha256 "31934ed4e2ab4d08eabd5f68fa625146eba371f8f588350b79e1fee7dd510bcc"
-  revision 103
+  url "https://github.com/facebook/rocksdb/archive/rocksdb-5.7.3.tar.gz"
+  sha256 "6256c5d0e95e513f71f5af0a409dab1b3e68f804f12270e687ab195c3ececfd0"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -21,10 +21,7 @@ class Rocksdb < AbstractOsqueryFormula
 
   def install
     ENV.cxx11
-
     ENV["PORTABLE"] = "1"
-    ENV["LIBNAME"] = "librocksdb_lite"
-    ENV.append_to_cflags "-DROCKSDB_LITE=1"
 
     system "make", "clean"
     system "make", "static_lib"

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -28,7 +28,7 @@ function distro_main() {
   package thrift-cpp
   package boost-libs
   package magic
-  package rocksdb-lite
+  package rocksdb
   package asio
   package cpp-netlib
   package linenoise-ng


### PR DESCRIPTION
This moves osquery off of RocksDB-LITE and onto RocksDB. While the LITE version saves near 1M of space, the APIs in the non-LITE are desirable. And in some cases, like with FreeBSD, the non-LITE version is better tested.

This bumps POSIX to version 5.7.3 (the same as FreeBSD) and removes the defines for LITE. It then implements the `RepairDB` API call and extends the test harness for this. The logic still allows the API call to fail and then will fall into the existing backup logic. It also adds a forced compaction to the `flush` API. On startup the RocksDB database plugin will count the number of live files and if this exceeds 1024 it will emit a warning.