### PR TITLE
tables: Add linux shadow table

### DIFF
--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <mutex>
+
+#include <shadow.h>
+
+#include <boost/regex.hpp>
+
+#include <osquery/core.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+const auto kPasswordHashAlgRegex = boost::regex("^\\$(\\w+)\\$");
+
+void genShadowForAccount(const struct spwd* spwd, QueryData& results) {
+  Row r;
+  r["last_change"] = BIGINT(spwd->sp_lstchg);
+  r["min"] = BIGINT(spwd->sp_min);
+  r["max"] = BIGINT(spwd->sp_max);
+  r["warning"] = BIGINT(spwd->sp_warn);
+  r["inactive"] = BIGINT(spwd->sp_inact);
+  r["expire"] = BIGINT(spwd->sp_expire);
+  r["flag"] = BIGINT(spwd->sp_flag);
+
+  r["username"] = spwd->sp_namp != nullptr ? TEXT(spwd->sp_namp) : "";
+
+  if (spwd->sp_pwdp != nullptr) {
+    std::string password = std::string(spwd->sp_pwdp);
+    boost::smatch matches;
+    if (password == "!!") {
+      r["password_status"] = "not_set";
+    } else if (password[0] == '!' || password[0] == '*' || password[0] == 'x') {
+      r["password_status"] = "locked";
+    } else {
+      r["password_status"] = "active";
+    }
+    if (boost::regex_search(password, matches, kPasswordHashAlgRegex)) {
+      r["hash_alg"] = std::string(matches[1]);
+    }
+  } else {
+    r["password_status"] = "empty";
+  }
+  results.push_back(r);
+}
+
+QueryData genShadow(QueryContext& context) {
+  QueryData results;
+  Mutex spwdEnumerationMutex;
+
+  struct spwd* spwd = nullptr;
+  if (context.constraints["username"].exists(EQUALS)) {
+    auto usernames = context.constraints["username"].getAll(EQUALS);
+    for (const auto& username : usernames) {
+      WriteLock lock(spwdEnumerationMutex);
+      spwd = getspnam(username.c_str());
+      if (spwd != nullptr) {
+        genShadowForAccount(spwd, results);
+      }
+    }
+  } else {
+    WriteLock lock(spwdEnumerationMutex);
+    spwd = getspent();
+    while (spwd != nullptr) {
+      genShadowForAccount(spwd, results);
+      spwd = getspent();
+    }
+    endspent();
+  }
+
+  return results;
+}
+}
+}

--- a/specs/linux/shadow.table
+++ b/specs/linux/shadow.table
@@ -1,0 +1,18 @@
+table_name("shadow")
+description("Local system users encrypted passwords and related information.")
+schema([
+    Column("password_status", TEXT, "Password status"),
+    Column("hash_alg", TEXT, "Password hashing algorithm"),
+    Column("last_change", BIGINT, "Date of last password change (starting from UNIX epoch date)"),
+    Column("min", BIGINT, "Minimal number of days between password changes"),
+    Column("max", BIGINT, "Maximum number of days between password changes"),
+    Column("warning", BIGINT, "Number of days before password expires to warn user about it"),
+    Column("inactive", BIGINT, "Number of days after password expires until account is blocked"),
+    Column("expire", BIGINT, "Number of days since UNIX epoch date until account is disabled"),
+    Column("flag", BIGINT, "Reserved"),
+    Column("username", TEXT, "Username", index=True),
+])
+implementation("system/shadow@genShadow")
+examples([
+  "select * from shadow where username = 'root'",
+])


### PR DESCRIPTION
Similar to the `users` table, but this uses `/etc/shadow` instead.