### PR TITLE
process: Aesthetic changes to process and process_ops

### DIFF
--- a/include/osquery/posix/system.h
+++ b/include/osquery/posix/system.h
@@ -16,6 +16,8 @@
 
 #include <boost/filesystem/path.hpp>
 
+#include <osquery/core.h>
+
 namespace osquery {
 
 /// The osquery platform agnostic process identifier type.

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -176,13 +176,10 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
   return std::make_shared<PlatformProcess>(ext_pid);
 }
 
-std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
+std::shared_ptr<PlatformProcess> PlatformProcess::launchTestPythonScript(
     const std::string& args) {
-  std::shared_ptr<PlatformProcess> process;
-  std::string argv;
   std::string osquery_path;
-
-  boost::optional<std::string> osquery_path_option = getEnvVar("OSQUERY_DEPS");
+  auto osquery_path_option = getEnvVar("OSQUERY_DEPS");
   if (osquery_path_option) {
     osquery_path = *osquery_path_option;
   } else {
@@ -193,8 +190,10 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
     }
   }
 
-  argv = osquery_path + "/bin/python " + args;
+  // The whole-string, space-delimited, python process arguments.
+  auto argv = osquery_path + "/bin/python " + args;
 
+  std::shared_ptr<PlatformProcess> process;
   int process_pid = ::fork();
   if (process_pid == 0) {
     // Start a Python script

--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -85,14 +85,10 @@ bool isUserAdmin() {
 }
 
 int platformGetPid() {
-  return (int)getpid();
+  return static_cast<int>(getpid());
 }
 
 int platformGetTid() {
-#if defined(__APPLE__) || defined(FREEBSD)
   return std::hash<std::thread::id>()(std::this_thread::get_id());
-#else
-  return (int)syscall(SYS_gettid);
-#endif
 }
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -165,12 +165,13 @@ class PlatformProcess : private boost::noncopyable {
       bool verbose = false);
 
   /**
-   * @brief Launches a new Python script
+   * @brief Launches a new test Python script.
    *
    * This will launch a new Python process to run the specified script and
-   * script arguments
+   * script arguments. This is used within the test harnesses to run example
+   * TLS server scripts.
    */
-  static std::shared_ptr<PlatformProcess> launchPythonScript(
+  static std::shared_ptr<PlatformProcess> launchTestPythonScript(
       const std::string& args);
 
  private:

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -299,10 +299,8 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
   return process;
 }
 
-std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
+std::shared_ptr<PlatformProcess> PlatformProcess::launchTestPythonScript(
     const std::string& args) {
-  std::shared_ptr<PlatformProcess> process;
-
   STARTUPINFOA si = {0};
   PROCESS_INFORMATION pi = {nullptr};
 
@@ -312,7 +310,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
   si.cb = sizeof(si);
 
   auto pythonEnv = getEnvVar("OSQUERY_PYTHON_PATH");
-  std::string pythonPath("");
+  std::string pythonPath;
   if (pythonEnv.is_initialized()) {
     pythonPath = *pythonEnv;
   }
@@ -322,6 +320,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchPythonScript(
   // environment variable.
   pythonPath += "\\python.exe";
 
+  std::shared_ptr<PlatformProcess> process;
   if (::CreateProcessA(pythonPath.c_str(),
                        mutable_argv.data(),
                        nullptr,

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -178,8 +178,6 @@ boost::optional<std::string> getEnvVar(const std::string& name) {
   auto value_len =
       ::GetEnvironmentVariableA(name.c_str(), buf.data(), kInitialBufferSize);
   if (value_len == 0) {
-    VLOG(1) << "Unable to find environment variable (" << GetLastError()
-            << "): " << name;
     return boost::none;
   }
 

--- a/osquery/tests/test_additional_util.cpp
+++ b/osquery/tests/test_additional_util.cpp
@@ -19,6 +19,7 @@
 #include <osquery/sql.h>
 
 #include "osquery/core/json.h"
+#include "osquery/core/process.h"
 #include "osquery/tests/test_additional_util.h"
 #include "osquery/tests/test_util.h"
 
@@ -46,7 +47,7 @@ void TLSServerRunner::start() {
                            .make_preferred()
                            .string() +
                        " --tls " + self.port_;
-  self.server_ = PlatformProcess::launchPythonScript(python_server);
+  self.server_ = PlatformProcess::launchTestPythonScript(python_server);
   if (self.server_ == nullptr) {
     return;
   }
@@ -64,7 +65,8 @@ void TLSServerRunner::start() {
           new PlatformProcess(std::atoi(results.rows()[0].at("pid").c_str())));
       break;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    sleepFor(100);
     delay += 100;
   }
 }


### PR DESCRIPTION
This most important changes here:
- Do not emit a verbose log line in Windows when an environment variable cannot be found.
- Call the `launchPythonScript` `launchTestPythonScript`, there is no way to run a python script within osquery.