### PR TITLE
tables: Require explicit requests for query results caching

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -47,23 +47,25 @@ inline std::string getExtensionSocket(
 Status queryExternal(const std::string& query, QueryData& results);
 
 /// External (extensions) SQL implementation of the osquery getQueryColumns API.
-Status getQueryColumnsExternal(const std::string& q, TableColumns& columns);
+Status getQueryColumnsExternal(const std::string& query, TableColumns& columns);
 
 /// External (extensions) SQL implementation plugin provider for "sql" registry.
 class ExternalSQLPlugin : public SQLPlugin {
  public:
-  Status query(const std::string& q, QueryData& results) const override {
-    return queryExternal(q, results);
+  Status query(const std::string& query,
+               QueryData& results,
+               bool use_cache = false) const override {
+    return queryExternal(query, results);
   }
 
-  Status getQueryTables(const std::string& q,
+  Status getQueryTables(const std::string& query,
                         std::vector<std::string>& tables) const override {
     return Status(0, "Not used");
   }
 
-  Status getQueryColumns(const std::string& q,
+  Status getQueryColumns(const std::string& query,
                          TableColumns& columns) const override {
-    return getQueryColumnsExternal(q, columns);
+    return getQueryColumnsExternal(query, columns);
   }
 };
 

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -46,9 +46,10 @@ class SQL : private only_movable {
   /**
    * @brief Instantiate an instance of the class with a query.
    *
-   * @param q An osquery SQL query.
+   * @param query An osquery SQL query.
+   * @param use_cache [optional] Set true to use the query cache.
    */
-  explicit SQL(const std::string& q);
+  explicit SQL(const std::string& query, bool use_cache = false);
 
   /// Allow moving.
   SQL(SQL&&) = default;
@@ -69,14 +70,14 @@ class SQL : private only_movable {
    *
    * @return A ColumnNames object for the query
    */
-  const ColumnNames& columns();
+  const ColumnNames& columns() const;
 
   /**
    * @brief Accessor to switch off of when checking the success of a query.
    *
    * @return A bool indicating the success or failure of the operation.
    */
-  bool ok();
+  bool ok() const;
 
   /**
    * @brief Get the status returned by the query.
@@ -90,7 +91,7 @@ class SQL : private only_movable {
    *
    * @return The message string indicating the status of the query.
    */
-  std::string getMessageString();
+  std::string getMessageString() const;
 
   /// ASCII escape the results of the query.
   void escapeResults();
@@ -128,9 +129,6 @@ class SQL : private only_movable {
   SQL() {}
 
  protected:
-  /// The internal member which holds the query string
-  std::string q_;
-
   /// The internal member which holds the results of the query.
   QueryData results_;
 
@@ -160,15 +158,17 @@ class SQL : private only_movable {
 class SQLPlugin : public Plugin {
  public:
   /// Run a SQL query string against the SQL implementation.
-  virtual Status query(const std::string& q, QueryData& results) const = 0;
+  virtual Status query(const std::string& query,
+                       QueryData& results,
+                       bool use_cache = false) const = 0;
 
   /// Use the SQL implementation to parse a query string and return details
   /// (name, type) about the columns.
-  virtual Status getQueryColumns(const std::string& q,
+  virtual Status getQueryColumns(const std::string& query,
                                  TableColumns& columns) const = 0;
 
   /// Given a query, return the list of scanned tables.
-  virtual Status getQueryTables(const std::string& q,
+  virtual Status getQueryTables(const std::string& query,
                                 std::vector<std::string>& tables) const = 0;
 
   /**
@@ -210,10 +210,13 @@ class SQLPlugin : public Plugin {
  * @endcode
  *
  * @param query the query to execute
- * @param results A QueryData structure to emit result rows on success.
+ * @param results [output] A QueryData structure to emit result rows on success.
+ * @param use_cache [optional] Set true to use the query cache.
  * @return A status indicating query success.
  */
-Status query(const std::string& query, QueryData& results);
+Status query(const std::string& query,
+             QueryData& results,
+             bool use_cache = false);
 
 /**
  * @brief Analyze a query, providing information about the result columns.

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -625,39 +625,37 @@ struct QueryContext : private only_movable {
                            std::set<std::string>& output)> predicate);
 
   /// Check if a table-defined index exists within the query cache.
-  bool isCached(const std::string& index) const {
-    return (table_->cache.count(index) != 0);
-  }
+  bool isCached(const std::string& index) const;
 
   /// Retrieve an index within the query cache.
-  const Row& getCache(const std::string& index) {
-    return table_->cache[index];
-  }
+  const Row& getCache(const std::string& index);
 
   /// Helper to retrieve a keyed element within the query cache.
-  const std::string& getCache(const std::string& index,
-                              const std::string& key) {
-    return table_->cache[index][key];
-  }
+  const std::string& getCache(const std::string& index, const std::string& key);
+
+  /// Request the context use the warm query cache.
+  void useCache(bool use_cache);
+
+  /// Check if the query requested use of the warm query cache.
+  bool useCache() const;
 
   /// Set the entire cache for an index.
-  void setCache(const std::string& index, Row _cache) {
-    table_->cache[index] = std::move(_cache);
-  }
+  void setCache(const std::string& index, Row _cache);
 
   /// Helper to set a keyed element within the query cache.
   void setCache(const std::string& index,
                 const std::string& key,
-                std::string _item) {
-    table_->cache[index][key] = std::move(_item);
-  }
+                std::string _item);
 
   /// The map of column name to constraint list.
   ConstraintMap constraints;
 
  private:
-  /// If false then the context is maintaining a ephemeral cache.
+  /// If false then the context is maintaining an ephemeral cache.
   bool enable_cache_{false};
+
+  /// If the context is allowed to use the warm query cache.
+  bool use_cache_{false};
 
   /// Persistent table content for table caching.
   VirtualTableContent* table_{nullptr};

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -170,6 +170,11 @@ PluginResponse TablePlugin::routeInfo() const {
 }
 
 static bool cacheAllowed(const TableColumns& cols, const QueryContext& ctx) {
+  if (!ctx.useCache()) {
+    // The query execution did not request use of the warm cache.
+    return false;
+  }
+
   auto uncachable = ColumnOptions::INDEX | ColumnOptions::REQUIRED |
                     ColumnOptions::ADDITIONAL | ColumnOptions::OPTIMIZED;
   for (const auto& column : cols) {
@@ -407,6 +412,37 @@ void ConstraintList::unserialize(const boost::property_tree::ptree& tree) {
     constraints_.push_back(constraint);
   }
   affinity = columnTypeName(tree.get<std::string>("affinity", "UNKNOWN"));
+}
+
+void QueryContext::useCache(bool use_cache) {
+  use_cache_ = use_cache;
+}
+
+bool QueryContext::useCache() const {
+  return use_cache_;
+}
+
+void QueryContext::setCache(const std::string& index, Row _cache) {
+  table_->cache[index] = std::move(_cache);
+}
+
+void QueryContext::setCache(const std::string& index,
+                            const std::string& key,
+                            std::string _item) {
+  table_->cache[index][key] = std::move(_item);
+}
+
+bool QueryContext::isCached(const std::string& index) const {
+  return (table_->cache.count(index) != 0);
+}
+
+const Row& QueryContext::getCache(const std::string& index) {
+  return table_->cache[index];
+}
+
+const std::string& QueryContext::getCache(const std::string& index,
+                                          const std::string& key) {
+  return table_->cache[index][key];
 }
 
 bool QueryContext::hasConstraint(const std::string& column,

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -143,11 +143,13 @@ class TestTablePlugin : public TablePlugin {
   void testSetCache(size_t step, size_t interval) {
     QueryData r;
     QueryContext ctx;
+    ctx.useCache(true);
     setCache(step, interval, ctx, r);
   }
 
   bool testIsCached(size_t interval) {
     QueryContext ctx;
+    ctx.useCache(true);
     return isCached(interval, ctx);
   }
 };

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -50,7 +50,7 @@ SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
   auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
   auto t0 = getUnixTime();
   Config::get().recordQueryStart(name);
-  SQLInternal sql(query.query);
+  SQLInternal sql(query.query, true);
   // Snapshot the performance after, and compare.
   auto t1 = getUnixTime();
   auto r1 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -110,14 +110,16 @@ const std::map<std::string, QueryPlanner::Opcode> kSQLOpcodes = {
 class SQLiteSQLPlugin : public SQLPlugin {
  public:
   /// Execute SQL and store results.
-  Status query(const std::string& q, QueryData& results) const override;
+  Status query(const std::string& query,
+               QueryData& results,
+               bool use_cache) const override;
 
   /// Introspect, explain, the suspected types selected in an SQL statement.
-  Status getQueryColumns(const std::string& q,
+  Status getQueryColumns(const std::string& query,
                          TableColumns& columns) const override;
 
   /// Similar to getQueryColumns but return the scanned tables.
-  Status getQueryTables(const std::string& q,
+  Status getQueryTables(const std::string& query,
                         std::vector<std::string>& tables) const override;
 
   /// Create a SQLite module and attach (CREATE).
@@ -140,36 +142,44 @@ std::string getStringForSQLiteReturnCode(int code) {
   }
 }
 
-Status SQLiteSQLPlugin::query(const std::string& q, QueryData& results) const {
+Status SQLiteSQLPlugin::query(const std::string& query,
+                              QueryData& results,
+                              bool use_cache) const {
   auto dbc = SQLiteDBManager::get();
-  auto result = queryInternal(q, results, dbc->db());
+  dbc->useCache(use_cache);
+  auto result = queryInternal(query, results, dbc->db());
   dbc->clearAffectedTables();
   return result;
 }
 
-Status SQLiteSQLPlugin::getQueryColumns(const std::string& q,
+Status SQLiteSQLPlugin::getQueryColumns(const std::string& query,
                                         TableColumns& columns) const {
   auto dbc = SQLiteDBManager::get();
-  return getQueryColumnsInternal(q, columns, dbc->db());
+  return getQueryColumnsInternal(query, columns, dbc->db());
 }
 
-Status SQLiteSQLPlugin::getQueryTables(const std::string& q,
+Status SQLiteSQLPlugin::getQueryTables(const std::string& query,
                                        std::vector<std::string>& tables) const {
   auto dbc = SQLiteDBManager::get();
-  QueryPlanner planner(q, dbc->db());
+  QueryPlanner planner(query, dbc->db());
   tables = planner.tables();
   return Status(0);
 }
 
-SQLInternal::SQLInternal(const std::string& q) {
+SQLInternal::SQLInternal(const std::string& query, bool use_cache) {
   auto dbc = SQLiteDBManager::get();
-  status_ = queryInternal(q, results_, dbc->db());
+  dbc->useCache(use_cache);
+  status_ = queryInternal(query, results_, dbc->db());
 
   // One of the advantages of using SQLInternal (aside from the Registry-bypass)
   // is the ability to "deep-inspect" the table attributes and actions.
   event_based_ = (dbc->getAttributes() & TableAttributes::EVENT_BASED) != 0;
 
   dbc->clearAffectedTables();
+}
+
+bool SQLInternal::eventBased() const {
+  return event_based_;
 }
 
 Status SQLiteSQLPlugin::attach(const std::string& name) {
@@ -233,6 +243,14 @@ void SQLiteDBInstance::init() {
   openOptimized(db_);
 }
 
+void SQLiteDBInstance::useCache(bool use_cache) {
+  use_cache_ = use_cache;
+}
+
+bool SQLiteDBInstance::useCache() const {
+  return use_cache_;
+}
+
 void SQLiteDBInstance::addAffectedTable(VirtualTableContent* table) {
   // An xFilter/scan was requested for this virtual table.
   affected_tables_.insert(std::make_pair(table->name, table));
@@ -271,6 +289,7 @@ void SQLiteDBInstance::clearAffectedTables() {
   // Since the affected tables are cleared, there are no more affected tables.
   // There is no concept of compounding tables between queries.
   affected_tables_.clear();
+  use_cache_ = false;
 }
 
 SQLiteDBInstance::~SQLiteDBInstance() {

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -71,6 +71,12 @@ class SQLiteDBInstance : private boost::noncopyable {
   /// Check if a virtual table had been called already.
   bool tableCalled(VirtualTableContent* table);
 
+  /// Request that virtual tables use a warm cache for their results.
+  void useCache(bool use_cache);
+
+  /// Check if the query requested use of the warm query cache.
+  bool useCache() const;
+
  private:
   /// Handle the primary/forwarding requests for table attribute accesses.
   TableAttributes getAttributes() const;
@@ -86,6 +92,9 @@ class SQLiteDBInstance : private boost::noncopyable {
 
   /// Track whether this instance is managed internally by the DB manager.
   bool managed_{false};
+
+  /// True if this query should bypass table cache.
+  bool use_cache_{false};
 
   /// Either the managed primary database or an ephemeral instance.
   sqlite3* db_{nullptr};
@@ -312,9 +321,10 @@ class SQLInternal : public SQL {
   /**
    * @brief Instantiate an instance of the class with an internal query.
    *
-   * @param q An osquery SQL query.
+   * @param query An osquery SQL query.
+   * @param use_cache [optional] Set true to use the query cache.
    */
-  explicit SQLInternal(const std::string& q);
+  explicit SQLInternal(const std::string& query, bool use_cache = false);
 
  public:
   /**
@@ -328,9 +338,7 @@ class SQLInternal : public SQL {
    * All the tables used in the query will be checked. The TableAttributes of
    * each will be ORed and if any include EVENT_BASED, this will return true.
    */
-  bool eventBased() const {
-    return event_based_;
-  }
+  bool eventBased() const;
 
  private:
   /// Before completing the execution, store a check for EVENT_BASED.

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -449,6 +449,9 @@ static int xFilter(sqlite3_vtab_cursor* pVtabCursor,
   pCur->n = 0;
   QueryContext context(content);
 
+  // The SQLite instance communicates to the TablePlugin via the context.
+  context.useCache(pVtab->instance->useCache());
+
   // Track required columns, this is different than the requirements check
   // that occurs within BestIndex because this scan includes a cursor.
   // For each cursor used, if a requirement exists, we need to scan the


### PR DESCRIPTION
Fixes #3733 

We implement a "warm" query cache for the scheduler. This allows queries in the schedule that use the same virtual table to access the values from the warm cache without running the query logic again. This unexpectedly effected "live" or "distributed" queries. Before this change a distributed query may also have used the warm cache.

The new experience is the expected one. Distributed queries act on live data, they do not use the query cache. This is now the default for the entire application. Only the scheduler overrides the default action and chooses to use a query cache.