### PR TITLE
Updated it-compliance query pack for browser extensions

### DIFF
--- a/packs/it-compliance.conf
+++ b/packs/it-compliance.conf
@@ -85,7 +85,7 @@
       "value" : "General security posture."
     },
     "browser_plugins": {
-      "query" : "select * from browser_plugins;",
+      "query" : "select * from users join browser_plugins using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -93,7 +93,7 @@
       "value" : "General security posture."
     },
     "safari_extensions": {
-      "query" : "select * from safari_extensions;",
+      "query" : "select * from users join safari_extensions using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",
@@ -101,14 +101,14 @@
       "value" : "General security posture."
     },
     "chrome_extensions": {
-      "query" : "select * from chrome_extensions;",
+      "query" : "select * from users join chrome_extensions using (uid);",
       "interval" : "86400",
       "version" : "1.4.5",
       "description" : "Retrieves the list of extensions for Chrome in the target system.",
       "value" : "General security posture."
     },
     "firefox_addons": {
-      "query" : "select * from firefox_addons;",
+      "query" : "select * from users join firefox_addons using (uid);",
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.5",


### PR DESCRIPTION
Super minor diff, this is just to have querypacks automatically collect browser extension data for all users on a machine. 