### PR TITLE
Fix typos

### DIFF
--- a/osquery/tables/lldpd/lldp_neighbors.cpp
+++ b/osquery/tables/lldpd/lldp_neighbors.cpp
@@ -347,7 +347,7 @@ void LLDPNeighbor::getChassis() {
 }
 
 /**
- * @brief getNeighbor retreives all LLDP information of the given neighbor port
+ * @brief getNeighbor retrieves all LLDP information of the given neighbor port
  * and chassis.
  *
  * @return filled osquery::Row of lldp information for a given interface

--- a/osquery/tables/networking/windows/win_sockets.h
+++ b/osquery/tables/networking/windows/win_sockets.h
@@ -25,7 +25,7 @@ enum class WinSockTableType { tcp, tcp6, udp, udp6 };
 
 class WinSockets : private boost::noncopyable {
  public:
-  /// Retreives all of the socket table structures from the Windows API
+  /// Retrieves all of the socket table structures from the Windows API
   WinSockets();
 
   /// Ensures that all Socket tables have been deallocated

--- a/packs/incident-response.conf
+++ b/packs/incident-response.conf
@@ -254,7 +254,7 @@
       "interval" : "86400",
       "platform" : "darwin",
       "version" : "1.4.7",
-      "description" : "Retreives the list of application scheme/protocol-based IPC handlers.",
+      "description" : "Retrieves the list of application scheme/protocol-based IPC handlers.",
       "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
     },
     "sandboxes": {


### PR DESCRIPTION
Noticed the documentation on https://osquery.io/schema/packs/ was off, so fixed this.

Also updated the other wrong occurrences.