### PR TITLE
build: adding logic to discern python path on windows

### DIFF
--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -129,8 +129,10 @@ function Start-OsqueryProcess {
   $p.WaitForExit()
   $stdout = $p.StandardOutput.ReadToEnd()
   $stderr = $p.StandardError.ReadToEnd()
-  if ($stderr) {
-    Write-Error $stderr
+  $exit = $p.ExitCode
+  [PSCustomObject] @{
+    stdout = $stdout
+    stderr = $stderr
+    exitcode = $exit
   }
-  return $stdout
 }


### PR DESCRIPTION
Having multiple installations of Python on Windows systems can occasionally happen. This removes our restriction to use an explicit python path, and allows for leveraging python installs already present on the system, to avoid potentially many python installs and conflicting system environments.