### PR TITLE
manage-osqueryd.ps1: Fix for -args parameter

### DIFF
--- a/tools/manage-osqueryd.ps1
+++ b/tools/manage-osqueryd.ps1
@@ -6,7 +6,7 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 param(
-  [string] $args = "",
+  [string] $startup_args = "",
   [switch] $install = $false,
   [switch] $uninstall = $false,
   
@@ -35,7 +35,7 @@ function Do-Help {
   Write-Host "  Only one of the following options can be used. Using multiple will result in "
   Write-Host "  options being ignored."
   Write-Host "    -install          Install the osqueryd service"
-  Write-Host "    -args             Specifies additional arguments for the service (only used with -install)"
+  Write-Host "    -startup_args     Specifies additional arguments for the service (only used with -install)"
   Write-Host "    -uninstall        Uninstall the osqueryd service"
   Write-Host "    -start            Start the osqueryd service"
   Write-Host "    -stop             Stop the osqueryd service"
@@ -58,7 +58,7 @@ function Do-Service {
       Write-Host "'$kServiceName' is already installed." -foregroundcolor Yellow
       Exit 1
     } else {
-      New-Service -BinaryPathName "$kServiceBinaryPath $args" -Name $kServiceName -DisplayName $kServiceName -StartupType Automatic
+      New-Service -BinaryPathName "$kServiceBinaryPath $startup_args" -Name $kServiceName -DisplayName $kServiceName -StartupType Automatic
       Write-Host "Installed '$kServiceName' system service." -foregroundcolor Cyan
       Exit 0
     }

--- a/tools/manage-osqueryd.ps1
+++ b/tools/manage-osqueryd.ps1
@@ -6,7 +6,7 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 param(
-  [string] $startup_args = "",
+  [string] $startupArgs = "",
   [switch] $install = $false,
   [switch] $uninstall = $false,
   
@@ -35,7 +35,7 @@ function Do-Help {
   Write-Host "  Only one of the following options can be used. Using multiple will result in "
   Write-Host "  options being ignored."
   Write-Host "    -install          Install the osqueryd service"
-  Write-Host "    -startup_args     Specifies additional arguments for the service (only used with -install)"
+  Write-Host "    -startupArgs     Specifies additional arguments for the service (only used with -install)"
   Write-Host "    -uninstall        Uninstall the osqueryd service"
   Write-Host "    -start            Start the osqueryd service"
   Write-Host "    -stop             Stop the osqueryd service"
@@ -58,7 +58,7 @@ function Do-Service {
       Write-Host "'$kServiceName' is already installed." -foregroundcolor Yellow
       Exit 1
     } else {
-      New-Service -BinaryPathName "$kServiceBinaryPath $startup_args" -Name $kServiceName -DisplayName $kServiceName -StartupType Automatic
+      New-Service -BinaryPathName "$kServiceBinaryPath $startupArgs" -Name $kServiceName -DisplayName $kServiceName -StartupType Automatic
       Write-Host "Installed '$kServiceName' system service." -foregroundcolor Cyan
       Exit 0
     }


### PR DESCRIPTION
osquery version: 2.8.0
OS: Windows 10

**Problem:**
$args is a an automatically defined variable in Powershell (https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-5.1)

Because of this, any parameter passed via the `-args` flag does not get parsed by `manage-osqueryd.ps1` and it will always contain a blank string. Simply add a `write-host "Arguments: $args"` anywhere in the script to verify this behavior.

By renaming `$args` to something different like `$startup_args`, we avoid this issue. This code has been tested and works on my Win10 host.