### PR TITLE
Query "counter" to differentiate initial results

### DIFF
--- a/docs/wiki/deployment/anomaly-detection.md
+++ b/docs/wiki/deployment/anomaly-detection.md
@@ -34,8 +34,9 @@ Using the [log aggregation guide](log-aggregation.md), you will receive log line
     },
     "hostname":  "ted-osx.local",
     "calendarTime":  "Fri Nov  7 09:42:42 2014",
-    "unixTime":  1415382685,
-    "epoch": 314159265
+    "unixTime":  "1415382685",
+    "epoch": "314159265",
+    "counter": "1"
 }
 ```
 

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -95,7 +95,8 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "hostname": "hostname.local",
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
-  "epoch": "314159265"
+  "epoch": "314159265",
+  "counter": "1"
 }
 ```
 
@@ -111,7 +112,8 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "hostname": "hostname.local",
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
-  "epoch": "314159265"
+  "epoch": "314159265",
+  "counter": "1"
 }
 ```
 
@@ -151,7 +153,8 @@ Consider the following example:
   "hostIdentifier": "hostname.local",
   "calendarTime": "Mon May  2 22:27:32 2016 UTC",
   "unixTime": "1462228052",
-  "epoch": "314159265"
+  "epoch": "314159265",
+  "counter": "1"
 }
 ```
 
@@ -185,16 +188,22 @@ Example output of `SELECT name, path, pid FROM processes;` (whitespace added for
   "hostname": "hostname.local",
   "calendarTime": "Tue Sep 30 17:37:30 2014",
   "unixTime": "1412123850",
-  "epoch": "314159265"
+  "epoch": "314159265",
+  "counter": "1"
 }
 ```
 
 Most of the time the **Event format** is the most appropriate. The next section in the deployment guide describes [log aggregation](log-aggregation.md) methods. The aggregation methods describe collecting, searching, and alerting on the results from a query schedule.
 
 ## Schedule epoch
-When [differential logs](#differential-logs) were described above, we mentioned that after the initial execution of a scheduled query, only differential results are logged. While this is very efficient from a size-of-logs perspective, it introduces some challenges. To begin with, if the logs are stored in a log management system of some kind, it becomes difficult or impossible to identify which log results are from the initial run of the query, and which ones are differentials to the initial results. In some situations, this becomes problematic - for example, for some tables like the users table that don't change very often at all and so don't generate differential results very often, one would have to search far into historical logs to find the last results returned by osquery; conversely, for some tables like processes that change frequently, one would have to do a fair amount of logic applying the effects of added and removed rows to reconstruct the current state of running processes. 
 
-To aid with this, osquery maintains an epoch marker along with each scheduled query execution, and calculates differentials only if the epoch of the last run matches the current epoch. If it doesn't, then it treats the current execution of the query as an initial run. You can set the epoch marker by starting osquery with the --schedule_epoch=<some 64bit int> flag or by updating the schedule_epoch flag remotely from a TLS backend. The epoch is transmitted with each log result, so that it is easy to identify which results belong to which execution of the scheduled query. 
+When [differential logs](#differential-logs) were described above, we mentioned that after the initial execution of a scheduled query, only differential results are logged. While this is very efficient from a size-of-logs perspective, it introduces some challenges. To begin with, if the logs are stored in a log management system of some kind, it becomes difficult or impossible to identify which log results are from the initial run of the query, and which ones are differentials to the initial results. In some situations, this becomes problematic - for example, for some tables like the users table that don't change very often at all and so don't generate differential results very often, one would have to search far into historical logs to find the last results returned by osquery; conversely, for some tables like processes that change frequently, one would have to do a fair amount of logic applying the effects of added and removed rows to reconstruct the current state of running processes.
+
+To aid with this, osquery maintains an **epoch** marker along with each scheduled query execution, and calculates differentials only if the epoch of the last run matches the current epoch. If it doesn't, then it treats the current execution of the query as an initial run. You can set the epoch marker by starting osquery with the --schedule_epoch=<some 64bit int> flag or by updating the schedule_epoch flag remotely from a TLS backend. The epoch is transmitted with each log result, so that it is easy to identify which results belong to which execution of the scheduled query.
+
+## Schedule counter
+
+When setting up alerts for [differential logs](#differential-logs) data you might want to skip the initial **added** records. **counter** can be used to identify if the added records are all records from initial query of if they are new records. For initial query results that includes all records counter will be **"0"**. For subsequent query executions counter will be incremented by **1**. When **epoch** changes, counter will be reset back to "0".
 
 ## Unique host identification
 

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -325,6 +325,9 @@ struct QueryLogItem {
   /// The epoch at the time the query was executed
   uint64_t epoch;
 
+  /// Query execution counter for current epoch
+  uint64_t counter{0};
+
   /// The time that the query was executed, an ASCII string.
   std::string calendar_time;
 
@@ -424,14 +427,27 @@ class Query {
   Status getPreviousQueryResults(QueryData& results) const;
 
   /**
-   * @brief Get the epoch associated with the previous query results
+   * @brief Get the epoch associated with the previous query results.
    *
    * This method retrieves the epoch associated with the results data that was
-   * was stored in rocksdb
+   * was stored in rocksdb.
    *
    * @return the epoch associated with the previous query results.
    */
   uint64_t getPreviousEpoch() const;
+
+  /**
+   * @brief Get the query invocation counter.
+   *
+   * This method returns query invocation counter. If the query is a new query,
+   * 0 is returned. Otherwise the counter associated with the query is retrieved
+   * from database and incremented by 1.
+   *
+   * @param new_query Whether or not the query is new.
+   *
+   * @return the query invocation counter.
+   */
+  uint64_t getQueryCounter(bool new_query) const;
 
   /**
    * @brief Check if a given scheduled query exists in the database.
@@ -455,10 +471,13 @@ class Query {
    *
    * @param qd the QueryData object, which has the results of the query.
    * @param epoch the epoch associatted with QueryData
+   * @param counter the output that holds the query execution counter.
    *
    * @return the success or failure of the operation.
    */
-  Status addNewResults(const QueryData& qd, const uint64_t epoch) const;
+  Status addNewResults(const QueryData& qd,
+                       const uint64_t epoch,
+                       uint64_t& counter) const;
 
   /**
    * @brief Add a new set of results to the persistent storage and get back
@@ -470,6 +489,7 @@ class Query {
    *
    * @param qd the QueryData object containing query results to store.
    * @param epoch the epoch associated with QueryData
+   * @param counter the output that holds the query execution counter.
    * @param dr an output to a DiffResults object populated based on last run.
    * @param calculate_diff default true to populate dr.
    *
@@ -477,6 +497,7 @@ class Query {
    */
   Status addNewResults(const QueryData& qd,
                        const uint64_t epoch,
+                       uint64_t& counter,
                        DiffResults& dr,
                        bool calculate_diff = true) const;
 

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -84,6 +84,7 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
 
   QueryLogItem item;
   item.epoch = 0L;
+  item.counter = 0L;
   getDecorations(item.decorations);
   ASSERT_EQ(item.decorations.size(), 2U);
   EXPECT_EQ(item.decorations.at("internal_60_test"), "test");
@@ -93,8 +94,8 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   std::string expected =
       "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"\","
       "\"hostIdentifier\":\"\",\"calendarTime\":\"\",\"unixTime\":\"0\","
-      "\"epoch\":\"0\",\"decorations\":{\"internal_60_test\":\"test\","
-      "\"one\":\"1\"}}\n";
+      "\"epoch\":\"0\",\"counter\":\"0\","
+      "\"decorations\":{\"internal_60_test\":\"test\",\"one\":\"1\"}}\n";
   EXPECT_EQ(log_line, expected);
 
   // Now clear and run again.

--- a/osquery/database/benchmarks/database_benchmarks.cpp
+++ b/osquery/database/benchmarks/database_benchmarks.cpp
@@ -137,8 +137,9 @@ static void DATABASE_query_results(benchmark::State& state) {
   auto query = getOsqueryScheduledQuery();
   while (state.KeepRunning()) {
     DiffResults diff_results;
+    uint64_t counter;
     auto dbq = Query("default", query);
-    dbq.addNewResults(qd, 0, diff_results);
+    dbq.addNewResults(qd, 0, counter, diff_results);
   }
 }
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -113,7 +113,8 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
   // We can then ask for a differential from the last time this named query
   // was executed by exact matching each row.
   if (!FLAGS_events_optimize || !sql.eventBased()) {
-    status = dbQuery.addNewResults(sql.rows(), item.epoch, diff_results);
+    status = dbQuery.addNewResults(
+        sql.rows(), item.epoch, item.counter, diff_results);
     if (!status.ok()) {
       std::string line =
           "Error adding new results to database: " + status.what();

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -145,6 +145,7 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   item.time = 0;
   item.calendar_time = "test";
   item.epoch = 0L;
+  item.counter = 0L;
 
   EXPECT_TRUE(logSnapshotQuery(item));
   auto snapshot_path = fs::path(FLAGS_logger_path) / "osqueryd.snapshots.log";
@@ -158,11 +159,11 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
 
   std::string expected =
       "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"test\","
-      "\"hostIdentifier\":\"test\","
-      "\"calendarTime\":\"test\",\"unixTime\":\"0\",\"epoch\":\"0\"}\n"
+      "\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
+      "\"unixTime\":\"0\",\"epoch\":\"0\",\"counter\":\"0\"}\n"
       "{\"snapshot\":\"\",\"action\":\"snapshot\","
       "\"name\":\"test\",\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":\"0\",\"epoch\":\"0\"}\n";
+      "\"unixTime\":\"0\",\"epoch\":\"0\",\"counter\":\"0\"}\n";
   EXPECT_EQ(content, expected);
 }
 }

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -331,6 +331,7 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   item.time = 0;
   item.calendar_time = "no_time";
   item.epoch = 0L;
+  item.counter = 0L;
   item.results.added.push_back({{"test_column", "test_value"}});
   logQueryLogItem(item);
   EXPECT_EQ(1U, LoggerTests::log_lines.size());
@@ -343,7 +344,8 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
       "\"calendarTime\":\"no_time\",\"unixTime\":\"0\",\"epoch\":\"0\","
-      "\"columns\":{\"test_column\":\"test_value\"},\"action\":\"added\"}";
+      "\"counter\":\"0\",\"columns\":{\"test_column\":\"test_value\"},"
+      "\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }
 

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -323,12 +323,14 @@ std::pair<pt::ptree, QueryLogItem> getSerializedQueryLogItem() {
   i.time = 1408993857;
   i.identifier = "foobaz";
   i.epoch = 0L;
+  i.counter = 0L;
   root.add_child("diffResults", dr.first);
   root.put<std::string>("name", "foobar");
   root.put<std::string>("hostIdentifier", "foobaz");
   root.put<std::string>("calendarTime", "Mon Aug 25 12:10:57 2014");
   root.put<int>("unixTime", 1408993857);
   root.put<uint64_t>("epoch", 0L);
+  root.put<uint64_t>("counter", 0L);
   return std::make_pair(root, i);
 }
 


### PR DESCRIPTION
When setting up alerts for differential logs data you might want to skip the
initial added records. counter can be used to identify if the added records
are all records from initial query of if they are new records. For initial
query results that includes all records counter will be "0". For subsequent
query executions counter will be incremented by 1. When epoch changes, counter
will be reset back to "0".