### PR TITLE
filesystem: Use fs::path for PlatformFile ctor

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -151,7 +151,7 @@ void Carver::start() {
   }
   for (const auto& p : carvePaths_) {
     // Ensure the file is a flat file on disk before carving
-    PlatformFile pFile(p.string(), PF_OPEN_EXISTING | PF_READ);
+    PlatformFile pFile(p, PF_OPEN_EXISTING | PF_READ);
     if (!pFile.isValid() || isDirectory(p)) {
       VLOG(1) << "File does not exist on disk or is subdirectory: " << p;
       continue;
@@ -187,7 +187,7 @@ void Carver::start() {
     uploadPath = archivePath_;
   }
 
-  PlatformFile uploadFile(uploadPath.string(), PF_OPEN_EXISTING | PF_READ);
+  PlatformFile uploadFile(uploadPath, PF_OPEN_EXISTING | PF_READ);
   updateCarveValue(carveGuid_, "size", std::to_string(uploadFile.size()));
 
   std::string uploadHash =
@@ -209,9 +209,8 @@ void Carver::start() {
 };
 
 Status Carver::carve(const boost::filesystem::path& path) {
-  PlatformFile src(path.string(), PF_OPEN_EXISTING | PF_READ);
-  PlatformFile dst((carveDir_ / path.leaf()).string(),
-                   PF_CREATE_NEW | PF_WRITE);
+  PlatformFile src(path, PF_OPEN_EXISTING | PF_READ);
+  PlatformFile dst(carveDir_ / path.leaf(), PF_CREATE_NEW | PF_WRITE);
 
   if (!dst.isValid()) {
     return Status(1, "Destination tmp FS is not valid.");
@@ -239,7 +238,7 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   auto startRequest = Request<TLSTransport, JSONSerializer>(startUri_);
 
   // Perform the start request to get the session id
-  PlatformFile pFile(path.string(), PF_OPEN_EXISTING | PF_READ);
+  PlatformFile pFile(path, PF_OPEN_EXISTING | PF_READ);
   auto blkCount =
       static_cast<size_t>(ceil(static_cast<double>(pFile.size()) /
                                static_cast<double>(FLAGS_carver_block_size)));

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -32,8 +32,8 @@ DECLARE_uint32(carver_block_size);
 
 Status compress(const boost::filesystem::path& in,
                 const boost::filesystem::path& out) {
-  PlatformFile inFile(in.string(), PF_OPEN_EXISTING | PF_READ);
-  PlatformFile outFile(out.string(), PF_CREATE_NEW | PF_WRITE);
+  PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
+  PlatformFile outFile(out, PF_CREATE_NEW | PF_WRITE);
 
   auto inFileSize = inFile.size();
   ZSTD_CStream* const cstream = ZSTD_createCStream();
@@ -99,8 +99,8 @@ Status compress(const boost::filesystem::path& in,
 
 Status decompress(const boost::filesystem::path& in,
                   const boost::filesystem::path& out) {
-  PlatformFile inFile(in.string(), PF_OPEN_EXISTING | PF_READ);
-  PlatformFile outFile(out.string(), PF_CREATE_NEW | PF_WRITE);
+  PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
+  PlatformFile outFile(out, PF_CREATE_NEW | PF_WRITE);
 
   auto inFileSize = inFile.size();
   size_t const buffInSize = ZSTD_DStreamInSize();
@@ -165,7 +165,7 @@ Status archive(const std::set<boost::filesystem::path>& paths,
     return Status(1, "Failed to open tar archive for writing");
   }
   for (const auto& f : paths) {
-    PlatformFile pFile(f.string(), PF_OPEN_EXISTING | PF_READ);
+    PlatformFile pFile(f, PF_OPEN_EXISTING | PF_READ);
 
     auto entry = archive_entry_new();
     archive_entry_set_pathname(entry, f.leaf().string().c_str());

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -25,11 +25,10 @@
 #include <vector>
 
 #include <boost/filesystem.hpp>
+#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 
 #include <osquery/status.h>
-
-namespace fs = boost::filesystem;
 
 namespace osquery {
 
@@ -109,14 +108,14 @@ LONGLONG filetimeToUnixtime(const FILETIME& ft);
 
 /**
  * @brief Stores information about the last Windows async request
- * @note Currently, we have rudimentary support for non-blocking operations
- *       on Windows. The implementation attempts to emulate POSIX non-blocking
- *       IO semantics using the Windows asynchronous API. As such, there are
- *       currently limitations. For example, opening a non-blocking file with
- *       read and write privileges may produce some problems. If a write
- *       operation does not immediately succeed, we cancel IO instead of
- *       waiting on it. As a result, on-going async read operations will get
- *       canceled and data might get lost.
+ *
+ * Currently, we have rudimentary support for non-blocking operations on
+ * Windows. The implementation attempts to emulate POSIX non-blocking IO
+ * semantics using the Windows asynchronous API. As such, there are currently
+ * limitations. For example, opening a non-blocking file with read and write
+ * privileges may produce some problems. If a write operation does not
+ * immediately succeed, we cancel IO instead of waiting on it. As a result,
+ * on-going async read operations will get canceled and data might get lost.
  *
  * Windows-only class that deals with simulating POSIX asynchronous IO semantics
  * using Windows API calls
@@ -161,15 +160,12 @@ Status windowsGetFileVersion(const std::string& path, std::string& rVersion);
  * PlatformFile is a multi-platform class that offers input/output capabilities
  * for files.
  */
-class PlatformFile {
+class PlatformFile : private boost::noncopyable {
  public:
-  explicit PlatformFile(const std::string& path, int mode, int perms = -1);
+  explicit PlatformFile(const boost::filesystem::path& path,
+                        int mode,
+                        int perms = -1);
   explicit PlatformFile(PlatformHandle handle) : handle_(handle) {}
-
-  PlatformFile(PlatformFile&& src) noexcept {
-    handle_ = kInvalidHandle;
-    std::swap(handle_, src.handle_);
-  }
 
   ~PlatformFile();
 
@@ -200,9 +196,10 @@ class PlatformFile {
 
   /**
    * @brief Returns success if owner of the file is root.
-   * @note At the moment, we only determine that the owner of the current file
-   *       is a member of the Administrators group. We do not count files owned
-   *       by TrustedInstaller as owned by root.
+   *
+   * At the moment, we only determine that the owner of the current file is a
+   * member of the Administrators group. We do not count files owned by
+   * TrustedInstaller as owned by root.
    */
   Status isOwnerRoot() const;
 
@@ -214,31 +211,41 @@ class PlatformFile {
 
   /**
    * @brief Determines how immutable the file is to external modifications.
-   * @note Currently, this is only implemented on Windows. The Windows version
-   *       of this function ensures that writes are explicitly denied for the
-   *       file AND the file's parent directory.
+   *
+   * Currently, this is only implemented on Windows. The Windows version of this
+   * function ensures that writes are explicitly denied for the file AND the
+   * file's parent directory.
    */
   Status hasSafePermissions() const;
 
+  /// Return the modified, created, birth, updated, etc times.
   bool getFileTimes(PlatformTime& times);
 
+  /// Change the file times.
   bool setFileTimes(const PlatformTime& times);
 
+  /// Read a number of bytes into a buffer.
   ssize_t read(void* buf, size_t nbyte);
 
+  /// Write a number of bytes from a buffer.
   ssize_t write(const void* buf, size_t nbyte);
 
+  /// Use the platform-specific seek.
   off_t seek(off_t offset, SeekMode mode);
 
+  /// Inspect the file size.
   size_t size() const;
 
  private:
-  fs::path fname_;
+  boost::filesystem::path fname_;
 
+  /// The internal platform-specific open file handle.
   PlatformHandle handle_{kInvalidHandle};
 
+  /// Is the file opened in a non-blocking read mode.
   bool is_nonblock_{false};
 
+  /// Does the file have pending operations.
   bool has_pending_io_{false};
 
 #ifdef WIN32
@@ -309,10 +316,10 @@ int platformAccess(const std::string& path, mode_t mode);
  * @note This just compares the temporary directory path against the given path
  *       on Windows.
  */
-Status platformIsTmpDir(const fs::path& dir);
+Status platformIsTmpDir(const boost::filesystem::path& dir);
 
 /// Determines the accessibility and existence of the file path.
-Status platformIsFileAccessible(const fs::path& path);
+Status platformIsFileAccessible(const boost::filesystem::path& path);
 
 /// Determine if the FILE object points to a tty (console, serial port, etc).
 bool platformIsatty(FILE* f);
@@ -338,7 +345,8 @@ boost::optional<FILE*> platformFopen(const std::string& filename,
  * if the socket exists and removal was requested (and the attempt to remove
  * had failed).
  */
-Status socketExists(const fs::path& path, bool remove_socket = false);
+Status socketExists(const boost::filesystem::path& path,
+                    bool remove_socket = false);
 
 /**
  * @brief Returns the OS root system directory.
@@ -349,7 +357,7 @@ Status socketExists(const fs::path& path, bool remove_socket = false);
  *
  * On POSIX systems this returns "/".
  *
- * @return an instance of fs::path, containing the OS root location.
+ * @return boost::filesystem::path containing the OS root location.
  */
 boost::filesystem::path getSystemRoot();
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -54,7 +54,7 @@ Status writeTextFile(const fs::path& path,
                      bool force_permissions) {
   // Open the file with the request permissions.
   PlatformFile output_fd(
-      path.string(), PF_OPEN_ALWAYS | PF_WRITE | PF_APPEND, permissions);
+      path, PF_OPEN_ALWAYS | PF_WRITE | PF_APPEND, permissions);
   if (!output_fd.isValid()) {
     return Status(1, "Could not create file: " + path.string());
   }
@@ -83,7 +83,7 @@ struct OpenReadableFile : private boost::noncopyable {
     }
 
     // Open the file descriptor and allow caller to perform error checking.
-    fd.reset(new PlatformFile(path.string(), mode));
+    fd.reset(new PlatformFile(path, mode));
   }
 
  public:
@@ -211,7 +211,7 @@ Status isWritable(const fs::path& path, bool effective) {
   }
 
   if (effective) {
-    PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_WRITE);
+    PlatformFile fd(path, PF_OPEN_EXISTING | PF_WRITE);
     return Status(fd.isValid() ? 0 : 1);
   } else if (platformAccess(path.string(), W_OK) == 0) {
     return Status(0, "OK");
@@ -227,7 +227,7 @@ Status isReadable(const fs::path& path, bool effective) {
   }
 
   if (effective) {
-    PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_READ);
+    PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
     return Status(fd.isValid() ? 0 : 1);
   } else if (platformAccess(path.string(), R_OK) == 0) {
     return Status(0, "OK");
@@ -443,7 +443,7 @@ bool safePermissions(const fs::path& dir,
     return false;
   }
 
-  PlatformFile fd(path.string(), PF_OPEN_EXISTING | PF_READ);
+  PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
   if (!fd.isValid()) {
     return false;
   }

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -30,7 +30,8 @@ namespace errc = boost::system::errc;
 
 namespace osquery {
 
-PlatformFile::PlatformFile(const std::string& path, int mode, int perms) {
+PlatformFile::PlatformFile(const fs::path& path, int mode, int perms)
+    : fname_(path) {
   int oflag = 0;
   bool may_create = false;
   bool check_existence = false;
@@ -84,10 +85,10 @@ PlatformFile::PlatformFile(const std::string& path, int mode, int perms) {
 
   boost::system::error_code ec;
   if (check_existence &&
-      (!fs::exists(path.c_str(), ec) || ec.value() != errc::success)) {
+      (!fs::exists(fname_, ec) || ec.value() != errc::success)) {
     handle_ = kInvalidHandle;
   } else {
-    handle_ = ::open(path.c_str(), oflag, perms);
+    handle_ = ::open(fname_.c_str(), oflag, perms);
   }
 }
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -549,7 +549,7 @@ static AclObject modifyAcl(PACL acl,
   return std::move(new_acl_buffer);
 }
 
-PlatformFile::PlatformFile(const std::string& path, int mode, int perms)
+PlatformFile::PlatformFile(const fs::path& path, int mode, int perms)
     : fname_(path) {
   DWORD access_mask = 0;
   DWORD flags_and_attrs = 0;
@@ -593,7 +593,7 @@ PlatformFile::PlatformFile(const std::string& path, int mode, int perms)
     // TODO(#2001): set up a security descriptor based off the perms
   }
 
-  handle_ = ::CreateFileA(path.c_str(),
+  handle_ = ::CreateFileA(fname_.string().c_str(),
                           access_mask,
                           FILE_SHARE_READ,
                           security_attrs.get(),
@@ -1279,7 +1279,7 @@ static std::string normalizeDirPath(const fs::path& path) {
 
   // Obtain the full path of the fs::path object
   DWORD nret = ::GetFullPathNameA(
-      (LPCSTR)path.string().c_str(), MAX_PATH, full_path.data(), nullptr);
+      path.string().c_str(), MAX_PATH, full_path.data(), nullptr);
   if (nret == 0) {
     return std::string();
   }


### PR DESCRIPTION
This is a cleanup diff. The `PlatformFile` class is not trivially copyable, maybe it once was, but it's best to assume we shouldn't need to copy it. The constructor should take a `boost::filesystem::path` as most callsites are already operating on paths and on Windows a copy of a `boost::filesystem::path` was already stored though not really needed.