### PR TITLE
tables: Use FQDN for POSIX system_info hostname

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -13,6 +13,8 @@
 #include <sys/types.h>
 
 #ifndef WIN32
+#include <sys/socket.h>
+#include <netdb.h>
 #include <grp.h>
 #endif
 
@@ -119,14 +121,33 @@ std::string getHostname() {
 
 std::string getFqdn() {
   if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
-    return getHostname();
-  }
-  unsigned long size = 256;
-  std::vector<char> fqdn(size, 0x0);
-#ifdef WIN32
-  GetComputerNameEx(ComputerNameDnsFullyQualified, fqdn.data(), &size);
+    std::string fqdn_string = getHostname();
+
+#ifndef WIN32
+    struct addrinfo hints;
+    memset (&hints, 0, sizeof (hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_flags = AI_CANONNAME;
+
+    struct addrinfo* res = nullptr;
+    if (getaddrinfo(fqdn_string.c_str(), nullptr, &hints, &res) == 0) {
+      if (res->ai_canonname != nullptr) {
+        fqdn_string = res->ai_canonname;
+      }
+    }
+    if (res != nullptr) {
+      freeaddrinfo(res);
+    }
 #endif
-  return fqdn.data();
+    return fqdn_string;
+  } else {
+    unsigned long size = 256;
+    std::vector<char> fqdn(size, 0x0);
+#ifdef WIN32
+    GetComputerNameEx(ComputerNameDnsFullyQualified, fqdn.data(), &size);
+#endif
+    return fqdn.data();
+  }
 }
 
 std::string generateNewUUID() {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -13,9 +13,9 @@
 #include <sys/types.h>
 
 #ifndef WIN32
-#include <sys/socket.h>
-#include <netdb.h>
 #include <grp.h>
+#include <netdb.h>
+#include <sys/socket.h>
 #endif
 
 #include <signal.h>
@@ -125,7 +125,7 @@ std::string getFqdn() {
 
 #ifndef WIN32
     struct addrinfo hints;
-    memset (&hints, 0, sizeof (hints));
+    memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_flags = AI_CANONNAME;
 

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -78,13 +78,13 @@ QueryData genSystemInfo(QueryContext& context) {
   Row r;
 
   // OS X also defines a friendly ComputerName along with a hostname.
-  r["hostname"] = osquery::getHostname();
+  r["hostname"] = osquery::getFqdn();
   auto cn = SCDynamicStoreCopyComputerName(nullptr, nullptr);
   if (cn != nullptr) {
     r["computer_name"] = stringFromCFString(cn);
     CFRelease(cn);
   } else {
-    r["computer_name"] = r["hostname"];
+    r["computer_name"] = getHostname();
   }
 
   auto lhn = SCDynamicStoreCopyLocalHostName(nullptr);
@@ -92,7 +92,7 @@ QueryData genSystemInfo(QueryContext& context) {
     r["local_hostname"] = stringFromCFString(lhn);
     CFRelease(lhn);
   } else {
-    r["local_hostname"] = r["hostname"];
+    r["local_hostname"] = getHostname();
   }
 
   // The UUID for Apple devices is a device identifier.

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -23,8 +23,8 @@ namespace tables {
 
 QueryData genSystemInfo(QueryContext& context) {
   Row r;
-  r["hostname"] = osquery::getHostname();
-  r["computer_name"] = r["hostname"];
+  r["hostname"] = osquery::getFqdn();
+  r["computer_name"] = osquery::getHostname();
   r["local_hostname"] = r["hostname"];
 
   std::string uuid;

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -34,6 +34,12 @@ TEST_F(SystemsTablesTests, test_os_version) {
   EXPECT_FALSE(results.rows()[0].at("name").empty());
 }
 
+TEST_F(SystemsTablesTests, test_hostname) {
+  SQL results("select hostname from system_info");
+  EXPECT_EQ(results.rows().size(), 1U);
+  EXPECT_FALSE(results.rows()[0].at("hostname").empty());
+}
+
 TEST_F(SystemsTablesTests, test_process_info) {
   SQL results("select * from osquery_info join processes using (pid)");
   ASSERT_EQ(results.rows().size(), 1U);

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -57,9 +57,9 @@ QueryData genSystemInfo(QueryContext& context) {
   WmiRequest wmiBiosReq("select * from Win32_Bios");
   std::vector<WmiResultItem>& wmiBiosResults = wmiBiosReq.results();
   if (wmiBiosResults.size() != 0) {
-	  wmiBiosResults[0].GetString("SerialNumber", r["hardware_serial"]);
+    wmiBiosResults[0].GetString("SerialNumber", r["hardware_serial"]);
   } else {
-	  r["hardware_serial"] = "-1";
+    r["hardware_serial"] = "-1";
   }
 
   SYSTEM_INFO systemInfo;


### PR DESCRIPTION
This adopts the Windows `hostname` = `FQDN` for Linux and Darwin.