### PR TITLE
watcher: Add more details to the utilization limits docs

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -101,7 +101,7 @@ If this value is >0 then the watchdog level (`--watchdog_level`) for maximum mem
 
 If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 30% of a thread for more than 9 seconds of wall time. The length of sustained utilization is not independently configurable.
 
-This value is a maximum number of CPU cycles counted as the `process` table's `user_time` and `system_time`. The default is 90 seconds of cpu time per 3 seconds of wall time.
+This value is a maximum number of CPU cycles counted as the `processes` table's `user_time` and `system_time`. The default is 90, meaning less 90 seconds of cpu time per 3 seconds of wall time is allowed.
 
 `--watchdog_delay=60`
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -95,11 +95,13 @@ It is better to set the level to disabled `-1` compared to disabling the watchdo
 
 `--watchdog_memory_limit=0`
 
-If this value is non-0 the watchdog level (`--watchdog_level`) for maximum memory is overridden. Use this if you would like to allow the `osqueryd` process to allocate more than 100M, but somewhere less than 1G.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum memory is overridden. Use this if you would like to allow the `osqueryd` process to allocate more than 200M, but somewhere less than 1G. This memory limit is expressed as a value representing MB.
 
 `--watchdog_utilization_limit=0`
 
-If this value is non-0 the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 90% of a thread for more than 6 seconds of wall time.
+If this value is >0 then the watchdog level (`--watchdog_level`) for maximum sustained CPU utilization is overridden. Use this if you would like to allow the `osqueryd` process to use more than 30% of a thread for more than 9 seconds of wall time. The length of sustained utilization is not independently configurable.
+
+This value is a maximum number of CPU cycles counted as the `process` table's `user_time` and `system_time`. The default is 90 seconds of cpu time per 3 seconds of wall time.
 
 `--watchdog_delay=60`
 

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -213,7 +213,6 @@ using RecursiveMutex = std::recursive_mutex;
 
 /// Helper alias for write locking a recursive mutex.
 using RecursiveLock = std::lock_guard<std::recursive_mutex>;
-}
 
 /**
  * @brief An abstract similar to boost's noncopyable that defines moves.
@@ -239,3 +238,7 @@ class only_movable {
   /// Important, a private copy assignment constructor prevents copying.
   only_movable& operator=(const only_movable&);
 };
+
+/// Custom literal for size_t.
+size_t operator"" _sz(unsigned long long int x);
+}

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -139,4 +139,8 @@ std::string getBufferSHA1(const char* buffer, size_t size) {
   }
   return result.str();
 }
+
+size_t operator"" _sz(unsigned long long int x) {
+  return x;
+}
 }

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -242,7 +242,7 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
   EXPECT_EQ(100U, state.initial_footprint);
 
   // The measurement of latency applies an interval value normalization.
-  auto iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), (size_t)1);
+  auto iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1UL);
   EXPECT_EQ(100U / iv, state.user_time);
   EXPECT_EQ(0U, state.sustained_latency);
 

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -242,7 +242,7 @@ TEST_F(WatcherTests, test_watcherrunner_watcherhealth) {
   EXPECT_EQ(100U, state.initial_footprint);
 
   // The measurement of latency applies an interval value normalization.
-  auto iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1UL);
+  auto iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   EXPECT_EQ(100U / iv, state.user_time);
   EXPECT_EQ(0U, state.sustained_latency);
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -318,7 +318,7 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   PerformanceChange change;
 
   // IV is the check interval in seconds, and utilization is set per-second.
-  change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1UL);
+  change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
     change.parent =

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -70,7 +70,7 @@ CLI_FLAG(int32,
 CLI_FLAG(uint64,
          watchdog_memory_limit,
          0,
-         "Override watchdog profile memory limit");
+         "Override watchdog profile memory limit (e.g., 300, for 300MB)");
 
 CLI_FLAG(uint64,
          watchdog_utilization_limit,
@@ -318,7 +318,7 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   PerformanceChange change;
 
   // IV is the check interval in seconds, and utilization is set per-second.
-  change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), (size_t)1);
+  change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1UL);
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
     change.parent =
@@ -331,10 +331,9 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   }
 
   // Check the difference of CPU time used since last check.
-  if (user_time - state.user_time >
-          getWorkerLimit(WatchdogLimitType::UTILIZATION_LIMIT) ||
-      system_time - state.system_time >
-          getWorkerLimit(WatchdogLimitType::UTILIZATION_LIMIT)) {
+  auto ul = getWorkerLimit(WatchdogLimitType::UTILIZATION_LIMIT);
+  if (user_time - state.user_time > ul ||
+      system_time - state.system_time > ul) {
     state.sustained_latency++;
   } else {
     state.sustained_latency = 0;


### PR DESCRIPTION
The documentation for `--watchdog_memory_limit` and `--watchdog_utilization_limit` are a little weak. Let's provide a tiny bit more information to make them helpful.