### PR TITLE
Fix extended_schema on Windows

### DIFF
--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -90,7 +90,7 @@ TABLE_ATTRIBUTES = {
 
 
 def WINDOWS():
-    return PLATFORM in ['windows']
+    return PLATFORM in ['windows', 'win32', 'cygwin']
 
 
 def LINUX():


### PR DESCRIPTION
Python returns `win32` not `windows` for `sys.platform`.