### PR TITLE
Reinstate shell SQLite recursive lock

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -791,6 +791,7 @@ static int shell_exec(
 
   while (zSql[0] && (SQLITE_OK == rc)) {
     /* A lock for attaching virtual tables, but also the SQL object states. */
+    osquery::RecursiveLock lock(osquery::kAttachMutex);
     rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, &zLeftover);
     if (SQLITE_OK != rc) {
       if (pzErrMsg) {


### PR DESCRIPTION
It seems the absence of this lock is causing intermittent crashes in osqueryi.