### PR TITLE
deps: fixing up aws-sdk-cpp choco build script

### DIFF
--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -12,7 +12,23 @@
 #include <sstream>
 #include <string>
 
+// clang-format off
+#ifdef WIN32
+#pragma warning(push, 3)
+/*
+ * Suppressing warning C4005:
+ * 'ASIO_ERROR_CATEGORY_NOEXCEPT': macro redefinition
+ */
+#pragma warning(disable: 4005)
+#endif
 #include <boost/network/protocol/http/client.hpp>
+#ifdef WIN32
+#pragma warning(pop)
+/// We reinclude this to re-enable boost's warning suppression
+#include <boost/config/compiler/visualc.hpp>
+#endif
+// clang-format on
+
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -281,7 +281,7 @@ function Install-ThirdParty {
 
   # List of our third party packages, hosted in our AWS S3 bucket
   $packages = @(
-    "aws-sdk-cpp.1.0.107-r1",
+    "aws-sdk-cpp.1.1.44",
     "boost-msvc14.1.65.0",
     "bzip2.1.0.6",
     "cpp-netlib.0.12.0-r4",


### PR DESCRIPTION
This bumps the AWS SDK version in the provisioning scripts, as well as addresses a few small fixes in the choco build script.