### PR TITLE
deploy: Adding license and verification information to chocolatey package

### DIFF
--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -2,31 +2,42 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", '', Scope="Function", Target="*")]
 param()
 
+. 'tools\provision\chocolatey\osquery_utils.ps1'
+
 function Main() {
   $working_dir = Get-Location
-  if (-not (Get-Command 7z.exe)) {
-    Write-Host '[-] 7z note found!  Please run .\tools\make-win64-dev-env.bat before continuing!' -ForegroundColor Red
+  $7z = ''
+  if (-not (Get-Command '7z.exe')) {
+    $msg = '[-] 7z note found!  Please run .\tools\make-win64-dev-env.bat ' +
+           'before continuing!'
+    Write-Host $msg -ForegroundColor Red
     exit
+  } else {
+    $7z = (Get-Command '7z.exe').Source
   }
 
   if ($PSVersionTable.PSVersion.Major -lt 5) {
-    Write-Host '[-] Powershell 5.0 or great is required for this script.' -ForegroundColor Red
+    $msg = '[-] Powershell 5.0 or great is required for this script.'
+    Write-Host $msg -ForegroundColor Red
     exit
   }
 
   $version = git describe --tags
   $latestFullVersion = (git tag)[-2]
-  # If split len is greater than 1, this is a pre-release. Chocolatey is particular
-  # about the format of the version for pre-releases.
+  # If split len is greater than 1, this is a pre-release. Chocolatey is
+  # particular about the format of the version for pre-releases.
   if ($version.split('-').length -eq 3) {
     $version = $version.split('-')[0] + '-' + $version.split('-')[2]
   }
 
-  if (-not (Test-Path (Join-Path (Get-location).Path 'tools\make-win64-binaries.bat'))) {
-    Write-Host "[-] Did not find build script '.\tools\make-win64-binaries.bat'!" -ForegroundColor Red
-    Write-Host "[-] This script must be run from the osquery repo root!" -ForegroundColor Red
+  $relBuildScriptPath = 'tools\make-win64-binaries.bat'
+  if (-not (Test-Path (Join-Path (Get-location).Path $relBuildScriptPath))) {
+    $msg = "[-] Did not find build script $relBuildScriptPath!`n[-] This " +
+           'script must be run from the osquery repo root.'
+    Write-Host $msg -ForegroundColor Red
     exit
   }
+
   # Binaries might not be built, let's try to build them quick :)
   if (-not (Test-Path (Join-Path (Get-Location).Path 'build\windows10\osquery\Release'))) {
     & '.\tools\make-win64-binaries.bat'
@@ -50,10 +61,21 @@ function Main() {
     Write-Host "[*] Did not find example packs" -ForegroundColor Yellow
   }
 
+  $lic = Join-Path $scriptPath 'LICENSE'
+  if (-not (Test-Path $lic)) {
+    $msg = '[*] Did not find LICENSE file, package will fail ' +
+           'chocolatey validation'
+    Write-Host $msg -ForegroundColor Yellow
+  }
+
+  $buildDir = "$scriptPath\build\windows10\osquery\Release\"
+  $clientPath = Join-Path $buildDir 'osqueryi.exe'
+  $daemonPath = Join-Path $buildDir 'osqueryd.exe'
+  $mgmtScript = "$scriptPath\tools\manage-osqueryd.ps1"
+
   $nupkg =
 @'
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>osquery</id>
@@ -112,10 +134,25 @@ $nupkg +=
   Copy-Item -Recurse -Force "$scriptPath\tools\deployment\chocolatey\tools" "$osqueryChocoPath"
   Copy-Item -Recurse -Force "$scriptPath\tools\provision\chocolatey\osquery_utils.ps1" "$osqueryChocoPath\tools\osquery_utils.ps1"
 
-  $buildDir = "$scriptPath\build\windows10\osquery\Release\"
-  $clientPath = Join-Path $buildDir 'osqueryi.exe'
-  $daemonPath = Join-Path $buildDir 'osqueryd.exe'
-  $mgmtScript = "$scriptPath\tools\manage-osqueryd.ps1"
+  $license = Join-Path "$osqueryChocoPath\tools\" 'LICENSE.txt'
+  Copy-Item $lic $license
+  $verification = Join-Path "$osqueryChocoPath\tools\" 'VERFICATION.txt'
+  $verMessage =
+@'
+To verify the osquery binaries are valid and not corrupted, one can run one of the following:
+
+C:\Users\> Get-FileHash -Algorithm SHA256 .\build\windows10\osquery\Release\osqueryd.exe
+C:\Users\> Get-FileHash -Algorithm SHA1 .\build\windows10\osquery\Release\osqueryd.exe
+C:\Users\> Get-FileHash -Algorithm MD5 .\build\windows10\osquery\Release\osqueryd.exe
+
+And verify that the digests match one of the below values:
+
+'@
+  $verMessage += 'SHA256: ' + (Get-FileHash -Algorithm SHA256 $daemonPath).Hash + "`r`n"
+  $verMessage += 'SHA1: ' + (Get-FileHash -Algorithm SHA1 $daemonPath).Hash + "`r`n"
+  $verMessage += 'MD5: ' + (Get-FileHash -Algorithm MD5 $daemonPath).Hash + "`r`n"
+
+  $verMessage | Out-File -Encoding "UTF8" $verification
   $nupkg | Out-File -Encoding "UTF8" "$osqueryChocoPath\osquery.nuspec"
   if (-not ((Test-Path $clientPath) -or (Test-Path $daemonPath))) {
     Write-Host '[-] Unable to find osquery binaries!  Check the results of the build scripts!' -ForegroundColor Red
@@ -123,7 +160,20 @@ $nupkg +=
   }
 
   # This bundles up all of the files we distribute.
-  7z a "$osqueryChocoPath\tools\bin\osquery.zip" $clientPath $daemonPath $certs $conf $packs $mgmtScript
+  $7zArgs = @(
+    'a',
+    "$osqueryChocoPath\tools\bin\osquery.zip",
+    "$clientPath",
+    "$daemonPath",
+    "$certs",
+    "$conf",
+    "$packs",
+    "$mgmtScript",
+    "$license",
+    "$verification"
+  )
+  Write-Host $7z
+  Start-OsqueryProcess $7z $7zArgs
   Write-Debug "[+] Creating the chocolatey package for osquery $version"
   Set-Location "$osqueryChocoPath"
   choco pack

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -115,13 +115,20 @@ function Get-OsqueryBuildPath {
 function Start-OsqueryProcess {
   param(
     [string] $binaryPath = '',
-    [array] $buildArgs = @()
+    [array] $binaryArgs = @()
   )
-  $out = Start-Process `
-          -FilePath $binaryPath `
-          -ArgumentList $buildArgs `
-          -NoNewWindow `
-          -PassThru
-  $out.WaitForExit()
-  return $out
+  $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+  $pinfo.FileName = $binaryPath
+  $pinfo.RedirectStandardError = $true
+  $pinfo.RedirectStandardOutput = $true
+  $pinfo.UseShellExecute = $false
+  $pinfo.Arguments = $binaryArgs
+  $p = New-Object System.Diagnostics.Process
+  $p.StartInfo = $pinfo
+  $p.Start() | Out-Null
+  $p.WaitForExit()
+  $stdout = $p.StandardOutput.ReadToEnd()
+  $stderr = $p.StandardError.ReadToEnd()
+  Write-Debug $stderr
+  return $stdout
 }


### PR DESCRIPTION
With a recent upgrade to how Chocolatey packages work, we're being required to add in the LICENSE file as well as a file detailing how to verify the package shipped is correct. This brings logic to our deployment script to copy the LICENSE file as well as generate a verification text file with instructions how to verify the binary obtained is the correct binary.