### PR TITLE
tables: Add exception handling within constraints matching

### DIFF
--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -328,21 +328,24 @@ bool ConstraintList::exists(const ConstraintOperatorFlag ops) const {
 
 bool ConstraintList::matches(const std::string& expr) const {
   // Support each SQL affinity type casting.
-  if (affinity == TEXT_TYPE) {
-    return literal_matches<TEXT_LITERAL>(expr);
-  } else if (affinity == INTEGER_TYPE) {
-    INTEGER_LITERAL lexpr = AS_LITERAL(INTEGER_LITERAL, expr);
-    return literal_matches<INTEGER_LITERAL>(lexpr);
-  } else if (affinity == BIGINT_TYPE) {
-    BIGINT_LITERAL lexpr = AS_LITERAL(BIGINT_LITERAL, expr);
-    return literal_matches<BIGINT_LITERAL>(lexpr);
-  } else if (affinity == UNSIGNED_BIGINT_TYPE) {
-    UNSIGNED_BIGINT_LITERAL lexpr = AS_LITERAL(UNSIGNED_BIGINT_LITERAL, expr);
-    return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr);
-  } else {
-    // Unsupported affinity type.
-    return false;
+  try {
+    if (affinity == TEXT_TYPE) {
+      return literal_matches<TEXT_LITERAL>(expr);
+    } else if (affinity == INTEGER_TYPE) {
+      INTEGER_LITERAL lexpr = AS_LITERAL(INTEGER_LITERAL, expr);
+      return literal_matches<INTEGER_LITERAL>(lexpr);
+    } else if (affinity == BIGINT_TYPE) {
+      BIGINT_LITERAL lexpr = AS_LITERAL(BIGINT_LITERAL, expr);
+      return literal_matches<BIGINT_LITERAL>(lexpr);
+    } else if (affinity == UNSIGNED_BIGINT_TYPE) {
+      UNSIGNED_BIGINT_LITERAL lexpr = AS_LITERAL(UNSIGNED_BIGINT_LITERAL, expr);
+      return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr);
+    }
+  } catch (const boost::bad_lexical_cast& /* e */) {
+    // Unsupported affinity type or unable to cast content type.
   }
+
+  return false;
 }
 
 template <typename T>

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -129,6 +129,15 @@ TEST_F(TablesTests, test_constraint_map) {
   EXPECT_TRUE(cm["path"].existsAndMatches("some"));
 }
 
+TEST_F(TablesTests, test_constraint_map_cast) {
+  ConstraintMap cm;
+
+  cm["num"].affinity = INTEGER_TYPE;
+  cm["num"].add(Constraint(EQUALS, "hello"));
+
+  EXPECT_FALSE(cm["num"].existsAndMatches("hello"));
+}
+
 class TestTablePlugin : public TablePlugin {
  public:
   void testSetCache(size_t step, size_t interval) {


### PR DESCRIPTION
This places a `try` `catch` block around the constraints matching. If a constraint fails to be casted to the target column type the result of the match will be `false`.