### PR TITLE
[Fix #3625] Use readlink and add test for listening_ports

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -430,7 +430,7 @@ if(NOT SKIP_TESTS)
     add_test(osquery_additional_tests osquery_additional_tests ${TEST_ARGS})
 
     # osquery tables set of unit tests (extracted for organization).
-    add_executable(osquery_tables_tests main/tests.cpp ${OSQUERY_TABLES_TESTS})
+    add_executable(osquery_tables_tests tests/test_additional_util.cpp main/tests.cpp ${OSQUERY_TABLES_TESTS})
     ADD_DEFAULT_LINKS(osquery_tables_tests TRUE)
     target_link_libraries(osquery_tables_tests gtest gmock libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_tables_tests "${GTEST_FLAGS} ${CXX_COMPILE_FLAGS}")

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -65,13 +65,12 @@ Status procReadDescriptor(const std::string& process,
                           std::string& result) {
   auto link = kLinuxProcPath + "/" + process + "/fd/" + descriptor;
 
-  char* result_path = realpath(link.c_str(), nullptr);
-  if (result_path != nullptr) {
+  char result_path[PATH_MAX] = {0};
+  auto size = readlink(link.c_str(), result_path, sizeof(result_path) - 1);
+  if (size >= 0) {
     result = std::string(result_path);
-    free(result_path);
-    return Status(0, "OK");
+    return Status(0);
   }
-
   return Status(1, "Could not read path");
 }
 }

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -11,16 +11,16 @@
 #include <gtest/gtest.h>
 
 #include <osquery/logger.h>
+#include <osquery/sql.h>
 
+#include "osquery/tests/test_additional_util.h"
 #include "osquery/tests/test_util.h"
 
 namespace osquery {
 namespace tables {
 
-osquery::QueryData parseEtcHostsContent(const std::string& content);
-#ifndef WIN32
-osquery::QueryData parseEtcProtocolsContent(const std::string& content);
-#endif
+QueryData parseEtcHostsContent(const std::string& content);
+QueryData parseEtcProtocolsContent(const std::string& content);
 
 class NetworkingTablesTests : public testing::Test {};
 
@@ -29,11 +29,27 @@ TEST_F(NetworkingTablesTests, test_parse_etc_hosts_content) {
             getEtcHostsExpectedResults());
 }
 
-#ifndef WIN32
 TEST_F(NetworkingTablesTests, test_parse_etc_protocols_content) {
   EXPECT_EQ(parseEtcProtocolsContent(getEtcProtocolsContent()),
             getEtcProtocolsExpectedResults());
 }
-#endif
+
+TEST_F(NetworkingTablesTests, test_listening_ports) {
+  auto& server = TLSServerRunner::instance();
+  server.start();
+  auto results = SQL::selectAllFrom("listening_ports");
+
+  std::string pid;
+  for (const auto& row : results) {
+    // Expect to find a process PID for the server.
+    if (row.at("port") == server.port()) {
+      pid = row.at("pid");
+    }
+  }
+
+  EXPECT_GT(pid.size(), 0U);
+  EXPECT_NE(pid, "-1");
+  server.stop();
+}
 }
 }


### PR DESCRIPTION
This reverts a change added as the result of static analysis to replace `readlink` with `readpath`. From what I can tell, we're using `readlink` safely: https://www.securecoding.cert.org/confluence/display/c/POS30-C.+Use+the+readlink%28%29+function+properly

This adds a test for `listening_ports` using the internal `TLSServerRunner` so we do not regress again.