### PR TITLE
release: Make build_release idempotent

### DIFF
--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -49,33 +49,42 @@ function main() {
   "
 
   cd $OSQUERY
+  echo "[!] Please make sure you run:"
+  echo "      vagrant destroy $LINUX_BOX"
+  echo "      vagrant destroy $DARWIN_BOX"
+  echo ""
   echo "[+] Checking out version $VERSION"
 
   PKG_DIR="build/$VERSION"
   mkdir -p $PKG_DIR
 
-  echo "[+] Vagrant up $LINUX_BOX"
-  OSQUERY_BUILD_CPUS=4 vagrant up $LINUX_BOX
-  echo "[+] Building linux packages..."
-  vagrant ssh $LINUX_BOX -c "$BUILD_CMD"
-  echo "[+] Running package build command for linux..."
-  vagrant ssh $LINUX_BOX -c "$PACKAGES_CMD"
-  echo "[+] Copying linux packages to $PKG_DIR"
-  vagrant scp "$LINUX_BOX:/build/build/linux/osquery*$VERSION*" ./$PKG_DIR
-  vagrant halt $LINUX_BOX
+  if [[ ! -f "$PKG_DIR/osquery-${VERSION}_1.linux_x86_64.tar.gz" ]]; then
+    echo "[+] Vagrant up $LINUX_BOX"
+    OSQUERY_BUILD_CPUS=4 vagrant up $LINUX_BOX
+    echo "[+] Building linux packages..."
+    vagrant ssh $LINUX_BOX -c "$BUILD_CMD"
+    echo "[+] Running package build command for linux..."
+    vagrant ssh $LINUX_BOX -c "$PACKAGES_CMD"
+    echo "[+] Copying linux packages to $PKG_DIR"
+    vagrant scp "$LINUX_BOX:/build/build/linux/osquery*$VERSION*" ./$PKG_DIR
+    vagrant halt $LINUX_BOX
+  fi
 
-  echo "[+] Vagrant up $DARWIN_BOX"
-  OSQUERY_BUILD_CPUS=4 vagrant up $DARWIN_BOX
-  echo "[+] Running initial softwareupdate check..."
-  vagrant ssh $DARWIN_BOX -c "$DARWIN_SETUP"
-  echo "[+] Running build command for macOS..."
-  vagrant ssh $DARWIN_BOX -c "$BUILD_CMD"
-  vagrant ssh $DARWIN_BOX -c "/usr/local/osquery/bin/brew install rpm"
-  echo "[+] Running package build command for macOS..."
-  vagrant ssh $DARWIN_BOX -c "$PACKAGES_CMD"
-  echo "[+] Copying macOS packages to $PKG_DIR"
-  vagrant scp "$DARWIN_BOX:/build/build/darwin/osquery*$VERSION*" ./$PKG_DIR
-  vagrant halt $DARWIN_BOX
+  if [[ ! -f "$PKG_DIR/osquery-${VERSION}-1.darwin.i386.rpm" ]]; then
+    echo "[+] Vagrant up $DARWIN_BOX"
+    OSQUERY_BUILD_CPUS=4 vagrant up $DARWIN_BOX
+    echo "[+] Running initial softwareupdate check..."
+    vagrant ssh $DARWIN_BOX -c "$DARWIN_SETUP"
+    echo "[+] Running build command for macOS..."
+    vagrant ssh $DARWIN_BOX -c "$BUILD_CMD"
+    vagrant ssh $DARWIN_BOX -c "/usr/local/osquery/bin/brew update || true"
+    vagrant ssh $DARWIN_BOX -c "/usr/local/osquery/bin/brew install rpm"
+    echo "[+] Running package build command for macOS..."
+    vagrant ssh $DARWIN_BOX -c "$PACKAGES_CMD"
+    echo "[+] Copying macOS packages to $PKG_DIR"
+    vagrant scp "$DARWIN_BOX:/build/build/darwin/osquery*$VERSION*" ./$PKG_DIR
+    vagrant halt $DARWIN_BOX
+  fi
 
   echo "[+] Packages copied to $OSQUERY ./$PKG_DIR"
   echo "[+] Finished"


### PR DESCRIPTION
I found it's hard to re-run the `./tools/release/build_release.sh` script if something breaks (like updating `brew`). So this adds two checks around the Linux and Darwin build to skip them if packages already exist from their outputs.