### PR TITLE
deps: Update libcryptsetup formula to version 1.7.5

### DIFF
--- a/tools/provision/formula/libcryptsetup.rb
+++ b/tools/provision/formula/libcryptsetup.rb
@@ -3,13 +3,15 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libcryptsetup < AbstractOsqueryFormula
   desc "Open source disk encryption libraries"
   homepage "https://gitlab.com/cryptsetup/cryptsetup"
-  url "https://osquery-packages.s3.amazonaws.com/deps/cryptsetup-1.6.7.tar.gz"
-  revision 102
+  url "https://gitlab.com/cryptsetup/cryptsetup/repository/v1_7_5/archive.tar.gz"
+  sha256 "6dead2f1420ab1c84a7e82f0ee197861f4a52e4c3284a0bfef824a90c392e077"
+  version "1.7.5"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "7beee01a3d695bcc583a98ad0baca1d79a89c09598939f50c1229eb2c336b09c" => :x86_64_linux
+    sha256 "c8d9ab1d4dd42b4046edd8e111f46cc9ce72498a1d2a41f2d052696eb3551a80" => :x86_64_linux
   end
 
   def install


### PR DESCRIPTION
This significantly improves `libcryptsetup`. It now uses a source-repo-provided package and includes a pinned `sha256`. Previously, the osquery team could have patched our provided `libcryptsetup` source tarball during source dependency builds.