### PR TITLE
Add previous version downloads

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,6 @@ This will be run in the `Code Audit` Jenkins job.
 1. Update code in `/tools` to produce the correct `version.yml` for new releases.
 2. Convert the deprecated ReadTheDocs wiki pages to Jekyll docs.
 3. Look for existing common redirects for backwards compatibility.
-4. Update the `downloads` page to list old versions and their hashes.
 
 ## ReadTheDocs Wiki (deprecated)
 

--- a/docs/downloads/downloads.html
+++ b/docs/downloads/downloads.html
@@ -5,7 +5,6 @@ permalink: /downloads/
 ---
 
 {% assign versions = site.data.versions %}
-{% assign version = versions.first.version %}
 
 <section class="features">
   <div class="grid">
@@ -26,21 +25,24 @@ permalink: /downloads/
           <span class="prompt">$</span>
           <span class="command">ls osquery-latest/ | ./hashthem.sh</span>
         </p>
-        {% for dist in versions.first %}
-        {% if dist[0] != 'version' and dist[0] != 'debug' %}
-        {% assign key = dist[0] %}
-        {% assign prefix = site.prefixes[key] %}
-        {% assign sep = site.separators[key] %}
+        {% assign current_version = versions.first %}
+        {% assign version_number = current_version.version %}
+        {% for key in current_version %}
+        {% if key[0] != 'version' and key[0] != 'debug' %}
+        {% assign os = key[0] %}
+        {% assign prefix = site.prefixes[os] %}
+        {% assign sep = site.separators[os] %}
+        {% assign hash = key[1] %}
           <p class="line" style="margin-top: 10px">
             <span class="output">
-              <a href="https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}{{prefix}}">
-                https://pkg.osquery.io/{{key}}/osquery{{sep}}{{version}}{{prefix}}
+              <a href="https://pkg.osquery.io/{{os}}/osquery{{sep}}{{version_number}}{{prefix}}">
+                https://pkg.osquery.io/{{os}}/osquery{{sep}}{{version_number}}{{prefix}}
               </a>
              </span>
           </p>
           <p class="line">
             <span class="output">
-              {{dist[1]}}
+              {{hash}}
              </span>
           </p>
         {% endif %}
@@ -204,7 +206,7 @@ permalink: /downloads/
     </div>
   </div>
 </section>
-<section class="quickstart">
+<section class="quickstart quickstart-second">
   <div class="grid">
     <div class="unit code">
       <p class="title">Debug Downloads</p>
@@ -214,21 +216,24 @@ permalink: /downloads/
           <span class="prompt">$</span>
           <span class="command">ls osquery-debug-latest/ | ./hashthem.sh</span>
         </p>
-        {% for dist in versions.first.debug %}
-        {% assign key = dist[0] %}
-        {% assign prefix = site.prefixes[key] %}
-        {% assign sep = site.separators[key] %}
-        {% assign dbg = site.debug_prefixes[key] %}
+        {% assign current_version = versions.first %}
+        {% assign version_number = current_version.version %}
+        {% for key in current_version.debug %}
+        {% assign os = key[0] %}
+        {% assign prefix = site.prefixes[os] %}
+        {% assign sep = site.separators[os] %}
+        {% assign hash = key[1] %}
+        {% assign dbg = site.debug_prefixes[os] %}
           <p class="line" style="margin-top: 10px">
             <span class="output">
-              <a href="https://pkg.osquery.io/{{key}}/osquery-{{dbg}}{{sep}}{{version}}{{prefix}}">
-                https://pkg.osquery.io/{{key}}/osquery-{{dbg}}{{sep}}{{version}}{{prefix}}
+              <a href="https://pkg.osquery.io/{{os}}/osquery-{{dbg}}{{sep}}{{version_number}}{{prefix}}">
+                https://pkg.osquery.io/{{os}}/osquery-{{dbg}}{{sep}}{{version_number}}{{prefix}}
               </a>
              </span>
           </p>
           <p class="line">
             <span class="output">
-              {{dist[1]}}
+              {{hash}}
              </span>
           </p>
         {% endfor %}

--- a/docs/downloads/downloads.html
+++ b/docs/downloads/downloads.html
@@ -242,3 +242,54 @@ permalink: /downloads/
     <div class="clear"></div>
   </div>
 </section>
+
+<section class="previous">
+  <div class="grid">
+    <div class="unit whole">
+      <h2><span class="fa fa-backward"></span> Previous Releases</h2>
+      <p>We continue to host previous releases of osquery and make them available for download. These are our last three releases for Linux and Darwin.
+      </p>
+    </div>
+  </div>
+</section>
+<section class="quickstart quickstart-second">
+  <div class="grid">
+    <div class="unit code">
+      <p class="title">Previous Releases</p>
+      <div class="shell">
+        {% assign previous_version_operating_systems = 'linux darwin' | split: ' ' %}
+        {% for previous_os in previous_version_operating_systems %}
+        <p class="line">
+          <span class="path">~</span>
+          <span class="prompt">$</span>
+          <span class="command">ls osquery-previous-{{previous_os}}/ | ./hashthem.sh</span>
+        </p>
+        {% for previous_version in versions offset:1 limit:3 %}
+        {% assign version_number = previous_version.version %}
+        {% for key in previous_version %}
+        {% if key[0] == previous_os %}
+        {% assign prefix = site.prefixes[previous_os] %}
+        {% assign sep = site.separators[previous_os] %}
+        {% assign hash = key[1] %}
+          <p class="line" style="margin-top: 10px">
+            <span class="output">
+              <a href="https://pkg.osquery.io/{{previous_os}}/osquery{{sep}}{{version_number}}{{prefix}}">
+                https://pkg.osquery.io/{{previous_os}}/osquery{{sep}}{{version_number}}{{prefix}}
+              </a>
+             </span>
+          </p>
+          <p class="line">
+            <span class="output">
+              {{hash}}
+             </span>
+          </p>
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
+        <p class="line">&nbsp;</p>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="clear"></div>
+  </div>
+</section>


### PR DESCRIPTION
I refactored the downloads page template to make it more readable, removed a style from the "debug" section, and then added the previous versions section.

This is for issue #3796 