### PR TITLE
enroll: Fix bug in CMake that removed enroll tests

### DIFF
--- a/osquery/remote/CMakeLists.txt
+++ b/osquery/remote/CMakeLists.txt
@@ -16,7 +16,7 @@ ADD_OSQUERY_LIBRARY(FALSE osquery_enrollment_plugins
   enroll/plugins/tls_enroll.cpp
 )
 
-file(GLOB OSQUERY_ENROLLMENT_PLUGIN_TESTS "enrollment/plugins/tests/*.cpp")
+file(GLOB OSQUERY_ENROLLMENT_PLUGIN_TESTS "enroll/plugins/tests/*.cpp")
 ADD_OSQUERY_TEST(FALSE ${OSQUERY_ENROLLMENT_PLUGIN_TESTS})
 
 file(GLOB OSQUERY_REMOTE_TESTS "tests/*.cpp")


### PR DESCRIPTION
A refactor from far off lands had removed the enroll tests from the build.