### PR TITLE
Fix the memory leak in the macOS certificates table

### DIFF
--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -113,6 +113,7 @@ void genAlgorithmProperties(X509* cert,
         }
       }
     }
+    EVP_PKEY_free(pkey);
   }
 
   OSX_OPENSSL(nid = OBJ_obj2nid(cert->cert_info->signature->algorithm));


### PR DESCRIPTION
Fix the memory leak in the certificates table on macOS
<img width="1556" alt="screen shot 2017-10-16 at 8 26 00 pm" src="https://user-images.githubusercontent.com/2386877/31645324-49e709ce-b2b0-11e7-8747-06befd5292fc.png">
