### PR TITLE
aws_kinesis/aws_firehose: Be more verbose when complete failures occur.

### DIFF
--- a/osquery/logger/plugins/tests/aws_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_logger_tests.cpp
@@ -31,13 +31,20 @@ class AwsLoggerTests : public testing::Test {
   void SetUp() override {}
 };
 
+class DummyOutcome final : public Aws::Kinesis::Model::PutRecordsOutcome {
+ public:
+  bool IsSuccess() {
+    return true;
+  }
+};
+
 using RawBatch = std::vector<std::string>;
 using RawBatchList = std::vector<RawBatch>;
 
 using IDummyLogForwarder =
     AwsLogForwarder<Aws::Kinesis::Model::PutRecordsRequestEntry,
                     Aws::Kinesis::KinesisClient,
-                    Aws::Kinesis::Model::PutRecordsOutcome,
+                    DummyOutcome,
                     Aws::Vector<Aws::Kinesis::Model::PutRecordsResultEntry>>;
 
 class DummyLogForwarder final : public IDummyLogForwarder {


### PR DESCRIPTION
This is a small change to make sure that the administrator is notified right away when the configuration of the Firehose and/or Kinesis plugins are not (or no longer) valid.

Without this patch, such errors are not shown until the retry count expires; this value is usually pretty high (100 by default on Firehose) and we must take into account that there's also a pause between each attempt.