### PR TITLE
tables: alf_services should not be hardcoded

### DIFF
--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -23,7 +23,7 @@ namespace tables {
  * @brief Well known path to the Application Layer Firewall configuration.
  *
  * This plist contains all of the details about the ALF.
- * It is used to populated all of the tables here.
+ * It is used to populate all of the tables here.
  */
 const std::string kALFPlistPath{"/Library/Preferences/com.apple.alf.plist"};
 

--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include <boost/lexical_cast.hpp>
-
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
@@ -21,28 +19,18 @@ namespace pt = boost::property_tree;
 namespace osquery {
 namespace tables {
 
-const std::string kALFPlistPath = "/Library/Preferences/com.apple.alf.plist";
+/**
+ * @brief Well known path to the Application Layer Firewall configuration.
+ *
+ * This plist contains all of the details about the ALF.
+ * It is used to populated all of the tables here.
+ */
+const std::string kALFPlistPath{"/Library/Preferences/com.apple.alf.plist"};
 
-// it.first represents the key that is used in com.apple.alf.plist to identify
-// the data in question. it.second represents the value of the "service" column
-// in the alf_services table.
-const std::map<std::string, std::string> kFirewallTreeKeys = {
-    {"Apple Remote Desktop", "Apple Remote Desktop"},
-    {"FTP Access", "FTP"},
-    {"ODSAgent", "ODSAgent"},
-    {"Personal File Sharing", "File Sharing"},
-    {"Personal Web Sharing", "Web Sharing"},
-    {"Printer Sharing", "Printer Sharing"},
-    {"Remote Apple Events", "Remote Apple Events"},
-    {"Remote Login - SSH", "SSH"},
-    {"Samba Sharing", "Samba Sharing"},
-};
-
-// it.first represents the top level keys in com.apple.alf.plist to identify
-// the data in question. it.second represents the names of the columns that
-// each sample of data can be found under in the alf table.
-const std::map<std::string, std::string> kTopLevelIntKeys = {
+/// Well known keys within the plist containing settings.
+const std::map<std::string, std::string> kTopLevelIntKeys{
     {"allowsignedenabled", "allow_signed_enabled"},
+    {"allowdownloadsignedenabled", "allow_downloads_signed_enabled"},
     {"firewallunload", "firewall_unload"},
     {"globalstate", "global_state"},
     {"loggingenabled", "logging_enabled"},
@@ -50,10 +38,8 @@ const std::map<std::string, std::string> kTopLevelIntKeys = {
     {"stealthenabled", "stealth_enabled"},
 };
 
-// it.first represents the top level keys in com.apple.alf.plist to identify
-// the data in question. it.second represents the names of the columns that
-// each sample of data can be found under in the alf table.
-const std::map<std::string, std::string> kTopLevelStringKeys = {
+/// Well known keys within the plist containing settings (as strings).
+const std::map<std::string, std::string> kTopLevelStringKeys{
     {"version", "version"},
 };
 
@@ -146,13 +132,12 @@ QueryData parseALFServicesTree(const pt::ptree& tree) {
     return {};
   }
 
-  auto firewall_tree = tree.get_child("firewall");
-  for (const auto& it : kFirewallTreeKeys) {
+  auto& firewall_tree = tree.get_child("firewall");
+  for (const auto& it : firewall_tree) {
     Row r;
-    auto subtree = firewall_tree.get_child(it.first);
-    r["service"] = it.second;
-    r["process"] = subtree.get("proc", "");
-    r["state"] = INTEGER(subtree.get("state", -1));
+    r["service"] = it.first;
+    r["process"] = it.second.get("proc", "");
+    r["state"] = INTEGER(it.second.get("state", -1));
     results.push_back(r);
   }
   return results;

--- a/osquery/tables/system/darwin/tests/firewall_tests.cpp
+++ b/osquery/tables/system/darwin/tests/firewall_tests.cpp
@@ -13,8 +13,8 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
-#include "osquery/tests/test_util.h"
 #include "osquery/tables/system/darwin/firewall.h"
+#include "osquery/tests/test_util.h"
 
 namespace pt = boost::property_tree;
 
@@ -37,13 +37,13 @@ TEST_F(FirewallTests, test_parse_alf_tree) {
   auto results = parseALFTree(tree);
   osquery::QueryData expected = {
       {
-       {"allow_signed_enabled", "1"},
-       {"firewall_unload", "0"},
-       {"global_state", "0"},
-       {"logging_enabled", "0"},
-       {"logging_option", "0"},
-       {"stealth_enabled", "0"},
-       {"version", "1.0a25"},
+          {"allow_signed_enabled", "1"},
+          {"firewall_unload", "0"},
+          {"global_state", "0"},
+          {"logging_enabled", "0"},
+          {"logging_option", "0"},
+          {"stealth_enabled", "0"},
+          {"version", "1.0a25"},
       },
   };
   EXPECT_EQ(results, expected);
@@ -85,37 +85,39 @@ TEST_F(FirewallTests, test_parse_alf_services_tree) {
   auto results = parseALFServicesTree(tree);
   osquery::QueryData expected = {
       {
-       {"service", "Apple Remote Desktop"},
-       {"process", "AppleVNCServer"},
-       {"state", "0"},
+          {"service", "Apple Remote Desktop"},
+          {"process", "AppleVNCServer"},
+          {"state", "0"},
       },
       {
-       {"service", "FTP"}, {"process", "ftpd"}, {"state", "0"},
+          {"service", "FTP"}, {"process", "ftpd"}, {"state", "0"},
       },
       {
-       {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
+          {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
       },
       {
-       {"service", "File Sharing"},
-       {"process", "AppleFileServer"},
-       {"state", "0"},
+          {"service", "File Sharing"},
+          {"process", "AppleFileServer"},
+          {"state", "0"},
       },
       {
-       {"service", "Web Sharing"}, {"process", "httpd"}, {"state", "0"},
+          {"service", "Web Sharing"}, {"process", "httpd"}, {"state", "0"},
       },
       {
-       {"service", "Printer Sharing"}, {"process", "cupsd"}, {"state", "0"},
+          {"service", "Printer Sharing"}, {"process", "cupsd"}, {"state", "0"},
       },
       {
-       {"service", "Remote Apple Events"},
-       {"process", "AEServer"},
-       {"state", "0"},
+          {"service", "Remote Apple Events"},
+          {"process", "AEServer"},
+          {"state", "0"},
       },
       {
-       {"service", "SSH"}, {"process", "sshd-keygen-wrapper"}, {"state", "0"},
+          {"service", "SSH"},
+          {"process", "sshd-keygen-wrapper"},
+          {"state", "0"},
       },
       {
-       {"service", "Samba Sharing"}, {"process", "smbd"}, {"state", "0"},
+          {"service", "Samba Sharing"}, {"process", "smbd"}, {"state", "0"},
       },
   };
   EXPECT_EQ(results, expected);

--- a/osquery/tables/system/darwin/tests/firewall_tests.cpp
+++ b/osquery/tables/system/darwin/tests/firewall_tests.cpp
@@ -37,6 +37,7 @@ TEST_F(FirewallTests, test_parse_alf_tree) {
   auto results = parseALFTree(tree);
   osquery::QueryData expected = {
       {
+          {"allow_downloads_signed_enabled", "-1"},
           {"allow_signed_enabled", "1"},
           {"firewall_unload", "0"},
           {"global_state", "0"},
@@ -85,23 +86,9 @@ TEST_F(FirewallTests, test_parse_alf_services_tree) {
   auto results = parseALFServicesTree(tree);
   osquery::QueryData expected = {
       {
-          {"service", "Apple Remote Desktop"},
-          {"process", "AppleVNCServer"},
+          {"service", "Personal Web Sharing"},
+          {"process", "httpd"},
           {"state", "0"},
-      },
-      {
-          {"service", "FTP"}, {"process", "ftpd"}, {"state", "0"},
-      },
-      {
-          {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
-      },
-      {
-          {"service", "File Sharing"},
-          {"process", "AppleFileServer"},
-          {"state", "0"},
-      },
-      {
-          {"service", "Web Sharing"}, {"process", "httpd"}, {"state", "0"},
       },
       {
           {"service", "Printer Sharing"}, {"process", "cupsd"}, {"state", "0"},
@@ -112,12 +99,28 @@ TEST_F(FirewallTests, test_parse_alf_services_tree) {
           {"state", "0"},
       },
       {
-          {"service", "SSH"},
+          {"service", "FTP Access"}, {"process", "ftpd"}, {"state", "0"},
+      },
+      {
+          {"service", "Personal File Sharing"},
+          {"process", "AppleFileServer"},
+          {"state", "0"},
+      },
+      {
+          {"service", "Remote Login - SSH"},
           {"process", "sshd-keygen-wrapper"},
           {"state", "0"},
       },
       {
           {"service", "Samba Sharing"}, {"process", "smbd"}, {"state", "0"},
+      },
+      {
+          {"service", "Apple Remote Desktop"},
+          {"process", "AppleVNCServer"},
+          {"state", "0"},
+      },
+      {
+          {"service", "ODSAgent"}, {"process", "ODSAgent"}, {"state", "0"},
       },
   };
   EXPECT_EQ(results, expected);

--- a/osquery/tables/system/darwin/tests/firewall_tests.cpp
+++ b/osquery/tables/system/darwin/tests/firewall_tests.cpp
@@ -145,10 +145,6 @@ TEST_F(FirewallTests, test_on_disk_format) {
     EXPECT_NO_THROW(tree.get<std::string>(it.first));
   }
   EXPECT_NO_THROW(tree.get_child("firewall"));
-  auto firewall = tree.get_child("firewall");
-  for (const auto& it : kFirewallTreeKeys) {
-    EXPECT_NO_THROW(firewall.get_child(it.first));
-  }
 }
 }
 }


### PR DESCRIPTION
This will generate all of the `alf_services`.

Working towards solving #2322.