### PR TITLE
shell: ensuring shell does not access stop event

### DIFF
--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -77,6 +77,10 @@ static void UpdateServiceStatus(DWORD controls,
 }
 
 static auto kShutdownCallable = ([]() {
+  // To prevent invalid access to the stop event, we return if running as shell
+  if (Initializer::isShell()) {
+    return;
+  }
   // The event only gets initialized in the entry point of the service. Child
   // processes and those run from the commandline will not have a stop event.
   auto stopEvent = osquery::getStopEvent();


### PR DESCRIPTION
This addresses #3637

As we've merged the binaries into one, the shell is attempting to grab the stop event, which doesn't exist when running as the interactive shell. This checks to ensure we're only processing the stop event if we're the daemon.