### PR TITLE
Adding a pack for unwanted chrome extensions

### DIFF
--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -1,0 +1,65 @@
+{
+  "platform": "windows,darwin",
+  "queries": {
+    "Unwanted_Chrome_Extension_BetternetVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_Chrometana": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_CopyFish": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_Giphy": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
+      "interval": 86400,
+      "description": "https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_HolaVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
+      "interval": 86400,
+      "description": "http://adios-hola.org",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_InfinityNewTab": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_SocialFixer": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_TouchVPN": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_WebDeveloper": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/",
+      "snapshot": true
+    },
+    "Unwanted_Chrome_Extension_WebPaint": {
+      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
+      "interval": 86400,
+      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
+      "snapshot": true
+    }
+  }
+}

--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -1,61 +1,61 @@
 {
   "platform": "windows,darwin",
   "queries": {
-    "Unwanted_Chrome_Extension_BetternetVPN": {
+    "BetternetVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_Chrometana": {
+    "Chrometana": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_CopyFish": {
+    "CopyFish": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_Giphy": {
+    "Giphy": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
       "interval": 86400,
       "description": "https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_HolaVPN": {
+    "HolaVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
       "interval": 86400,
       "description": "http://adios-hola.org",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_InfinityNewTab": {
+    "InfinityNewTab": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_SocialFixer": {
+    "SocialFixer": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_TouchVPN": {
+    "TouchVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_WebDeveloper": {
+    "WebDeveloper": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/",
       "snapshot": true
     },
-    "Unwanted_Chrome_Extension_WebPaint": {
+    "WebPaint": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
       "interval": 86400,
       "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",

--- a/packs/unwanted-chrome-extensions.conf
+++ b/packs/unwanted-chrome-extensions.conf
@@ -3,63 +3,53 @@
   "queries": {
     "BetternetVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gjknjjomckknofjidppipffbpoekiipm';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "Chrometana": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "CopyFish": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='eenjdnjldapjajjofmldgmkjaienebbj';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/copyfish-chrome-extension-hijacked-to-show-adware/)"
     },
     "Giphy": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='kaicbfmipfpfpjmlbpejaoaflfdnabnc';",
-      "interval": 86400,
-      "description": "https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.reddit.com/r/chrome/comments/6htzan/psawarning_giphy_extension_6172017_is_now_malware/)"
     },
     "HolaVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='gkojfkhlekighikafcpjkiklfbnlmeio';",
-      "interval": 86400,
-      "description": "http://adios-hola.org",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(http://adios-hola.org)"
     },
     "InfinityNewTab": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='dbfmnekepjoapopniengjbcpnbljalfg';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "SocialFixer": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='ifmhoabcaeehkljcfclfiieohkohdgbb';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "TouchVPN": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bihmplhobchoageeokmgbdihknkjbknd';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     },
     "WebDeveloper": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='bfbameneiokkgbdmiekhjnmfkcnldhhm';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/chrome-extension-with-over-one-million-users-hijacked-to-serve-adware/)"
     },
     "WebPaint": {
       "query": "SELECT * FROM users JOIN chrome_extensions USING (uid) WHERE identifier='emeokgokialpjadjaoeiplmnkjoaegng';",
-      "interval": 86400,
-      "description": "https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/",
-      "snapshot": true
+      "interval": 3600,
+      "description": "(https://www.bleepingcomputer.com/news/security/eight-chrome-extensions-hijacked-to-deliver-malicious-code-to-4-8-million-users/)"
     }
   }
 }


### PR DESCRIPTION
The purpose of this pack would be to track a list of chrome extensions that:
- Have been hijacked
- Serve ads
- Exhibit sketchy behavior
- Can't be trusted for whatever reason

The most straightforward way to track extensions seems to be by identifier. Totally open to feedback on this concept.