### PR TITLE
build: installing Windows 10 SDK during provisioning

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -443,6 +443,7 @@ function Main {
   $out = Install-ChocoPackage '7zip.commandline'
   $out = Install-ChocoPackage 'vswhere'
   $out = Install-ChocoPackage 'cmake.portable'
+  $out = Install-ChocoPackage 'windows-sdk-10.0'
 
   # Only install python if it's not needed
   $pythonInstall = Test-PythonInstalled


### PR DESCRIPTION
This adds in the Windows 10 SDK to our provisioning, thus allowing more advanced virtual tables to be built using additional Windows libraries. There are a few packages hosted by Chocolatey already, and some [cursory glances at other Microsoft open source projects](https://github.com/PowerShell/PowerShell/blob/2cc091115b2279a2d5efa2e8ff67fea8185a0e17/build.psm1#L1500) shows that this SDK is likely maintained by MS.