### PR TITLE
Publisher and Table for Event Tap Capture (KeyDown)

### DIFF
--- a/osquery/events/darwin/event_taps.cpp
+++ b/osquery/events/darwin/event_taps.cpp
@@ -18,9 +18,10 @@ namespace osquery {
 
 /// Flag that turns the eventing system for event taps on or off
 FLAG(bool,
-	disable_event_tapping,
-	true,
-	"Disable receiving and subscribing to events from the event taps subsystem");
+     disable_event_tapping,
+     true,
+     "Disable receiving and subscribing to events from the event taps "
+     "subsystem");
 
 REGISTER(EventTappingEventPublisher, "event_publisher", "event_tapping");
 

--- a/osquery/events/darwin/event_taps.cpp
+++ b/osquery/events/darwin/event_taps.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <ApplicationServices/ApplicationServices.h>
+
+#include <osquery/flags.h>
+
+#include "osquery/events/darwin/event_taps.h"
+
+namespace osquery {
+
+/// Flag that turns the eventing system for event taps on or off
+FLAG(bool,
+	disable_event_tapping,
+	true,
+	"Disable receiving and subscribing to events from the event taps subsystem");
+
+REGISTER(EventTappingEventPublisher, "event_publisher", "event_tapping");
+
+CGEventRef EventTappingEventPublisher::eventCallback(CGEventTapProxy proxy,
+                                                     CGEventType type,
+                                                     CGEventRef event,
+                                                     void* refcon) {
+  auto ec = createEventContext();
+  EventFactory::fire<EventTappingEventPublisher>(ec);
+  return event;
+}
+
+Status EventTappingEventPublisher::setUp() {
+  if (FLAGS_disable_event_tapping) {
+    return Status(1, "Publisher disabled via configuration");
+  }
+  return Status(0);
+}
+
+void EventTappingEventPublisher::configure() {
+  WriteLock lock(mutex_);
+  restart();
+}
+
+void EventTappingEventPublisher::tearDown() {
+  stop();
+
+  WriteLock lock(mutex_);
+  run_loop_ = nullptr;
+}
+
+void EventTappingEventPublisher::stop() {
+  WriteLock lock(mutex_);
+
+  if (run_loop_source_ != nullptr) {
+    CFRunLoopRemoveSource(
+        CFRunLoopGetCurrent(), run_loop_source_, kCFRunLoopCommonModes);
+    run_loop_source_ = nullptr;
+  }
+  if (run_loop_ != nullptr) {
+    CFRunLoopStop(run_loop_);
+  }
+}
+
+void EventTappingEventPublisher::restart() {
+  if (run_loop_ == nullptr) {
+    return;
+  }
+  stop();
+  WriteLock lock(mutex_);
+  CGEventMask eventMask = (1 << kCGEventKeyDown);
+  CFMachPortRef eventTap = CGEventTapCreate(kCGSessionEventTap,
+                                            kCGHeadInsertEventTap,
+                                            kCGEventTapOptionListenOnly,
+                                            eventMask,
+                                            eventCallback,
+                                            NULL);
+  run_loop_source_ =
+      CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
+  CFRunLoopAddSource(
+      CFRunLoopGetCurrent(), run_loop_source_, kCFRunLoopCommonModes);
+  CGEventTapEnable(eventTap, true);
+}
+
+Status EventTappingEventPublisher::run() {
+  if (run_loop_ == nullptr) {
+    run_loop_ = CFRunLoopGetCurrent();
+    restart();
+  }
+
+  CFRunLoopRun();
+  return Status(0);
+}
+
+bool EventTappingEventPublisher::shouldFire(
+    const EventTappingSubscriptionContextRef& mc,
+    const EventTappingEventContextRef& ec) const {
+  return true;
+}
+}

--- a/osquery/events/darwin/event_taps.h
+++ b/osquery/events/darwin/event_taps.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <ApplicationServices/ApplicationServices.h>
+
 #include <osquery/events.h>
 
 namespace osquery {
@@ -31,8 +33,6 @@ class EventTappingEventPublisher
 
  public:
   Status setUp() override;
-
-  void configure() override;
 
   void tearDown() override;
 
@@ -63,6 +63,6 @@ class EventTappingEventPublisher
   CFRunLoopRef run_loop_{nullptr};
 
   /// Storage/container operations protection mutex.
-  mutable Mutex mutex_;
+  mutable Mutex run_loop_mutex_;
 };
 } // namespace osquery

--- a/osquery/events/darwin/event_taps.h
+++ b/osquery/events/darwin/event_taps.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <osquery/events.h>
+
+namespace osquery {
+
+struct EventTappingSubscriptionContext : public SubscriptionContext {};
+struct EventTappingEventContext : public EventContext {};
+
+using EventTappingEventContextRef = std::shared_ptr<EventTappingEventContext>;
+using EventTappingSubscriptionContextRef =
+    std::shared_ptr<EventTappingSubscriptionContext>;
+
+/// This is a dispatched service that handles published EventTapping events.
+class EventTappingConsumerRunner;
+
+class EventTappingEventPublisher
+    : public EventPublisher<EventTappingSubscriptionContext, EventTappingEventContext> {
+  DECLARE_PUBLISHER("event_tapping");
+
+ public:
+  Status setUp() override;
+
+  void configure() override;
+
+  void tearDown() override;
+
+  void stop() override;
+
+  void restart();
+
+  Status run() override;
+
+  EventTappingEventPublisher() : EventPublisher() {}
+
+  virtual ~EventTappingEventPublisher() {
+    tearDown();
+  }
+
+ private:
+  /// Apply normal subscription to event matching logic.
+  bool shouldFire(const EventTappingSubscriptionContextRef& mc,
+                  const EventTappingEventContextRef& ec) const override;
+
+  static CGEventRef eventCallback(CGEventTapProxy proxy,
+                                  CGEventType type,
+                                  CGEventRef event,
+                                  void* refcon);
+
+  /// This publisher thread's runloop.
+  CFRunLoopSourceRef run_loop_source_{nullptr};
+  CFRunLoopRef run_loop_{nullptr};
+
+  /// Storage/container operations protection mutex.
+  mutable Mutex mutex_;
+};
+} // namespace osquery

--- a/osquery/events/darwin/event_taps.h
+++ b/osquery/events/darwin/event_taps.h
@@ -25,7 +25,8 @@ using EventTappingSubscriptionContextRef =
 class EventTappingConsumerRunner;
 
 class EventTappingEventPublisher
-    : public EventPublisher<EventTappingSubscriptionContext, EventTappingEventContext> {
+    : public EventPublisher<EventTappingSubscriptionContext,
+                            EventTappingEventContext> {
   DECLARE_PUBLISHER("event_tapping");
 
  public:

--- a/osquery/tables/events/darwin/key_events.cpp
+++ b/osquery/tables/events/darwin/key_events.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <ApplicationServices/ApplicationServices.h>
+
 #include "osquery/events/darwin/event_taps.h"
 
 namespace osquery {

--- a/osquery/tables/events/darwin/key_events.cpp
+++ b/osquery/tables/events/darwin/key_events.cpp
@@ -8,8 +8,6 @@
  *
  */
 
-#include <ApplicationServices/ApplicationServices.h>
-
 #include "osquery/events/darwin/event_taps.h"
 
 namespace osquery {

--- a/osquery/tables/events/darwin/key_events.cpp
+++ b/osquery/tables/events/darwin/key_events.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <ApplicationServices/ApplicationServices.h>
+#include "osquery/events/darwin/event_taps.h"
+
+namespace osquery {
+
+class EventTapsKeySubscriber
+    : public EventSubscriber<EventTappingEventPublisher> {
+ public:
+  Status init() override {
+    return Status(0);
+  }
+
+  void configure() override;
+
+  Status Callback(const EventTappingEventContextRef& ec,
+                  const EventTappingSubscriptionContextRef& sc);
+};
+
+REGISTER(EventTapsKeySubscriber, "event_subscriber", "key_events");
+
+void EventTapsKeySubscriber::configure() {
+  auto sc = createSubscriptionContext();
+  subscribe(&EventTapsKeySubscriber::Callback, sc);
+}
+
+Status EventTapsKeySubscriber::Callback(
+    const EventTappingEventContextRef& ec,
+    const EventTappingSubscriptionContextRef& sc) {
+  Row r;
+  add(r);
+  return Status(0);
+}
+} // namespace osquery

--- a/specs/darwin/key_events.table
+++ b/specs/darwin/key_events.table
@@ -1,0 +1,7 @@
+table_name("key_events")
+description("Track key events.")
+schema([
+    Column("time", BIGINT, "Time")
+])
+attributes(event_subscriber=True)
+implementation("events/darwin/key_events@key_events::genTable")


### PR DESCRIPTION
This adds and event publisher and table consumer for keydown events. We consume these from the operating system by registering an event tap.

You can see the event tap created by osquery with the following query:
```SQL
select * from event_taps;
```

You can get times for keydown events with:
```SQL
select * from key_events;
```

To break the key events down by minute:
```SQL
select time/60*60 as minute_started, count(time/60) as number_of_events from key_events group by (time/60);
```