### PR TITLE
Detect Proton.C variant detection from Elmedia Player

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -469,18 +469,26 @@
     "OSX_Proton_Files": {
       "query" : "select * from file \
         where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
-        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist';",
+        path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR \
+        path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app';",
       "interval" : "3600",
       "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of handbrake: (https://objective-see.com/blog/blog_0x1D.html)",
+      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "value" : "Artifacts created by this malware"
+    },
+    "OSX_Proton_Launchd": {
+      "query" : "select * from launchd where name='com.Eltima.UpdaterAgent.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description" : "OSX/Proton bundled with a tampered version of Elmedia Player: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
       "value" : "Artifacts created by this malware"
     },
     "OSX_Proton_Process": {
       "query" : "select * from processes \
-        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent';",
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent';",
       "interval" : "3600",
       "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of handbrake: (https://objective-see.com/blog/blog_0x1D.html)",
+      "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
       "value" : "Artifacts created by this malware"
     },
     "EmPyre_Agent": {


### PR DESCRIPTION
Adding:
- Additional file paths
- Launchd detection query
- Additional process path

https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/