### PR TITLE
Vagrant tweaks and SuSE support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,27 +1,21 @@
 targets = {
-  "debian7" => {
-    "box" => "bento/debian-7.9"
-  },
   "macos10.12" => {
     "box" => "jhcook/macos-sierra"
   },
+  "debian7" => {
+    "box" => "bento/debian-7"
+  },
   "debian8" => {
-    "box" => "bento/debian-8.2"
+    "box" => "bento/debian-8"
   },
   "debian9" => {
-    "box" => "bento/debian-9.0"
+    "box" => "bento/debian-9"
   },
   "centos6" => {
-    "box" => "centos/6"
-  },
-  "centos6.5" => {
-    "box" => "bento/centos-6.7"
+    "box" => "elastic/centos-6-x86_64"
   },
   "centos7" => {
-    "box" => "centos/7"
-  },
-  "centos7.1" => {
-    "box" => "bento/centos-7.1"
+    "box" => "elastic/centos-7-x86_64"
   },
   "ubuntu15.04" => {
     "box" => "bento/ubuntu-15.04"
@@ -36,7 +30,7 @@ targets = {
     "box" => "bento/ubuntu-16.10"
   },
   "ubuntu17.04" => {
-    "box" => "wholebits/ubuntu17.04-64"
+    "box" => "bento/ubuntu17.04"
   },
   "ubuntu12" => {
     "box" => "ubuntu/precise64"
@@ -48,13 +42,19 @@ targets = {
     "box" => "ubuntu/xenial64"
   },
   "freebsd10" => {
-    "box" => "bento/freebsd-10.2"
+    "box" => "bento/freebsd-10"
   },
   "freebsd11" => {
-    "box" => "bento/freebsd-11.0"
+    "box" => "bento/freebsd-11"
   },
   "archlinux" => {
-    "box" => "terrywang/archlinux"
+    "box" => "archlinux/archlinux"
+  },
+  "suse11" => {
+    "box" => "elastic/sles-11-x86_64"
+  },
+  "suse12" => {
+    "box" => "elastic/sles-12-x86_64"
   },
   "aws-amazon2015.03" => {
     "box" => "andytson/aws-dummy",
@@ -223,7 +223,7 @@ Vagrant.configure("2") do |config|
       if name.start_with?('ubuntu', 'debian')
         build.vm.provision 'bootstrap', type: 'shell' do |s|
           s.inline = 'sudo apt-get update;'\
-                     'sudo apt-get install --yes git;'
+                     'sudo apt-get install --yes git make python;'
         end
       end
     end

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -24,6 +24,7 @@ SYSTEM_RELEASE = "/etc/system-release"
 LSB_RELEASE    = "/etc/lsb-release"
 DEBIAN_VERSION = "/etc/debian_version"
 GENTOO_RELEASE = "/etc/gentoo-release"
+SUSE_RELEASE   = "/etc/SuSE-release"
 
 def _platform():
     osType, _, _, _, _, _ = platform.uname()
@@ -71,6 +72,9 @@ def _platform():
 
         if os.path.exists(GENTOO_RELEASE):
             return ("gentoo", "gentoo")
+
+        if os.path.exists(SUSE_RELEASE):
+            return ("suse", "suse")
     else:
         return (None, osType.lower())
 
@@ -154,6 +158,12 @@ def _distro(osType):
           results = contents.split()
         if len(results) > 0:
           return results[len(results) -1]
+    elif osType == "suse":
+        with open(SUSE_RELEASE, "r") as fd:
+            contents = fd.read()
+            results = re.findall(r'VERSION = (.*)', contents)
+            if len(results) == 1:
+                return results[0]
     elif osType == "windows":
         return "windows%s" % osVersion
 

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -7,10 +7,6 @@
 #  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
 
-ORACLE_RELEASE=/etc/oracle-release
-SYSTEM_RELEASE=/etc/system-release
-LSB_RELEASE=/etc/lsb-release
-DEBIAN_VERSION=/etc/debian_version
 LIB_SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 # For OS X, define the distro that builds the kernel extension.
@@ -40,7 +36,7 @@ function _distro() {
 function threads() {
   local __out=$1
   platform OS
-  if [[ $FAMILY = "redhat" ]] || [[ $FAMILY = "debian" ]]; then
+  if [[ $FAMILY = "redhat" ]] || [[ $FAMILY = "debian" ]] || [[ $FAMILY = "suse" ]]; then
     eval $__out=`cat /proc/cpuinfo | grep processor | wc -l`
   elif [[ $OS = "darwin" ]]; then
     eval $__out=`sysctl hw.ncpu | awk '{print $2}'`

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -63,6 +63,7 @@ function platform_linux_main() {
   brew_tool libidn
   brew_tool libedit
   brew_tool libtool
+  brew_tool libyaml
   brew_tool m4
   brew_tool autoconf
   brew_tool automake

--- a/tools/provision/amazon.sh
+++ b/tools/provision/amazon.sh
@@ -10,22 +10,6 @@
 function distro_main() {
   do_sudo yum update -y
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package ruby-irb
-  package gcc
-  package gcc-c++
-  package bzip2
-  package gettext-devel
-  package bison
-  package flex
   package doxygen
   package valgrind
-
-  package rpm-devel
-  package rpm-build
 }

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -10,15 +10,6 @@
 function distro_main() {
   do_sudo pacman -Syu
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package bzip2
-  package bison
-  package flex
   package doxygen
   package valgrind
 }

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -10,22 +10,6 @@
 function distro_main() {
   do_sudo yum update -y
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package ruby-irb
-  package gcc
-  package gcc-c++
-  package bzip2
-  package gettext-devel
-  package bison
-  package flex
   package doxygen
   package valgrind
-
-  package rpm-devel
-  package rpm-build
 }

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -10,15 +10,6 @@
 function distro_main() {
   do_sudo apt-get -y update
 
-  package git
-  package gawk
-  package autotools-dev
-  package autopoint
-  package g++
-  package ruby
-  package curl
-  package bison
-  package flex
   package doxygen
   package valgrind
 }

--- a/tools/provision/manjaro.sh
+++ b/tools/provision/manjaro.sh
@@ -10,15 +10,6 @@
 function distro_main() {
   do_sudo pacman -Syu
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package bzip2
-  package bison
-  package flex
   package doxygen
   package valgrind
 }

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -10,21 +10,6 @@
 function distro_main() {
   do_sudo yum update -y
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package ruby-irb
-  package gcc
-  package bzip2
-  package gettext-devel
-  package bison
-  package flex
   package doxygen
   package valgrind
-
-  package rpm-devel
-  package rpm-build
 }

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -10,22 +10,6 @@
 function distro_main() {
   do_sudo yum update -y
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package ruby-irb
-  package gcc
-  package gcc-c++
-  package bzip2
-  package gettext-devel
-  package bison
-  package flex
   package doxygen
   package valgrind
-
-  package rpm-devel
-  package rpm-build
 }

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -10,21 +10,6 @@
 function distro_main() {
   do_sudo yum update -y
 
-  package wget
-  package git
-  package unzip
-  package gawk
-  package xz
-  package ruby
-  package ruby-irb
-  package gcc
-  package bzip2
-  package gettext-devel
-  package bison
-  package flex
   package doxygen
   package valgrind
-
-  package rpm-devel
-  package rpm-build
 }

--- a/tools/provision/suse.sh
+++ b/tools/provision/suse.sh
@@ -8,8 +8,5 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 function distro_main() {
-  do_sudo dnf update -y
-
-  package doxygen
-  package valgrind
+  do_sudo zypper update -y
 }

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -10,7 +10,6 @@
 function distro_main() {
   do_sudo apt-get -y update
 
-  package git
   package gawk
   package autotools-dev
   package autopoint
@@ -26,5 +25,5 @@ function distro_main() {
   package valgrind
 
   GEM=`which gem`
-  do_sudo $GEM install fpm 
+  do_sudo $GEM install --no-ri --no-rdoc fpm
 }


### PR DESCRIPTION
Vagrant tweaks and SuSE support

Changed vagrant boxes:
* debian updated to target latest bento/debian boxes
* Removed centos6.5 (which was incorrectly pointing to centos-6.7 box)
* Removed centos7.1 (centos7 can be used instead)
* Changed centos boxes to use elastic. These seems to be actively updated
* Changed ubuntu17.04 to use bento/ubuntu17.04
* Updated freebsd to latest bento boxes
* Updated archlinux to official archlinux box
* Added suse11 and suse12 from elastic
* Install git, make and python on ubuntu boxes from Vagrantfile

Updated tools/get_platform.py and tools/lib.sh  to handle SuSE

Added tools/provision/suse.sh. It just invokes zypper update

pip installation on some Ubuntu16 and CentOS7 fails with compilation issues
(when setting up PyYAML). Added libyaml dependency.

Cleaned up most of provision scripts to reduce sysprep time.
Only install doxygen and valgrind.

Tested (sysprep and test) on the following vagrant targets:
* centos6
* centos7
* debian8
* ubuntu12
* ubuntu14
* ubuntu16
* suse12