### PR TITLE
tables: adding windows physical disk perfmon table

### DIFF
--- a/osquery/tables/system/windows/physical_disk_performance.cpp
+++ b/osquery/tables/system/windows/physical_disk_performance.cpp
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) 2014-present, Facebook, Inc.
+*  All rights reserved.
+*
+*  This source code is licensed under the BSD-style license found in the
+*  LICENSE file in the root directory of this source tree. An additional grant
+*  of patent rights can be found in the PATENTS file in the same directory.
+*
+*/
+
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genPhysicalDiskPerformance(QueryContext& context) {
+  QueryData results;
+
+  auto query = "SELECT * FROM Win32_PerfFormattedData_PerfDisk_PhysicalDisk";
+  WmiRequest perfReq(query);
+  if (!perfReq.getStatus().ok()) {
+    return results;
+  }
+  auto& perfRes = perfReq.results();
+  for (const auto& disk : perfRes) {
+    Row r;
+    std::string sPlaceHolder;
+    unsigned long long ullPlaceHolder = 0;
+
+    disk.GetString("Name", r["name"]);
+
+    disk.GetString("AvgDiskBytesPerRead", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_bytes_per_read"] = BIGINT(ullPlaceHolder);
+    disk.GetString("AvgDiskBytesPerWrite", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_bytes_per_write"] = BIGINT(ullPlaceHolder);
+
+    disk.GetString("AvgDiskReadQueueLength", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_read_queue_length"] = BIGINT(ullPlaceHolder);
+    disk.GetString("AvgDiskWriteQueueLength", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_write_queue_length"] = BIGINT(ullPlaceHolder);
+
+    disk.GetString("AvgDiskSecPerRead", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_sec_per_read"] = INTEGER(ullPlaceHolder);
+    disk.GetString("AvgDiskSecPerWrite", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["avg_disk_sec_per_write"] = INTEGER(ullPlaceHolder);
+
+    disk.GetString("PercentDiskReadTime", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["percent_disk_read_time"] = INTEGER(ullPlaceHolder);
+    disk.GetString("PercentDiskWriteTime", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["percent_disk_write_time"] = INTEGER(ullPlaceHolder);
+
+    disk.GetString("CurrentDiskQueueLength", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["current_disk_queue_length"] = INTEGER(ullPlaceHolder);
+
+    disk.GetString("PercentDiskTime", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["percent_disk_time"] = INTEGER(ullPlaceHolder);
+
+    disk.GetString("PercentIdleTime", sPlaceHolder);
+    safeStrtoull(sPlaceHolder, 10, ullPlaceHolder);
+    r["percent_idle_time"] = INTEGER(ullPlaceHolder);
+
+    results.push_back(r);
+  }
+  return results;
+}
+}
+}

--- a/specs/windows/physical_disk_performance.table
+++ b/specs/windows/physical_disk_performance.table
@@ -1,0 +1,17 @@
+table_name("physical_disk_performance")
+description("Provides provides raw data from performance counters that monitor hard or fixed disk drives on the system.")
+schema([
+    Column("name", TEXT, "Name of the physical disk"),
+    Column("avg_disk_bytes_per_read", BIGINT, "Average number of bytes transferred from the disk during read operations"),
+    Column("avg_disk_bytes_per_write", BIGINT, "Average number of bytes transferred to the disk during write operations"),
+    Column("avg_disk_read_queue_length", BIGINT, "Average number of read requests that were queued for the selected disk during the sample interval"),
+    Column("avg_disk_write_queue_length", BIGINT, "Average number of write requests that were queued for the selected disk during the sample interval"),
+    Column("avg_disk_sec_per_read", INTEGER, "Average time, in seconds, of a read operation of data from the disk"),
+    Column("avg_disk_sec_per_write", INTEGER, "Average time, in seconds, of a write operation of data to the disk"),
+    Column("current_disk_queue_length", INTEGER, "Number of requests outstanding on the disk at the time the performance data is collected"),
+    Column("percent_disk_read_time", BIGINT, "Percentage of elapsed time that the selected disk drive is busy servicing read requests"),
+    Column("percent_disk_write_time", BIGINT, "Percentage of elapsed time that the selected disk drive is busy servicing write requests"),
+    Column("percent_disk_time", BIGINT, "Percentage of elapsed time that the selected disk drive is busy servicing read or write requests"),
+    Column("percent_idle_time", BIGINT, "Percentage of time during the sample interval that the disk was idle")
+])
+implementation("system/windows/physical_disk_performance@genPhysicalDiskPerformance")


### PR DESCRIPTION
To test this out, I spun up another instance of osquery and hashed the entire fs, then queryed:
```
osquery> select * from physical_disk_perf;
                       name = _Total
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 13703
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 1
          percent_disk_time = 1
          percent_idle_time = 98

                       name = 0 C:
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 13703
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 6
          percent_disk_time = 6
          percent_idle_time = 91

                       name = 1 D:
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 0
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 0
          percent_disk_time = 0
          percent_idle_time = 100

                       name = 2 F:
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 0
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 0
          percent_disk_time = 0
          percent_idle_time = 100

                       name = 3 G:
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 0
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 0
          percent_disk_time = 0
          percent_idle_time = 100

                       name = 4 H:
    avg_disk_bytes_per_read = 0
   avg_disk_bytes_per_write = 0
 avg_disk_read_queue_length = 0
avg_disk_write_queue_length = 0
      avg_disk_sec_per_read = 0
     avg_disk_sec_per_write = 0
  current_disk_queue_length = 0
     percent_disk_read_time = 0
    percent_disk_write_time = 0
          percent_disk_time = 0
          percent_idle_time = 100
```