### PR TITLE
deps: building portable rocksdb libs

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -292,7 +292,7 @@ function Install-ThirdParty {
     "linenoise-ng.1.0.0-r1",
     "llvm-clang.4.0.1",
     "openssl.1.0.2-k",
-    "rocksdb.5.7.1",
+    "rocksdb.5.7.1-r1",
     "thrift-dev.0.10.0-r4",
     "zlib.1.2.8",
     "libarchive.3.3.1-r1",

--- a/tools/provision/chocolatey/rocksdb.ps1
+++ b/tools/provision/chocolatey/rocksdb.ps1
@@ -11,7 +11,7 @@
 # $chocoVersion - The chocolatey package version, used for incremental bumps
 #                 without changing the version of the software package
 $version = '5.7.1'
-$chocoVersion = '5.7.1'
+$chocoVersion = '5.7.1-r1'
 $packageName = "rocksdb"
 $projectSource = 'https://github.com/facebook/rocksdb/'
 $packageSourceUrl = 'https://github.com/facebook/rocksdb/'
@@ -102,7 +102,8 @@ Invoke-BatchFile "$env:VS140COMNTOOLS\..\..\vc\vcvarsall.bat" $platform
 $cmake = (Get-Command 'cmake').Source
 $cmakeArgs = @(
   "-G `"$cmakeBuildType`"",
-  '-DROCKSDB_LITE=1',
+  '-DPORTABLE=ON',
+  '-DROCKSDB_LITE=ON',
   '../'
 )
 Start-OsqueryProcess $cmake $cmakeArgs


### PR DESCRIPTION
The previous upgrade of rocksdb for Windows was not built for portable, which was causing build fails on some platforms. This updates the libs builds to be portable.