### PR TITLE
logger: Port status serialization to rapidjson

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -20,8 +20,10 @@
 #include <osquery/logger.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/core/json.h"
 
 namespace bai = boost::archive::iterators;
+namespace rj = rapidjson;
 
 namespace osquery {
 
@@ -29,6 +31,68 @@ typedef bai::binary_from_base64<const char*> base64_str;
 typedef bai::transform_width<base64_str, 8, 6> base64_dec;
 typedef bai::transform_width<std::string::const_iterator, 6, 8> base64_enc;
 typedef bai::base64_from_binary<base64_enc> it_base64;
+
+JSON::JSON(decltype(rj::kObjectType) type) : type_(type) {
+  if (type_ == rj::kObjectType) {
+    doc_.SetObject();
+  } else {
+    doc_.SetArray();
+  }
+}
+
+JSON JSON::newObject() {
+  return JSON(rj::kObjectType);
+}
+
+JSON JSON::newArray() {
+  return JSON(rj::kArrayType);
+}
+
+rj::Document JSON::getObject() const {
+  rj::Document line;
+  line.SetObject();
+  return line;
+}
+
+rj::Document JSON::getArray() const {
+  rj::Document line;
+  line.SetArray();
+  return line;
+}
+
+void JSON::push(rj::Document& line) {
+  assert(type_ == rj::kArrayType);
+  doc_.PushBack(rj::Value(line, doc_.GetAllocator()).Move(),
+                doc_.GetAllocator());
+}
+
+void JSON::add(rj::Document& line,
+               const std::string& key,
+               const std::string& value) {
+  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
+                 rj::Value(value, doc_.GetAllocator()).Move(),
+                 doc_.GetAllocator());
+}
+
+void JSON::add(rj::Document& line, const std::string& key, size_t value) {
+  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
+                 rj::Value(static_cast<uint64_t>(value)).Move(),
+                 doc_.GetAllocator());
+}
+
+void JSON::add(rj::Document& line, const std::string& key, int value) {
+  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
+                 rj::Value(value).Move(),
+                 doc_.GetAllocator());
+}
+
+Status JSON::toString(std::string& str) {
+  rj::StringBuffer sb;
+  rj::Writer<rj::StringBuffer> writer(sb);
+  doc_.Accept(writer);
+  str = sb.GetString();
+  return Status();
+}
 
 std::string base64Decode(const std::string& encoded) {
   std::string is;

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -66,32 +66,62 @@ void JSON::push(rj::Document& line) {
                 doc_.GetAllocator());
 }
 
-void JSON::add(rj::Document& line,
-               const std::string& key,
-               const std::string& value) {
-  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
-                 rj::Value(value, doc_.GetAllocator()).Move(),
+void JSON::addCopy(const std::string& key,
+                   const std::string& value,
+                   rj::Document& line) {
+  rj::Value sc;
+  sc.SetString(value.c_str(), value.size(), doc_.GetAllocator());
+  line.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                 sc.Move(),
                  doc_.GetAllocator());
 }
 
-void JSON::add(rj::Document& line, const std::string& key, size_t value) {
-  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
+void JSON::addCopy(const std::string& key, const std::string& value) {
+  addCopy(key, value, doc());
+}
+
+void JSON::addRef(const std::string& key,
+                  const std::string& value,
+                  rj::Document& line) {
+  line.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                 rj::Value(rj::StringRef(value), doc_.GetAllocator()).Move(),
+                 doc_.GetAllocator());
+}
+
+void JSON::addRef(const std::string& key, const std::string& value) {
+  addRef(key, value, doc());
+}
+
+void JSON::add(const std::string& key, size_t value, rj::Document& line) {
+  line.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
                  rj::Value(static_cast<uint64_t>(value)).Move(),
                  doc_.GetAllocator());
 }
 
-void JSON::add(rj::Document& line, const std::string& key, int value) {
-  line.AddMember(rj::Value(key, doc_.GetAllocator()).Move(),
+void JSON::add(const std::string& key, size_t value) {
+  add(key, value, doc());
+}
+
+void JSON::add(const std::string& key, int value, rj::Document& line) {
+  line.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
                  rj::Value(value).Move(),
                  doc_.GetAllocator());
 }
 
-Status JSON::toString(std::string& str) {
+void JSON::add(const std::string& key, int value) {
+  add(key, value, doc());
+}
+
+Status JSON::toString(std::string& str) const {
   rj::StringBuffer sb;
   rj::Writer<rj::StringBuffer> writer(sb);
   doc_.Accept(writer);
   str = sb.GetString();
   return Status();
+}
+
+rj::Document& JSON::doc() {
+  return doc_;
 }
 
 std::string base64Decode(const std::string& encoded) {

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -70,19 +70,83 @@ class JSON : private only_movable {
   /// Add a JSON object or array to a list.
   void push(rapidjson::Document& line);
 
-  /// Add a string value to a JSON object.
-  void add(rapidjson::Document& line,
-           const std::string& key,
-           const std::string& value);
+  /**
+   * @brief Add a string value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document.
+   * The input document must be an object type.
+   */
+  void addCopy(const std::string& key,
+               const std::string& value,
+               rapidjson::Document& line);
 
-  /// Add a size_t value to a JSON object.
-  void add(rapidjson::Document& line, const std::string& key, size_t value);
+  /**
+   * @brief Add a string value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document.
+   * The document must be an object type.
+   */
+  void addCopy(const std::string& key, const std::string& value);
 
-  /// Add an int value to a JSON object.
-  void add(rapidjson::Document& line, const std::string& key, int value);
+  /**
+   * @brief Add a string value to a JSON object by referencing the contents.
+   *
+   * The string value must live longer than the document's use.
+   *
+   * This will add the key and value to an input document.
+   * The input document must be an object type.
+   */
+  void addRef(const std::string& key,
+              const std::string& value,
+              rapidjson::Document& line);
+
+  /**
+   * @brief Add a string value to a JSON object by referencing the contents.
+   *
+   * The string value must live longer than the document's use.
+   *
+   * This will add the key and value to the JSON document.
+   * The input document must be an object type.
+   */
+  void addRef(const std::string& key, const std::string& value);
+
+  /**
+   * @brief Add a size_t value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, size_t value, rapidjson::Document& line);
+
+  /**
+   * @brief Add a size_t value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, size_t value);
+
+  /**
+   * @brief Add a int value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, int value, rapidjson::Document& line);
+
+  /**
+   * @brief Add a int value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, int value);
 
   /// Convert this document to a JSON string.
-  Status toString(std::string& str);
+  Status toString(std::string& str) const;
+
+  /// Access the internal document containing the allocator.
+  rapidjson::Document& doc();
 
  private:
   rapidjson::Document doc_;

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -10,12 +10,21 @@
 
 #pragma once
 
+#include <osquery/core.h>
+
 #ifdef WIN32
 #pragma warning(push, 3)
 #pragma warning(disable : 4715)
 #endif
 
 #include <boost/property_tree/json_parser.hpp>
+
+#define RAPIDJSON_HAS_STDSTRING 1
+
+#define RAPIDJSON_NO_SIZETYPEDEFINE
+namespace rapidjson {
+typedef ::std::size_t SizeType;
+}
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
@@ -28,3 +37,55 @@
 // We need to reinclude this to re-enable boost's warning suppression
 #include <boost/config/compiler/visualc.hpp>
 #endif
+
+namespace osquery {
+/**
+ * @brief This provides a small wrapper around constructing JSON objects.
+ *
+ * Constructing RapidJSON objects can be slightly tricky. In our original
+ * refactoring we found several opportunities to leak memory and cause faults.
+ * This was mostly causes by setting allocators incorrectly.
+ */
+class JSON : private only_movable {
+ private:
+  explicit JSON(decltype(rapidjson::kObjectType) type);
+
+ public:
+  JSON(JSON&&) = default;
+  JSON& operator=(JSON&&) = default;
+
+  /// Create a JSON wrapper for an Object (map).
+  static JSON newObject();
+
+  /// Create a JSON wrapper for an Array (list).
+  static JSON newArray();
+
+ public:
+  /// Make a JSON object (map).
+  rapidjson::Document getObject() const;
+
+  /// Make a JSON array (list).
+  rapidjson::Document getArray() const;
+
+  /// Add a JSON object or array to a list.
+  void push(rapidjson::Document& line);
+
+  /// Add a string value to a JSON object.
+  void add(rapidjson::Document& line,
+           const std::string& key,
+           const std::string& value);
+
+  /// Add a size_t value to a JSON object.
+  void add(rapidjson::Document& line, const std::string& key, size_t value);
+
+  /// Add an int value to a JSON object.
+  void add(rapidjson::Document& line, const std::string& key, int value);
+
+  /// Convert this document to a JSON string.
+  Status toString(std::string& str);
+
+ private:
+  rapidjson::Document doc_;
+  decltype(rapidjson::kObjectType) type_;
+};
+}

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -100,4 +100,54 @@ TEST_F(ConversionsTests, test_buffer_sha1) {
   EXPECT_EQ("4e1243bd22c66e76c2ba9eddc1f91394e57f9f83",
             getBufferSHA1(test.c_str(), test.size()));
 }
+
+TEST_F(ConversionsTests, test_json_array) {
+  auto doc = JSON::newArray();
+
+  {
+    auto line = doc.getObject();
+    size_t value = 10_sz;
+    doc.add("key", value, line);
+    doc.push(line);
+  }
+
+  std::string result;
+  EXPECT_TRUE(doc.toString(result));
+
+  std::string expected = "[{\"key\":10}]";
+  EXPECT_EQ(expected, result);
+}
+
+TEST_F(ConversionsTests, test_json_object) {
+  auto doc = JSON::newObject();
+
+  {
+    size_t value = 10_sz;
+    doc.add("key", value);
+  }
+
+  std::string result;
+  EXPECT_TRUE(doc.toString(result));
+
+  std::string expected = "{\"key\":10}";
+  EXPECT_EQ(expected, result);
+}
+
+TEST_F(ConversionsTests, test_json_strings) {
+  auto doc = JSON::newObject();
+
+  {
+    std::string value("value");
+    doc.addCopy("key", value);
+  }
+
+  std::string value2("value2");
+  doc.addRef("key2", value2);
+
+  std::string result;
+  EXPECT_TRUE(doc.toString(result));
+
+  std::string expected = "{\"key\":\"value\",\"key2\":\"value2\"}";
+  EXPECT_EQ(expected, result);
+}
 }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -661,9 +661,6 @@ void relayStatusLogs(bool async) {
       }
 
       serializeIntermediateLog(status_logs, request);
-      if (!request["log"].empty()) {
-        request["log"].pop_back();
-      }
 
       // Flush the buffered status logs.
       status_logs.clear();

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -31,6 +31,7 @@
 #include "osquery/core/json.h"
 
 namespace pt = boost::property_tree;
+namespace rj = rapidjson;
 
 namespace osquery {
 
@@ -265,27 +266,20 @@ class LoggerDisabler : private boost::noncopyable {
 
 static void serializeIntermediateLog(const std::vector<StatusLogLine>& log,
                                      PluginRequest& request) {
-  try {
-    pt::ptree tree;
-    for (const auto& log_item : log) {
-      pt::ptree child;
-      child.put("s", log_item.severity);
-      child.put("f", log_item.filename);
-      child.put("i", log_item.line);
-      child.put("m", log_item.message);
-      child.put("h", log_item.identifier);
-      child.put("c", log_item.calendar_time);
-      child.put("u", log_item.time);
-      tree.push_back(std::make_pair("", std::move(child)));
-    }
-
-    // Save the log as a request JSON string.
-    std::ostringstream output;
-    pt::write_json(output, tree, false);
-    request["log"] = output.str();
-  } catch (const pt::ptree_error& e) {
-    VLOG(1) << "Error serializing log entries: " << e.what();
+  auto doc = JSON::newArray();
+  for (const auto& i : log) {
+    auto line = doc.getObject();
+    doc.add(line, "s", static_cast<int>(i.severity));
+    doc.add(line, "f", i.filename);
+    doc.add(line, "i", i.line);
+    doc.add(line, "m", i.message);
+    doc.add(line, "h", i.identifier);
+    doc.add(line, "c", i.calendar_time);
+    doc.add(line, "u", i.time);
+    doc.push(line);
   }
+
+  doc.toString(request["log"]);
 }
 
 static void deserializeIntermediateLog(const PluginRequest& request,
@@ -294,25 +288,20 @@ static void deserializeIntermediateLog(const PluginRequest& request,
     return;
   }
 
-  // Read the plugin request string into a JSON tree and enumerate.
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << request.at("log");
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
+  rj::Document doc;
+  if (doc.Parse(request.at("log").c_str()).HasParseError()) {
     return;
   }
 
-  for (const auto& item : tree.get_child("")) {
+  for (auto& line : doc.GetArray()) {
     log.push_back({
-        (StatusLogSeverity)item.second.get<int>("s", O_INFO),
-        item.second.get<std::string>("f", "<unknown>"),
-        item.second.get<size_t>("i", 0),
-        item.second.get<std::string>("m", ""),
-        item.second.get<std::string>("c", ""),
-        item.second.get<size_t>("u", 0),
-        item.second.get<std::string>("h", ""),
+        static_cast<StatusLogSeverity>(line["s"].GetInt()),
+        line["f"].GetString(),
+        line["i"].GetUint64(),
+        line["m"].GetString(),
+        line["c"].GetString(),
+        line["u"].GetUint64(),
+        line["h"].GetString(),
     });
   }
 }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -269,13 +269,13 @@ static void serializeIntermediateLog(const std::vector<StatusLogLine>& log,
   auto doc = JSON::newArray();
   for (const auto& i : log) {
     auto line = doc.getObject();
-    doc.add(line, "s", static_cast<int>(i.severity));
-    doc.add(line, "f", i.filename);
-    doc.add(line, "i", i.line);
-    doc.add(line, "m", i.message);
-    doc.add(line, "h", i.identifier);
-    doc.add(line, "c", i.calendar_time);
-    doc.add(line, "u", i.time);
+    doc.add("s", static_cast<int>(i.severity), line);
+    doc.addRef("f", i.filename, line);
+    doc.add("i", i.line, line);
+    doc.addRef("m", i.message, line);
+    doc.addRef("h", i.identifier, line);
+    doc.addRef("c", i.calendar_time, line);
+    doc.add("u", i.time, line);
     doc.push(line);
   }
 


### PR DESCRIPTION
This introduces a small wrapper around some `rapidjson` APIs, called `JSON` to protect us from making easy mistakes. We then port the logger's status logging serialization and deserialization to use `JSON` instead of Boost property trees.