### PR TITLE
Document fix for yum download instructions.

### DIFF
--- a/docs/downloads/downloads.html
+++ b/docs/downloads/downloads.html
@@ -111,7 +111,7 @@ permalink: /downloads/
       <div class="shell">
         <p class="line">
           <span class="prompt">$</span>
-          <span class="command">curl https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery</span>
+          <span class="command">curl -L https://pkg.osquery.io/rpm/GPG | sudo tee /etc/pki/rpm-gpg/RPM-GPG-KEY-osquery</span>
         </p>
         <p class="line">
           <span class="prompt">$</span>


### PR DESCRIPTION
See issue #3806.

Corrected curl command so that the GPG key is properly downloaded.