### PR TITLE
[Fix #3859] Lock every access to SQLiteDBInstance::db

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -15,11 +15,8 @@
 #include <string>
 #include <vector>
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#else
-#include <shared_mutex>
-#endif
 
 #include <osquery/status.h>
 
@@ -193,26 +190,20 @@ inline bool isPlatform(PlatformType a, const PlatformType& t = kPlatformType) {
   return (static_cast<int>(t) & static_cast<int>(a)) != 0;
 }
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#define MUTEX_IMPL boost
-#else
-#define MUTEX_IMPL std
-#endif
-
 /// Helper alias for defining mutexes.
-using Mutex = MUTEX_IMPL::shared_timed_mutex;
+using Mutex = boost::shared_timed_mutex;
 
 /// Helper alias for write locking a mutex.
-using WriteLock = MUTEX_IMPL::unique_lock<Mutex>;
+using WriteLock = boost::unique_lock<Mutex>;
 
 /// Helper alias for read locking a mutex.
-using ReadLock = MUTEX_IMPL::shared_lock<Mutex>;
+using ReadLock = boost::shared_lock<Mutex>;
 
 /// Helper alias for defining recursive mutexes.
-using RecursiveMutex = std::recursive_mutex;
+using RecursiveMutex = boost::recursive_mutex;
 
 /// Helper alias for write locking a recursive mutex.
-using RecursiveLock = std::lock_guard<std::recursive_mutex>;
+using RecursiveLock = boost::unique_lock<boost::recursive_mutex>;
 
 /**
  * @brief An abstract similar to boost's noncopyable that defines moves.

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -79,7 +79,7 @@ int profile(int argc, char* argv[]) {
   auto dbc = osquery::SQLiteDBManager::get();
   for (size_t i = 0; i < static_cast<size_t>(osquery::FLAGS_profile); ++i) {
     osquery::QueryData results;
-    auto status = osquery::queryInternal(query, results, dbc->db());
+    auto status = osquery::queryInternal(query, results, dbc);
     dbc->clearAffectedTables();
     if (!status) {
       fprintf(stderr,

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -84,7 +84,7 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from benchmark", results, dbc->db());
+    queryInternal("select * from benchmark", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -104,7 +104,7 @@ static void SQL_virtual_table_internal_yield(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from benchmark_yield", results, dbc->db());
+    queryInternal("select * from benchmark_yield", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -124,7 +124,7 @@ static void SQL_virtual_table_internal_global(benchmark::State& state) {
     attachTableInternal("benchmark", columnDefinition(res), dbc);
 
     QueryData results;
-    queryInternal("select * from benchmark", results, dbc->db());
+    queryInternal("select * from benchmark", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -144,7 +144,7 @@ static void SQL_virtual_table_internal_unique(benchmark::State& state) {
     attachTableInternal("benchmark", columnDefinition(res), dbc);
 
     QueryData results;
-    queryInternal("select * from benchmark", results, dbc->db());
+    queryInternal("select * from benchmark", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -182,7 +182,7 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
 
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from long_benchmark", results, dbc->db());
+    queryInternal("select * from long_benchmark", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -246,7 +246,7 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
   kWideCount = state.range_y();
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from wide_benchmark", results, dbc->db());
+    queryInternal("select * from wide_benchmark", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -272,7 +272,7 @@ static void SQL_virtual_table_internal_wide_yield(benchmark::State& state) {
   kWideCount = state.range_y();
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal("select * from wide_benchmark_yield", results, dbc->db());
+    queryInternal("select * from wide_benchmark_yield", results, dbc);
     dbc->clearAffectedTables();
   }
 }
@@ -287,8 +287,7 @@ static void SQL_select_metadata(benchmark::State& state) {
   auto dbc = SQLiteDBManager::getUnique();
   while (state.KeepRunning()) {
     QueryData results;
-    queryInternal(
-        "select count(*) from sqlite_temp_master;", results, dbc->db());
+    queryInternal("select count(*) from sqlite_temp_master;", results, dbc);
     dbc->clearAffectedTables();
   }
 }

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -106,6 +106,8 @@ const std::map<std::string, QueryPlanner::Opcode> kSQLOpcodes = {
     OpComparator("IfNotZero"),
 };
 
+RecursiveMutex SQLiteDBInstance::kPrimaryAttachMutex;
+
 /// The SQLiteSQLPlugin implements the "sql" registry for internal/core.
 class SQLiteSQLPlugin : public SQLPlugin {
  public:
@@ -147,7 +149,7 @@ Status SQLiteSQLPlugin::query(const std::string& query,
                               bool use_cache) const {
   auto dbc = SQLiteDBManager::get();
   dbc->useCache(use_cache);
-  auto result = queryInternal(query, results, dbc->db());
+  auto result = queryInternal(query, results, dbc);
   dbc->clearAffectedTables();
   return result;
 }
@@ -155,13 +157,13 @@ Status SQLiteSQLPlugin::query(const std::string& query,
 Status SQLiteSQLPlugin::getQueryColumns(const std::string& query,
                                         TableColumns& columns) const {
   auto dbc = SQLiteDBManager::get();
-  return getQueryColumnsInternal(query, columns, dbc->db());
+  return getQueryColumnsInternal(query, columns, dbc);
 }
 
 Status SQLiteSQLPlugin::getQueryTables(const std::string& query,
                                        std::vector<std::string>& tables) const {
   auto dbc = SQLiteDBManager::get();
-  QueryPlanner planner(query, dbc->db());
+  QueryPlanner planner(query, dbc);
   tables = planner.tables();
   return Status(0);
 }
@@ -169,7 +171,7 @@ Status SQLiteSQLPlugin::getQueryTables(const std::string& query,
 SQLInternal::SQLInternal(const std::string& query, bool use_cache) {
   auto dbc = SQLiteDBManager::get();
   dbc->useCache(use_cache);
-  status_ = queryInternal(query, results_, dbc->db());
+  status_ = queryInternal(query, results_, dbc);
 
   // One of the advantages of using SQLInternal (aside from the Registry-bypass)
   // is the ability to "deep-inspect" the table attributes and actions.
@@ -207,7 +209,7 @@ void SQLiteSQLPlugin::detach(const std::string& name) {
 }
 
 SQLiteDBInstance::SQLiteDBInstance(sqlite3*& db, Mutex& mtx)
-    : db_(db), lock_(mtx, MUTEX_IMPL::try_to_lock) {
+    : db_(db), lock_(mtx, boost::try_to_lock) {
   if (lock_.owns_lock()) {
     primary_ = true;
   } else {
@@ -251,8 +253,11 @@ bool SQLiteDBInstance::useCache() const {
   return use_cache_;
 }
 
-WriteLock SQLiteDBInstance::attachLock() const {
-  return WriteLock(attach_mutex_);
+RecursiveLock SQLiteDBInstance::attachLock() const {
+  if (primary_) {
+    return RecursiveLock(kPrimaryAttachMutex);
+  }
+  return RecursiveLock(attach_mutex_);
 }
 
 void SQLiteDBInstance::addAffectedTable(VirtualTableContent* table) {
@@ -371,10 +376,11 @@ SQLiteDBManager::~SQLiteDBManager() {
   }
 }
 
-QueryPlanner::QueryPlanner(const std::string& query, sqlite3* db) {
+QueryPlanner::QueryPlanner(const std::string& query,
+                           const SQLiteDBInstanceRef& instance) {
   QueryData plan;
-  queryInternal("EXPLAIN QUERY PLAN " + query, plan, db);
-  queryInternal("EXPLAIN " + query, program_, db);
+  queryInternal("EXPLAIN QUERY PLAN " + query, plan, instance);
+  queryInternal("EXPLAIN " + query, program_, instance);
 
   for (const auto& row : plan) {
     auto details = osquery::split(row.at("detail"));
@@ -442,10 +448,13 @@ int queryDataCallback(void* argument, int argc, char* argv[], char* column[]) {
   return 0;
 }
 
-Status queryInternal(const std::string& q, QueryData& results, sqlite3* db) {
+Status queryInternal(const std::string& q,
+                     QueryData& results,
+                     const SQLiteDBInstanceRef& instance) {
   char* err = nullptr;
-  sqlite3_exec(db, q.c_str(), queryDataCallback, &results, &err);
-  sqlite3_db_release_memory(db);
+  auto lock = instance->attachLock();
+  sqlite3_exec(instance->db(), q.c_str(), queryDataCallback, &results, &err);
+  sqlite3_db_release_memory(instance->db());
   if (err != nullptr) {
     auto error_string = std::string(err);
     sqlite3_free(err);
@@ -456,55 +465,62 @@ Status queryInternal(const std::string& q, QueryData& results, sqlite3* db) {
 
 Status getQueryColumnsInternal(const std::string& q,
                                TableColumns& columns,
-                               sqlite3* db) {
-  // Turn the query into a prepared statement
-  sqlite3_stmt* stmt{nullptr};
-  auto rc = sqlite3_prepare_v2(
-      db, q.c_str(), static_cast<int>(q.length() + 1), &stmt, nullptr);
-  if (rc != SQLITE_OK || stmt == nullptr) {
-    if (stmt != nullptr) {
-      sqlite3_finalize(stmt);
-    }
-    return Status(1, sqlite3_errmsg(db));
-  }
-
-  // Get column count
-  auto num_columns = sqlite3_column_count(stmt);
-  TableColumns results;
-  results.reserve(num_columns);
-
-  // Get column names and types
+                               const SQLiteDBInstanceRef& instance) {
   Status status = Status();
-  bool unknown_type = false;
-  for (int i = 0; i < num_columns; ++i) {
-    auto col_name = sqlite3_column_name(stmt, i);
-    auto col_type = sqlite3_column_decltype(stmt, i);
+  TableColumns results;
+  {
+    auto lock = instance->attachLock();
 
-    if (col_name == nullptr) {
-      status = Status(1, "Could not get column type");
-      break;
+    // Turn the query into a prepared statement
+    sqlite3_stmt* stmt{nullptr};
+    auto rc = sqlite3_prepare_v2(instance->db(),
+                                 q.c_str(),
+                                 static_cast<int>(q.length() + 1),
+                                 &stmt,
+                                 nullptr);
+    if (rc != SQLITE_OK || stmt == nullptr) {
+      if (stmt != nullptr) {
+        sqlite3_finalize(stmt);
+      }
+      return Status(1, sqlite3_errmsg(instance->db()));
     }
 
-    if (col_type == nullptr) {
-      // Types are only returned for table columns (not expressions).
-      col_type = "UNKNOWN";
-      unknown_type = true;
-    }
-    results.push_back(std::make_tuple(
-        col_name, columnTypeName(col_type), ColumnOptions::DEFAULT));
-  }
+    // Get column count
+    auto num_columns = sqlite3_column_count(stmt);
+    results.reserve(num_columns);
 
-  // An unknown type means we have to parse the plan and SQLite opcodes.
-  if (unknown_type) {
-    QueryPlanner planner(q, db);
-    planner.applyTypes(results);
+    // Get column names and types
+    bool unknown_type = false;
+    for (int i = 0; i < num_columns; ++i) {
+      auto col_name = sqlite3_column_name(stmt, i);
+      auto col_type = sqlite3_column_decltype(stmt, i);
+
+      if (col_name == nullptr) {
+        status = Status(1, "Could not get column type");
+        break;
+      }
+
+      if (col_type == nullptr) {
+        // Types are only returned for table columns (not expressions).
+        col_type = "UNKNOWN";
+        unknown_type = true;
+      }
+      results.push_back(std::make_tuple(
+          col_name, columnTypeName(col_type), ColumnOptions::DEFAULT));
+    }
+
+    // An unknown type means we have to parse the plan and SQLite opcodes.
+    if (unknown_type) {
+      QueryPlanner planner(q, instance);
+      planner.applyTypes(results);
+    }
+    sqlite3_finalize(stmt);
   }
 
   if (status.ok()) {
     columns = std::move(results);
   }
 
-  sqlite3_finalize(stmt);
   return status;
 }
 }

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -254,7 +254,7 @@ bool SQLiteDBInstance::useCache() const {
 }
 
 RecursiveLock SQLiteDBInstance::attachLock() const {
-  if (primary_) {
+  if (isPrimary()) {
     return RecursiveLock(kPrimaryAttachMutex);
   }
   return RecursiveLock(attach_mutex_);

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -78,7 +78,7 @@ class SQLiteDBInstance : private boost::noncopyable {
   bool useCache() const;
 
   /// Lock the database for attaching virtual tables.
-  WriteLock attachLock() const;
+  RecursiveLock attachLock() const;
 
  private:
   /// Handle the primary/forwarding requests for table attribute accesses.
@@ -102,11 +102,25 @@ class SQLiteDBInstance : private boost::noncopyable {
   /// Either the managed primary database or an ephemeral instance.
   sqlite3* db_{nullptr};
 
-  /// An attempted unique lock on the manager's primary database access mutex.
+  /**
+   * @brief An attempted unique lock on the manager's primary database mutex.
+   *
+   * This lock is not always acquired. If it is then this instance has locked
+   * access to the 'primary' SQLite database.
+   */
   WriteLock lock_;
 
-  /// Attaching can occur async from the registry APIs.
-  mutable Mutex attach_mutex_;
+  /**
+   * @brief A mutex protecting access to this instance's SQLite database.
+   *
+   * Attaching, and other access, can occur async from the registry APIs.
+   *
+   * If a database is primary then the static attach mutex is used.
+   */
+  mutable RecursiveMutex attach_mutex_;
+
+  /// See attach_mutex_ but used for the primary database.
+  static RecursiveMutex kPrimaryAttachMutex;
 
   /// Vector of tables that need their constraints cleared after execution.
   std::map<std::string, VirtualTableContent*> affected_tables_;
@@ -227,8 +241,8 @@ class SQLiteDBManager : private boost::noncopyable {
 class QueryPlanner : private boost::noncopyable {
  public:
   explicit QueryPlanner(const std::string& query)
-      : QueryPlanner(query, SQLiteDBManager::get()->db()) {}
-  QueryPlanner(const std::string& query, sqlite3* db);
+      : QueryPlanner(query, SQLiteDBManager::get()) {}
+  QueryPlanner(const std::string& query, const SQLiteDBInstanceRef& instance);
   ~QueryPlanner() {}
 
  public:
@@ -298,7 +312,9 @@ extern const std::map<std::string, QueryPlanner::Opcode> kSQLOpcodes;
  *
  * @return A status indicating SQL query results.
  */
-Status queryInternal(const std::string& q, QueryData& results, sqlite3* db);
+Status queryInternal(const std::string& q,
+                     QueryData& results,
+                     const SQLiteDBInstanceRef& instance);
 
 /**
  * @brief SQLite Intern: Analyze a query, providing information about the
@@ -317,7 +333,7 @@ Status queryInternal(const std::string& q, QueryData& results, sqlite3* db);
  */
 Status getQueryColumnsInternal(const std::string& q,
                                TableColumns& columns,
-                               sqlite3* db);
+                               const SQLiteDBInstanceRef& instance);
 
 /**
  * @brief SQLInternal: SQL, but backed by internal calls.

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -78,7 +78,7 @@ TEST_F(SQLiteUtilTests, test_reset) {
   auto instance = SQLiteDBManager::get();
 
   QueryData results;
-  queryInternal("select * from test_view", results, instance->db());
+  queryInternal("select * from test_view", results, instance);
 
   // Assume the internal (primary) database we reset and recreated.
   EXPECT_EQ(results.size(), 0U);
@@ -87,7 +87,7 @@ TEST_F(SQLiteUtilTests, test_reset) {
 TEST_F(SQLiteUtilTests, test_direct_query_execution) {
   auto dbc = getTestDBC();
   QueryData results;
-  auto status = queryInternal(kTestQuery, results, dbc->db());
+  auto status = queryInternal(kTestQuery, results, dbc);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(results, getTestDBExpectedResults());
 }
@@ -105,7 +105,7 @@ TEST_F(SQLiteUtilTests, test_passing_callback_no_data_param) {
 TEST_F(SQLiteUtilTests, test_aggregate_query) {
   auto dbc = getTestDBC();
   QueryData results;
-  auto status = queryInternal(kTestQuery, results, dbc->db());
+  auto status = queryInternal(kTestQuery, results, dbc);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(results, getTestDBExpectedResults());
 }
@@ -123,7 +123,7 @@ TEST_F(SQLiteUtilTests, test_get_test_db_result_stream) {
     }
 
     QueryData expected;
-    auto status = queryInternal(kTestQuery, expected, dbc->db());
+    auto status = queryInternal(kTestQuery, expected, dbc);
     EXPECT_EQ(expected, r.second);
   }
 }
@@ -131,7 +131,7 @@ TEST_F(SQLiteUtilTests, test_get_test_db_result_stream) {
 TEST_F(SQLiteUtilTests, test_affected_tables) {
   auto dbc = getTestDBC();
   QueryData results;
-  auto status = queryInternal("SELECT * FROM time", results, dbc->db());
+  auto status = queryInternal("SELECT * FROM time", results, dbc);
 
   // Since the table scanned from "time", it should be recorded as affected.
   EXPECT_EQ(dbc->affected_tables_.count("time"), 1U);
@@ -160,7 +160,7 @@ TEST_F(SQLiteUtilTests, test_get_query_columns) {
   TableColumns results;
 
   std::string query = "SELECT seconds, version FROM time JOIN osquery_info";
-  auto status = getQueryColumnsInternal(query, results, dbc->db());
+  auto status = getQueryColumnsInternal(query, results, dbc);
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(2U, results.size());
   EXPECT_EQ(std::make_tuple(
@@ -171,7 +171,7 @@ TEST_F(SQLiteUtilTests, test_get_query_columns) {
             results[1]);
 
   query = "SELECT * FROM foo";
-  status = getQueryColumnsInternal(query, results, dbc->db());
+  status = getQueryColumnsInternal(query, results, dbc);
   ASSERT_FALSE(status.ok());
 }
 
@@ -201,60 +201,60 @@ TEST_F(SQLiteUtilTests, test_query_planner) {
   TableColumns columns;
 
   std::string query = "select path, path from file";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE, TEXT_TYPE}));
 
   query = "select path, seconds from file, time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE, INTEGER_TYPE}));
 
   query = "select path || path from file";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE}));
 
   query = "select seconds, path || path from file, time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({INTEGER_TYPE, TEXT_TYPE}));
 
   query = "select seconds, seconds from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({INTEGER_TYPE, INTEGER_TYPE}));
 
   query = "select count(*) from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({BIGINT_TYPE}));
 
   query = "select count(*), count(seconds), seconds from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns),
             TypeList({BIGINT_TYPE, BIGINT_TYPE, INTEGER_TYPE}));
 
   query = "select 1, 'path', path from file";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({INTEGER_TYPE, TEXT_TYPE, TEXT_TYPE}));
 
   query = "select weekday, day, count(*), seconds from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns),
             TypeList({TEXT_TYPE, INTEGER_TYPE, BIGINT_TYPE, INTEGER_TYPE}));
 
   query = "select seconds + 1 from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({BIGINT_TYPE}));
 
   query = "select seconds * seconds from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({BIGINT_TYPE}));
 
   query = "select seconds > 1, seconds, count(seconds) from time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns),
             TypeList({INTEGER_TYPE, INTEGER_TYPE, BIGINT_TYPE}));
 
   query =
       "select f1.*, seconds, f2.directory from (select path || path from file) "
       "f1, file as f2, time";
-  getQueryColumnsInternal(query, columns, dbc->db());
+  getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE, INTEGER_TYPE, TEXT_TYPE}));
 }
 }

--- a/osquery/sql/tests/virtual_table_tests.cpp
+++ b/osquery/sql/tests/virtual_table_tests.cpp
@@ -186,7 +186,7 @@ TEST_F(VirtualTableTests, test_sqlite3_attach_vtable) {
 
   std::string q = "SELECT sql FROM sqlite_temp_master WHERE tbl_name='sample';";
   QueryData results;
-  status = queryInternal(q, results, dbc->db());
+  status = queryInternal(q, results, dbc);
   EXPECT_EQ(
       "CREATE VIRTUAL TABLE sample USING sample(`foo` INTEGER, `bar` TEXT)",
       results[0]["sql"]);
@@ -200,7 +200,7 @@ TEST_F(VirtualTableTests, test_sqlite3_table_joins) {
   // Run a query with a join within.
   std::string statement =
       "SELECT p.pid FROM osquery_info oi, processes p WHERE oi.pid = p.pid";
-  auto status = queryInternal(statement, results, dbc->db());
+  auto status = queryInternal(statement, results, dbc);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(results.size(), 1U);
 }
@@ -302,7 +302,7 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
 
   for (const auto& test : constraint_tests) {
     QueryData results;
-    queryInternal(test.first, results, dbc->db());
+    queryInternal(test.first, results, dbc);
     EXPECT_EQ(results, test.second);
   }
 
@@ -321,7 +321,7 @@ TEST_F(VirtualTableTests, test_constraints_stacking) {
   size_t index = 0;
   for (const auto& test : constraint_tests) {
     QueryData results;
-    queryInternal(test.first + " union " + test.first, results, dbc->db());
+    queryInternal(test.first + " union " + test.first, results, dbc);
     EXPECT_EQ(results, union_results[index++]);
   }
 }
@@ -358,7 +358,7 @@ TEST_F(VirtualTableTests, test_json_extract) {
   // Run a query with a join within.
   std::string statement =
       "SELECT JSON_EXTRACT(data, '$.test') AS test FROM json;";
-  auto status = queryInternal(statement, results, dbc->db());
+  auto status = queryInternal(statement, results, dbc);
   EXPECT_TRUE(status.ok());
   ASSERT_EQ(results.size(), 1U);
   EXPECT_EQ(results[0]["test"], "1");
@@ -370,7 +370,7 @@ TEST_F(VirtualTableTests, test_null_values) {
   std::string statement = "SELECT NULL as null_value;";
   {
     QueryData results;
-    auto status = queryInternal(statement, results, dbc->db());
+    auto status = queryInternal(statement, results, dbc);
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(results[0]["null_value"], "");
   }
@@ -379,7 +379,7 @@ TEST_F(VirtualTableTests, test_null_values) {
   {
     QueryData results;
     statement = "SELECT CAST(NULL as INTEGER) as null_value;";
-    queryInternal(statement, results, dbc->db());
+    queryInternal(statement, results, dbc);
     EXPECT_EQ(results[0]["null_value"], "");
   }
 
@@ -387,7 +387,7 @@ TEST_F(VirtualTableTests, test_null_values) {
   {
     QueryData results;
     statement = "SELECT CAST(NULL as BIGINT) as null_value;";
-    queryInternal(statement, results, dbc->db());
+    queryInternal(statement, results, dbc);
     EXPECT_EQ(results[0]["null_value"], "");
   }
 
@@ -395,7 +395,7 @@ TEST_F(VirtualTableTests, test_null_values) {
   {
     QueryData results;
     statement = "SELECT CAST(NULL as DOUBLE) as null_value;";
-    queryInternal(statement, results, dbc->db());
+    queryInternal(statement, results, dbc);
     EXPECT_EQ(results[0]["null_value"], "");
   }
 }
@@ -435,7 +435,7 @@ TEST_F(VirtualTableTests, test_table_cache) {
   QueryData results;
   // Run a query with a join within.
   std::string statement = "SELECT c2.data as data FROM cache c1, cache c2;";
-  auto status = queryInternal(statement, results, dbc->db());
+  auto status = queryInternal(statement, results, dbc);
   dbc->clearAffectedTables();
   EXPECT_TRUE(status.ok());
   ASSERT_EQ(results.size(), 1U);
@@ -444,7 +444,7 @@ TEST_F(VirtualTableTests, test_table_cache) {
   // Run the query again, the virtual table cache should have been expired.
   results.clear();
   statement = "SELECT data from cache c1";
-  queryInternal(statement, results, dbc->db());
+  queryInternal(statement, results, dbc);
   ASSERT_EQ(results.size(), 1U);
   ASSERT_EQ(results[0]["data"], "awesome_data");
 }
@@ -487,7 +487,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
 
   QueryData results;
   std::string statement = "SELECT * from table_cache;";
-  auto status = queryInternal(statement, results, dbc->db());
+  auto status = queryInternal(statement, results, dbc);
   dbc->clearAffectedTables();
 
   EXPECT_TRUE(status.ok());
@@ -497,7 +497,7 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   // Run the query again, the virtual table cache was not requested.
   results.clear();
   statement = "SELECT * from table_cache;";
-  queryInternal(statement, results, dbc->db());
+  queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
 
   // The table should have used the cache.
@@ -509,21 +509,21 @@ TEST_F(VirtualTableTests, test_table_results_cache) {
   // Run the query again, the virtual table cache will be populated.
   results.clear();
   statement = "SELECT * from table_cache;";
-  queryInternal(statement, results, dbc->db());
+  queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
   EXPECT_EQ(cache->generates_, 3U);
 
   // Run the query again, the virtual table cache will be returned.
   results.clear();
   statement = "SELECT * from table_cache;";
-  queryInternal(statement, results, dbc->db());
+  queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
   EXPECT_EQ(cache->generates_, 3U);
 
   // Once last time with constraints that invalidate the cache results.
   results.clear();
   statement = "SELECT * from table_cache where i = '1';";
-  queryInternal(statement, results, dbc->db());
+  queryInternal(statement, results, dbc);
   EXPECT_EQ(results.size(), 1U);
 
   // The table should NOT have used the cache.
@@ -564,13 +564,13 @@ TEST_F(VirtualTableTests, test_yield_generator) {
   attachTableInternal("yield", table->columnDefinition(), dbc);
 
   QueryData results;
-  queryInternal("SELECT * from yield", results, dbc->db());
+  queryInternal("SELECT * from yield", results, dbc);
   dbc->clearAffectedTables();
   EXPECT_EQ(results.size(), 10U);
   EXPECT_EQ(results[0]["index"], "0");
 
   results.clear();
-  queryInternal("SELECT * from yield", results, dbc->db());
+  queryInternal("SELECT * from yield", results, dbc);
   dbc->clearAffectedTables();
   EXPECT_EQ(results[0]["index"], "10");
 }
@@ -623,12 +623,12 @@ TEST_F(VirtualTableTests, test_like_constraints) {
 
   // Base case, without constrains this table has no results.
   QueryData results;
-  queryInternal("SELECT * FROM like_table", results, dbc->db());
+  queryInternal("SELECT * FROM like_table", results, dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 0U);
 
   // A single EQUAL constraint's value is emitted.
-  queryInternal("SELECT * FROM like_table WHERE i = '1'", results, dbc->db());
+  queryInternal("SELECT * FROM like_table WHERE i = '1'", results, dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 1U);
   EXPECT_EQ(results[0]["i"], "1");
@@ -637,7 +637,7 @@ TEST_F(VirtualTableTests, test_like_constraints) {
   // When using OR, both values should be added.
   results.clear();
   queryInternal(
-      "SELECT * FROM like_table WHERE i = '1' OR i = '2'", results, dbc->db());
+      "SELECT * FROM like_table WHERE i = '1' OR i = '2'", results, dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 2U);
   EXPECT_EQ(results[0]["i"], "1");
@@ -648,7 +648,7 @@ TEST_F(VirtualTableTests, test_like_constraints) {
   // When using a LIKE, the value (with substitution character) is emitted.
   results.clear();
   queryInternal(
-      "SELECT * FROM like_table WHERE i LIKE '/test/1/%'", results, dbc->db());
+      "SELECT * FROM like_table WHERE i LIKE '/test/1/%'", results, dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 1U);
   EXPECT_EQ(results[0]["i"], "/test/1/%");
@@ -659,7 +659,7 @@ TEST_F(VirtualTableTests, test_like_constraints) {
   queryInternal(
       "SELECT * FROM like_table WHERE i LIKE '/test/1/%' OR i LIKE '/test/2/%'",
       results,
-      dbc->db());
+      dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 2U);
   EXPECT_EQ(results[0]["i"], "/test/1/%");
@@ -673,7 +673,7 @@ TEST_F(VirtualTableTests, test_like_constraints) {
       "SELECT * FROM like_table WHERE i LIKE '/home/%/downloads' OR i LIKE "
       "'/home/%/documents'",
       results,
-      dbc->db());
+      dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(results.size(), 2U);
   EXPECT_EQ(results[0]["i"], "/home/%/downloads");
@@ -788,7 +788,7 @@ TEST_F(VirtualTableTests, test_indexing_costs) {
 
   QueryData results;
   queryInternal(
-      "SELECT * from default_scan JOIN index_i using (i);", results, dbc->db());
+      "SELECT * from default_scan JOIN index_i using (i);", results, dbc);
   dbc->clearAffectedTables();
 
   // We expect index_i to optimize, meaning the constraint evaluation
@@ -802,7 +802,7 @@ TEST_F(VirtualTableTests, test_indexing_costs) {
 
   // The inverse should also hold, all cost evaluations will be high.
   queryInternal(
-      "SELECT * from index_i JOIN default_scan using (i);", results, dbc->db());
+      "SELECT * from index_i JOIN default_scan using (i);", results, dbc);
   dbc->clearAffectedTables();
   EXPECT_EQ(10U, i->scans);
   EXPECT_EQ(1U, default_scan->scans);
@@ -815,7 +815,7 @@ TEST_F(VirtualTableTests, test_indexing_costs) {
       "SELECT * from default_scan join index_i using (i) join index_j using "
       "(j);",
       results,
-      dbc->db());
+      dbc);
   dbc->clearAffectedTables();
   ASSERT_EQ(1U, default_scan->scans);
   EXPECT_EQ(10U, i->scans);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -625,6 +625,7 @@ Status attachTableInternal(const std::string& name,
   // Note, if the clientData API is used then this will save a registry call
   // within xCreate.
   auto lock(instance->attachLock());
+
   int rc = sqlite3_create_module(
       instance->db(), name.c_str(), &module, (void*)&(*instance));
   if (rc == SQLITE_OK || rc == SQLITE_MISUSE) {


### PR DESCRIPTION
Some more refactors to `SQLiteDBInstance` to lock all intended uses of `::db()`. This deserves some profiling using `osquery_benchmarks` before and after this change.