### PR TITLE
[Fix #3717] Check crypt API values before constructing strings

### DIFF
--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -10,14 +10,18 @@
 
 #include <unistd.h>
 
+#include <vector>
+
 #include <osquery/core.h>
 #include <osquery/logger.h>
-#include <osquery/tables.h>
 #include <osquery/sql.h>
+#include <osquery/tables.h>
 
 extern "C" {
 #include <libcryptsetup.h>
 }
+
+#include "osquery/core/conversions.h"
 
 namespace osquery {
 namespace tables {
@@ -32,38 +36,44 @@ void genFDEStatusForBlockDevice(const std::string& name,
   r["uuid"] = uuid;
 
   struct crypt_device* cd = nullptr;
-  struct crypt_active_device cad;
-  crypt_status_info ci;
-  std::string type;
-  std::string cipher;
-  std::string cipher_mode;
-  ci = crypt_status(cd, name.c_str());
+  auto ci = crypt_status(cd, name.c_str());
+
   switch (ci) {
   case CRYPT_ACTIVE:
   case CRYPT_BUSY: {
     r["encrypted"] = "1";
 
-    int crypt_init;
-#if defined(CENTOS_CENTOS6) || defined(RHEL_RHEL6) || \
-    defined(SCIENTIFIC_SCIENTIFIC6)
-    crypt_init = crypt_init_by_name(&cd, name.c_str());
-#else
-    crypt_init = crypt_init_by_name_and_header(&cd, name.c_str(), nullptr);
-#endif
-
+    auto crypt_init = crypt_init_by_name_and_header(&cd, name.c_str(), nullptr);
     if (crypt_init < 0) {
       VLOG(1) << "Unable to initialize crypt device for " << name;
       break;
     }
 
-    type = crypt_get_type(cd);
+    struct crypt_active_device cad;
     if (crypt_get_active_device(cd, name.c_str(), &cad) < 0) {
       VLOG(1) << "Unable to get active device for " << name;
       break;
     }
-    cipher = crypt_get_cipher(cd);
-    cipher_mode = crypt_get_cipher_mode(cd);
-    r["type"] = type + "-" + cipher + "-" + cipher_mode;
+
+    // Construct the "type" with the cipher and mode too.
+    std::vector<std::string> items;
+
+    auto ctype = crypt_get_type(cd);
+    if (ctype != nullptr) {
+      items.push_back(ctype);
+    }
+
+    auto ccipher = crypt_get_cipher(cd);
+    if (ccipher != nullptr) {
+      items.push_back(ccipher);
+    }
+
+    auto ccipher_mode = crypt_get_cipher_mode(cd);
+    if (ccipher_mode != nullptr) {
+      items.push_back(ccipher_mode);
+    }
+
+    r["type"] = osquery::join(items, "-");
     encrypted_rows[name] = r;
     break;
   }
@@ -77,13 +87,14 @@ void genFDEStatusForBlockDevice(const std::string& name,
       r["encrypted"] = "0";
     }
   }
+
   if (cd != nullptr) {
     crypt_free(cd);
   }
   results.push_back(r);
 }
 
-QueryData genFDEStatus(QueryContext &context) {
+QueryData genFDEStatus(QueryContext& context) {
   QueryData results;
 
   if (getuid() || geteuid()) {
@@ -93,7 +104,7 @@ QueryData genFDEStatus(QueryContext &context) {
 
   std::map<std::string, Row> encrypted_rows;
   auto block_devices = SQL::selectAllFrom("block_devices");
-  for (const auto &row : block_devices) {
+  for (const auto& row : block_devices) {
     const auto name = (row.count("name") > 0) ? row.at("name") : "";
     const auto uuid = (row.count("uuid") > 0) ? row.at("uuid") : "";
     const auto parent_name = (row.count("parent") > 0 ? row.at("parent") : "");


### PR DESCRIPTION
Previously the `char *` values from `crypt_`* APIs were auto-constructed into `std::string`s. These must be checked for `nullptr` return values first.