### PR TITLE
enroll: Add host_details to TLSEnrollPlugin

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -1,4 +1,4 @@
-osquery's remote configuration and logger plugins are completely optional. The only built-in optional plugins are **tls**. They very simply, receive and report via **https://** URI endpoints. osquery provides somewhat flexible node (the machine running osquery) authentication and identification though an 'enrollment' concept.
+osquery's remote configuration and logger plugins are completely optional. The only built-in optional plugins are **tls**. They very simply, receive and report via **https:// ** URI endpoints. osquery provides somewhat flexible node (the machine running osquery) authentication and identification though an 'enrollment' concept.
 
 The remote settings and plugins are mostly provided as examples. It is best to write custom plugins that implement specific web services or integrations. The remote settings uses a lot of additional [CLI-flags](../installation/cli-flags.md) for configuring the osquery clients, they are mostly organized under the **Remote Settings** heading.
 
@@ -11,10 +11,10 @@ The initial step is called an "enroll step" and in the case of **tls** plugins, 
 1. Configure a target `--tls_hostname`, `--enroll_tls_endpoint`.
 2. Place your server's root certificate authority's PEM-encoded certificate into a file, for example `/path/to/server-root.pem` and configure the note client to pin this root: `--tls_server_certs=`.
 3. Submit an `--enroll_secret_path`, an `--enroll_secret_env`, or use TLS-client authentication, to the enroll endpoint.
-4. Receive a **node_key** and store within the node's backing store (RocksDB).
+4. Receive a **node_key** and store within the node's persistent storage (RocksDB).
 5. Make config/logger requests while providing **node_key** as identification/authentication.
 
-The validity of a **node_key** is determined and implemented in the TLS server. The node only manages to ask for the content during enroll, and posts the content during subsequent requests.
+The validity of a **node_key** is determined and implemented in the TLS server. The node will request the key during an initial enroll step then post the key during subsequent requests for config or logging.
 
 ### Simple shared secret enrollment
 
@@ -27,7 +27,7 @@ The shared secret can alternatively be kept in an environment variable which is 
 
 ### TLS client-auth enrollment
 
-If the **node** machines have a deployed TLS client certificate and key they should include those paths using `--tls_client_cert` and `--tls_client_key`. The TLS server may implement an enroll process to supply **nodes** with identifying **node_key**s or return blank keys during enrollment and require TLS client authentication for every endpoint request.
+If the **node** machines have a deployed TLS client certificate and key they should include those paths using `--tls_client_cert` and `--tls_client_key`. The TLS server may implement an enroll process to supply nodes with identifying **node_key**s or return blank keys during enrollment and require TLS client authentication for every endpoint request.
 
 If using TLS client authentication the enrollment step can be skipped entirely. Note that it is NOT skipped automatically. If your service does not need/implement enrollment include `--disable_enrollment` in the osquery configuration.
 
@@ -40,6 +40,11 @@ The most basic TLS-based server should implement 3 HTTP POST endpoints. This API
 {
   "enroll_secret": "...", // Optional.
   "host_identifier": "..." // Determined by the --host_identifier flag
+  "host_details": { // A dictionary of keys mapping to helpful osquery tables.
+    "osquery_info": {},
+    "system_info": {},
+    "platform_info": {}
+  }
 }
 ```
 

--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -41,6 +41,7 @@ The most basic TLS-based server should implement 3 HTTP POST endpoints. This API
   "enroll_secret": "...", // Optional.
   "host_identifier": "..." // Determined by the --host_identifier flag
   "host_details": { // A dictionary of keys mapping to helpful osquery tables.
+    "os_version": {},
     "osquery_info": {},
     "system_info": {},
     "platform_info": {}

--- a/include/osquery/enroll.h
+++ b/include/osquery/enroll.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 
 #include <osquery/flags.h>
@@ -19,6 +20,14 @@ namespace osquery {
 
 /// Allow users to disable enrollment features.
 DECLARE_bool(disable_enrollment);
+
+/**
+ * @brief These tables populate the "host_details" content.
+ *
+ * Enrollment plugins should send 'default' host details to enroll request
+ * endpoints. This allows the enrollment service to identify the new node.
+ */
+extern const std::set<std::string> kEnrollHostDetails;
 
 /**
  * @brief Superclass for enroll plugins.

--- a/include/osquery/enroll.h
+++ b/include/osquery/enroll.h
@@ -13,6 +13,8 @@
 #include <set>
 #include <string>
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <osquery/flags.h>
 #include <osquery/registry.h>
 
@@ -59,6 +61,17 @@ class EnrollPlugin : public Plugin {
    * @return An enrollment secret or key material or identifier.
    */
   virtual std::string enroll() = 0;
+
+  /**
+   * @brief Populate a property tree with host details.
+   *
+   * This will use kEnrollHostDetails to select from each table and
+   * construct a property tree from the results of the first row of each.
+   * The input property tree will have a key set for each table.
+   *
+   * @param host_details An output property tree containing each table.
+   */
+  void genHostDetails(boost::property_tree::ptree& host_details);
 };
 
 /**

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -65,7 +65,7 @@ CLI_FLAG(bool,
 CREATE_LAZY_REGISTRY(EnrollPlugin, "enroll");
 
 const std::set<std::string> kEnrollHostDetails{
-    "osquery_info", "system_info", "platform_info",
+    "os_version", "osquery_info", "system_info", "platform_info",
 };
 
 Status clearNodeKey() {

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -60,6 +60,10 @@ CLI_FLAG(bool,
  */
 CREATE_LAZY_REGISTRY(EnrollPlugin, "enroll");
 
+const std::set<std::string> kEnrollHostDetails{
+    "osquery_info", "system_info", "platform_info",
+};
+
 Status clearNodeKey() {
   return deleteDatabaseValue(kPersistentSettings, "nodeKey");
 }
@@ -91,7 +95,7 @@ const std::string getEnrollSecret() {
   std::string enrollment_secret;
 
   if (FLAGS_enroll_secret_path != "") {
-    osquery::readFile(FLAGS_enroll_secret_path, enrollment_secret);
+    readFile(FLAGS_enroll_secret_path, enrollment_secret);
     boost::trim(enrollment_secret);
   } else {
     auto env_secret = getEnvVar(FLAGS_enroll_secret_env);

--- a/osquery/remote/enroll/plugins/tests/tls_enroll_tests.cpp
+++ b/osquery/remote/enroll/plugins/tests/tls_enroll_tests.cpp
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/config.h>
+#include <osquery/database.h>
+#include <osquery/sql.h>
+#include <osquery/system.h>
+
+#include "osquery/remote/requests.h"
+#include "osquery/remote/serializers/json.h"
+#include "osquery/remote/transports/tls.h"
+#include "osquery/tests/test_additional_util.h"
+#include "osquery/tests/test_util.h"
+
+#include "osquery/remote/enroll/plugins/tls_enroll.h"
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+DECLARE_string(tls_hostname);
+
+class TLSEnrollTests : public testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  Status testReadRequests(pt::ptree& response_tree);
+
+ private:
+  std::string test_read_uri_;
+};
+
+void TLSEnrollTests::SetUp() {
+  // Start a server.
+  TLSServerRunner::start();
+  TLSServerRunner::setClientConfig();
+  clearNodeKey();
+
+  test_read_uri_ =
+      "https://" + Flag::getValue("tls_hostname") + "/test_read_requests";
+}
+
+void TLSEnrollTests::TearDown() {
+  // Stop the server.
+  TLSServerRunner::unsetClientConfig();
+  TLSServerRunner::stop();
+}
+
+Status TLSEnrollTests::testReadRequests(pt::ptree& response_tree) {
+  auto request_ = Request<TLSTransport, JSONSerializer>(test_read_uri_);
+  request_.setOption("hostname", Flag::getValue("tls_hostname"));
+  auto status = request_.call(pt::ptree());
+  if (status.ok()) {
+    status = request_.getResponse(response_tree);
+  }
+  return status;
+}
+
+TEST_F(TLSEnrollTests, test_tls_enroll) {
+  auto node_key = getNodeKey("tls");
+
+  pt::ptree response;
+  auto status = testReadRequests(response);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(response.size(), 1U);
+
+  auto value = response.get<std::string>(".command");
+  EXPECT_EQ(value, "enroll");
+
+  value = response.get<std::string>(".host_identifier");
+  EXPECT_EQ(value, getHostIdentifier());
+
+  // Check that osquery_info exists in the host_details.
+  ASSERT_EQ(kEnrollHostDetails.count("osquery_info"), 1U);
+  auto osquery_info = SQL::selectAllFrom("osquery_info");
+  ASSERT_EQ(osquery_info.size(), 1U);
+  ASSERT_EQ(osquery_info[0].count("uuid"), 1U);
+
+  value = response.get<std::string>(".host_details.osquery_info.uuid");
+  EXPECT_EQ(osquery_info[0]["uuid"], value);
+}
+}

--- a/osquery/remote/enroll/plugins/tests/tls_enroll_tests.cpp
+++ b/osquery/remote/enroll/plugins/tests/tls_enroll_tests.cpp
@@ -16,8 +16,8 @@
 
 #include <osquery/config.h>
 #include <osquery/database.h>
+#include <osquery/flags.h>
 #include <osquery/sql.h>
-#include <osquery/system.h>
 
 #include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"

--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -8,21 +8,28 @@
  *
  */
 
+#include <boost/property_tree/ptree.hpp>
+
 #include <osquery/enroll.h>
-#include <osquery/filesystem.h>
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/sql.h>
 #include <osquery/system.h>
 
 #include "osquery/remote/requests.h"
 #include "osquery/remote/serializers/json.h"
 #include "osquery/remote/transports/tls.h"
-
-// Ordering is messed up because of tls.h
 #include "osquery/core/process.h"
+
+#include "osquery/remote/enroll/plugins/tls_enroll.h"
+
+namespace pt = boost::property_tree;
 
 namespace osquery {
 
 DECLARE_string(enroll_secret_path);
 DECLARE_bool(disable_enrollment);
+DECLARE_uint64(config_tls_max_attempts);
 
 /// Enrollment TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,
@@ -42,25 +49,13 @@ HIDDEN_FLAG(string,
             "enroll_secret",
             "Override the TLS enroll secret key name");
 
-DECLARE_uint64(config_tls_max_attempts);
-
-class TLSEnrollPlugin : public EnrollPlugin {
- private:
-  /// Enroll called, return cached key or if no key cached, call requestKey.
-  std::string enroll() override;
-
- private:
-  /// Request an enrollment key response from the TLS endpoint.
-  Status requestKey(const std::string& uri, std::string& node_key);
-};
-
 REGISTER(TLSEnrollPlugin, "enroll", "tls");
 
 std::string TLSEnrollPlugin::enroll() {
   // If no node secret has been negotiated, try a TLS request.
   auto uri = "https://" + FLAGS_tls_hostname + FLAGS_enroll_tls_endpoint;
   if (FLAGS_tls_secret_always) {
-    uri += ((uri.find('?') != std::string::npos) ? "&" : "?") +
+    uri += ((uri.find('?') != std::string::npos) ? '&' : '?') +
            FLAGS_tls_enroll_override + "=" + getEnrollSecret();
   }
 
@@ -83,11 +78,25 @@ std::string TLSEnrollPlugin::enroll() {
 Status TLSEnrollPlugin::requestKey(const std::string& uri,
                                    std::string& node_key) {
   // Read the optional enrollment secret data (sent with an enrollment request).
-  boost::property_tree::ptree params;
+  pt::ptree params;
   params.put<std::string>(FLAGS_tls_enroll_override, getEnrollSecret());
   params.put<std::string>("host_identifier", getHostIdentifier());
   params.put<std::string>("platform_type",
       boost::lexical_cast<std::string>(static_cast<uint64_t>(kPlatformType)));
+
+  // Select from each table describing host details.
+  pt::ptree host_details;
+  for (const auto& table : kEnrollHostDetails) {
+    auto results = SQL::selectAllFrom(table);
+    if (!results.empty()) {
+      pt::ptree details;
+      for (const auto& detail : results[0]) {
+        details.put<std::string>(detail.first, detail.second);
+      }
+      host_details.put_child(table, details);
+    }
+  }
+  params.put_child("host_details", host_details);
 
   auto request = Request<TLSTransport, JSONSerializer>(uri);
   request.setOption("hostname", FLAGS_tls_hostname);
@@ -110,7 +119,7 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
     node_key = recv.get("id", "");
   }
 
-  if (node_key.size() == 0) {
+  if (node_key.empty()) {
     return Status(1, "No node key returned from TLS enroll plugin");
   }
   return Status(0, "OK");

--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -86,16 +86,7 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
 
   // Select from each table describing host details.
   pt::ptree host_details;
-  for (const auto& table : kEnrollHostDetails) {
-    auto results = SQL::selectAllFrom(table);
-    if (!results.empty()) {
-      pt::ptree details;
-      for (const auto& detail : results[0]) {
-        details.put<std::string>(detail.first, detail.second);
-      }
-      host_details.put_child(table, details);
-    }
-  }
+  genHostDetails(host_details);
   params.put_child("host_details", host_details);
 
   auto request = Request<TLSTransport, JSONSerializer>(uri);

--- a/osquery/remote/enroll/plugins/tls_enroll.h
+++ b/osquery/remote/enroll/plugins/tls_enroll.h
@@ -1,0 +1,38 @@
+
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <osquery/enroll.h>
+
+namespace osquery {
+
+/**
+ * @brief These tables populate the "host_details" content.
+ *
+ * Enrollment plugins should send 'default' host details to enroll request
+ * endpoints. This allows the enrollment service to identify the new node.
+ */
+extern const std::set<std::string> kEnrollHostDetails;
+
+class TLSEnrollPlugin : public EnrollPlugin {
+ private:
+  /// Enroll called, return cached key or if no key cached, call requestKey.
+  std::string enroll() override;
+
+ private:
+  /// Request an enrollment key response from the TLS endpoint.
+  Status requestKey(const std::string& uri, std::string& node_key);
+
+ private:
+  friend class TLSEnrollTests;
+};
+}

--- a/osquery/remote/enroll/plugins/tls_enroll.h
+++ b/osquery/remote/enroll/plugins/tls_enroll.h
@@ -15,14 +15,6 @@
 
 namespace osquery {
 
-/**
- * @brief These tables populate the "host_details" content.
- *
- * Enrollment plugins should send 'default' host details to enroll request
- * endpoints. This allows the enrollment service to identify the new node.
- */
-extern const std::set<std::string> kEnrollHostDetails;
-
 class TLSEnrollPlugin : public EnrollPlugin {
  private:
   /// Enroll called, return cached key or if no key cached, call requestKey.


### PR DESCRIPTION
This closes #2560.

This pull request implements a simple `host_details` key addition to the `tls` enroll plugin.

The tables:
- `osquery_info`
- `platform_info`
- `system_info`

Populate the `host_details` key. The results of each table are included as keys themselves. These tables *should* only return a single row so that expectation is used to flatten the results into key->value. So expect: `{host_details.osquery_info.build_platform=ubuntu}` if building on a Ubuntu host.