### PR TITLE
deps: Bumping windows glog to 0.3.5

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -287,7 +287,7 @@ function Install-ThirdParty {
     "cpp-netlib.0.12.0-r4",
     "doxygen.1.8.11",
     "gflags-dev.2.2.0-r1",
-    "glog.0.3.4-r1",
+    "glog.0.3.5",
     "libarchive.3.3.1-r1",
     "linenoise-ng.1.0.0-r1",
     "llvm-clang.4.0.1",

--- a/tools/provision/chocolatey/glog.ps1
+++ b/tools/provision/chocolatey/glog.ps1
@@ -10,8 +10,8 @@
 # $version - The version of the software package to build
 # $chocoVersion - The chocolatey package version, used for incremental bumps
 #                 without changing the version of the software package
-$version = '0.3.4'
-$chocoVersion = '0.3.4'
+$version = '0.3.5'
+$chocoVersion = '0.3.5'
 $packageName = 'glog'
 $projectSource = 'https://github.com/google/glog'
 $packageSourceUrl = 'https://github.com/google/glog'
@@ -33,6 +33,9 @@ $sw = [System.Diagnostics.StopWatch]::startnew()
 # Keep the location of build script, to bring with in the chocolatey package
 $buildScript = $MyInvocation.MyCommand.Definition
 
+# Grab the cwd to restore after the build completes
+$workingDir = Get-Location
+
 # Create the choco build dir if needed
 $buildPath = Get-OsqueryBuildPath
 if ($buildPath -eq '') {
@@ -50,17 +53,46 @@ git clone $url
 Set-Location "glog"
 
 # Set the cmake logic to generate a static build for us
-Add-Content -NoNewline -Path 'CMakeLists.txt' -Value "`nset(CMAKE_CXX_FLAGS_RELEASE `"`${CMAKE_CXX_FLAGS_RELEASE} /MT`")`nset(CMAKE_CXX_FLAGS_DEBUG `"`${CMAKE_CXX_FLAGS_DEBUG} /MTd`")"
+$staticContent = "`nset(CMAKE_CXX_FLAGS_RELEASE `"`${CMAKE_CXX_FLAGS_RELEASE} " +
+"/MT`")`nset(CMAKE_CXX_FLAGS_DEBUG `"`${CMAKE_CXX_FLAGS_DEBUG} /MTd`")"
+Add-Content `
+  -NoNewline `
+  -Path 'CMakeLists.txt' `
+  -Value $staticContent
 
 # Build the libraries
 $buildDir = New-Item -Force -ItemType Directory -Path "osquery-win-build"
 Set-Location $buildDir
 
 # Generate the .sln
-cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_PREFIX_PATH=C:\ProgramData\chocolatey\lib\gflags\local\lib\ ..\
+$cmake = (Get-Command 'cmake').Source
+$cmakeArgs = @(
+  '-G "Visual Studio 14 2015 Win64"',
+  '-DCMAKE_PREFIX_PATH=C:\ProgramData\chocolatey\lib\gflags\local\',
+  '..\'
+) 
+$out = Start-OsqueryProcess $cmake $cmakeArgs
 
-msbuild 'google-glog.sln' /p:Configuration=Release /m /t:glog /v:m
-msbuild 'google-glog.sln' /p:Configuration=Debug /m /t:glog /v:m
+
+# Build the libraries
+$msbuild = (Get-Command 'msbuild').Source
+$msbuildArgs = @(
+  'glog.sln',
+  '/p:Configuration=Release',
+  '/t:glog',
+  '/m',
+  '/v:m'
+)
+$out = Start-OsqueryProcess $msbuild $msbuildArgs
+
+$msbuildArgs = @(
+  'glog.sln',
+  '/p:Configuration=Debug',
+  '/t:glog',
+  '/m',
+  '/v:m'
+)
+Start-OsqueryProcess $msbuild $msbuildArgs
 
 # Construct the Chocolatey Package
 $chocoDir = New-Item -ItemType Directory -Path "osquery-choco"
@@ -69,7 +101,15 @@ $includeDir = New-Item -ItemType Directory -Path "local\include"
 $libDir = New-Item -ItemType Directory -Path "local\lib"
 $srcDir = New-Item -ItemType Directory -Path "local\src"
 
-Write-NuSpec $packageName $chocoVersion $authors $owners $projectSource $packageSourceUrl $copyright $license
+Write-NuSpec `
+  $packageName `
+  $chocoVersion `
+  $authors `
+  $owners `
+  $projectSource `
+  $packageSourceUrl `
+  $copyright `
+  $license
 
 # Rename the Debug libraries to end with a `_dbg.lib`
 foreach ($lib in Get-ChildItem "$buildDir\Debug\") {
@@ -83,10 +123,17 @@ Copy-Item -Recurse "$buildDir\..\src\windows\glog" $includeDir
 Copy-Item $buildScript $srcDir
 choco pack
 
-Write-Host "[*] Build took $($sw.ElapsedMilliseconds) ms" -foregroundcolor DarkGreen
+Write-Host "[*] Build took $($sw.ElapsedMilliseconds) ms" `
+  -ForegroundColor DarkGreen
 if (Test-Path "$packageName.$chocoVersion.nupkg") {
-  Write-Host "[+] Finished building $packageName v$chocoVersion." -foregroundcolor Green
+  Write-Host `
+    "[+] Finished building $packageName v$chocoVersion." `
+    -ForegroundColor Green
+} else {
+  Write-Host `
+    "[-] Failed to build $packageName v$chocoVersion." `
+    -ForegroundColor Red
 }
-else {
-  Write-Host "[-] Failed to build $packageName v$chocoVersion." -foregroundcolor Red
-}
+
+# Restore the working dir
+Set-Location $workingDir


### PR DESCRIPTION
This bumps glog to 0.3.5 on Windows, as well as brings some of the aesthetic updates to the packaging we've got in other scripts.