### PR TITLE
deps: If DEPS_DIR exists and is a git checkout assume Homebrew

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -249,7 +249,7 @@ function main() {
     do_sudo chown $USER "$DEPS_DIR" > /dev/null 2>&1 || true
   elif [[ ! -d "$DEPS_DIR/.git" ]]; then
     # If the dependency directory (DEPS_DIR) already exists, there will be problems
-    fatal "dependencies directory '$DEPS_DIR' already exists"
+    log "[notice] dependencies directory '$DEPS_DIR' already exists"
   fi
 
   # Save the directory we're executing from and change to the deps directory.

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -247,7 +247,7 @@ function main() {
     log "creating build dir: $DEPS_DIR"
     do_sudo mkdir -p "$DEPS_DIR"
     do_sudo chown $USER "$DEPS_DIR" > /dev/null 2>&1 || true
-  else
+  elif [[ ! -d "$DEPS_DIR/.git" ]]; then
     # If the dependency directory (DEPS_DIR) already exists, there will be problems
     fatal "dependencies directory '$DEPS_DIR' already exists"
   fi


### PR DESCRIPTION
Resolves regressions from #3877.

We normally expect the `DEPS_DIR` to exist after repeated runs of `make deps`.