### PR TITLE
deps: Use persistent LVM source url

### DIFF
--- a/tools/provision/formula/libdevmapper.rb
+++ b/tools/provision/formula/libdevmapper.rb
@@ -3,7 +3,7 @@ require File.expand_path("../Abstract/abstract-osquery-formula", __FILE__)
 class Libdevmapper < AbstractOsqueryFormula
   desc "Device Mapper development"
   homepage "https://www.sourceware.org/dm/"
-  url "ftp://sources.redhat.com/pub/lvm2/LVM2.2.02.173.tgz"
+  url "https://www.mirrorservice.org/sites/sourceware.org/pub/lvm2/old/LVM2.2.02.173.tgz"
   sha256 "ceb9168c7e009ef487f96a1fe969b23cbb07d920ffb71769affdbdf30fea8d64"
   revision 2
 


### PR DESCRIPTION
The "from source" Jenkins job has been failing because the LVM source package was removed from `sources.redhat.com`. It seems that `mirrorservice.com` keeps all the versions in the `./old` directory.