### PR TITLE
website: Render 2.8.0 schema and add schema scrollTo

### DIFF
--- a/docs/_layouts/schema.html
+++ b/docs/_layouts/schema.html
@@ -169,6 +169,14 @@ $(document).ready(function() {
 
         $('#output').append(ui);
       }
+
+      if (window.location.hash) {
+        tb = $(window.location.hash);
+        if (tb.length) {
+          hb = $('html,body');
+          hb.scrollTop(tb.offset().top - hb.offset().top + hb.scrollTop());
+        }
+      }
     });
 });
 </script>

--- a/docs/_schema/2.8.0.md
+++ b/docs/_schema/2.8.0.md
@@ -1,0 +1,4 @@
+---
+version: 2.8.0
+redirect_from: /docs/tables/2.8.0/index.html
+---


### PR DESCRIPTION
This renders the `2.8.0` schema (forget to include this redirect and render before). And adds some javascript that allows a `#table_name` focus request to scroll after the rendering.