### PR TITLE
Exiting with a message if DEPS_DIR exists

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -248,7 +248,7 @@ function main() {
     do_sudo chown $USER "$DEPS_DIR" > /dev/null 2>&1 || true
   else
     # If the dependency directory (DEPS_DIR) already exists, there will be problems
-    fatal "build dir $DEPS_DIR already exists"
+    fatal "dependencies directory '$DEPS_DIR' already exists"
   fi
 
   # Save the directory we're executing from and change to the deps directory.

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -246,6 +246,9 @@ function main() {
     log "creating build dir: $DEPS_DIR"
     do_sudo mkdir -p "$DEPS_DIR"
     do_sudo chown $USER "$DEPS_DIR" > /dev/null 2>&1 || true
+  else
+    # If the dependency directory (DEPS_DIR) already exists, there will be problems
+    fatal "build dir $DEPS_DIR already exists"
   fi
 
   # Save the directory we're executing from and change to the deps directory.


### PR DESCRIPTION
DEPS_DIR is by default `/usr/local/osquery` and if that location exists before `make deps`, the provisioning will fail. Adding this message will at least provide some information why the provisioning has failed. Resolves #3860 