### PR TITLE
readme: Add callout for osquery devteam recruiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,5 +107,7 @@ Facebook has a [bug bounty](https://www.facebook.com/whitehat/) program that inc
 
 ## Learn more
 
+**Want to be a Security Engineer at Facebook?** The osquery development team is hiring! Our team's mission is detect external and internal threats to users' data. We do that by building, deploying, and using intrusion detection tools like osquery. Check out our [position description](https://www.facebook.com/careers/jobs/a0I1200000JXmWQEA1/) or reach out to [`@theopolis`](https://github.com/theopolis).
+
 Read the [launch blog post](https://code.facebook.com/posts/844436395567983/introducing-osquery/) for background on the project.
 If you're interested in learning more about osquery, visit the [users guide](https://osquery.readthedocs.org/) and browse our RFC-labeled Github issues. Development and usage discussion is happing in the osquery Slack, grab an invite automatically: [https://osquery-slack.herokuapp.com/](https://osquery-slack.herokuapp.com/)!


### PR DESCRIPTION
Several folks have been asking if the osquery team is hiring. Let's place a link in the README to direct them to the right place.