### PR TITLE
[Fix #3683] Setting interface id for interface_addresses

### DIFF
--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -169,6 +169,20 @@ inline Status safeStrtoll(const std::string& rep, size_t base, long long& out) {
   return Status(0);
 }
 
+/// Safely convert a string representation of an integer base.
+inline Status safeStrtoull(const std::string& rep,
+                           size_t base,
+                           unsigned long long& out) {
+  char* end{nullptr};
+  out = strtoull(rep.c_str(), &end, static_cast<int>(base));
+  if (end == nullptr || end == rep.c_str() || *end != '\0' ||
+      (out == ULLONG_MAX && errno == ERANGE)) {
+    out = 0;
+    return Status(1);
+  }
+  return Status(0);
+}
+
 /// Safely convert unicode escaped ASCII.
 inline std::string unescapeUnicode(const std::string& escaped) {
   if (escaped.size() < 6) {

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -113,7 +113,7 @@ Status WmiResultItem::GetUnsignedShort(const std::string& name,
   if (hr != S_OK) {
     return Status(-1, "Error retrieving data from WMI query.");
   }
-  if (value.vt != VT_I4) {
+  if (value.vt != VT_UI2) {
     VariantClear(&value);
     return Status(-1, "Invalid data type returned.");
   }
@@ -131,7 +131,7 @@ Status WmiResultItem::GetUnsignedInt32(const std::string& name,
   if (hr != S_OK) {
     return Status(-1, "Error retrieving data from WMI query.");
   }
-  if (value.vt != VT_I4) {
+  if (value.vt != VT_UINT) {
     VariantClear(&value);
     return Status(-1, "Invalid data type returned.");
   }

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -51,5 +51,16 @@ TEST_F(NetworkingTablesTests, test_listening_ports) {
   EXPECT_NE(pid, "-1");
   server.stop();
 }
+
+TEST_F(NetworkingTablesTests, test_address_details_join) {
+  // Expect that we can join interface addresses with details
+  auto query = "select * from interface_details id, interface_addresses ia "
+               "on ia.interface = id.interface "
+               "where ia.address = '127.0.0.1';";
+
+  auto results = SQL::SQL(query);
+  EXPECT_GT(results.rows().size(), 0U);
+  
+}
 }
 }

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -54,13 +54,13 @@ TEST_F(NetworkingTablesTests, test_listening_ports) {
 
 TEST_F(NetworkingTablesTests, test_address_details_join) {
   // Expect that we can join interface addresses with details
-  auto query = "select * from interface_details id, interface_addresses ia "
-               "on ia.interface = id.interface "
-               "where ia.address = '127.0.0.1';";
+  auto query =
+      "select * from interface_details id, interface_addresses ia "
+      "on ia.interface = id.interface "
+      "where ia.address = '127.0.0.1';";
 
   auto results = SQL::SQL(query);
   EXPECT_GT(results.rows().size(), 0U);
-  
 }
 }
 }

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -59,7 +59,7 @@ TEST_F(NetworkingTablesTests, test_address_details_join) {
       "on ia.interface = id.interface "
       "where ia.address = '127.0.0.1';";
 
-  auto results = SQL::SQL(query);
+  auto results = SQL(query);
   EXPECT_GT(results.rows().size(), 0U);
 }
 }

--- a/osquery/tables/networking/windows/arp_cache.cpp
+++ b/osquery/tables/networking/windows/arp_cache.cpp
@@ -19,7 +19,7 @@
 namespace osquery {
 namespace tables {
 
-const std::map<unsigned short, const std::string> kMapOfAddressFamily = {
+const std::map<long, const std::string> kMapOfAddressFamily = {
     {2, "IPv4"}, {23, "IPv6"},
 };
 
@@ -47,10 +47,6 @@ QueryData genIPv4ArpCache(QueryContext& context) {
   std::map<long, std::string> mapOfInterfaces = {
       {1, ""}, // loopback
   };
-  unsigned short usiPlaceHolder;
-  unsigned char cPlaceHolder;
-  unsigned int uiPlaceHolder;
-  std::string strPlaceHolder;
 
   for (const auto& iface : interfaces) {
     long interfaceIndex;
@@ -62,11 +58,14 @@ QueryData genIPv4ArpCache(QueryContext& context) {
     }
   }
 
+  long lPlaceHolder = 0;
+  unsigned char cPlaceHolder;
+  std::string strPlaceHolder;
   for (const auto& item : wmiResults) {
     Row r;
-    item.GetUnsignedShort("AddressFamily", usiPlaceHolder);
-    r["address_family"] = kMapOfAddressFamily.count(usiPlaceHolder) > 0
-                              ? kMapOfAddressFamily.at(usiPlaceHolder)
+    item.GetLong("AddressFamily", lPlaceHolder);
+    r["address_family"] = kMapOfAddressFamily.count(lPlaceHolder) > 0
+                              ? kMapOfAddressFamily.at(lPlaceHolder)
                               : "-1";
     item.GetUChar("Store", cPlaceHolder);
     r["store"] = kMapOfStore.count(cPlaceHolder) > 0
@@ -76,9 +75,9 @@ QueryData genIPv4ArpCache(QueryContext& context) {
     r["state"] = kMapOfState.count(cPlaceHolder) > 0
                      ? kMapOfState.at(cPlaceHolder)
                      : "-1";
-    item.GetUnsignedInt32("InterfaceIndex", uiPlaceHolder);
-    r["interface"] = mapOfInterfaces.count(uiPlaceHolder) > 0
-                         ? mapOfInterfaces.at(uiPlaceHolder)
+    item.GetLong("InterfaceIndex", lPlaceHolder);
+    r["interface"] = mapOfInterfaces.count(lPlaceHolder) > 0
+                         ? mapOfInterfaces.at(lPlaceHolder)
                          : "-1";
     item.GetString("IPAddress", r["ip_address"]);
     item.GetString("InterfaceAlias", r["interface_alias"]);

--- a/specs/interface_addresses.table
+++ b/specs/interface_addresses.table
@@ -8,5 +8,8 @@ schema([
     Column("point_to_point", TEXT, "PtP address for the interface"),
     Column("type", TEXT, "Type of address. One of dhcp, manual, auto, other")
 ])
+extended_schema(WINDOWS, [
+    Column("friendly_name", TEXT, "The friendly display name of the interface."),
+])
 attributes(cacheable=True)
 implementation("interfaces@genInterfaceAddresses")

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -19,6 +19,7 @@ schema([
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
 ])
 extended_schema(WINDOWS, [
+    Column("friendly_name", TEXT, "The friendly display name of the interface."),
     Column("description", TEXT, "Short description of the object—a one-line string."),
     Column("manufacturer", TEXT, "Name of the network adapter's manufacturer."),
     Column("connection_id", TEXT, "Name of the network connection as it appears in the Network Connections Control Panel program."),


### PR DESCRIPTION
This changes the value of the `Interface` column on Windows systems to be that of the interface index used by Windows. This change allows us to join the `interface_addresses` table with the `interface_details` table on this common index value to get extended interface information per interface address value. Further this PR gets data for interface packet sent/received, bytes sent/received and inbound/outbound errors as well as populates the `type`, `metric`, and `flags` columns thus addressing #2907