### PR TITLE
website: Add Jekyll CI checks using html-proofer

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -23,4 +23,3 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'html-proofer'
-

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -22,3 +22,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'html-proofer'
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,14 @@ It's just a Jekyll site, afterall!
 
 This [GitHub guide](https://help.github.com/articles/adding-a-jekyll-theme-to-your-github-pages-site/) was helpful for getting started.
 
+To test the site use:
+
+```
+bundle exec htmlproofer ./_site --only-4xx --check-favicon --check-html
+```
+
+This will be run in the `Code Audit` Jenkins job.
+
 ### Updating Font Awesome
 
 1. Go to <https://icomoon.io/app/>
@@ -109,6 +117,8 @@ Use: `./tools/codegen/genapi.py` to generate the amalgamated schema. To generate
 ./tools/codegen/genapi.py --diff ./build/docs/OLD.json ./build/docs/CURRENT.json
 ```
 
-Packs do not require any processing, they can be copied to the homepage's data folder.
+We keep the table schema in [`osquery/osquery`](https://github.com/osquery/osquery)'s `/schema` directory.
+This protects the `facebook/osquery` repo from 1000+ LoC checkins of generated JSON.
 
-
+The `/docs/_data/packs.yml` holds the name of each pack and a friendly title.
+The Jekyll site will fetch each title from the `/packs` directory in `facebook/osquery`.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -56,12 +56,19 @@ plugins:
 exclude:
   - .gitignore
   - README.md
+  - doxygen
+  - wiki
 
 prefixes:
-  darwin: pkg
-  deb: linux.amd64.deb
-  rpm: linux.x86_64.rpm
-  linux: linux_x86_64.tar.gz
+  darwin: .pkg
+  deb: _1.linux.amd64.deb
+  rpm: -1.linux.x86_64.rpm
+  linux: _1.linux_x86_64.tar.gz
+
+debug_prefixes:
+  darwin: debug
+  deb: dbg
+  rpm: debuginfo
 
 separators:
   darwin: "-"

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -28,7 +28,7 @@
         </a>
         <br />
         <a href="https://www.macstadium.com/">
-          <img src="/img/macstadium.png" width="100" />
+          <img src="/img/macstadium.png" alt="Mac Stadium Logo" width="100" />
         </a>
       </p>
     </div>

--- a/docs/downloads/downloads.html
+++ b/docs/downloads/downloads.html
@@ -33,8 +33,8 @@ permalink: /downloads/
         {% assign sep = site.separators[key] %}
           <p class="line" style="margin-top: 10px">
             <span class="output">
-              <a href="https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}.{{prefix}}">
-                https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}.{{prefix}}
+              <a href="https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}{{prefix}}">
+                https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}{{prefix}}
               </a>
              </span>
           </p>
@@ -218,10 +218,11 @@ permalink: /downloads/
         {% assign key = dist[0] %}
         {% assign prefix = site.prefixes[key] %}
         {% assign sep = site.separators[key] %}
+        {% assign dbg = site.debug_prefixes[key] %}
           <p class="line" style="margin-top: 10px">
             <span class="output">
-              <a href="https://pkg.osquery.io/{{key}}/osquery-debug{{sep}}{{version}}.{{prefix}}">
-                https://pkg.osquery.io/{{key}}/osquery-debug{{sep}}{{version}}.{{prefix}}
+              <a href="https://pkg.osquery.io/{{key}}/osquery-{{dbg}}{{sep}}{{version}}{{prefix}}">
+                https://pkg.osquery.io/{{key}}/osquery-{{dbg}}{{sep}}{{version}}{{prefix}}
               </a>
              </span>
           </p>


### PR DESCRIPTION
This is a work in progress as I test the viability of `html-proofer`. Currently it finds quite a few errors. If it runs in the Jenkins job without too many dependencies then it will be enabled for all PRs.