### PR TITLE
socket_events: Fix IPv6 family

### DIFF
--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -80,7 +80,7 @@ bool parseSockAddr(const std::string& saddr, AuditFields& r) {
     r["remote_address"] = ip4FromSaddr(saddr, 8);
   } else if (saddr[0] == '0' && saddr[1] == 'A') {
     // IPv6
-    r["family"] = "11";
+    r["family"] = "10";
     long result{0};
     safeStrtol(saddr.substr(4, 4), 16, result);
     r["remote_port"] = INTEGER(result);


### PR DESCRIPTION
Hello,

The family of IPv6 sockets, in **osquery 2.7.0**, is converted from 'A' to '11'.

According to the mapping of protocol to integer values, the correct family identifier for IPv6 sockets is 10. Therefore, I am opening this PR to fix it.

https://github.com/torvalds/linux/blob/80cee03bf1d626db0278271b505d7f5febb37bba/include/linux/socket.h#L171