### PR TITLE
deps: Update libgcrypt to version 1.8.1

### DIFF
--- a/tools/provision/formula/libgcrypt.rb
+++ b/tools/provision/formula/libgcrypt.rb
@@ -3,15 +3,15 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libgcrypt < AbstractOsqueryFormula
   desc "Cryptographic library based on the code from GnuPG"
   homepage "https://directory.fsf.org/wiki/Libgcrypt"
-  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.6.5.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.6.5.tar.bz2"
-  sha256 "f49ebc5842d455ae7019def33eb5a014a0f07a2a8353dc3aa50a76fd1dafa924"
-  revision 101
+  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgcrypt/libgcrypt-1.8.1.tar.bz2"
+  sha256 "7a2875f8b1ae0301732e878c0cca2c9664ff09ef71408f085c50e332656a78b3"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "d33dac41ffc0fadad593ecafdd6bbd275826b3abfbefadfedfd76b5db1853d24" => :x86_64_linux
+    sha256 "61cf14831c2b8d8f36688fbca3ee6c7dc9293c485fb633020383b2df676dee4f" => :x86_64_linux
   end
 
   depends_on "libgpg-error"

--- a/tools/provision/formula/libgpg-error.rb
+++ b/tools/provision/formula/libgpg-error.rb
@@ -3,15 +3,15 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class LibgpgError < AbstractOsqueryFormula
   desc "Common error values for all GnuPG components"
   homepage "https://www.gnupg.org/related_software/libgpg-error/"
-  url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
-  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.24.tar.bz2"
-  sha256 "9268e1cc487de5e6e4460fca612a06e4f383072ac43ae90603e5e46783d3e540"
-  revision 101
+  url "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libgpg-error/libgpg-error-1.27.tar.bz2"
+  sha256 "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "1c397f85d9117da00482daccb758136c2e672fd8f2b6ac24aa68595766a799dd" => :x86_64_linux
+    sha256 "f614bec1a3fe6a23a99a38343a8cb681d2f56cace1dca936c346b1403a35bc22" => :x86_64_linux
   end
 
   option :universal


### PR DESCRIPTION
This updates both `libgcrypt` and `libgpg-error`. 