### PR TITLE
Convert Linux process_events mode column to octal

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -84,9 +84,8 @@ bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
     if (fields.count("mode")) {
       std::stringstream ss;
       ss << "0" << std::oct << fields.at("mode");
-      r["mode"] = std::move(ss.str());
-    }
-    else {
+      ss >> r["mode"];
+    } else {
       r["mode"] = "";
     }
     r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -24,15 +24,6 @@ namespace tables {
 extern long getUptime();
 }
 
-static inline unsigned long decimalToOct(unsigned long dec){
-  unsigned long oct = 00;
-  for(auto i = 1; dec > 0; i *= 10){
-    oct += (dec & 07) * i;
-    dec >>= 3;
-  }
-  return oct;
-}
-
 bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   if (type == AUDIT_SYSCALL) {
     r["auid"] = (fields.count("auid")) ? fields.at("auid") : "0";
@@ -90,7 +81,9 @@ bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   }
 
   if (type == AUDIT_PATH) {
-    r["mode"] = (fields.count("mode")) ? decimalToOct(fields.at("mode")) : "";
+    std::stringstream ss;
+    ss << "0" << std::oct << fields.at("mode");
+    r["mode"] = std::move(ss.str());
     r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";
     r["owner_gid"] = fields.count("ogid") ? fields.at("ogid") : "0";
   }

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -81,9 +81,14 @@ bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   }
 
   if (type == AUDIT_PATH) {
-    std::stringstream ss;
-    ss << "0" << std::oct << fields.at("mode");
-    r["mode"] = std::move(ss.str());
+    if (fields.count("mode")) {
+      std::stringstream ss;
+      ss << "0" << std::oct << fields.at("mode");
+      r["mode"] = std::move(ss.str());
+    }
+    else {
+      r["mode"] = "";
+    }
     r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";
     r["owner_gid"] = fields.count("ogid") ? fields.at("ogid") : "0";
   }

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -24,6 +24,15 @@ namespace tables {
 extern long getUptime();
 }
 
+static inline unsigned long decimalToOct(unsigned long dec){
+  unsigned long oct = 00;
+  for(auto i = 1; dec > 0; i *= 10){
+    oct += (dec & 07) * i;
+    dec >>= 3;
+  }
+  return oct;
+}
+
 bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   if (type == AUDIT_SYSCALL) {
     r["auid"] = (fields.count("auid")) ? fields.at("auid") : "0";
@@ -81,7 +90,7 @@ bool ProcessUpdate(size_t type, const AuditFields& fields, AuditFields& r) {
   }
 
   if (type == AUDIT_PATH) {
-    r["mode"] = (fields.count("mode")) ? fields.at("mode") : "";
+    r["mode"] = (fields.count("mode")) ? decimalToOct(fields.at("mode")) : "";
     r["owner_uid"] = fields.count("ouid") ? fields.at("ouid") : "0";
     r["owner_gid"] = fields.count("ogid") ? fields.at("ogid") : "0";
   }

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -3,7 +3,7 @@ description("Track time/action process executions.")
 schema([
     Column("pid", BIGINT, "Process (or thread) ID"),
     Column("path", TEXT, "Path of executed file"),
-    Column("mode", TEXT, "File mode permissions"),
+    Column("mode", BIGINT, "File mode permissions"),
     Column("cmdline", TEXT, "Command line arguments (argv)"),
     Column("cmdline_size", BIGINT, "Actual size (bytes) of command line arguments",
         hidden=True),

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -3,7 +3,7 @@ description("Track time/action process executions.")
 schema([
     Column("pid", BIGINT, "Process (or thread) ID"),
     Column("path", TEXT, "Path of executed file"),
-    Column("mode", BIGINT, "File mode permissions"),
+    Column("mode", TEXT, "File mode permissions"),
     Column("cmdline", TEXT, "Command line arguments (argv)"),
     Column("cmdline_size", BIGINT, "Actual size (bytes) of command line arguments",
         hidden=True),


### PR DESCRIPTION
Added a method to convert decimal to octal, and used it to convert the "mode" column to octal in the ProcessUpdate method.