### PR TITLE
preferences: Report both Current Host and Any Host

### DIFF
--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -9,6 +9,8 @@ schema([
     Column("forced", INTEGER, "1 if the value is forced/managed, else 0"),
     Column("username", TEXT, "(optional) read preferences for a specific user",
       additional=True),
+    Column("host", TEXT,
+      "'current' or 'any' host, where 'current' takes precedence"),
 ])
 attributes(user_data=True)
 implementation("system/darwin/preferences@genOSXDefaultPreferences")


### PR DESCRIPTION
This implements #3501.

Instead of performing the 'override' detection, the table now includes a `host` column (similar to Apple's parameter name when using the preferences APIs). A user of the table must apply the knowledge of what host "type" overrides.