### PR TITLE
vagrant: Use quarterly packages on FreeBSD

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -209,7 +209,9 @@ Vagrant.configure("2") do |config|
           ]
         build.vm.provision 'shell',
           inline:
-            "sudo sed -i '' -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf;"\
+            # Switching to latest may cause failures if dependencies are not built.
+            # "sudo sed -i '' -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf;"\
+            "su -m root -c 'hostname vagrant';"\
             "su -m root -c 'pkg update -f';"\
             "sudo pkg install -y openjdk8 bash git gmake python ruby;"\
             "sudo mount -t fdescfs fdesc /dev/fd;"\


### PR DESCRIPTION
We had been using the "latest" repository of packages for FreeBSD so we could access newly-introduced packages like `rocksdb-lite`. These are now provided in the stable quarterly. The issue with "latest" is that a package build may fail, then the package is no longer available. This was the case with `aws-sdk-cpp`. 

We also set the hostname to `vagrant` because recent versions of `sudo` on FreeBSD we're sefaulting with an empty hostname.