### PR TITLE
deps: Tap homebrew-core manually and fix initial sysprep

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -17,6 +17,9 @@ FORMULA_DIR="$SCRIPT_DIR/provision/formula"
 HOMEBREW_REPO="https://github.com/Homebrew/brew"
 LINUXBREW_REPO="https://github.com/Linuxbrew/brew"
 
+HOMEBREW_CORE_REPO="https://github.com/Homebrew/homebrew-core"
+LINUXBREW_CORE_REPO="https://github.com/Linuxbrew/homebrew-core"
+
 # Set the SHA1 commit hashes for the pinned homebrew Taps.
 # Pinning allows determinism for bottle availability, expect to update often.
 HOMEBREW_CORE="941ca36839ea354031846d73ad538e1e44e673f4"

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -18,10 +18,12 @@ function setup_brew() {
     BREW_REPO=$LINUXBREW_REPO
     BREW_COMMIT=$LINUXBREW_BREW
     CORE_COMMIT=$LINUXBREW_CORE
+    CORE_REPO=$LINUXBREW_CORE_REPO
   else
     BREW_REPO=$HOMEBREW_REPO
     BREW_COMMIT=$HOMEBREW_BREW
     CORE_COMMIT=$HOMEBREW_CORE
+    CORE_REPO=$HOMEBREW_CORE_REPO
   fi
 
   # Checkout new brew in local deps dir
@@ -43,9 +45,11 @@ function setup_brew() {
 
   # Always update the location of the local tap link.
   log "refreshing local tap: osquery-local"
-  mkdir -p "$DEPS/Library/Taps/osquery/"
 
-  FORMULA_TAP="$DEPS/Library/Taps/osquery/homebrew-osquery-local"
+  TAPS="$DEPS/Library/Taps/"
+  mkdir -p "$TAPS/osquery/"
+
+  FORMULA_TAP="$TAPS/osquery/homebrew-osquery-local"
   if [[ -L "$FORMULA_TAP" ]]; then
     rm -f "$FORMULA_TAP"
   fi
@@ -58,14 +62,23 @@ function setup_brew() {
   export HOMEBREW_NO_EMOJI=1
   export HOMEBREW_BOTTLE_ARCH=core2
   export BREW="$DEPS/bin/brew"
-  TAPS="$DEPS/Library/Taps/"
 
   # Grab full clone to perform a pin
   if [[ ! "$ACTION" = "bottle" ]]; then
     log "installing and updating Homebrew core"
-    $BREW tap homebrew/core --full
-    (cd $TAPS/homebrew/homebrew-core && git pull > /dev/null && \
-        git reset --hard $CORE_COMMIT)
+    # Using a manual tap below, see: Homebrew/homebrew-core#19221
+    # $BREW tap homebrew/core --full
+    # (cd $TAPS/homebrew/homebrew-core && git pull > /dev/null && \
+    #     git reset --hard $CORE_COMMIT)
+
+    # This manually checks/clones/pulls the homebrew-core repo.
+    if [[ ! -d "$TAPS/homebrew/homebrew-core/.git" ]]; then
+      mkdir -p $TAPS/homebrew
+      (cd $TAPS/homebrew; git clone $CORE_REPO)
+    else
+      (cd $TAPS/homebrew/homebrew-core; git pull > /dev/null)
+    fi
+    (cd $TAPS/homebrew/homebrew-core; git reset --hard $CORE_COMMIT)
   fi
 
   # Create a 'legacy' mirror.
@@ -83,15 +96,12 @@ function setup_brew() {
 
 # json_attributes JSON [ATTRIBUTE_PATH, ...]
 #   1: JSON blob
-#   N: path(s) to desired attributes
+#   N: print lines for desired attributes
 function json_attributes() {
   CMD="import json,sys;obj=json.load(sys.stdin)"
+  CMD="$CMD;${@:2}"
 
-  for attr in ${@:2}; do
-    CMD="$CMD;print $attr"
-  done
-
-  RESULT=`(echo "${1}" | python -c "${CMD}") 2>/dev/null || echo 'NAN'`
+  RESULT=`(echo "${1}" | python -c "${CMD}") 2>/dev/null || echo 'Error'`
   echo $RESULT
 }
 
@@ -127,10 +137,12 @@ function brew_internal() {
 
   FORMULA="$TOOL"
   INFO=`$BREW info --json=v1 "${FORMULA}"`
-  RESULTS=$(json_attributes "$INFO" 'obj[0]["installed"][0]["version"]' \
-                                    'obj[0]["versions"]["stable"]' \
-                                    'obj[0]["revision"]' \
-                                    'obj[0]["linked_keg"]')
+
+  RESULTS=$(json_attributes "$INFO" \
+    'print(obj[0]["installed"][0]["version"] if len(obj[0]["installed"]) > 0 else "None");' \
+    'print(obj[0]["versions"]["stable"]);' \
+    'print(obj[0]["revision"]);' \
+    'print(obj[0]["linked_keg"] if obj[0]["linked_keg"] is not None else "None")')
   read -r -a RESULTS <<< "$RESULTS"
 
   INSTALLED="${RESULTS[0]}"
@@ -146,7 +158,7 @@ function brew_internal() {
   ARGS="$@"
 
   if [[ "$TYPE" = "uninstall" ]]; then
-    if [[ ! "$INSTALLED" = "NAN" ]]; then
+    if [[ ! "$INSTALLED" = "None" ]]; then
       log "brew package $TOOL uninstalling version: ${STABLE}"
       $BREW uninstall --force "${FORMULA}"
     fi
@@ -195,14 +207,14 @@ function brew_internal() {
   if [[ ! -z "$OSQUERY_BUILD_BOTTLES" && "$FORMULA" == *"osquery"* ]]; then
     $BREW bottle --skip-relocation "${FORMULA}"
   elif [[ "$TYPE" = "clean" ]]; then
-    if [[ "${STABLE}" = "NAN_NAN" ]]; then
+    if [[ "${STABLE}" = "None_None" ]]; then
       log "brew cleaning older or forward-dependent version of $TOOL: ${INSTALLED}"
       $BREW uninstall --ignore-dependencies "${FORMULA}"
-    elif [[ ! "${INSTALLED}" = "${STABLE}" && ! "${INSTALLED}" = "NAN" ]]; then
+    elif [[ ! "${INSTALLED}" = "${STABLE}" && ! "${INSTALLED}" = "None" ]]; then
       log "brew cleaning older version of $TOOL: ${INSTALLED}"
       $BREW uninstall --ignore-dependencies "${FORMULA}"
     fi
-  elif [[ "${INSTALLED}" = "NAN" || "${INSTALLED}" = "None" ]]; then
+  elif [[ "${INSTALLED}" = "None" ]]; then
     log "brew package $TOOL installing new version: ${STABLE}"
     $BREW install $ARGS "${FORMULA}"
   elif [[ ! "${INSTALLED}" = "${STABLE}" || "${FROM_BOTTLE}" = "true" ]]; then
@@ -253,7 +265,8 @@ function brew_bottle() {
   $BREW bottle --skip-relocation "${FORMULA}"
 
   INFO=`$BREW info --json=v1 "${FORMULA}"`
-  INSTALLED=$(json_attributes "${INFO}" 'obj[0]["installed"][0]["version"]')
+  INSTALLED=$(json_attributes "${INFO}" \
+    'print(obj[0]["installed"][0]["version"]);')
 
   ARIN=(${FORMULA//// })
   TOOL=${ARIN[2]}


### PR DESCRIPTION
This side-steps using the `brew tap` command. Instead we choose to checkout the `homebrew-core` repo into `./Library/Taps/homebrew/homebrew-core` manually. This avoids checks that `brew tap` applies unfortunately, but does break-fix initial `make deps` builds.

This also handles several bugs with parsing `brew info` output for new build environment setups.