### PR TITLE
deps: Update libxml2 to version 2.9.5

### DIFF
--- a/tools/provision/formula/libxml2.rb
+++ b/tools/provision/formula/libxml2.rb
@@ -3,16 +3,16 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libxml2 < AbstractOsqueryFormula
   desc "GNOME XML library"
   homepage "http://xmlsoft.org"
-  url "http://xmlsoft.org/sources/libxml2-2.9.4.tar.gz"
-  mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.4.tar.gz"
-  sha256 "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c"
-  revision 101
+  url "http://xmlsoft.org/sources/libxml2-2.9.5.tar.gz"
+  mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.5.tar.gz"
+  sha256 "4031c1ecee9ce7ba4f313e91ef6284164885cdb69937a123f6a83bb6a72dcd38"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "73f8b62e310889441ff1f3ae2515fb3a6a2cac493f04489afd062d1c8ca5e48c" => :sierra
-    sha256 "779b194af3e967606fc801babdbe4e3454d2803ebce77eaa14d370b13245c05c" => :x86_64_linux
+    sha256 "145739ead08f85fff40695ac83d615aeaae9a121d388f675f29f7330fcade892" => :sierra
+    sha256 "899d898d6930c15b21e97c62091fe70640ce93b37dbe08273e6b694d33de40b9" => :x86_64_linux
   end
 
   option :universal


### PR DESCRIPTION
This updates `libxml2` to version 2.9.5, the version we had been statically linking, 2.9.4 has known weaknesses.