### PR TITLE
Support date type in OS X Preferences table (#3585)

### DIFF
--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -106,6 +106,10 @@ void genOSXPrefValues(const CFTypeRef& value,
     r["value"] = stringFromCFNumber(static_cast<CFDataRef>(value));
   } else if (CFGetTypeID(value) == CFStringGetTypeID()) {
     r["value"] = stringFromCFString(static_cast<CFStringRef>(value));
+  } else if (CFGetTypeID(value) == CFDateGetTypeID()) {
+    auto unix_time = CFDateGetAbsoluteTime(static_cast<CFDateRef>(value)) +
+                     kCFAbsoluteTimeIntervalSince1970;
+    r["value"] = boost::lexical_cast<std::string>(std::llround(unix_time));
   } else if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
     r["value"] = (CFBooleanGetValue(static_cast<CFBooleanRef>(value)) == TRUE)
                      ? "true"


### PR DESCRIPTION
This commit writes `CFDate` values in the preferences tables as unix-timestamps-as-strings, in the same way we handle dates in property list files through the `plist` table.