### PR TITLE
build: small fix to osquery utils Start-Process cmdlet

### DIFF
--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -121,6 +121,7 @@ function Start-OsqueryProcess {
           -FilePath $binaryPath `
           -ArgumentList $buildArgs `
           -NoNewWindow `
-          -Wait | Wait-Process
+          -PassThru
+  $out.WaitForExit()
   return $out
 }


### PR DESCRIPTION
The `Osquery-StartProcess` cmdlet occasionally hangs based off of the behavior of the called subprocess. This fixes the cmdlet to ensure that we always return, as opposed to stalling.