### PR TITLE
deps: Install librpm on macOS

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -107,7 +107,6 @@ function platform_linux_main() {
   brew_dependency osquery/osquery-local/libudev
   brew_dependency osquery/osquery-local/libaudit
   brew_dependency osquery/osquery-local/libdpkg
-  brew_dependency osquery/osquery-local/librpm
 }
 
 function platform_darwin_main() {
@@ -127,6 +126,10 @@ function platform_darwin_main() {
   brew_dependency osquery/osquery-local/openssl
   brew_tool osquery/osquery-local/python
   brew_tool osquery/osquery-local/bison
+
+  brew_tool osquery/osquery-local/berkeley-db
+  brew_tool osquery/osquery-local/popt
+  brew_tool osquery/osquery-local/beecrypt
 
   platform_posix_main
 }
@@ -155,6 +158,7 @@ function platform_darwin_main() {
   brew_dependency osquery/osquery-local/augeas
   brew_dependency osquery/osquery-local/lldpd
   brew_dependency osquery/osquery-local/librdkafka
+  brew_dependency osquery/osquery-local/librpm
 
   # POSIX-shared locally-managed tools.
   brew_dependency osquery/osquery-local/zzuf

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -84,11 +84,6 @@ function platform_linux_main() {
   brew_tool osquery/osquery-local/curl
   brew_tool osquery/osquery-local/python
 
-  # Linux library secondary dependencies.
-  brew_tool osquery/osquery-local/berkeley-db
-  brew_tool osquery/osquery-local/popt
-  brew_tool osquery/osquery-local/beecrypt
-
   # LLVM/Clang.
   brew_tool osquery/osquery-local/llvm
 
@@ -124,17 +119,19 @@ function platform_darwin_main() {
 
   brew_dependency osquery/osquery-local/libxml2
   brew_dependency osquery/osquery-local/openssl
+
   brew_tool osquery/osquery-local/python
   brew_tool osquery/osquery-local/bison
-
-  brew_tool osquery/osquery-local/berkeley-db
-  brew_tool osquery/osquery-local/popt
-  brew_tool osquery/osquery-local/beecrypt
 
   platform_posix_main
 }
 
  function platform_posix_main() {
+  # Library secondary dependencies.
+  brew_dependency osquery/osquery-local/popt
+  brew_dependency osquery/osquery-local/beecrypt
+  brew_dependency osquery/osquery-local/berkeley-db
+
   # libarchive for file carving
   brew_dependency osquery/osquery-local/libarchive
   brew_dependency osquery/osquery-local/rapidjson

--- a/tools/provision/formula/beecrypt.rb
+++ b/tools/provision/formula/beecrypt.rb
@@ -31,6 +31,7 @@ class Beecrypt < AbstractOsqueryFormula
     ]
 
     system "./autogen.sh"
+    system "autoreconf", "--force", "--install" if OS.mac?
     system "./configure", "--prefix=#{prefix}", *args
     system "make"
     system "make", "check"

--- a/tools/provision/formula/beecrypt.rb
+++ b/tools/provision/formula/beecrypt.rb
@@ -5,12 +5,13 @@ class Beecrypt < AbstractOsqueryFormula
   homepage "http://beecrypt.sourceforge.net"
   url "https://downloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
   sha256 "286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
-  revision 101
+  revision 102
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "20f9a37cd35bc4adf05f0e68bd5c430b3c010903cdc05f50bfc89d9216e9a797" => :x86_64_linux
+    sha256 "5be90841e0d956f54dfbb4c877432087089721cb4b8092b0a4f61fa65720fa5c" => :sierra
+    sha256 "5588e3cec4a7efcd88013f03f87a047f66b1876e78a583ed3b5e0c2e7955e127" => :x86_64_linux
   end
 
   depends_on "libtool" => :build

--- a/tools/provision/formula/berkeley-db.rb
+++ b/tools/provision/formula/berkeley-db.rb
@@ -5,12 +5,13 @@ class BerkeleyDb < AbstractOsqueryFormula
   homepage "https://www.oracle.com/technology/products/berkeley-db/index.html"
   url "http://download.oracle.com/berkeley-db/db-6.1.26.tar.gz"
   sha256 "dd1417af5443f326ee3998e40986c3c60e2a7cfb5bfa25177ef7cadb2afb13a6"
-  revision 101
+  revision 102
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "918bc7f64a50a3f8a397739e0476f801ef1fa8d734e9a1045975f1c75099c2b9" => :x86_64_linux
+    sha256 "564398bbad9afe8c0f60c2c5ae2c592eab4a390fc096bac135f6b1d70c53319d" => :sierra
+    sha256 "0c4225add337be64c394d2f777329f25a1f4eb6bb59546eaddaee25cbf8f8f75" => :x86_64_linux
   end
 
   option "with-java", "Compile with Java support."

--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -3,10 +3,9 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Librpm < AbstractOsqueryFormula
   desc "The RPM Package Manager (RPM) development libraries"
   homepage "http://rpm.org/"
-  url "https://github.com/rpm-software-management/rpm/releases/download/rpm-4.13.0-release/rpm-4.13.0.tar.bz2"
-  sha256 "221166b61584721a8ca979d7d8576078a5dadaf09a44208f69cc1b353240ba1b"
-  version "4.13.0"
-  revision 102
+  url "http://ftp.rpm.org/releases/rpm-4.14.x/rpm-4.14.0.tar.bz2"
+  sha256 "06a0ad54600d3c42e42e02701697a8857dc4b639f6476edefffa714d9f496314"
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -20,6 +19,8 @@ class Librpm < AbstractOsqueryFormula
 
   def install
     ENV.append "CFLAGS", "-I#{HOMEBREW_PREFIX}/include/beecrypt"
+    ENV.append "LDFLAGS", "-lz -liconv" if OS.mac?
+
 
     args = [
       "--disable-dependency-tracking",
@@ -35,8 +36,11 @@ class Librpm < AbstractOsqueryFormula
       "--disable-shared",
       "--disable-python",
       "--enable-static",
-      "--with-beecrypt",
+      "--with-crypto=beecrypt",
     ]
+
+    inreplace "Makefile.in", "rpm2cpio.$(OBJEXT)", "rpm2cpio.$(OBJEXT) lib/poptALL.$(OBJEXT) lib/poptQV.$(OBJEXT)" if OS.mac?
+    inreplace "Makefile.in", "rpmspec-rpmspec.$(OBJEXT)", "rpmspec-rpmspec.$(OBJEXT) lib/poptQV.$(OBJEXT)" if OS.mac?
 
     system "./configure", "--prefix=#{prefix}", *args
     system "make"

--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -10,7 +10,8 @@ class Librpm < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "02be69d20e5b713d320118f78262eba1ef458f47e587f7c9e8111827eb7bec40" => :x86_64_linux
+    sha256 "cdec41658bf34f547819025b88910e2f94ed6929067755cf3cc08f7499391ee8" => :sierra
+    sha256 "521cd60e71aa3364af8ca9a997e61432dcca85901ec0bed46f495d34088b8678" => :x86_64_linux
   end
 
   depends_on "berkeley-db"
@@ -20,7 +21,6 @@ class Librpm < AbstractOsqueryFormula
   def install
     ENV.append "CFLAGS", "-I#{HOMEBREW_PREFIX}/include/beecrypt"
     ENV.append "LDFLAGS", "-lz -liconv" if OS.mac?
-
 
     args = [
       "--disable-dependency-tracking",

--- a/tools/provision/formula/librpm.rb
+++ b/tools/provision/formula/librpm.rb
@@ -36,6 +36,7 @@ class Librpm < AbstractOsqueryFormula
       "--disable-shared",
       "--disable-python",
       "--enable-static",
+      "--enable-zstd=no",
       "--with-crypto=beecrypt",
     ]
 

--- a/tools/provision/formula/popt.rb
+++ b/tools/provision/formula/popt.rb
@@ -5,12 +5,13 @@ class Popt < AbstractOsqueryFormula
   homepage "http://rpm5.org"
   url "http://rpm5.org/files/popt/popt-1.16.tar.gz"
   sha256 "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
-  revision 101
+  revision 102
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b81b6365bcb253eb561bc43229eab24f849364fe56168eb3e0ced60cf4db183d" => :x86_64_linux
+    sha256 "dd025386db52982536899c939b02f716274972407883b6fc733374879c7da379" => :sierra
+    sha256 "7fbf8db578b714069e2301ea6eb122cedd79a23bc151f555fb4c1ee1bcd6b7d9" => :x86_64_linux
   end
 
   option :universal


### PR DESCRIPTION
This installs `librpm` on macOS hosts. The dependencies for `librpm`: `popt`, `berkeley-db`, and the externally-managed `beecrypt` are also installed.

We will need `rpm_packages` on macOS eventually.