### PR TITLE
Known hosts table performance improvements

### DIFF
--- a/osquery/tables/system/posix/known_hosts.cpp
+++ b/osquery/tables/system/posix/known_hosts.cpp
@@ -38,10 +38,7 @@ void genSSHkeysForHosts(const std::string& uid,
 
     for (const auto& line : split(keys_content, "\n")) {
       if (!line.empty() && line[0] != '#') {
-        Row r;
-        r["uid"] = uid;
-        r["key"] = line;
-        r["key_file"] = keys_file.string();
+        Row r = {{"uid", uid}, {"key", line}, {"key_file", keys_file.string()}};
         results.push_back(r);
       }
     }

--- a/osquery/tables/system/posix/known_hosts.cpp
+++ b/osquery/tables/system/posix/known_hosts.cpp
@@ -51,8 +51,10 @@ QueryData getKnownHostsKeys(QueryContext& context) {
   // Iterate over each user
   auto users = usersFromContext(context);
   for (const auto& row : users) {
-    if (row.count("uid") > 0 && row.count("directory") > 0) {
-      genSSHkeysForHosts(row.at("uid"), row.at("directory"), results);
+    auto uid = row.find("uid");
+    auto directory = row.find("directory");
+    if (uid != row.end() && directory != row.end()) {
+      genSSHkeysForHosts(uid->second, directory->second, results);
     }
   }
 


### PR DESCRIPTION
Just some best practices.
Not sure what to do with kSSHKnownHostskeys vector yet.
In other tables we use a set for paths (See https://github.com/facebook/osquery/blob/master/osquery/tables/system/posix/python_packages.cpp#L30 for example).