### PR TITLE
website: Remove "home" change schema url to osquery/osquery-site

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -21,9 +21,6 @@ sitemap: false
       <nav class="main-nav">
         <ul>
           <li>
-            <a href="/">Home</a>
-          </li>
-          <li>
             <a href="/docs/home/">Docs</a>
           </li>
           <li>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -69,4 +69,4 @@ separators:
   rpm: "-"
   linux: "-"
 
-schema_url: https://raw.githubusercontent.com/theopolis/osquery-site/master/schema
+schema_url: https://raw.githubusercontent.com/osquery/osquery-site/master/schema

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -4,7 +4,7 @@
   </nav>
   <div class="grid">
     <div class="unit one-third center-on-mobiles">
-      <h1>
+      <h1 class="logoheader">
         <a class="logo" href="/">
           <span class="sr-only">osquery</span>
           <img src="/img/logo-2x.png" alt="osquery Logo">

--- a/docs/_includes/primary-nav-items.html
+++ b/docs/_includes/primary-nav-items.html
@@ -1,7 +1,4 @@
 <ul>
-  <li class="{% if page.overview %}current{% endif %}">
-    <a href="/">Home</a>
-  </li>
   <li class="{% if page.url contains '/docs/' %}current{% endif %}">
     <a href="/docs/home/">Docs</a>
   </li>

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -67,6 +67,10 @@ nav {
   li { display: inline-block; }
 }
 
+.logoheader {
+  white-space: nowrap;
+}
+
 .logo {
 
   color: #FFF;
@@ -74,9 +78,16 @@ nav {
   img {
     width: 60px;
     vertical-align: middle;
-    padding-top: 35px;
-    padding-bottom: 35px;
     margin-right: 15px;
+  }
+}
+
+@media (min-width: 796px) {
+  .logo {
+    img {
+      padding-top: 35px;
+      padding-bottom: 35px;
+    }
   }
 }
 
@@ -424,8 +435,15 @@ footer {
       display: block;
       margin: 0;
       padding: 0;
+      white-space: nowrap;
 
-      span { display: inline-block; }
+      span {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+        vertical-align: top;
+      }
     }
 
     .path {


### PR DESCRIPTION
This diff includes a few fixups for the new website.
- The `Home` button of the right-hand side top navbar is removed. This is a duplicated link, the logo, left-side also goes home.
- The schema is fetched and constructed at run-time from another "data" repo. Currently this is my local repo, we need to change this to the `osquery` organization's `osquery-site` repo.
- The logo is too large on mobile. This is fixed to remove the extra margins.
- The downloads and code-views overflow their windows now. This fixes them to use a hidden overflow and an ellipse indicating the content is clipped. 