### PR TITLE
[Fix #3831] Do not lock kAttachMutex within shell callbacks

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -791,8 +791,6 @@ static int shell_exec(
 
   while (zSql[0] && (SQLITE_OK == rc)) {
     /* A lock for attaching virtual tables, but also the SQL object states. */
-    osquery::RecursiveLock lock(osquery::kAttachMutex);
-
     rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
     if (SQLITE_OK != rc) {
       if (pzErrMsg) {

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -123,7 +123,8 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
     osquery::FLAGS_disable_events = true;
     osquery::FLAGS_disable_caching = true;
     // The shell may have loaded table extensions, if not, disable the manager.
-    if (!osquery::Watcher::get().hasManagedExtensions()) {
+    if (!osquery::Watcher::get().hasManagedExtensions() &&
+        Flag::isDefault("disable_extensions")) {
       osquery::FLAGS_disable_extensions = true;
     }
   }


### PR DESCRIPTION
In one terminal run:
```
./build/linux/osquery/example_extension.ext --socket ~/.osquery/shell.em --timeout 1000
```

In another run:
```
./build/linux/osquery/osqueryi --extensions_require=example --verbose --nodisable_extensions "select * from complex_example"
```

You can run the shell with `SANITIZE_THREAD=1 make sanitize` and observe no deadlock/unprotected critical sections. If you run without this patch the shell will hang, with this patch the table will execute correctly.