### PR TITLE
release: Add sign_release script

### DIFF
--- a/tools/release/sign_release.sh
+++ b/tools/release/sign_release.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+#  Copyright (c) 2015, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function usage() {
+  echo "${BASH_SOURCE[0]} VERSION PATH_TO_OSQUERY SIGN_HOST SIGN_USER SIGN_IDENT"
+  echo "  SIGN_HOST/SIGN_USER: hostname and user for signing machine"
+  echo "  SIGN_IDENT: SSH identity for signing machine"
+}
+
+function main() {
+  if [[ $# < 5 ]]; then
+    usage
+    exit 1
+  fi
+
+  VERSION=$1
+  OSQUERY=$2
+  HOST=$3
+  USER=$4
+  IDENT=$5
+
+  PKGS=$OSQUERY/build/$VERSION
+  if [[ ! -d "$PKGS" ]]; then
+    echo "Cannot find $PKGS directory?"
+    usage
+    exit 1
+  fi
+
+  echo "[+] Copying packages from $PKGS to signing host $HOST"
+  scp -i $IDENT -r $PKGS "$USER@$HOST":
+  SSH="ssh -t -i $IDENT $USER@$HOST"
+
+  $SSH "mv ./$VERSION/osquery-$VERSION-1.arch-x86_64.pkg.tar.xz ./local_packages/arch"
+  $SSH "mv ./$VERSION/osquery-$VERSION.pkg ./local_packages/darwin"
+  $SSH "mv ./$VERSION/osquery-debug-$VERSION.pkg ./local_packages/darwin"
+  $SSH "mv ./$VERSION/osquery-$VERSION-1.darwin.i386.rpm ./local_packages/darwin"
+  $SSH "mv ./$VERSION/osquery-debug-$VERSION-1.darwin.i386.rpm ./local_packages/darwin"
+  $SSH "mv ./$VERSION/osquery-${VERSION}_1.linux_x86_64.tar.gz ./local_packages/linux"
+  $SSH "cp ./$VERSION/osquery-$VERSION-1.linux.x86_64.rpm ./local_packages/rpm"
+  $SSH "cp ./$VERSION/osquery-debuginfo-$VERSION-1.linux.x86_64.rpm ./local_packages/rpm"
+  $SSH "cp ./$VERSION/osquery-$VERSION-1.linux.x86_64.rpm ./local_packages/centos6"
+  $SSH "cp ./$VERSION/osquery-debuginfo-$VERSION-1.linux.x86_64.rpm ./local_packages/centos6"
+  $SSH "cp ./$VERSION/osquery-$VERSION-1.linux.x86_64.rpm ./local_packages/centos7"
+  $SSH "cp ./$VERSION/osquery-debuginfo-$VERSION-1.linux.x86_64.rpm ./local_packages/centos7"
+  $SSH "cp ./$VERSION/osquery_${VERSION}_1.linux.amd64.deb ./local_packages/precise"
+  $SSH "cp ./$VERSION/osquery-dbg_${VERSION}_1.linux.amd64.deb ./local_packages/precise"
+  $SSH "cp ./$VERSION/osquery_${VERSION}_1.linux.amd64.deb ./local_packages/trusty"
+  $SSH "cp ./$VERSION/osquery-dbg_${VERSION}_1.linux.amd64.deb ./local_packages/trusty"
+  $SSH "cp ./$VERSION/osquery_${VERSION}_1.linux.amd64.deb ./local_packages/xenial"
+  $SSH "cp ./$VERSION/osquery-dbg_${VERSION}_1.linux.amd64.deb ./local_packages/xenial"
+  $SSH "cp ./$VERSION/osquery_${VERSION}_1.linux.amd64.deb ./local_packages/deb"
+  $SSH "cp ./$VERSION/osquery-dbg_${VERSION}_1.linux.amd64.deb ./local_packages/deb"
+
+  echo "[!] Now run: ./package_publisher please"
+  $SSH "bash --login"
+
+  echo "[+] Packages signed"
+}
+
+main $@


### PR DESCRIPTION
This `sign_script` is used with a `package_publisher` script to produce the structure and results here: https://github.com/osquery/osquery-packages the use of a signing-host is still a black-box that I'm working to make repeatable and auditable. The host is not 'online' and the contents and keys are encrypted.

Eventually the `package_publisher` script will be kept side-by-side as well as a script on how to create protected keying material and a script to bootstrap a signing host.