### PR TITLE
Print correct address family id for AF_UNIX sockets

### DIFF
--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -106,7 +106,7 @@ void genSocketsFromProc(const InodeMap &inodes,
     Row r;
     if (family == AF_UNIX) {
       r["socket"] = fields[6];
-      r["family"] = "0";
+      r["family"] = "1";
       r["protocol"] = fields[2];
       r["local_address"] = "";
       r["local_port"] = "0";


### PR DESCRIPTION
AF_UNIX is actually defined as 1 instead of 0.

$ cat /tmp/af-unix-print.c
#include <stdio.h>
#include <sys/socket.h>
#include <sys/un.h>

int main(void) {
        printf("%d\n", AF_UNIX);
        return 0;
}

$ gcc -o af-unix-print /tmp/af-unix-print.c

$ ./af-unix-print
1