### PR TITLE
Add logger_snapshot_event_type flag for snapshot events

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -322,6 +322,10 @@ Disable ERROR/WARNING/INFO (called status logs) and query result [logging](../de
 
 Log scheduled results as events.
 
+`--logger_snapshot_event_type=false`
+
+Log scheduled snapshot results as events, similar to differential results. If this is set to `true` then each row from a snapshot query will be logged individually.
+
 `--host_identifier=hostname`
 
 Field used to identify the host running osquery: **hostname**, **uuid**, **ephemeral**, **instance**.

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -531,7 +531,7 @@ static inline Status serializeEvent(const QueryLogItem& item,
                                     pt::ptree& tree) {
   addLegacyFieldsAndDecorations(item, tree);
   pt::ptree columns;
-  for (auto& i : event) {
+  for (const auto& i : event) {
     // Yield results as a "columns." map to avoid namespace collisions.
     columns.put<std::string>(i.first, i.second.get_value<std::string>());
   }
@@ -543,12 +543,12 @@ static inline Status serializeEvent(const QueryLogItem& item,
 Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
                                      pt::ptree& tree) {
   pt::ptree results;
-  if (item.results.added.size() > 0 || item.results.removed.size() > 0) {
+  if (!item.results.added.empty() || !item.results.removed.empty()) {
     auto status = serializeDiffResults(item.results, results);
     if (!status.ok()) {
       return status;
     }
-  } else if (item.snapshot_results.size() > 0) {
+  } else if (!item.snapshot_results.empty()) {
     pt::ptree snapshot_results;
     auto status = serializeQueryData(item.snapshot_results, snapshot_results);
     if (!status.ok()) {
@@ -560,8 +560,8 @@ Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
     return Status(1, "No diff results or snapshot results");
   }
 
-  for (auto& action : results) {
-    for (auto& row : action.second) {
+  for (const auto& action : results) {
+    for (const auto& row : action.second) {
       pt::ptree event;
       serializeEvent(item, row.second, event);
       event.put<std::string>("action", action.first);

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -513,7 +513,7 @@ Status serializeQueryLogItem(const QueryLogItem& item, pt::ptree& tree) {
       return status;
     }
     tree.add_child("diffResults", results);
-  } else if (item.snapshot_results.size() > 0) {
+  } else {
     auto status = serializeQueryData(item.snapshot_results, results);
     if (!status.ok()) {
       return status;

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -21,6 +21,8 @@ namespace osquery {
 
 DECLARE_bool(logger_secondary_status_only);
 DECLARE_bool(logger_status_sync);
+DECLARE_bool(logger_event_type);
+DECLARE_bool(logger_snapshot_event_type);
 
 class LoggerTests : public testing::Test {
  public:
@@ -249,6 +251,16 @@ TEST_F(LoggerTests, test_logger_snapshots) {
 
   // Expect the plugin to optionally handle snapshot logging.
   EXPECT_EQ(1U, LoggerTests::snapshot_rows_added);
+
+  // Expect a single event, event though there were two added.
+  item.results.added.push_back({{"test_column", "test_value"}});
+  logSnapshotQuery(item);
+  EXPECT_EQ(2U, LoggerTests::snapshot_rows_added);
+
+  FLAGS_logger_snapshot_event_type = true;
+  logSnapshotQuery(item);
+  EXPECT_EQ(4U, LoggerTests::snapshot_rows_added);
+  FLAGS_logger_snapshot_event_type = false;
 }
 
 class SecondTestLoggerPlugin : public LoggerPlugin {
@@ -336,9 +348,16 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
   logQueryLogItem(item);
   EXPECT_EQ(1U, LoggerTests::log_lines.size());
 
+  // The entire removed/added is one event when result events is false.
+  FLAGS_logger_event_type = false;
   item.results.removed.push_back({{"test_column", "test_new_value\n"}});
   logQueryLogItem(item);
-  ASSERT_EQ(3U, LoggerTests::log_lines.size());
+  EXPECT_EQ(2U, LoggerTests::log_lines.size());
+  FLAGS_logger_event_type = true;
+
+  // Now the two removed will be individual events.
+  logQueryLogItem(item);
+  EXPECT_EQ(4U, LoggerTests::log_lines.size());
 
   // Make sure the JSON output does not have a newline.
   std::string expected =


### PR DESCRIPTION
This implements #3701.

```
» cat ./build/example.conf 
{
  "options": {
    "logger_snapshot_event_type": "true"
  },
  "schedule": {
    "3groups": {
      "query": "select * from groups limit 3",
      "interval": 5,
      "snapshot": "true"
    }
  }
}
» ./build/linux/osquery/osqueryd --ephemeral --disable_database --logger_plugin=stdout --config_path ./build/example.conf
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:00 2017 UTC","unixTime":"1508133000","epoch":"0","counter":"0","columns":{"gid":"0","gid_signed":"0","groupname":"root"},"action":"snapshot"}
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:00 2017 UTC","unixTime":"1508133000","epoch":"0","counter":"0","columns":{"gid":"1","gid_signed":"1","groupname":"daemon"},"action":"snapshot"}
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:00 2017 UTC","unixTime":"1508133000","epoch":"0","counter":"0","columns":{"gid":"2","gid_signed":"2","groupname":"bin"},"action":"snapshot"}
severity=0 location=events.cpp:824 message=Event publisher not enabled: audit: Publisher disabled via configuration
severity=0 location=events.cpp:824 message=Event publisher not enabled: syslog: Publisher disabled via configuration
severity=0 location=scheduler.cpp:75 message=Executing scheduled query 3groups: select * from groups limit 3
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:05 2017 UTC","unixTime":"1508133005","epoch":"0","counter":"0","columns":{"gid":"0","gid_signed":"0","groupname":"root"},"action":"snapshot"}
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:05 2017 UTC","unixTime":"1508133005","epoch":"0","counter":"0","columns":{"gid":"1","gid_signed":"1","groupname":"daemon"},"action":"snapshot"}
{"name":"3groups","hostIdentifier":"maverics","calendarTime":"Mon Oct 16 05:50:05 2017 UTC","unixTime":"1508133005","epoch":"0","counter":"0","columns":{"gid":"2","gid_signed":"2","groupname":"bin"},"action":"snapshot"}
severity=0 location=scheduler.cpp:75 message=Executing scheduled query 3groups: select * from groups limit 3
```