### PR TITLE
extensions: Add 5min timeouts for read and send client calls

### DIFF
--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -121,7 +121,7 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
       try {
         ExtensionStatus status;
         // Create a client with a 2-second receive timeout.
-        EXManagerClient client(path, 2 * 1000);
+        EXManagerClient client(path, 10 * 1000);
         client.get()->ping(status);
         return Status(0, "OK");
       } catch (const std::exception& /* e */) {

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -120,7 +120,7 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
     if (socketExists(path)) {
       try {
         ExtensionStatus status;
-        // Create a client with a 2-second receive timeout.
+        // Create a client with a 10-second receive timeout.
         EXManagerClient client(path, 10 * 1000);
         client.get()->ping(status);
         return Status(0, "OK");

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -120,7 +120,8 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
     if (socketExists(path)) {
       try {
         ExtensionStatus status;
-        EXManagerClient client(path);
+        // Create a client with a 2-second receive timeout.
+        EXManagerClient client(path, 2 * 1000);
         client.get()->ping(status);
         return Status(0, "OK");
       } catch (const std::exception& /* e */) {
@@ -133,6 +134,14 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
     }
     return Status(1, "Extension socket not available: " + path);
   }));
+}
+
+ExtensionWatcher::ExtensionWatcher(const std::string& path,
+                                   size_t interval,
+                                   bool fatal)
+    : path_(path), interval_(interval), fatal_(fatal) {
+  // Set the interval to a minimum of 200 milliseconds.
+  interval_ = (interval_ < 200) ? 200 : interval_;
 }
 
 void ExtensionWatcher::start() {

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -139,7 +139,10 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
 ExtensionWatcher::ExtensionWatcher(const std::string& path,
                                    size_t interval,
                                    bool fatal)
-    : path_(path), interval_(interval), fatal_(fatal) {
+    : InternalRunnable("ExtensionWatcher"),
+      path_(path),
+      interval_(interval),
+      fatal_(fatal) {
   // Set the interval to a minimum of 200 milliseconds.
   interval_ = (interval_ < 200) ? 200 : interval_;
 }

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -352,8 +352,11 @@ EXInternal::~EXInternal() {
 }
 
 void EXInternal::setTimeouts(size_t timeouts) {
+#ifndef WIN32
+  // Windows TPipe does not support timeouts.
   socket_->setRecvTimeout(timeouts);
   socket_->setSendTimeout(timeouts);
+#endif
 }
 
 EXClient::EXClient(const std::string& path, size_t timeout)


### PR DESCRIPTION
This fixes #3764.

All extension clients will now set their receive and send timeouts to 5mins. The socket-alive function will set it to 2 seconds. So a hanging 'old' socket path will only rarely delay the shell by 2 seconds.