### PR TITLE
website: Prevent readthedocs from a 301 to http

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -77,7 +77,7 @@ separators:
   rpm: "-"
   linux: "-"
 
-docs_url: https://osquery.readthedocs.io/en/stable
+docs_url: https://osquery.readthedocs.io/en/stable/
 schema_url: https://raw.githubusercontent.com/osquery/osquery-site/master/schema
 packs_url: https://raw.githubusercontent.com/facebook/osquery/master/packs
 slack_url: https://osquery-slack.herokuapp.com


### PR DESCRIPTION
This is a huge nitpick, but without the trailing slash ReadTheDocs will 301 the client to non-https version of the documentation. 