### PR TITLE
website: Point docs link to ReadTheDocs

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -21,9 +21,6 @@ sitemap: false
       <nav class="main-nav">
         <ul>
           <li>
-            <a href="/docs/home/">Docs</a>
-          </li>
-          <li>
             <a href="/news/">News</a>
           </li>
           <li>
@@ -31,6 +28,9 @@ sitemap: false
           </li>
           <li>
             <a href="/downloads/">Downloads</a>
+          </li>
+          <li>
+            <a href="{{ site.docs_url }}">Docs</a>
           </li>
         </ul>
       </nav>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -77,6 +77,7 @@ separators:
   rpm: "-"
   linux: "-"
 
+docs_url: https://osquery.readthedocs.io/en/stable
 schema_url: https://raw.githubusercontent.com/osquery/osquery-site/master/schema
 packs_url: https://raw.githubusercontent.com/facebook/osquery/master/packs
 slack_url: https://osquery-slack.herokuapp.com

--- a/docs/_includes/primary-nav-items.html
+++ b/docs/_includes/primary-nav-items.html
@@ -1,7 +1,4 @@
 <ul>
-  <li class="{% if page.url contains '/docs/' %}current{% endif %}">
-    <a href="/docs/home/">Docs</a>
-  </li>
   <li class="{% if page.author %}current{% endif %}">
     <a href="/news/">News</a>
   </li>
@@ -10,6 +7,9 @@
   </li>
   <li class="{% if page.url contains '/downloads/' %}current{% endif %}">
     <a href="/downloads/">Downloads</a>
+  </li>
+  <li class="{% if page.url contains '/docs/' %}current{% endif %}">
+    <a href="{{ site.docs_url }}">Docs</a>
   </li>
   <li>
     <a href="{{ site.repository }}">GitHub</a>

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -114,6 +114,25 @@ nav {
       }
     }
 
+    a[href^="https://"]:after {
+      content: "\f08e";
+      font-family: FontAwesome;
+      font-weight: normal;
+      font-style: normal;
+      font-size: 10px;
+      display: inline-block;
+      text-decoration: none;
+      padding-left: 4px;
+    }
+
+    /* Strip from links to own domain or with class no_icon */
+    a[href^="{{ site.url }}"]:after,
+    a.no_icon:after {
+      content:"" !important;
+      padding-left: 0;
+    }
+
+
     &.current {
 
       a {


### PR DESCRIPTION
Several folks have pinged about the `/docs` page linking to an example. This was intentional but it is not the best UX. Until there is documentation/content, let's redirect to ReadTheDocs.