### PR TITLE
deps: Update bottles for glog gflags libmagic aws-sdk-cpp

### DIFF
--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -10,8 +10,8 @@ class AwsSdkCpp < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "68a77b8250e9408bc365c43a0701ff389f39db61ee1d7f876459501236004c44" => :sierra
-    sha256 "e89d2f3a6d190c2b8a02b61fa396588ec23c6fae0aad8307b1fb5d0bdeecae99" => :x86_64_linux
+    sha256 "7ee648587946bee53a22e12c391b3176bc48c5a9b5a7ae6bb7fad158bbe9adc6" => :sierra
+    sha256 "900b4f5ed5c5b6dbbeae72e939a5d2fcd4fbdf889d6fa316eb9b5d96afe91db5" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/gflags.rb
+++ b/tools/provision/formula/gflags.rb
@@ -10,8 +10,8 @@ class Gflags < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "bc53cf0242cec67e7892686ce64b1ce624e2a8b6f6f3ccc6f608b6c9c1d15a54" => :sierra
-    sha256 "1f146fd08755ffdd334f5fe07ba64e703e52aa11e8a3f2faf9ad57897dfbb47c" => :x86_64_linux
+    sha256 "7dcbcafe75a7ea73b5e558e83f78b0d2ce8a194b9cdc92d2860ec465396b7020" => :sierra
+    sha256 "3a7723739d6b7280dfb36e030b15ec75669e95e041596cb6e9f387cd7e3858e4" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/tools/provision/formula/glog.rb
+++ b/tools/provision/formula/glog.rb
@@ -10,8 +10,8 @@ class Glog < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "020ea9bbbc0437cbe4aae54ace88c7ab0e7961602fd61e51ddd20d3d1e58710a" => :sierra
-    sha256 "b8e1f109493fd0c8ee7deb79da248fd94eca533822c26a6e0bce1c0f69aa9400" => :x86_64_linux
+    sha256 "c0583120f5af2306783d351718be3fa8f14f080c79b83e1e12480eae91c8d491" => :sierra
+    sha256 "84bdecca8fc4d412a53f5d93d5d5b6756915f180ec2a74207f9c7b07dd757b3e" => :x86_64_linux
   end
 
   depends_on "gflags"

--- a/tools/provision/formula/libmagic.rb
+++ b/tools/provision/formula/libmagic.rb
@@ -10,8 +10,8 @@ class Libmagic < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "6f472165a18ab7c5587eeb3646db16c7a6659cb8ce27b57fb99cd6d64d8aaee8" => :sierra
-    sha256 "3778b2485218af6402419314b6702f355b8a0499586bc7d544bca993a408e02e" => :x86_64_linux
+    sha256 "9018d1df107b9e02f7c2bc09722f5db47e3f9fcd1f5e78ddf6fc93f4c6c56d14" => :sierra
+    sha256 "fc93dc4fff2228058abbc7e6acb6de2c86af40338cf4c09bd2af46495f1f959f" => :x86_64_linux
   end
 
   depends_on :python => :optional


### PR DESCRIPTION
This is a roll-up of bottles for `libmagic`, `glog`, `gflags`, and `aws-sdk-cpp` for Linux and macOS.