### PR TITLE
AWS code refactoring.

### DIFF
--- a/osquery/tables/cloud/ec2_instance_metadata.cpp
+++ b/osquery/tables/cloud/ec2_instance_metadata.cpp
@@ -19,6 +19,8 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+#include "osquery/utils/aws_util.h"
+
 namespace pt = boost::property_tree;
 namespace http = boost::network::http;
 
@@ -126,7 +128,7 @@ class JSONEc2MetaData : public Ec2MetaData {
 };
 
 std::string Ec2MetaData::doGet() const {
-  const static std::string ec2_metadata_url{"http://169.254.169.254/latest/"};
+  const static std::string ec2_metadata_url{kEc2MetadataUrl};
 
   http::client::request req(ec2_metadata_url + url_suffix_);
   http::client::options options;
@@ -202,39 +204,6 @@ void JSONEc2MetaData::extractResult(const std::string& http_body,
   } catch (const pt::json_parser::json_parser_error& e) {
     VLOG(1) << "Could not parse JSON from " << url_suffix_ << ": " << e.what();
   }
-}
-
-static bool isEc2Instance() {
-  static std::atomic<bool> checked(false);
-  static std::atomic<bool> is_ec2_instance(false);
-  if (checked) {
-    return is_ec2_instance; // Return if already checked
-  }
-
-  static std::once_flag once_flag;
-  std::call_once(once_flag, []() {
-    if (checked) {
-      return;
-    }
-
-    checked = true;
-    http::client::request req("http://169.254.169.254");
-    http::client::options options;
-    options.timeout(3);
-    http::client client(options);
-
-    try {
-      http::client::response res = client.get(req);
-      if (res.status() == 200) {
-        is_ec2_instance = true;
-      }
-    } catch (const std::system_error& e) {
-      // Assume that this is not EC2 instance
-      VLOG(1) << "Error checking if this is EC2 instance: " << e.what();
-    }
-  });
-
-  return is_ec2_instance;
 }
 
 QueryData genEc2Metadata(QueryContext& context) {

--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <fstream>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -353,8 +354,8 @@ void getInstanceIDAndRegion(std::string& instance_id, std::string& region) {
   static std::atomic<bool> checked(false);
   static std::string cached_id;
   static std::string cached_region;
-  if (checked) {
-    // Return if already checked
+  if (checked || !isEc2Instance()) {
+    // Return if already checked or this is not EC2 instance
     instance_id = cached_id;
     region = cached_region;
     return;
@@ -367,8 +368,8 @@ void getInstanceIDAndRegion(std::string& instance_id, std::string& region) {
     }
 
     initAwsSdk();
-    http::client::request req(
-        "http://169.254.169.254/latest/dynamic/instance-identity/document");
+    http::client::request req(kEc2MetadataUrl +
+                              "dynamic/instance-identity/document");
     http::client::options options;
     options.timeout(3);
     http::client client(options);
@@ -393,6 +394,47 @@ void getInstanceIDAndRegion(std::string& instance_id, std::string& region) {
 
   instance_id = cached_id;
   region = cached_region;
+}
+
+bool isEc2Instance() {
+  static std::atomic<bool> checked(false);
+  static std::atomic<bool> is_ec2_instance(false);
+  if (checked) {
+    return is_ec2_instance; // Return if already checked
+  }
+
+  static std::once_flag once_flag;
+  std::call_once(once_flag, []() {
+    if (checked) {
+      return;
+    }
+    checked = true;
+
+    std::ifstream fd(kHypervisorUuid, std::ifstream::in);
+    if (!fd) {
+      return; // No hypervisor UUID file. Not EC2
+    }
+    if (!(fd.get() == 'e' && fd.get() == 'c' && fd.get() == '2')) {
+      return; // Not EC2 instance
+    }
+
+    http::client::request req(kEc2MetadataUrl);
+    http::client::options options;
+    options.timeout(3);
+    http::client client(options);
+
+    try {
+      http::client::response res = client.get(req);
+      if (res.status() == 200) {
+        is_ec2_instance = true;
+      }
+    } catch (const std::system_error& e) {
+      // Assume that this is not EC2 instance
+      VLOG(1) << "Error checking if this is EC2 instance: " << e.what();
+    }
+  });
+
+  return is_ec2_instance;
 }
 
 Status getAWSRegion(std::string& region, bool sts) {

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -30,6 +30,12 @@ namespace osquery {
 
 using RegionName = const char* const;
 
+/// EC2 instance latestmetadata URL
+const std::string kEc2MetadataUrl = "http://169.254.169.254/latest/";
+
+/// Hypervisor UUID file
+const std::string kHypervisorUuid = "/sys/hypervisor/uuid";
+
 /**
  * @brief Client factory for the netlib HTTP client
  */
@@ -139,13 +145,22 @@ class OsqueryAWSCredentialsProviderChain
 void initAwsSdk();
 
 /**
+ * @brief Checks to see if this machine is EC2 instance.
+ *
+ * This method caches results after first check and returns cached data. It
+ * first checks if /sys/hypervisor/uuid file exists and its contents starts with
+ * 'ec2'. If UUID prefix matches, it then connects to EC2 latest metadata URL.
+ * If both checks pass, this method returns true. Otherwise false.
+ */
+bool isEc2Instance();
+
+/**
  * @brief Returns EC2 instance ID and region of this machine.
  *
  * If this is EC2 instance, returns the instance ID and region by querying the
  * EC2 metadata service. If this is not EC2 instance, returns empty strings.
  * This function makes HTTP call to EC2 metadata service. EC2 instance ID and
- * region are cached. First call to this method on non-EC2 instance machines can
- * take up to 3 seconds (HTTP timeout).
+ * region are cached.
  */
 void getInstanceIDAndRegion(std::string& instance_id, std::string& region);
 


### PR DESCRIPTION
Moved isEc2Instance check to utility class.
Add faster check to see if instance is EC2 (using hypervisor UUID).
This avoids the 3 second initial timeout on non-EC2 instances.
Changed EC2 metadata URL to a constant.