### PR TITLE
Add SECURITY.md security issues tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ There are several forms of [eventing](http://osquery.readthedocs.org/en/stable/d
 
 ## Vulnerabilities
 
+We keep track of security announcements in our tagged version release notes on GitHub. We aggregate these into [SECURITY.md](https://github.com/facebook/osquery/blob/master/SECURITY.md) too.
+
 Facebook has a [bug bounty](https://www.facebook.com/whitehat/) program that includes osquery. If you find a security vulnerability in osquery, please submit it via the process outlined on that page and do not file a public issue. For more information on finding vulnerabilities in osquery, see a recent blog post about [bug-hunting osquery](https://www.facebook.com/notes/facebook-bug-bounty/bug-hunting-osquery/954850014529225).
 
 ## Learn more

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,6 @@ If you are editing this document please feel encouraged to change this format to
 - #1598 `readFile` TOCTOU error - 1.6.0 - NCC Group
 - #1596 Uncaught exception in config JSON parsing - 1.6.0 - NCC Group
 - #1585 Various comparisons of integers of different signs - 1.6.0 - NCC Group
+- #993 Add restricted permissions to RocksDB - 1.4.5 - Anonymous security review
+- #740 Add hardening compile flags and `-fPIE` - 1.4.1 - Anonymous security review
 - #300 Add restricted permissions to osqueryd logging - 1.0.4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Issues
+
+This document aggregates security issues (weaknesses and vulnerabilities) affecting osquery. It tracks issues in the format:
+
+```
+#PRNumber Title - (Optional CVE) - Fixed in Version - Optional Reporter
+```
+
+There are several types of issues that do not include a CVE or reporter. The project maintainers should try to tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) tag. There may be changes with this label that are not directly security issues.
+
+If you are editing this document please feel encouraged to change this format to provide more details. This is intended to be a helpful resource so please keep content valuable and concise.
+
+- #3133 Bad output size for TLS compression - 2.4.0 - Facebook Whitehat
+- #2447 Multiple fixes to macOS `crashes` - 2.0.0 - Facebook Whitehat and zzuf
+- #2330 Add size checks to `package_bom` - 2.0.0 - Facebook Whitehat
+- #1598 `readFile` TOCTOU error - 1.6.0 - NCC Group
+- #1596 Uncaught exception in config JSON parsing - 1.6.0 - NCC Group
+- #1585 Various comparisons of integers of different signs - 1.6.0 - NCC Group
+- #300 Add restricted permissions to osqueryd logging - 1.0.4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ This document aggregates security issues (weaknesses and vulnerabilities) affect
 #PRNumber Title - (Optional CVE) - Fixed in Version - Optional Reporter
 ```
 
-There are several types of issues that do not include a CVE or reporter. The project maintainers should try to tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) tag. There may be changes with this label that are not directly security issues.
+There are several types of issues that do not include a CVE or reporter. If you find a security issue and believe a CVE should be assigned, please contact the project maintainers in the [osquery Slack](https://osquery-slack.herokuapp.com), we are happy to submit the request and provide attribution to you. The project maintainers will tag related issues and pull requests with the [`hardening`](https://github.com/facebook/osquery/issues?q=is%3Aissue+is%3Aopen+label%3Ahardening) label. There may be changes with this label that are not directly security issues.
 
 If you are editing this document please feel encouraged to change this format to provide more details. This is intended to be a helpful resource so please keep content valuable and concise.
 


### PR DESCRIPTION
There is no existing resource mapping potential weaknesses in osquery to versions including mitigation/fixes.

This list should be iterated soon to include higher priority fixes from third-party dependencies. It's difficult to track these in general, so we'll ask for forgiveness initially if we do not retroactively populate a mapping of dependency vulnerabilities to osquery versions including fixes.