### PR TITLE
remote: Various refactors for the http_client

### DIFF
--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -263,12 +263,13 @@ class Client {
   boost_asio::deadline_timer timer_;
   std::shared_ptr<ssl_stream> ssl_sock_;
   boost_system::error_code ec_;
-  bool ssl_connection = false;
-  static const long SHORT_READ_ERROR = 0x140000dbL;
-  /// Setting the default port to squid proxy default port
-  static const int PROXY_DEFAUT_PORT = 3128;
-  static const int HTTP_DEFAULT_PORT = 80;
-  static const int HTTPS_DEFAULT_PORT = 443;
+
+  /**
+   * @brief This general-purpose HTTP Client allows HTTP.
+   *
+   * This does not allow HTTP for the TLS logger plugins.
+   */
+  bool ssl_connection{false};
 };
 
 /**
@@ -304,17 +305,31 @@ class HTTP_Request : public T {
 
   /// Returns the host part of a uri.
   boost::optional<std::string> remoteHost() {
-    return uri_.host().size() ? uri_.host() : boost::optional<std::string>();
+    return (!uri_.host().empty()) ? uri_.host()
+                                  : boost::optional<std::string>();
   }
 
   /// Returns the port part of a uri.
   boost::optional<std::string> remotePort() {
-    return uri_.port().size() ? uri_.port() : boost::optional<std::string>();
+    return (!uri_.port().empty()) ? uri_.port()
+                                  : boost::optional<std::string>();
   }
 
   /// Returns the path part of a uri.
   boost::optional<std::string> remotePath() {
-    return uri_.path().size() ? uri_.path() : boost::optional<std::string>();
+    std::string path;
+    if (!uri_.path().empty()) {
+      path += uri_.path();
+    }
+
+    if (!uri_.query().empty()) {
+      path += '?' + uri_.query();
+    }
+
+    if (!uri_.fragment().empty()) {
+      path += '#' + uri_.fragment();
+    }
+    return (!path.empty()) ? path : boost::optional<std::string>();
   }
 
   /// Returns the protocol part of a uri. E.g. 'http' or 'https'

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -59,7 +59,6 @@
 #define OPENSSL_NO_MD5 1
 #define OPENSSL_NO_DEPRECATED 1
 
-/// Newer versions of LibreSSL will lack SSL methods.
 extern "C" {
 #if defined(NO_SSL_TXT_SSLV3)
 SSL_METHOD* SSLv3_server_method(void);
@@ -92,7 +91,7 @@ typedef HTTP_Request<beast_http_request> Request;
 typedef HTTP_Response<beast_http_response> Response;
 
 /**
- * @brief a simple http client class based upon boost.beast.
+ * @brief a simple HTTP client class based upon boost.beast.
  *
  * Implements put, post, get, head and delete methods.
  * These methods take request as reference and  return response by value.
@@ -200,33 +199,33 @@ class Client {
   Client(Options const& opts = Options())
       : client_options_(opts), r_(ios_), sock_(ios_), timer_(ios_) {}
 
-  /// HTTP put request method
+  /// HTTP put request method.
   Response put(Request& req,
                std::string const& body,
                std::string const& content_type = std::string());
 
-  /// HTTP put request method with rvalue reference to body param
+  /// HTTP put request method with rvalue reference to body param.
   Response put(Request& req,
                std::string&& body,
                std::string const& content_type = std::string());
 
-  /// HTTP post request method
+  /// HTTP post request method.
   Response post(Request& req,
                 std::string const& body,
                 std::string const& content_type = std::string());
 
-  /// HTTP post request method with rvalue reference to body param
+  /// HTTP post request method with rvalue reference to body param.
   Response post(Request& req,
                 std::string&& body,
                 std::string const& content_type = std::string());
 
-  /// HTTP get request method
+  /// HTTP get request method.
   Response get(Request& req);
 
-  /// HTTP head request method
+  /// HTTP head request method.
   Response head(Request& req);
 
-  /// HTTP delete_ request method
+  /// HTTP delete_ request method.
   Response delete_(Request& req);
 
   ~Client() {
@@ -234,10 +233,10 @@ class Client {
   }
 
  private:
-  /// Create Connection to server, if proxy option is set, connect to proxy
+  /// Create Connection to server, if proxy option is set, connect to proxy.
   void createConnection();
 
-  /// Convert plain socket to ssl socket
+  /// Convert plain socket to TLS socket.
   void encryptConnection();
 
   template <typename STREAM_TYPE>
@@ -247,10 +246,16 @@ class Client {
 
   Response sendHTTPRequest(Request& req);
 
-  /// Handles HTTP request timeout
+  /// Handles HTTP request timeout.
   void timeoutHandler(boost_system::error_code const& ec);
 
-  /// Handles respone code, if requests completes or aborted due to timeout
+  /**
+   * @brief Handles response if requests completes or aborted due to timeout.
+   *
+   * In the postResponseHandler, treating SHORT_READ_ERROR as success for TLS
+   * connections. This can happen if a remote server did not call shutdown on
+   * the TLS connection.
+   */
   void postResponseHandler(boost_system::error_code const& ec);
 
   void closeSocket();
@@ -265,29 +270,30 @@ class Client {
   boost_system::error_code ec_;
 
   /**
-   * @brief This general-purpose HTTP Client allows HTTP.
+   * @brief This general-purpose HTTP Client allows HTTP and HTTPS.
    *
    * This does not allow HTTP for the TLS logger plugins.
+   * It uses a state variable `ssl_connection` to determine if the connection
+   * should be wrapped in a TLS socket.
    */
   bool ssl_connection{false};
 };
 
 /**
- * @brief HTTP request class
+ * @brief HTTP request class.
  *
- * This class is inherited from implemention(boost.beast) request class.
- * It extends the functionality via providing uri parsing.
+ * This class is inherited from implementation(boost.beast) request class.
+ * It extends the functionality via providing URI parsing.
  *
  */
 template <typename T>
 class HTTP_Request : public T {
  public:
   /**
-   * @brief HTTP request header helper class
+   * @brief HTTP request header helper class.
    *
-   * constructor of this class takes (name, value)
-   * pair, which is used to set the request header
-   * of a http request with the help of overloaded
+   * Constructor of this class takes (name, value) pair, which is used to set
+   * the request header of a HTTP request with the help of overloaded
    * function 'operator<<' of HTTP_Request class.
    */
   struct Header {
@@ -303,19 +309,19 @@ class HTTP_Request : public T {
  public:
   HTTP_Request(const std::string& url = std::string()) : uri_(url) {}
 
-  /// Returns the host part of a uri.
+  /// Returns the host part of a URI.
   boost::optional<std::string> remoteHost() {
     return (!uri_.host().empty()) ? uri_.host()
                                   : boost::optional<std::string>();
   }
 
-  /// Returns the port part of a uri.
+  /// Returns the port part of a URI.
   boost::optional<std::string> remotePort() {
     return (!uri_.port().empty()) ? uri_.port()
                                   : boost::optional<std::string>();
   }
 
-  /// Returns the path part of a uri.
+  /// Returns the path, query, and fragment parts of a URI.
   boost::optional<std::string> remotePath() {
     std::string path;
     if (!uri_.path().empty()) {
@@ -332,19 +338,19 @@ class HTTP_Request : public T {
     return (!path.empty()) ? path : boost::optional<std::string>();
   }
 
-  /// Returns the protocol part of a uri. E.g. 'http' or 'https'
+  /// Returns the protocol part of a URI. E.g. 'http' or 'https'
   boost::optional<std::string> protocol() {
     return uri_.scheme().size() ? uri_.scheme()
                                 : boost::optional<std::string>();
   }
 
-  /// overloaded operator to set header of an http request
+  /// overloaded operator to set header of a HTTP request
   HTTP_Request& operator<<(const Header& h) {
     this->T::set(h.name_, h.value_);
     return *this;
   }
 
-  /// uri can also be set via this method, useful for redirected request.
+  /// URI can also be set via this method, useful for redirected request.
   void uri(const std::string& url) {
     uri_ = url;
   }
@@ -354,11 +360,11 @@ class HTTP_Request : public T {
 };
 
 /**
- * @brief HTTP response class
+ * @brief HTTP response class.
  *
- * This class is inherited from implementation(boost.beast) http response class.
- * This class gives convenient access to some functionality of implemention
- * specific http response class.
+ * This class is inherited from implementation(boost.beast) HTTP response class.
+ * This class gives convenient access to some functionality of implementation
+ * specific HTTP response class.
  *
  */
 template <typename T>
@@ -372,18 +378,21 @@ class HTTP_Response : public T {
   class Iterator;
   class Headers;
 
-  /// status of an http response
+  /// status of a HTTP response.
   unsigned status() {
     return this->T::result_int();
   }
 
-  /// body of an http response
+  /// body of a HTTP response.
   const std::string& body() {
     return this->T::body;
   }
 
-  /// All headers of an http response.
-  /// Headers can be accesed via HTTP_Response<T>::Iterator class
+  /**
+   * @brief All headers of a HTTP response.
+   *
+   * Headers can be accessed via HTTP_Response<T>::Iterator class.
+   */
   Headers headers() {
     return Headers(this);
   }
@@ -429,10 +438,9 @@ class HTTP_Response<T>::Iterator {
 };
 
 /**
- * @brief HTTP response headers helper class
+ * @brief HTTP response headers helper class.
  *
- * This class gives convenient access to all the
- * headers of http response.
+ * This class gives convenient access to all the headers of the HTTP response.
  *
  * e.g. -
  * for (const auto& header : resp.headers()) {

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -33,8 +33,8 @@ CLI_FLAG(string,
          "",
          "TLS/HTTPS hostname for Config, Logger, and Enroll plugins");
 
-/// proxy server hostname.
-CLI_FLAG(string, proxy_hostname, "", "proxy hostname");
+/// Optional HTTP proxy server hostname.
+CLI_FLAG(string, proxy_hostname, "", "Optional HTTP proxy hostname");
 
 /// Path to optional TLS server/CA certificate(s), used for pinning.
 CLI_FLAG(string,
@@ -80,10 +80,8 @@ TLSTransport::TLSTransport() : verify_peer_(true) {
 }
 
 void TLSTransport::decorateRequest(http::Request& r) {
-  r << http::Request::Header("Connection", "close");
   r << http::Request::Header("Content-Type", serializer_->getContentType());
   r << http::Request::Header("Accept", serializer_->getContentType());
-  r << http::Request::Header("Host", FLAGS_tls_hostname);
   r << http::Request::Header("User-Agent", kTLSUserAgentBase + kVersion);
 }
 

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include <osquery/flags.h>
-#include <osquery/http_client.h>
 
+#include "osquery/remote/http_client.h"
 #include "osquery/remote/requests.h"
 
 namespace osquery {

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -229,6 +229,14 @@ class TLSRequestHelper : private boost::noncopyable {
                    std::string& output,
                    const size_t attempts) {
     Status s;
+
+    boost::property_tree::ptree override_params;
+    for (const auto& param : params) {
+      if (param.first.find('_') == 0) {
+        override_params.put(param.first, param.second.data());
+      }
+    }
+
     for (size_t i = 1; i <= attempts; i++) {
       s = TLSRequestHelper::go<TSerializer>(uri, params, output);
       if (s.ok()) {
@@ -236,6 +244,9 @@ class TLSRequestHelper : private boost::noncopyable {
       }
       if (i == attempts) {
         break;
+      }
+      for (const auto& param : override_params) {
+        params.put(param.first, param.second.data());
       }
       sleepFor(i * i * 1000);
     }

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -10,13 +10,12 @@
 #include <sstream>
 
 #include <osquery/config.h>
-#include <osquery/http_client.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include <osquery/core/conversions.h>
-
 #include "osquery/config/parsers/prometheus_targets.h"
+#include "osquery/core/conversions.h"
+#include "osquery/remote/http_client.h"
 #include "osquery/tables/applications/posix/prometheus_metrics.h"
 
 namespace osquery {

--- a/osquery/tables/cloud/ec2_instance_metadata.cpp
+++ b/osquery/tables/cloud/ec2_instance_metadata.cpp
@@ -15,10 +15,10 @@
 #include <boost/property_tree/json_parser.hpp>
 
 #include <osquery/core.h>
-#include <osquery/http_client.h>
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
+#include "osquery/remote/http_client.h"
 #include "osquery/utils/aws_util.h"
 
 namespace pt = boost::property_tree;

--- a/osquery/tables/networking/posix/curl.cpp
+++ b/osquery/tables/networking/posix/curl.cpp
@@ -12,12 +12,11 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 
-#include <osquery/http_client.h>
 #include <osquery/logger.h>
 #include <osquery/status.h>
 #include <osquery/tables.h>
 
-using namespace std::chrono;
+#include "osquery/remote/http_client.h"
 
 namespace osquery {
 namespace tables {
@@ -34,13 +33,16 @@ Status processRequest(Row& r) {
     request_ << osquery::http::Request::Header("User-Agent", r["user_agent"]);
 
     // Measure the rtt using the system clock
-    time_point<system_clock> start = std::chrono::system_clock::now();
+    std::chrono::time_point<std::chrono::system_clock> start =
+        std::chrono::system_clock::now();
     response_ = client_.get(request_);
-    time_point<system_clock> end = std::chrono::system_clock::now();
+    std::chrono::time_point<std::chrono::system_clock> end =
+        std::chrono::system_clock::now();
 
     r["response_code"] = INTEGER(static_cast<int>(response_.status()));
-    r["round_trip_time"] =
-        BIGINT(duration_cast<microseconds>(end - start).count());
+    r["round_trip_time"] = BIGINT(
+        std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+            .count());
     r["result"] = response_.body();
     r["bytes"] = BIGINT(r["result"].size());
   } catch (const std::exception& e) {

--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -27,16 +27,15 @@
 #include <aws/sts/model/Credentials.h>
 
 #include <osquery/flags.h>
-#include <osquery/http_client.h>
 #include <osquery/logger.h>
 #include <osquery/system.h>
 
 #include "osquery/core/json.h"
+#include "osquery/remote/http_client.h"
 #include "osquery/remote/transports/tls.h"
 #include "osquery/utils/aws_util.h"
 
 namespace pt = boost::property_tree;
-namespace uri = boost::network::uri;
 
 namespace Standard = Aws::Http::Standard;
 namespace Model = Aws::STS::Model;


### PR DESCRIPTION
This fixes a bug with the new `http_client` implementation where the "path" component was not including the query string or URI fragment.

It also moves `http_client.h` out of the installed headers for osquery. This is a specialized utility.

It also fixes a retry-force-get problem with the TLS utilities class and addresses minor nits in places where `http_client.h` needed to be code-modded.