### PR TITLE
deps: bumping aws-sdk-cpp to 1.2.7 on windows

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -281,7 +281,7 @@ function Install-ThirdParty {
 
   # List of our third party packages, hosted in our AWS S3 bucket
   $packages = @(
-    "aws-sdk-cpp.1.1.44",
+    "aws-sdk-cpp.1.2.7",
     "boost-msvc14.1.65.0",
     "bzip2.1.0.6",
     "cpp-netlib.0.12.0-r4",

--- a/tools/provision/chocolatey/aws-sdk-cpp.ps1
+++ b/tools/provision/chocolatey/aws-sdk-cpp.ps1
@@ -6,8 +6,8 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 
 # Update-able metadata
-$version = '1.1.44'
-$chocoVersion = '1.1.44'
+$version = '1.2.7'
+$chocoVersion = '1.2.7'
 $packageName = 'aws-sdk-cpp'
 $projectSource = 'https://github.com/aws/aws-sdk-cpp'
 $packageSourceUrl = "https://github.com/aws/aws-sdk-cpp/archive/$version.zip"
@@ -52,8 +52,11 @@ if (-not (Test-Path "$chocoBuildPath")) {
 }
 Set-Location $chocoBuildPath
 
-# Retrieve the source
-Invoke-WebRequest $url -OutFile "$packageName-$version.zip"
+# Retrieve the source only if we don't already have it
+$zipFile = "$packageName-$version.zip"
+if(-Not (Test-Path $zipFile)) {
+  Invoke-WebRequest $url -OutFile "$zipFile"
+}
 
 # Extract the source
 $sourceDir = "$packageName-$version"
@@ -68,10 +71,11 @@ Set-Location $sourceDir
 $staticBuild = "`nset(CMAKE_CXX_FLAGS_RELEASE `"`${CMAKE_CXX_FLAGS_RELEASE} " +
               "/MT`")`nset(CMAKE_CXX_FLAGS_DEBUG `"`${CMAKE_CXX_FLAGS_DEBUG} " +
               "/MTd`")"
-$libs | Foreach-Object {
+
+foreach($lib in $libs) {
   Add-Content `
     -NoNewline `
-    -Path "$_\CMakeLists.txt" `
+    -Path "$lib\CMakeLists.txt" `
     -Value $staticBuild
 }
 
@@ -95,7 +99,7 @@ $msbuild = (Get-Command 'msbuild').Source
 $sln = 'AWSSDK.sln'
 foreach($target in $libs) {
   $msbuildArgs = @(
-    "`"$sln`"",
+    "$buildDir\$sln",
     "/p:Configuration=Release",
     "/t:$target",
     '/m',
@@ -105,7 +109,7 @@ foreach($target in $libs) {
 
   # Bundle debug libs for troubleshooting
   $msbuildArgs = @(
-    "`"$sln`"",
+    "$buildDir\$sln",
     "/p:Configuration=Debug",
     "/t:$target",
     '/m',
@@ -152,8 +156,7 @@ if (Test-Path "$packageName.$chocoVersion.nupkg") {
   $package = "$(Get-Location)\$packageName.$chocoVersion.nupkg"
   Write-Host `
     "[+] Finished building. Package written to $package" -ForegroundColor Green
-}
-else {
+} else {
   Write-Host `
     "[-] Failed to build $packageName v$chocoVersion." `
     -ForegroundColor Red

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -125,7 +125,7 @@ function Start-OsqueryProcess {
   $pinfo.Arguments = $binaryArgs
   $p = New-Object System.Diagnostics.Process
   $p.StartInfo = $pinfo
-  $p.Start() | Out-Null
+  $p.Start()
   $p.WaitForExit()
   $stdout = $p.StandardOutput.ReadToEnd()
   $stderr = $p.StandardError.ReadToEnd()


### PR DESCRIPTION
This bumps the AWS cpp SDK to 1.2.7