### PR TITLE
[Fix #3619] Better shutdown logic for Windows service controller

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -206,7 +206,7 @@ class Initializer : private boost::noncopyable {
   static std::function<void()> shutdown_;
 
   /// Mutex to protect use of the shutdown callable.
-  static Mutex shutdown_mutex_;
+  static RecursiveMutex shutdown_mutex_;
 };
 
 /**

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -479,29 +479,6 @@ void Initializer::initWatcher() const {
     Dispatcher::addService(
         std::make_shared<WatcherRunner>(*argc_, *argv_, isWatcher()));
   }
-
-  if (isWatcher()) {
-    if (shutdown_ != nullptr) {
-      shutdown_();
-    }
-
-    // If there are no autoloaded extensions, the watcher service will end,
-    // otherwise it will continue as a background thread and respawn them.
-    // If the watcher is also a worker watchdog it will do nothing but monitor
-    // the extensions and worker process.
-    Dispatcher::joinServices();
-    // Execution should only reach this point if a signal was handled by the
-    // worker and watcher.
-    auto retcode = 0;
-    if (kHandledSignal > 0) {
-      retcode = 128 + kHandledSignal;
-    } else if (Watcher::get().getWorkerStatus() >= 0) {
-      retcode = Watcher::get().getWorkerStatus();
-    } else {
-      retcode = EXIT_FAILURE;
-    }
-    requestShutdown(retcode);
-  }
 }
 
 void Initializer::initWorker(const std::string& name) const {

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -318,7 +318,6 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
         CloseHandle(stopEvent);
       }
     }
-    // UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 
     break;
   default:

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -15,6 +15,7 @@
 #include <shellapi.h>
 
 #include <osquery/core.h>
+#include <osquery/dispatcher.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/system.h>
@@ -54,7 +55,21 @@ void DebugPrintf(const std::string& s) {
 HANDLE getStopEvent() {
   auto stopEvent = ::OpenEventA(
       SYNCHRONIZE | EVENT_MODIFY_STATE, FALSE, osquery::kStopEventName.c_str());
+
   if (stopEvent == nullptr) {
+    return stopEvent;
+  }
+
+  auto ret = WaitForSingleObject(stopEvent, 0);
+
+  // The object has already been signaled
+  if (ret == WAIT_OBJECT_0) {
+    return nullptr;
+  }
+
+  // ERROR_FILE_NOT_FOUND indicates the event was never created.
+  // Likely the process running as the daemon at the command line.
+  if (stopEvent == nullptr && GetLastError() != ERROR_FILE_NOT_FOUND) {
     SLOG("OpenEventA failed for event name " + osquery::kStopEventName +
          " (lasterror=" + std::to_string(GetLastError()) + ")");
   }
@@ -84,12 +99,16 @@ static auto kShutdownCallable = ([]() {
   // The event only gets initialized in the entry point of the service. Child
   // processes and those run from the commandline will not have a stop event.
   auto stopEvent = osquery::getStopEvent();
-  if (stopEvent != nullptr && !Initializer::isWorker()) {
+  if (stopEvent != nullptr) {
+    // Wait forever, until the service handler signals us
     ::WaitForSingleObject(stopEvent, INFINITE);
-
-    UpdateServiceStatus(0, SERVICE_STOPPED, 0, 3);
-    Initializer::requestShutdown();
-    ::CloseHandle(stopEvent);
+    // Interup the worker service threads before joining
+    Dispatcher::stopServices();
+    auto ret = ::CloseHandle(stopEvent);
+    if (ret != TRUE) {
+      SLOG("kShutdownCallable failed to call CloseHandle with (" +
+           std::to_string(GetLastError()) + ")");
+    }
   }
 });
 
@@ -287,7 +306,7 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
       break;
     }
 
-    UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 4);
+    UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 3);
     {
       auto stopEvent = osquery::getStopEvent();
       if (stopEvent != nullptr) {
@@ -299,6 +318,7 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
         CloseHandle(stopEvent);
       }
     }
+    // UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 
     break;
   default:
@@ -340,7 +360,7 @@ void WINAPI ServiceMain(DWORD argc, LPSTR* argv) {
          std::to_string(GetLastError()) + ")");
   }
 
-  UpdateServiceStatus(0, SERVICE_STOPPED, 0, 3);
+  UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 }
 } // namespace osquery
 


### PR DESCRIPTION
This PR adds better logic to the Windows service shut down process which ensures both worker and watcher `WaitForSingleObject` until the `stopEvent` is signaled, only one time.  Further we move the `UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);` to the end of our service control handler thread, to ensure that the process does not terminate before the watcher and worker both have an opportunity to `stop` and `join` all relevant service threads. This addresses #3619