### PR TITLE
website: Fix redirects with /osquery using empty baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ timezone: America/Los_Angeles
 name: osquery • Performant Endpoint Visibility
 description: Easily ask questions about your Linux, Windows, and macOS infrastructure
 url: https://osquery.io
+baseurl: ""
 
 twitter:
   username: osquery


### PR DESCRIPTION
The current set of redirects are including `/osquery`. This is because GitHub pages is setting `site.baseurl` to the project name. The redirect-from plugin respects this. Reading though https://github.com/github/pages-gem/issues/350 it seems we can set the `baseurl` to an empty string to 'fix' this for our proxying scenario.