### PR TITLE
[Fix #3140] Use IODeviceTree:/ for hardware fields

### DIFF
--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -15,31 +15,29 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <osquery/logger.h>
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
-#include "osquery/tables/system/darwin/smbios_utils.h"
+#include "osquery/events/darwin/iokit.h"
 
 namespace osquery {
 namespace tables {
 
-const std::string kMachCpuBrandStringKey = "machdep.cpu.brand_string";
-const std::string kHardwareModelNameKey = "hw.model";
-
-void genHostInfo(Row &r) {
+static inline void genHostInfo(Row& r) {
   auto host = mach_host_self();
+
   host_basic_info_data_t host_data;
   mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
-
   if (host_info(host, HOST_BASIC_INFO, (host_info_t)&host_data, &count) !=
       KERN_SUCCESS) {
     return;
   }
 
-  char *cpu_type = nullptr;
-  char *cpu_subtype = nullptr;
+  char* cpu_type = nullptr;
+  char* cpu_subtype = nullptr;
   // Get human readable strings
   slot_name(host_data.cpu_type, host_data.cpu_subtype, &cpu_type, &cpu_subtype);
 
@@ -51,7 +49,31 @@ void genHostInfo(Row &r) {
   r["physical_memory"] = BIGINT(host_data.max_mem);
 }
 
-QueryData genSystemInfo(QueryContext &context) {
+static inline void genHardwareInfo(Row& r) {
+  auto root = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/");
+  if (root == MACH_PORT_NULL) {
+    VLOG(1) << "Cannot get hardware information from IOKit";
+    return;
+  }
+
+  CFMutableDictionaryRef properties = nullptr;
+  auto kr = IORegistryEntryCreateCFProperties(
+      root, &properties, kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(root);
+
+  if (kr != KERN_SUCCESS) {
+    VLOG(1) << "Cannot get hardware properties from IOKit";
+    return;
+  }
+
+  r["hardware_version"] = getIOKitProperty(properties, "version");
+  r["hardware_vendor"] = getIOKitProperty(properties, "manufacturer");
+  r["hardware_model"] = getIOKitProperty(properties, "product-name");
+  r["hardware_serial"] = getIOKitProperty(properties, "IOPlatformSerialNumber");
+  CFRelease(properties);
+}
+
+QueryData genSystemInfo(QueryContext& context) {
   QueryData results;
   Row r;
 
@@ -78,38 +100,14 @@ QueryData genSystemInfo(QueryContext &context) {
   r["uuid"] = (osquery::getHostUUID(uuid)) ? uuid : "";
 
   genHostInfo(r);
+  genHardwareInfo(r);
 
   // The CPU brand string also exists in system_controls.
   auto qd = SQL::selectAllFrom("cpuid");
-  for (const auto &row : qd) {
+  for (const auto& row : qd) {
     if (row.at("feature") == "product_name") {
       r["cpu_brand"] = row.at("value");
       boost::trim(r["cpu_brand"]);
-    }
-  }
-
-  {
-    DarwinSMBIOSParser parser;
-    if (!parser.discover()) {
-      r["hardware_model"] = "";
-      r["hardware_vendor"] = "";
-      r["hardware_version"] = "";
-      r["hardware_serial"] = "";
-    } else {
-      parser.tables(([&r](size_t index,
-                          const SMBStructHeader *hdr,
-                          uint8_t *address,
-                          size_t size) {
-        if (hdr->type != kSMBIOSTypeSystem || size < 0x12) {
-          return;
-        }
-
-        uint8_t *data = address + hdr->length;
-        r["hardware_vendor"] = dmiString(data, address, 0x04);
-        r["hardware_model"] = dmiString(data, address, 0x05);
-        r["hardware_version"] = dmiString(data, address, 0x06);
-        r["hardware_serial"] = dmiString(data, address, 0x07);
-      }));
     }
   }
 


### PR DESCRIPTION
I am not sure if this method is more reliable. 