### PR TITLE
fuzz: Use example queries as input to make fuzz

### DIFF
--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -17,6 +17,9 @@ schema([
 ])
 attributes(user_data=True)
 implementation("applications/browser_chrome@genChromeExtensions")
+examples([
+    "select * from users join chrome_extensions using (uid)",
+])
 fuzz_paths([
     "/Library/Application Support/Google/Chrome/",
     "/Users",

--- a/specs/darwin/browser_plugins.table
+++ b/specs/darwin/browser_plugins.table
@@ -16,3 +16,10 @@ schema([
 ])
 attributes(user_data=True)
 implementation("applications/browser_plugins@genBrowserPlugins")
+examples([
+    "select * from users join browser_plugins using (uid)",
+])
+fuzz_paths([
+    "/Library/Internet Plug-Ins",
+    "/Users",
+])

--- a/specs/darwin/crashes.table
+++ b/specs/darwin/crashes.table
@@ -21,6 +21,9 @@ schema([
 ])
 attributes(user_data=True)
 implementation("crashes@genCrashLogs")
+examples([
+    "select * from users join crashes using (uid)",
+])
 fuzz_paths([
     "/Library/Logs/DiagnosticReports",
     "/Users",

--- a/specs/darwin/preferences.table
+++ b/specs/darwin/preferences.table
@@ -15,5 +15,9 @@ schema([
 attributes(user_data=True)
 implementation("system/darwin/preferences@genOSXDefaultPreferences")
 examples([
-  "select * from preferences where domain = 'loginwindow'",
+    "select * from preferences where domain = 'loginwindow'",
+    "select preferences.* from users join preferences using (username)",
+])
+fuzz_paths([
+    "/Users",
 ])

--- a/specs/posix/authorized_keys.table
+++ b/specs/posix/authorized_keys.table
@@ -8,8 +8,11 @@ schema([
     Column("key_file", TEXT, "Path to the authorized_keys file", index=True),
     ForeignKey(column="uid", table="users"),
 ])
-attributes(user_data=True)
+attributes(user_data=True, no_pkey=True)
 implementation("authorized_keys@getAuthorizedKeys")
+examples([
+  "select * from users join authorized_keys using (uid)",
+])
 fuzz_paths([
   "/home",
   "/Users",

--- a/specs/posix/firefox_addons.table
+++ b/specs/posix/firefox_addons.table
@@ -24,6 +24,9 @@ schema([
 ])
 attributes(user_data=True)
 implementation("applications/browser_firefox@genFirefoxAddons")
+examples([
+    "select * from users join firefox_addons using (uid)",
+])
 fuzz_paths([
     "/Library/Application Support/Firefox/Profiles/",
     "/Users",

--- a/specs/posix/known_hosts.table
+++ b/specs/posix/known_hosts.table
@@ -7,8 +7,11 @@ schema([
     Column("key_file", TEXT, "Path to known_hosts file", index=True),
     ForeignKey(column="uid", table="users"),
 ])
-attributes(user_data=True)
+attributes(user_data=True, no_pkey=True)
 implementation("known_hosts@getKnownHostsKeys")
+examples([
+    "select * from users join known_hosts using (uid)",
+])
 fuzz_paths([
     "/home",
     "/Users",

--- a/specs/posix/opera_extensions.table
+++ b/specs/posix/opera_extensions.table
@@ -17,3 +17,6 @@ schema([
 ])
 attributes(user_data=True)
 implementation("applications/browser_opera@genOperaExtensions")
+examples([
+    "select * from users join opera_extensions using (uid)",
+])

--- a/specs/posix/shell_history.table
+++ b/specs/posix/shell_history.table
@@ -9,6 +9,9 @@ schema([
 ])
 attributes(user_data=True, no_pkey=True)
 implementation("shell_history@genShellHistory")
+examples([
+    "select * from users join shell_history using (uid)",
+])
 fuzz_paths([
     "/home",
     "/Users",

--- a/specs/posix/user_ssh_keys.table
+++ b/specs/posix/user_ssh_keys.table
@@ -7,7 +7,11 @@ schema([
     Column("encrypted", INTEGER, "1 if key is encrypted, 0 otherwise"),
     ForeignKey(column="uid", table="users"),
 ])
+attributes(user_data=True, no_pkey=True)
 implementation("user_ssh_keys@getUserSshKeys")
+examples([
+    "select * from users join user_ssh_keys using (uid) where encrypted = 0",
+])
 fuzz_paths([
     "/home",
     "/Users",

--- a/tools/analysis/fuzz.py
+++ b/tools/analysis/fuzz.py
@@ -37,8 +37,7 @@ from gentable import \
   TEXT, DATE, DATETIME, INTEGER, BIGINT, UNSIGNED_BIGINT, DOUBLE, BLOB
 
 
-def _fuzz_paths(shell, name, paths):
-    global EXIT_CODE
+def _fuzz_paths(shell, name, paths, query):
     cmd = [
         "zzuf",
         "-r0.001:0.1", "-s%d:%d" % (args.s, args.s + args.n)
@@ -47,8 +46,8 @@ def _fuzz_paths(shell, name, paths):
         cmd.append("-I")
         cmd.append(path)
     cmd.append(shell)
-    cmd.append("select count(1) from %s" % name)
-
+    cmd.append("--disable_extensions")
+    cmd.append(query)
     if args.verbose:
         print (" ".join(cmd))
     proc = subprocess.Popen(
@@ -63,6 +62,18 @@ def _fuzz_paths(shell, name, paths):
         print (" ".join(cmd))
         print(stderr)
     return proc.returncode
+
+def _fuzz_queries(shell, name, paths, examples=[]):
+    print("Fuzzing file reads for: %s" % (name))
+    ret = _fuzz_paths(shell, name, paths, "select count(1) from `%s`" % (name))
+    if ret != 0:
+        return ret
+    for example in examples:
+        print("Fuzzing file reads for query: %s" % (example))
+        ret = _fuzz_paths(shell, name, paths, example)
+        if ret != 0:
+            return ret
+    return 0
 
 
 if __name__ == "__main__":
@@ -130,9 +141,8 @@ if __name__ == "__main__":
             # We may later introduce other (simple) types of fuzzing.
             if len(TableState.fuzz_paths) > 0:
                 # The table specification opted-into path-based fuzzing.
-                print("Fuzzing file reads for: %s" % (TableState.table_name))
-                ret = _fuzz_paths(args.shell, TableState.table_name,
-                    TableState.fuzz_paths)
+                ret = _fuzz_queries(args.shell, TableState.table_name,
+                    TableState.fuzz_paths, TableState.examples)
                 if ret > 0:
                     exit_code = ret
                 if not args.c and ret != 0:


### PR DESCRIPTION
The `make fuzz` zzuf usage may miss some table content because it does not use the example queries. This mostly applies to tables that need to be joined against `users` because they emit user-generated content.