### PR TITLE
Fixes compilation issues with latest master branch

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1185,7 +1185,7 @@ inline void meta_show(struct callback_data* p) {
 
   {
     fprintf(p->out, "\nNon-default flags/options:\n");
-    auto results = osquery::SQL::SQL(
+    auto results = osquery::SQL(
         "select * from osquery_flags where default_value <> value");
     for (const auto& flag : results.rows()) {
       fprintf(p->out,

--- a/osquery/tables/system/linux/tests/md_tables_tests.cpp
+++ b/osquery/tables/system/linux/tests/md_tables_tests.cpp
@@ -72,7 +72,7 @@ void GetDrivesForArrayTestHarness(std::string arrayName,
   EXPECT_CALL(md, getArrayInfo(arrayDevPath, _))
       .WillOnce(DoAll(SetArgReferee<1>(arrayInfo), Return(true)));
 
-  Sequence::Sequence s1;
+  Sequence s1;
   for (int i = 0; i < MD_SB_DISKS; i++) {
     mdu_disk_info_t diskInfo;
     diskInfo.number = i;


### PR DESCRIPTION
Get the following errors from the latest commit (702203086f88931e32a4a582edc79d4a33d44798):
```
[ 97%] Built target osquery_additional_tests
osquery-git/osquery/devtools/shell.cpp:1188:34: error: qualified reference to 'SQL' is a constructor name rather than a type in this context
    auto results = osquery::SQL::SQL(
                                 ^
1 error generated.
```

```
[ 97%] Built target shell
osquery-git/osquery/tables/system/linux/tests/md_tables_tests.cpp:75:13: error: qualified reference to 'Sequence' is a constructor name rather than a type in this context
  Sequence::Sequence s1;
            ^
1 error generated.
```

The attached PR fixes both of these. 