### PR TITLE
Avoid unnecessary ptree allocation.

### DIFF
--- a/osquery/logger/plugins/kafka_producer.cpp
+++ b/osquery/logger/plugins/kafka_producer.cpp
@@ -275,9 +275,10 @@ bool KafkaProducerPlugin::configureTopics() {
   auto parser = Config::getParser("kafka_topics");
 
   if (parser != nullptr || parser.get() != nullptr) {
-    const auto& config = parser->getData().get_child(
-        kKafkaTopicParserRootKey, boost::property_tree::ptree("UNEXPECTED"));
-    if (!config.empty() && config.get_value("") != "UNEXPECTED") {
+    const auto& root =
+        parser->getData().get_child_optional(kKafkaTopicParserRootKey);
+    if (root) {
+      const auto& config = root.get();
       for (const auto& t : config) {
         auto topic = initTopic(t.first);
         if (topic == nullptr) {

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -83,13 +83,14 @@ QueryData genPrometheusMetrics(QueryContext& context) {
   /* Add a specific value to the default property tree to differentiate it from
    * the scenario where the user does not provide any prometheus_targets config.
    */
-  const auto& config = parser->getData().get_child(
-      kConfigParserRootKey, boost::property_tree::ptree("UNEXPECTED"));
-  if (config.get_value("") == "UNEXPECTED") {
+  const auto& root = parser->getData().get_child_optional(kConfigParserRootKey);
+  if (!root) {
     LOG(WARNING) << "Could not load prometheus_targets root key: "
                  << kConfigParserRootKey;
     return result;
   }
+
+  const auto& config = root.get();
   if (config.count("urls") == 0) {
     /* Only warn the user if they supplied the config, but did not supply any
      * urls. */


### PR DESCRIPTION
Use get_child_optional instead of get_child.