### PR TITLE
Add last_opened_time to apps table

### DIFF
--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -184,6 +184,24 @@ void genApplication(const pt::ptree& tree,
   r["name"] = path.parent_path().parent_path().filename().string();
   r["path"] = path.parent_path().parent_path().string();
 
+  NSString* filePath =
+      [NSString stringWithUTF8String:path.parent_path().parent_path().c_str()];
+  MDItemRef mdItem = MDItemCreate(NULL, (CFStringRef)filePath);
+
+  if (mdItem != NULL) {
+    NSDate* lastOpened = (NSDate*)CFBridgingRelease(
+        MDItemCopyAttribute(mdItem, kMDItemLastUsedDate));
+    if (lastOpened != NULL) {
+      r["last_opened_time"] = INTEGER([lastOpened timeIntervalSince1970]);
+      CFRelease(mdItem);
+      mdItem = NULL;
+    } else {
+      r["last_opened_time"] = INTEGER(-1);
+    }
+  } else {
+    r["last_opened_time"] = INTEGER(-1);
+  }
+
   // Loop through each column and its mapped Info.plist key name.
   for (const auto& item : kAppsInfoPlistTopLevelStringKeys) {
     r[item.second] = tree.get<std::string>(item.first, "");

--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -188,16 +188,16 @@ void genApplication(const pt::ptree& tree,
       [NSString stringWithUTF8String:path.parent_path().parent_path().c_str()];
   MDItemRef mdItem = MDItemCreate(NULL, (CFStringRef)filePath);
 
-  if (mdItem != NULL) {
-    NSDate* lastOpened = (NSDate*)CFBridgingRelease(
-        MDItemCopyAttribute(mdItem, kMDItemLastUsedDate));
-    if (lastOpened != NULL) {
+  if (mdItem != nullptr) {
+    NSDate* lastOpened = static_cast<NSDate*>(
+        CFBridgingRelease(MDItemCopyAttribute(mdItem, kMDItemLastUsedDate)));
+    if (lastOpened != nullptr) {
       r["last_opened_time"] = INTEGER([lastOpened timeIntervalSince1970]);
-      CFRelease(mdItem);
-      mdItem = NULL;
     } else {
       r["last_opened_time"] = INTEGER(-1);
     }
+    CFRelease(mdItem);
+    mdItem = NULL;
   } else {
     r["last_opened_time"] = INTEGER(-1);
   }

--- a/specs/darwin/apps.table
+++ b/specs/darwin/apps.table
@@ -27,6 +27,7 @@ schema([
     Column("applescript_enabled", TEXT,
         "Info properties NSAppleScriptEnabled label"),
     Column("copyright", TEXT, "Info properties NSHumanReadableCopyright label"),
+    Column("last_opened_time", DOUBLE, "The time that the app was last used"),
 ])
 attributes(cacheable=True)
 implementation("apps@genApps")


### PR DESCRIPTION
This Pull Request adds a new column called `last_opened_time` to the Darwin apps table.

### Rationale

Users of Osquery may want to know when the last time an app was launched by a user. Examples of this need could be analyzing app useage for license recovery, or checking if an undesirable or malicious file was executed by a user.

Traditional methods of getting this data (atime) are usually inaccurate as the timestamp is updated when the app is accessed by a benign process (an indexer, or even Finder itself).

### Implementation Details
Spotlight's indexer maintains a special metadata attribute on files (and mach-o apps) called `kMDItemLastUsedDate`. Which Apple's docs define as...

> The date and time that the file was last used. This value is updated automatically by LaunchServices everytime a file is opened by double clicking, or by asking LaunchServices to open a file. A CFDate.

This roughly translates to the "Last Opened Time" in macOS' Finder (although if this attribute is nil Finder will fallback to less accurate values like a standard POSIX atime)

This results a really accurate usage date that is much more useful than the normal timestamps.
