### PR TITLE
soften language to not enabled rather than failed

### DIFF
--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -821,7 +821,7 @@ Status EventFactory::registerEventPublisher(const PluginRef& pub) {
     specialized_pub->state(EventState::EVENT_SETUP);
     if (!status.ok()) {
       // Only start event loop if setUp succeeds.
-      LOG(INFO) << "Event publisher failed setup: " << type_id << ": "
+      LOG(INFO) << "Event publisher not enabled: " << type_id << ": "
                 << status.what();
       specialized_pub->isEnding(true);
       return status;


### PR DESCRIPTION
per the discussion here 
```
yanxin [10:24 AM] 
Hello, try to use osquery on Ubuntu laptop
[10:24] 
got the error after basic config
[10:24] 
Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
I0928 09:51:42.747632 25866 events.cpp:824] Event publisher failed setup: audit: Publisher disabled via configuration
I0928 09:51:42.747768 25866 events.cpp:824] Event publisher failed setup: kernel: Cannot access /dev/osquery
I0928 09:51:42.747788 25866 events.cpp:824] Event publisher failed setup: syslog: Publisher disabled via configuration
yanxin [10:36 AM] 
anyone can help?
zwass [10:39 AM] 
Those are expected and don't indicate any problem unless you are explicitly trying to use those event publishers. (edited)
yanxin [10:51 AM] 
got it, thanks for explaining @zwass
[10:51] 
the error log is scared
zwass [10:51 AM] 
People are often confused by this...
groob [10:55 AM] 
logs should be in debug if they're not actionable
<snip> 

theopolis [3:24 PM] 
@stephen it's not broken, it's just waiting for someone to port all of the read-the-docs content over: https://osquery.readthedocs.io/en/stable/ :slightly_smiling_face:
[3:25] 
@groob @clippy IIRC when the logs were set to debug people had trouble debugging. They are set to INFO now, the real difficulty is you need to know that the initial "I" is the indicator for "INFO" in google-log world. Once you know that the world makes sense.
clippy [3:40 PM] 
@theopolis that's fair.  Maybe we could find some more friendly language to not make it sound like things went horribly wrong?  `Event publisher failed setup: kernel: Cannot access /dev/osquery` sounds very severe
[3:41] 
mostly because of the `failed` i think
[3:41] 
even something like `Event publisher not enabled`
```

I have updated the message to a slightly less alarming "not enabled"