### PR TITLE
tables: Adding a Named Pipes table for Windows

### DIFF
--- a/osquery/tables/system/windows/pipes.cpp
+++ b/osquery/tables/system/windows/pipes.cpp
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#define _WIN32_DCOM
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+#include <osquery/logger.h>
+
+#include "osquery/filesystem/fileops.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genPipes(QueryContext& context) {
+  QueryData results;
+  WIN32_FIND_DATA findFileData;
+
+  std::string pipePrefix = "\\\\.\\pipe\\*";
+  memset(&findFileData, 0, sizeof(findFileData));
+  auto findHandle = FindFirstFileA(pipePrefix.c_str(), &findFileData);
+
+  if (findHandle == INVALID_HANDLE_VALUE) {
+    LOG(INFO) << "Failed to enumerate system pipes";
+    return results;
+  }
+
+  do {
+    Row r;
+
+    r["name"] = findFileData.cFileName;
+    r["path"] = "\\\\.\\pipe\\" + r["name"];
+    r["creation_time"] = BIGINT(filetimeToUnixtime(findFileData.ftCreationTime));
+    r["last_access_time"] = BIGINT(filetimeToUnixtime(findFileData.ftLastAccessTime));
+
+    unsigned long pid = 0;
+    auto pipeHandle = CreateFile(r["path"].c_str(), GENERIC_READ , 0, NULL, OPEN_EXISTING, 0, NULL);
+
+    auto ret = GetNamedPipeServerProcessId(pipeHandle, &pid);
+    if (ret != TRUE) {
+      ret = GetNamedPipeClientProcessId(pipeHandle, &pid);
+    }
+    r["pid"] = ret == TRUE ? INTEGER(pid) : "-1";
+
+    results.push_back(r);
+  } while (FindNextFile(findHandle, &findFileData));
+
+  FindClose(findHandle);
+  return results;
+}
+}
+}

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -2,7 +2,7 @@ table_name("pipes")
 description("Named and Anonymous pipes.")
 schema([
     Column("pid", BIGINT, "Process ID of the process to which the pipe belongs", index=True),
-    Column("path", TEXT, "Path of the pipe"),
+    Column("name", TEXT, "Name of the pipe"),
     Column("instances", INTEGER, "Number of instances of the named pipe"),
     Column("max_instances", INTEGER, "The maximum number of instances creatable for this pipe"),
     Column("flags", TEXT, "The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes"),

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -1,0 +1,13 @@
+table_name("pipes")
+description("Named and Anonymous pipes.")
+schema([
+    Column("pid", BIGINT, "Process ID of the process to which the pipe belongs", index=True),
+    Column("path", TEXT, "Path of the pipe"),
+    Column("type", TEXT, "The type of pipe, anonymous or named"),
+    Column("creation_time", BIGINT, "Creation time of the pipe"),
+    Column("last_access_time", BIGINT, "Last time the pipe was accessed"),
+])
+implementation("pipes@genPipes")
+examples([
+  "select * from pipes",
+])

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -6,6 +6,8 @@ schema([
     Column("type", TEXT, "The type of pipe, anonymous or named"),
     Column("creation_time", BIGINT, "Creation time of the pipe"),
     Column("last_access_time", BIGINT, "Last time the pipe was accessed"),
+    Column("instances", INTEGER, "Number of instances of the named pipe"),
+    Column("user", TEXT, "The user, if any, associated with the client end of the pipe; this field may often be empty"),
 ])
 implementation("pipes@genPipes")
 examples([

--- a/specs/windows/pipes.table
+++ b/specs/windows/pipes.table
@@ -3,11 +3,9 @@ description("Named and Anonymous pipes.")
 schema([
     Column("pid", BIGINT, "Process ID of the process to which the pipe belongs", index=True),
     Column("path", TEXT, "Path of the pipe"),
-    Column("type", TEXT, "The type of pipe, anonymous or named"),
-    Column("creation_time", BIGINT, "Creation time of the pipe"),
-    Column("last_access_time", BIGINT, "Last time the pipe was accessed"),
     Column("instances", INTEGER, "Number of instances of the named pipe"),
-    Column("user", TEXT, "The user, if any, associated with the client end of the pipe; this field may often be empty"),
+    Column("max_instances", INTEGER, "The maximum number of instances creatable for this pipe"),
+    Column("flags", TEXT, "The flags indicating whether this pipe connection is a server or client end, and if the pipe for sending messages or bytes"),
 ])
 implementation("pipes@genPipes")
 examples([


### PR DESCRIPTION
This adds a table to query all named pipes on a system. Sample query follows:
```
osquery> select * from pipes;
+-------+------------------------------------------------------------------------------------------------------------------------+-----------+---------------+-----------------------------------+
| pid   | name                                                                                                                   | instances | max_instances | flags                             |
+-------+------------------------------------------------------------------------------------------------------------------------+-----------+---------------+-----------------------------------+
| 656   | InitShutdown                                                                                                           | 3         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
| 744   | lsass                                                                                                                  | 4         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
| 728   | ntsvcs                                                                                                                 | 3         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
| 728   | scerpc                                                                                                                 | 3         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
| -1    | Winsock2\CatalogChangeListener-3f8-0                                                                                   | -1        | -1            | PIPE_CLIENT_END,PIPE_TYPE_BYTE    |
| 1016  | epmapper                                                                                                               | 3         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
| -1    | Winsock2\CatalogChangeListener-290-0                                                                                   | -1        | -1            | PIPE_CLIENT_END,PIPE_TYPE_BYTE    |
| 484   | LSM_API_service                                                                                                        | 3         | 255           | PIPE_CLIENT_END,PIPE_TYPE_MESSAGE |
```