### PR TITLE
tables: Add dropTo with string UID and GID params

### DIFF
--- a/include/osquery/posix/system.h
+++ b/include/osquery/posix/system.h
@@ -44,6 +44,9 @@ class DropPrivileges : private boost::noncopyable {
    */
   bool dropToParent(const boost::filesystem::path& path);
 
+  /// See DropPrivileges::dropToParent but explicitiy set the UID and GID.
+  bool dropTo(const std::string& uid, const std::string& gid);
+
   /// See DropPrivileges::dropToParent but explicitly set the UID and GID.
   bool dropTo(uid_t uid, gid_t gid);
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -439,6 +439,16 @@ bool setThreadEffective(uid_t uid, gid_t gid) {
   return 0;
 }
 
+bool DropPrivileges::dropTo(const std::string& uid, const std::string& gid) {
+  unsigned long int _uid = 0;
+  unsigned long int _gid = 0;
+  if (!safeStrtoul(uid, 10, _uid).ok() || !safeStrtoul(gid, 10, _gid).ok() ||
+      !dropTo(static_cast<uid_t>(_uid), static_cast<gid_t>(_gid))) {
+    return false;
+  }
+  return true;
+}
+
 bool DropPrivileges::dropTo(uid_t uid, gid_t gid) {
   if (uid == geteuid() && gid == getegid()) {
     // Privileges do not need to be dropped.

--- a/osquery/core/tests/posix/permissions_tests.cpp
+++ b/osquery/core/tests/posix/permissions_tests.cpp
@@ -144,6 +144,13 @@ TEST_F(PermissionsTests, test_nobody_drop) {
     EXPECT_EQ(geteuid(), nobody->pw_uid);
   }
 
+  {
+    auto dropper = DropPrivileges::get();
+    EXPECT_TRUE(dropper->dropTo(std::to_string(nobody->pw_uid),
+                                std::to_string(nobody->pw_gid)));
+    EXPECT_EQ(geteuid(), nobody->pw_uid);
+  }
+
   // Now that the dropper is gone, the effective user/group should be restored.
   EXPECT_EQ(geteuid(), getuid());
   EXPECT_EQ(getegid(), getgid());

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -144,10 +144,7 @@ inline void genSafariExtension(const std::string& uid,
 
   // Finally drop privileges to the user controlling the extension.
   auto dropper = DropPrivileges::get();
-  unsigned long int _uid = 0;
-  unsigned long int _gid = 0;
-  if (!safeStrtoul(uid, 10, _uid).ok() || !safeStrtoul(gid, 10, _gid).ok() ||
-      !dropper->dropTo(static_cast<uid_t>(_uid), static_cast<gid_t>(_gid))) {
+  if (!dropper->dropTo(uid, gid)) {
     VLOG(1) << "Cannot drop privileges to UID " << uid;
     return;
   }

--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -12,8 +12,10 @@
 #include <vector>
 
 #include <osquery/core.h>
-#include <osquery/tables.h>
 #include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/posix/system.h>
+#include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/tables/system/system_utils.h"
@@ -25,14 +27,21 @@ const std::vector<std::string> kSSHAuthorizedkeys = {".ssh/authorized_keys",
                                                      ".ssh/authorized_keys2"};
 
 void genSSHkeysForUser(const std::string& uid,
+                       const std::string& gid,
                        const std::string& directory,
                        QueryData& results) {
+  auto dropper = DropPrivileges::get();
+  if (!dropper->dropTo(uid, gid)) {
+    VLOG(1) << "Cannot drop privileges to UID " << uid;
+    return;
+  }
+
   for (const auto& kfile : kSSHAuthorizedkeys) {
     boost::filesystem::path keys_file = directory;
     keys_file /= kfile;
 
     std::string keys_content;
-    if (!osquery::forensicReadFile(keys_file, keys_content).ok()) {
+    if (!forensicReadFile(keys_file, keys_content).ok()) {
       // Cannot read a specific keys file.
       continue;
     }
@@ -41,10 +50,7 @@ void genSSHkeysForUser(const std::string& uid,
     // base64-encoded key, comment.
     for (const auto& line : split(keys_content, "\n")) {
       if (!line.empty() && line[0] != '#') {
-        Row r;
-        r["uid"] = uid;
-        r["key"] = line;
-        r["key_file"] = keys_file.string();
+        Row r = {{"uid", uid}, {"key", line}, {"key_file", keys_file.string()}};
         results.push_back(r);
       }
     }
@@ -57,8 +63,11 @@ QueryData getAuthorizedKeys(QueryContext& context) {
   // Iterate over each user
   QueryData users = usersFromContext(context);
   for (const auto& row : users) {
-    if (row.count("uid") > 0 && row.count("directory") > 0) {
-      genSSHkeysForUser(row.at("uid"), row.at("directory"), results);
+    auto uid = row.find("uid");
+    auto gid = row.find("gid");
+    auto directory = row.find("directory");
+    if (uid != row.end() && gid != row.end() && directory != row.end()) {
+      genSSHkeysForUser(uid->second, gid->second, directory->second, results);
     }
   }
 

--- a/osquery/tables/system/posix/known_hosts.cpp
+++ b/osquery/tables/system/posix/known_hosts.cpp
@@ -30,10 +30,7 @@ void genSSHkeysForHosts(const std::string& uid,
                         const std::string& directory,
                         QueryData& results) {
   auto dropper = DropPrivileges::get();
-  unsigned long int _uid = 0;
-  unsigned long int _gid = 0;
-  if (!safeStrtoul(uid, 10, _uid).ok() || !safeStrtoul(gid, 10, _gid).ok() ||
-      !dropper->dropTo(static_cast<uid_t>(_uid), static_cast<gid_t>(_gid))) {
+  if (!dropper->dropTo(uid, gid)) {
     VLOG(1) << "Cannot drop privileges to UID " << uid;
     return;
   }

--- a/osquery/tables/system/posix/shell_history.cpp
+++ b/osquery/tables/system/posix/shell_history.cpp
@@ -14,8 +14,10 @@
 #include <boost/xpressive/xpressive.hpp>
 
 #include <osquery/core.h>
-#include <osquery/tables.h>
 #include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/posix/system.h>
+#include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/tables/system/system_utils.h"
@@ -30,13 +32,18 @@ const std::vector<std::string> kShellHistoryFiles = {
 };
 
 void genShellHistoryForUser(const std::string& uid,
+                            const std::string& gid,
                             const std::string& directory,
                             QueryData& results) {
+  auto dropper = DropPrivileges::get();
+  if (!dropper->dropTo(uid, gid)) {
+    VLOG(1) << "Cannot drop privileges to UID " << uid;
+    return;
+  }
+
   auto bash_timestamp_rx = xp::sregex::compile("^#(?P<timestamp>[0-9]+)$");
-  xp::smatch bash_timestamp_matches;
   auto zsh_timestamp_rx = xp::sregex::compile(
       "^: {0,10}(?P<timestamp>[0-9]{1,11}):[0-9]+;(?P<command>.*)$");
-  xp::smatch zsh_timestamp_matches;
 
   for (const auto& hfile : kShellHistoryFiles) {
     boost::filesystem::path history_file = directory;
@@ -50,6 +57,9 @@ void genShellHistoryForUser(const std::string& uid,
 
     std::string prev_bash_timestamp;
     for (const auto& line : split(history_content, "\n")) {
+      xp::smatch bash_timestamp_matches;
+      xp::smatch zsh_timestamp_matches;
+
       if (prev_bash_timestamp.empty() &&
           xp::regex_search(line, bash_timestamp_matches, bash_timestamp_rx)) {
         prev_bash_timestamp = bash_timestamp_matches["timestamp"];
@@ -83,8 +93,11 @@ QueryData genShellHistory(QueryContext& context) {
   // Iterate over each user
   QueryData users = usersFromContext(context);
   for (const auto& row : users) {
-    if (row.count("uid") > 0 && row.count("directory") > 0) {
-      genShellHistoryForUser(row.at("uid"), row.at("directory"), results);
+    auto uid = row.find("uid");
+    auto gid = row.find("gid");
+    auto dir = row.find("directory");
+    if (uid != row.end() && gid != row.end() && dir != row.end()) {
+      genShellHistoryForUser(uid->second, gid->second, dir->second, results);
     }
   }
 


### PR DESCRIPTION
The goal here is to (1) reduce code reuse, specifically casting UID and GIDs into `uid_t` and `gid_t`s within table implementations and (2) to adopt the priv-dropping on several additional Linux tables.