### PR TITLE
deps: Simplify librdkafka formula

### DIFF
--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -158,7 +158,7 @@ class AbstractOsqueryFormula < Formula
     append "CFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
     append "CXXFLAGS", "-fPIC -DNDEBUG -Os -march=core2"
 
-    if ENV["CC"].to_s.include?("clang") and !["librpm", "python", "librdkafka"].include?(self.name)
+    if ENV["CC"].to_s.include?("clang") and !["librpm", "python"].include?(self.name)
       append "CFLAGS", "-fvisibility=hidden -fvisibility-inlines-hidden"
       append "CXXFLAGS", "-fvisibility=hidden -fvisibility-inlines-hidden"
       append "CFLAGS", "-Wno-unused-command-line-argument"

--- a/tools/provision/formula/librdkafka.rb
+++ b/tools/provision/formula/librdkafka.rb
@@ -5,11 +5,7 @@ class Librdkafka < AbstractOsqueryFormula
   homepage "https://github.com/edenhill/librdkafka"
   url "https://github.com/edenhill/librdkafka/archive/v0.9.5.tar.gz"
   sha256 "dd395ffca89c9591e567366f3ad2517cee76578a10d0a16a93f990c33f553179"
-
-  depends_on "openssl"
-  depends_on "pkg-config" => :build
-  depends_on "lzlib"
-  depends_on "lz4" => :optional
+  revision 102
 
   def install
     args = [
@@ -17,11 +13,8 @@ class Librdkafka < AbstractOsqueryFormula
       "--prefix=#{prefix}",
       "--disable-sasl",
       "--disable-lz4",
+      "--enable-static",
     ]
-
-    if OS.linux?
-      ENV.append "LIBS", "-lpthread -lz -lssl -lcrypto -lrt"
-    end
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
This is a small simplification to the `librdkafka` formula. We are not using the `depends_on` and the link targets should be set implicitly.