### PR TITLE
Add version to usb_devices table

### DIFF
--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -19,10 +19,10 @@ namespace tables {
 
 std::string decodeUSBBCD(uint16_t bcd) {
   uint8_t array[2];
-  array[0]=bcd & 0xff;
-  array[1]=(bcd >> 8);
-  uint8_t major = ( (array[1]/16*10) + (array[1]%16) );
-  uint8_t minor = ( (array[0]/16*10) + (array[0]%16) );
+  array[0] = bcd & 0xff;
+  array[1] = (bcd >> 8);
+  uint8_t major = ((array[1] / 16 * 10) + (array[1] % 16));
+  uint8_t minor = ((array[0] / 16 * 10) + (array[0] % 16));
   return std::to_string(major) + "." + std::to_string(minor);
 }
 

--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -17,6 +17,15 @@
 namespace osquery {
 namespace tables {
 
+std::string decodeUSBBCD(uint16_t bcd) {
+  uint8_t array[2];
+  array[0]=bcd & 0xff;
+  array[1]=(bcd >> 8);
+  uint8_t major = ( (array[1]/16*10) + (array[1]%16) );
+  uint8_t minor = ( (array[0]/16*10) + (array[0]%16) );
+  return std::to_string(major) + "." + std::to_string(minor);
+}
+
 void genUSBDevice(const io_service_t& device, QueryData& results) {
   Row r;
 
@@ -40,6 +49,7 @@ void genUSBDevice(const io_service_t& device, QueryData& results) {
   r["model_id"] = getIOKitProperty(details, "idProduct");
   r["vendor"] = getIOKitProperty(details, "USB Vendor Name");
   r["vendor_id"] = getIOKitProperty(details, "idVendor");
+  r["version"] = decodeUSBBCD(getNumIOKitProperty(details, "bcdDevice"));
 
   r["serial"] = getIOKitProperty(details, "USB Serial Number");
   if (r.at("serial").size() == 0) {

--- a/osquery/tables/system/linux/usb_devices.cpp
+++ b/osquery/tables/system/linux/usb_devices.cpp
@@ -64,7 +64,8 @@ QueryData genUSBDevices(QueryContext &context) {
     // USB-specific vendor/model ID properties.
     r["model_id"] = UdevEventPublisher::getValue(device, kUSBKeyModelID);
     r["vendor_id"] = UdevEventPublisher::getValue(device, kUSBKeyVendorID);
-    r["version"] = UdevEventPublisher::getValue(device, kUSBDeviceReleaseNumber);
+    r["version"] =
+        UdevEventPublisher::getValue(device, kUSBDeviceReleaseNumber);
     r["serial"] = UdevEventPublisher::getValue(device, kUSBKeySerial);
 
     // This will be of the form class/subclass/protocol and has to be parsed

--- a/osquery/tables/system/linux/usb_devices.cpp
+++ b/osquery/tables/system/linux/usb_devices.cpp
@@ -23,6 +23,7 @@ const std::string kUSBKeyVendor = "ID_VENDOR_FROM_DATABASE";
 const std::string kUSBKeyModelID = "ID_MODEL_ID";
 const std::string kUSBKeyModel = "ID_MODEL_FROM_DATABASE";
 const std::string kUSBKeyModelFallback = "ID_MODEL";
+const std::string kUSBDeviceReleaseNumber = "ID_REVISION";
 const std::string kUSBKeyDriver = "ID_USB_DRIVER";
 const std::string kUSBKeySubsystem = "SUBSYSTEM";
 const std::string kUSBKeySerial = "ID_SERIAL_SHORT";
@@ -63,6 +64,7 @@ QueryData genUSBDevices(QueryContext &context) {
     // USB-specific vendor/model ID properties.
     r["model_id"] = UdevEventPublisher::getValue(device, kUSBKeyModelID);
     r["vendor_id"] = UdevEventPublisher::getValue(device, kUSBKeyVendorID);
+    r["version"] = UdevEventPublisher::getValue(device, kUSBDeviceReleaseNumber);
     r["serial"] = UdevEventPublisher::getValue(device, kUSBKeySerial);
 
     // This will be of the form class/subclass/protocol and has to be parsed

--- a/specs/posix/usb_devices.table
+++ b/specs/posix/usb_devices.table
@@ -5,6 +5,7 @@ schema([
     Column("usb_port", INTEGER, "USB Device used port"),
     Column("vendor", TEXT, "USB Device vendor string"),
     Column("vendor_id", TEXT, "Hex encoded USB Device vendor identifier"),
+    Column("version", TEXT, "USB Device version number"),
     Column("model", TEXT, "USB Device model string"),
     Column("model_id", TEXT, "Hex encoded USB Device model identifier"),
     Column("serial", TEXT, "USB Device serial connection"),


### PR DESCRIPTION
This adds device version to the usb_devices table.  It's a bit of a mess to deal with, because it comes back as an unsigned 16 bit integer of 4 bit binary coded decimals.  See from here http://www.beyondlogic.org/usbnutshell/usb5.shtml

```
The bcdUSB field reports the highest version of USB the device supports. The value is in binary coded decimal with a format of 0xJJMN where JJ is the major version number, M is the minor version number and N is the sub minor version number. e.g. USB 2.0 is reported as 0x0200, USB 1.1 as 0x0110 and USB 1.0 as 0x0100.

The bcdDevice has the same format than the bcdUSB and is used to provide a device version number. This value is assigned by the developer
```