### PR TITLE
Replace most of boost::property_tree with rapidjson

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -14,12 +14,12 @@
 #include <memory>
 #include <vector>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include <osquery/core.h>
 #include <osquery/query.h>
 #include <osquery/registry.h>
 #include <osquery/status.h>
+
+#include "osquery/core/json.h"
 
 namespace osquery {
 
@@ -131,7 +131,7 @@ class Config : private boost::noncopyable {
    */
   void addPack(const std::string& name,
                const std::string& source,
-               const boost::property_tree::ptree& tree);
+               const rapidjson::Value& obj);
 
   /**
    * @brief Remove a pack from the osquery schedule
@@ -277,22 +277,22 @@ class Config : private boost::noncopyable {
                  const std::string& target);
 
   /**
-   * @brief Apply each ConfigParser to an input property tree.
+   * @brief Apply each ConfigParser to an input JSON document.
    *
    * This iterates each discovered ConfigParser Plugin and the plugin's keys
-   * to match keys within the input property tree. If a key matches then the
+   * to match keys within the input JSON document. If a key matches then the
    * associated value is passed to the parser.
    *
-   * Use this utility method for both the top-level configuration tree and
+   * Use this utility method for both the top-level configuration JSON and
    * the content of each configuration pack. There is an optional black list
    * parameter to differentiate pack content.
    *
    * @param source The input configuration source name.
-   * @param tree The input configuration tree.
-   * @param pack True if the tree was built from pack data, otherwise false.
+   * @param obj The input configuration JSON.
+   * @param pack True if the JSON was built from pack data, otherwise false.
    */
   void applyParsers(const std::string& source,
-                    const boost::property_tree::ptree& tree,
+                    const rapidjson::Value& obj,
                     bool pack = false);
 
   /**
@@ -491,21 +491,21 @@ class ConfigPlugin : public Plugin {
  */
 class ConfigParserPlugin : public Plugin {
  public:
-  using ParserConfig = std::map<std::string, boost::property_tree::ptree>;
+  using ParserConfig = std::map<std::string, JSON>;
 
  public:
   /**
    * @brief Return a list of top-level config keys to receive in updates.
    *
    * The ConfigParserPlugin::update method will receive a map of these keys
-   * with a JSON-parsed property tree of configuration data.
+   * with a JSON-parsed document of configuration data.
    *
    * @return A list of string top-level JSON keys.
    */
   virtual std::vector<std::string> keys() const = 0;
 
   /**
-   * @brief Receive a merged property tree for each top-level config key.
+   * @brief Receive a merged JSON document for each top-level config key.
    *
    * Called when the Config instance is initially loaded with data from the
    * active config plugin and when it is updated via an async ConfigPlugin
@@ -513,7 +513,7 @@ class ConfigParserPlugin : public Plugin {
    * they requested in keys().
    *
    * @param source source of the config data
-   * @param config A JSON-parsed property tree map.
+   * @param config A JSON-parsed document map.
    * @return Failure if the parser should no longer receive updates.
    */
   virtual Status update(const std::string& source,
@@ -536,7 +536,7 @@ class ConfigParserPlugin : public Plugin {
    *
    * More complex parsers that require dynamic casting are not recommended.
    */
-  const boost::property_tree::ptree& getData() const {
+  const JSON& getData() const {
     return data_;
   }
 
@@ -546,14 +546,14 @@ class ConfigParserPlugin : public Plugin {
 
  protected:
   /// Allow the config parser to keep some global state.
-  boost::property_tree::ptree data_;
+  JSON data_;
 
  private:
   friend class Config;
 };
 
 /**
- * @brief Boost's 1.59 property tree based JSON parser does not accept comments.
+ * @brief JSON parsers may accept comments.
  *
  * For semi-compatibility with existing configurations we will attempt to strip
  * hash and C++ style comments. It is OK for the config update to be latent

--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -35,12 +35,14 @@ struct DistributedQueryRequest {
  * @brief Serialize a DistributedQueryRequest into a property tree
  *
  * @param r the DistributedQueryRequest to serialize
+ * @param doc the input JSON managed document
  * @param d the output rapidjson document
  *
  * @return Status indicating the success or failure of the operation
  */
 Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,
-                                        rapidjson::Document& d);
+                                        JSON& doc,
+                                        rapidjson::Value& d);
 
 /**
  * @brief Serialize a DistributedQueryRequest object into a JSON string
@@ -97,12 +99,14 @@ struct DistributedQueryResult {
  * @brief Serialize a DistributedQueryResult into a property tree
  *
  * @param r the DistributedQueryResult to serialize
+ * @param doc the input JSON managed document
  * @param d the output rapidjson document
  *
  * @return Status indicating the success or failure of the operation
  */
 Status serializeDistributedQueryResult(const DistributedQueryResult& r,
-                                       rapidjson::Document& d);
+                                       JSON& doc,
+                                       rapidjson::Value& d);
 /**
  * @brief Serialize a DistributedQueryResult object into a JSON string
  *
@@ -122,7 +126,7 @@ Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
  *
  * @return Status indicating the success or failure of the operation
  */
-Status deserializeDistributedQueryResult(const rapidjson::Document& d,
+Status deserializeDistributedQueryResult(const rapidjson::Value& d,
                                          DistributedQueryResult& r);
 
 /**

--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -36,13 +36,13 @@ struct DistributedQueryRequest {
  *
  * @param r the DistributedQueryRequest to serialize
  * @param doc the input JSON managed document
- * @param d the output rapidjson document
+ * @param obj the output rapidjson document [object]
  *
  * @return Status indicating the success or failure of the operation
  */
 Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,
                                         JSON& doc,
-                                        rapidjson::Value& d);
+                                        rapidjson::Value& obj);
 
 /**
  * @brief Serialize a DistributedQueryRequest object into a JSON string
@@ -58,12 +58,12 @@ Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
 /**
  * @brief Deserialize a DistributedQueryRequest object from a property tree
  *
- * @param d the input rapidjson value
+ * @param obj the input rapidjson value [object]
  * @param r the output DistributedQueryRequest structure
  *
  * @return Status indicating the success or failure of the operation
  */
-Status deserializeDistributedQueryRequest(const rapidjson::Value& d,
+Status deserializeDistributedQueryRequest(const rapidjson::Value& obj,
                                           DistributedQueryRequest& r);
 
 /**
@@ -100,13 +100,13 @@ struct DistributedQueryResult {
  *
  * @param r the DistributedQueryResult to serialize
  * @param doc the input JSON managed document
- * @param d the output rapidjson document
+ * @param obj the output rapidjson document [object]
  *
  * @return Status indicating the success or failure of the operation
  */
 Status serializeDistributedQueryResult(const DistributedQueryResult& r,
                                        JSON& doc,
-                                       rapidjson::Value& d);
+                                       rapidjson::Value& obj);
 /**
  * @brief Serialize a DistributedQueryResult object into a JSON string
  *
@@ -121,12 +121,12 @@ Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
 /**
  * @brief Deserialize a DistributedQueryResult object from a property tree
  *
- * @param d the input rapidjson document
+ * @param obj the input rapidjson document [object]
  * @param r the output DistributedQueryResult structure
  *
  * @return Status indicating the success or failure of the operation
  */
-Status deserializeDistributedQueryResult(const rapidjson::Value& d,
+Status deserializeDistributedQueryResult(const rapidjson::Value& obj,
                                          DistributedQueryResult& r);
 
 /**

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include <boost/noncopyable.hpp>
-#include <boost/property_tree/ptree.hpp>
 
 #include <osquery/query.h>
 
@@ -31,24 +30,21 @@ struct PackStats {
 
 /**
  * @brief The programmatic representation of a query pack
- *
- * Instantiating a new Pack object parses JSON and may throw a
- * boost::property_tree::json_parser::json_parser_error exception
  */
 class Pack : private boost::noncopyable {
  public:
-  Pack(const std::string& name, const boost::property_tree::ptree& tree)
-      : Pack(name, "", tree) {}
+  Pack(const std::string& name, const rapidjson::Value& obj)
+      : Pack(name, "", obj) {}
 
   Pack(const std::string& name,
        const std::string& source,
-       const boost::property_tree::ptree& tree) {
-    initialize(name, source, tree);
+       const rapidjson::Value& obj) {
+    initialize(name, source, obj);
   }
 
   void initialize(const std::string& name,
                   const std::string& source,
-                  const boost::property_tree::ptree& tree);
+                  const rapidjson::Value& obj);
   /**
    * @brief Getter for the pack's discovery query
    *

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -46,48 +46,45 @@ using Row = std::map<std::string, RowData>;
 using ColumnNames = std::vector<std::string>;
 
 /**
- * @brief Serialize a Row into a property tree
+ * @brief Serialize a Row into a property tree.
  *
- * @param r the Row to serialize
- * @param tree the output property tree
+ * @param r the Row to serialize.
+ * @param doc the managed JSON document.
+ * @param dict [output] the JSON object to assign values.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
-Status serializeRow(const Row& r, boost::property_tree::ptree& tree);
-Status serializeRowRJ(const Row& r, rapidjson::Document& d);
+Status serializeRow(const Row& r, JSON& doc, rapidjson::Document& dict);
 
 /**
- * @brief Serialize a Row object into a JSON string
+ * @brief Serialize a Row object into a JSON string.
  *
- * @param r the Row to serialize
- * @param json the output JSON string
+ * @param r the Row to serialize.
+ * @param json [output] the output JSON string.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeRowJSON(const Row& r, std::string& json);
-Status serializeRowJSONRJ(const Row& r, std::string& json);
 
 /**
- * @brief Deserialize a Row object from a property tree
+ * @brief Deserialize a Row object from JSON object.
  *
- * @param tree the input property tree
- * @param r the output Row structure
+ * @param doc the input JSON value (should be an object).
+ * @param r [output] the output Row structure.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
-Status deserializeRow(const boost::property_tree::ptree& tree, Row& r);
-Status deserializeRowRJ(const rapidjson::Value& v, Row& r);
+Status deserializeRow(const rapidjson::Value& doc, Row& r);
 
 /**
- * @brief Deserialize a Row object from a JSON string
+ * @brief Deserialize a Row object from a JSON string.
  *
- * @param json the input JSON string
- * @param r the output Row structure
+ * @param json the input JSON string.
+ * @param r [output] the output Row structure.
  *
  * @return Status indicating the success or failure of the operation
  */
 Status deserializeRowJSON(const std::string& json, Row& r);
-Status deserializeRowJSONRJ(const std::string& json, Row& r);
 
 /**
  * @brief The result set returned from a osquery SQL query
@@ -107,55 +104,52 @@ using QueryDataSet = std::multiset<Row>;
 /**
  * @brief Serialize a QueryData object into a property tree
  *
- * @param q the QueryData to serialize
- * @param tree the output property tree
+ * @param q the QueryData to serialize.
+ * @param doc the managed JSON document.
+ * @param arr [output] the output JSON array.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeQueryData(const QueryData& q,
-                          boost::property_tree::ptree& tree);
-Status serializeQueryDataRJ(const QueryData& q, rapidjson::Document& d);
+                          JSON& doc,
+                          rapidjson::Document& arr);
 
 /**
- * @brief Serialize a QueryData object into a property tree
+ * @brief Serialize a QueryData object into a JSON array.
  *
- * @param q the QueryData to serialize
- * @param cols the TableColumn vector indicating column order
- * @param tree the output property tree
+ * @param q the QueryData to serialize.
+ * @param cols the TableColumn vector indicating column order.
+ * @param doc the managed JSON document.
+ * @param arr [output] the output JSON array.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeQueryData(const QueryData& q,
                           const ColumnNames& cols,
-                          boost::property_tree::ptree& tree);
-Status serializeQueryDataRJ(const QueryData& q,
-                            const ColumnNames& cols,
-                            rapidjson::Document& d);
+                          JSON& doc,
+                          rapidjson::Document& arr);
 
 /**
- * @brief Serialize a QueryData object into a JSON string
+ * @brief Serialize a QueryData object into a JSON string.
  *
- * @param q the QueryData to serialize
- * @param json the output JSON string
+ * @param q the QueryData to serialize.
+ * @param json [output] the output JSON string.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeQueryDataJSON(const QueryData& q, std::string& json);
-Status serializeQueryDataJSONRJ(const QueryData& q, std::string& json);
 
 /// Inverse of serializeQueryData, convert property tree to QueryData.
-Status deserializeQueryData(const boost::property_tree::ptree& tree,
-                            QueryData& qd);
+Status deserializeQueryData(const rapidjson::Value& v, QueryData& qd);
+
 /// Inverse of serializeQueryData, convert property tree to QueryDataSet.
 Status deserializeQueryData(const boost::property_tree::ptree& tree,
                             QueryDataSet& qd);
 
-Status deserializeQueryDataRJ(const rapidjson::Value& v, QueryData& qd);
-
 /// Inverse of serializeQueryDataJSON, convert a JSON string to QueryData.
 Status deserializeQueryDataJSON(const std::string& json, QueryData& qd);
-/// Inverse of serializeQueryDataJSON, convert a JSON string to QueryDataSet.
 
+/// Inverse of serializeQueryDataJSON, convert a JSON string to QueryDataSet.
 Status deserializeQueryDataJSON(const std::string& json, QueryDataSet& qd);
 
 /**
@@ -185,24 +179,27 @@ struct DiffResults {
 };
 
 /**
- * @brief Serialize a DiffResults object into a property tree
+ * @brief Serialize a DiffResults object into a JSON object.
  *
- * @param d the DiffResults to serialize
- * @param tree the output property tree
+ * The object JSON will contain two new keys: added and removed.
  *
- * @return Status indicating the success or failure of the operation
+ * @param d the DiffResults to serialize.
+ * @param doc the managed JSON document.
+ * @param obj [output] the output JSON object.
+ *
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeDiffResults(const DiffResults& d,
-                            boost::property_tree::ptree& tree);
+                            JSON& doc,
+                            rapidjson::Document& obj);
 
 /**
- * @brief Serialize a DiffResults object into a JSON string
+ * @brief Serialize a DiffResults object into a JSON string.
  *
- * @param d the DiffResults to serialize
- * @param json the output JSON string
+ * @param d the DiffResults to serialize.
+ * @param json [output] the output JSON string.
  *
- * @return an instance of osquery::Status, indicating the success or failure
- * of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeDiffResultsJSON(const DiffResults& d, std::string& json);
 
@@ -210,8 +207,8 @@ Status serializeDiffResultsJSON(const DiffResults& d, std::string& json);
  * @brief Diff QueryDataSet object and QueryData object
  *        and create a DiffResults object
  *
- * @param old_ the "old" set of results
- * @param new_ the "new" set of results
+ * @param old_ the "old" set of results.
+ * @param new_ the "new" set of results.
  *
  * @return a DiffResults object which indicates the change from old_ to new_
  *
@@ -363,51 +360,49 @@ struct QueryLogItem {
 };
 
 /**
- * @brief Serialize a QueryLogItem object into a property tree
+ * @brief Serialize a QueryLogItem object into a JSON document.
  *
- * @param item the QueryLogItem to serialize
- * @param tree the output property tree
+ * @param item the QueryLogItem to serialize.
+ * @param doc [output] the output JSON document (object type).
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
-Status serializeQueryLogItem(const QueryLogItem& item,
-                             boost::property_tree::ptree& tree);
+Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc);
 
 /**
- * @brief Serialize a QueryLogItem object into a JSON string
+ * @brief Serialize a QueryLogItem object into a JSON string.
  *
- * @param item the QueryLogItem to serialize
- * @param json the output JSON string
+ * @param item the QueryLogItem to serialize.
+ * @param json [output] the output JSON string.
  *
- * @return Status indicating the success or failure of the operation
+ * @return Status indicating the success or failure of the operation.
  */
 Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json);
 
 /// Inverse of serializeQueryLogItem, convert property tree to QueryLogItem.
-Status deserializeQueryLogItem(const boost::property_tree::ptree& tree,
+Status deserializeQueryLogItem(const rapidjson::Document& doc,
                                QueryLogItem& item);
 
 /// Inverse of serializeQueryLogItem, convert a JSON string to QueryLogItem.
 Status deserializeQueryLogItemJSON(const std::string& json, QueryLogItem& item);
 
 /**
- * @brief Serialize a QueryLogItem object into a property tree
- * of events, a list of actions.
+ * @brief Serialize a QueryLogItem object into a JSON document containing
+ * events, a list of actions.
  *
  * @param item the QueryLogItem to serialize
- * @param tree the output property tree
+ * @param json [output] the output JSON document.
  *
  * @return Status indicating the success or failure of the operation
  */
-Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
-                                     boost::property_tree::ptree& tree);
+Status serializeQueryLogItemAsEvents(const QueryLogItem& item, JSON& json);
 
 /**
  * @brief Serialize a QueryLogItem object into a JSON string of events,
  * a list of actions.
  *
  * @param i the QueryLogItem to serialize
- * @param items vector of JSON output strings
+ * @param items [output] vector of JSON output strings
  *
  * @return Status indicating the success or failure of the operation
  */
@@ -487,8 +482,8 @@ class Query {
    * to the database using addNewResults.
    *
    * @param qd the QueryData object, which has the results of the query.
-   * @param epoch the epoch associatted with QueryData
-   * @param counter the output that holds the query execution counter.
+   * @param epoch the epoch associated with QueryData
+   * @param counter [output] the output that holds the query execution counter.
    *
    * @return the success or failure of the operation.
    */

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -100,7 +100,7 @@ using QueryData = std::vector<Row>;
 using QueryDataSet = std::multiset<Row>;
 
 /**
- * @brief Serialize a QueryData object into a property tree
+ * @brief Serialize a QueryData object into a JSON array.
  *
  * @param q the QueryData to serialize.
  * @param doc the managed JSON document.
@@ -140,8 +140,8 @@ Status serializeQueryDataJSON(const QueryData& q, std::string& json);
 /// Inverse of serializeQueryData, convert JSON to QueryData.
 Status deserializeQueryData(const rapidjson::Value& arr, QueryData& qd);
 
-/// Inverse of serializeQueryData, convert property tree to QueryDataSet.
-Status deserializeQueryData(const boost::property_tree::ptree& tree,
+/// Inverse of serializeQueryData, convert JSON to QueryDataSet.
+Status deserializeQueryData(const rapidjson::Value& arr,
                             QueryDataSet& qd);
 
 /// Inverse of serializeQueryDataJSON, convert a JSON string to QueryData.

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -48,11 +48,11 @@ using ColumnNames = std::vector<std::string>;
  *
  * @param r the Row to serialize.
  * @param doc the managed JSON document.
- * @param dict [output] the JSON object to assign values.
+ * @param obj [output] the JSON object to assign values.
  *
  * @return Status indicating the success or failure of the operation.
  */
-Status serializeRow(const Row& r, JSON& doc, rapidjson::Document& dict);
+Status serializeRow(const Row& r, JSON& doc, rapidjson::Value& obj);
 
 /**
  * @brief Serialize a Row object into a JSON string.
@@ -67,12 +67,12 @@ Status serializeRowJSON(const Row& r, std::string& json);
 /**
  * @brief Deserialize a Row object from JSON object.
  *
- * @param doc the input JSON value (should be an object).
+ * @param obj the input JSON value (should be an object).
  * @param r [output] the output Row structure.
  *
  * @return Status indicating the success or failure of the operation.
  */
-Status deserializeRow(const rapidjson::Value& doc, Row& r);
+Status deserializeRow(const rapidjson::Value& obj, Row& r);
 
 /**
  * @brief Deserialize a Row object from a JSON string.
@@ -138,7 +138,7 @@ Status serializeQueryData(const QueryData& q,
 Status serializeQueryDataJSON(const QueryData& q, std::string& json);
 
 /// Inverse of serializeQueryData, convert JSON to QueryData.
-Status deserializeQueryData(const rapidjson::Value& v, QueryData& qd);
+Status deserializeQueryData(const rapidjson::Value& arr, QueryData& qd);
 
 /// Inverse of serializeQueryData, convert property tree to QueryDataSet.
 Status deserializeQueryData(const boost::property_tree::ptree& tree,
@@ -378,8 +378,7 @@ Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc);
 Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json);
 
 /// Inverse of serializeQueryLogItem, convert JSON to QueryLogItem.
-Status deserializeQueryLogItem(const rapidjson::Document& doc,
-                               QueryLogItem& item);
+Status deserializeQueryLogItem(const JSON& doc, QueryLogItem& item);
 
 /// Inverse of serializeQueryLogItem, convert a JSON string to QueryLogItem.
 Status deserializeQueryLogItemJSON(const std::string& json, QueryLogItem& item);

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -141,8 +141,7 @@ Status serializeQueryDataJSON(const QueryData& q, std::string& json);
 Status deserializeQueryData(const rapidjson::Value& arr, QueryData& qd);
 
 /// Inverse of serializeQueryData, convert JSON to QueryDataSet.
-Status deserializeQueryData(const rapidjson::Value& arr,
-                            QueryDataSet& qd);
+Status deserializeQueryData(const rapidjson::Value& arr, QueryDataSet& qd);
 
 /// Inverse of serializeQueryDataJSON, convert a JSON string to QueryData.
 Status deserializeQueryDataJSON(const std::string& json, QueryData& qd);

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -16,8 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include <osquery/core.h>
 #include <osquery/status.h>
 
@@ -46,7 +44,7 @@ using Row = std::map<std::string, RowData>;
 using ColumnNames = std::vector<std::string>;
 
 /**
- * @brief Serialize a Row into a property tree.
+ * @brief Serialize a Row into a JSON document.
  *
  * @param r the Row to serialize.
  * @param doc the managed JSON document.
@@ -139,7 +137,7 @@ Status serializeQueryData(const QueryData& q,
  */
 Status serializeQueryDataJSON(const QueryData& q, std::string& json);
 
-/// Inverse of serializeQueryData, convert property tree to QueryData.
+/// Inverse of serializeQueryData, convert JSON to QueryData.
 Status deserializeQueryData(const rapidjson::Value& v, QueryData& qd);
 
 /// Inverse of serializeQueryData, convert property tree to QueryDataSet.
@@ -239,7 +237,7 @@ bool addUniqueRowToQueryData(QueryData& q, const Row& r);
  * This function is intended as a workaround for
  * https://svn.boost.org/trac/boost/ticket/8883,
  * and will allow rows containing data with non-ASCII characters to be stored in
- * the database and parsed back into a property tree.
+ * the database and parsed back into a JSON document.
  *
  * @param oldData the old QueryData to copy
  * @param newData the new escaped QueryData object
@@ -379,7 +377,7 @@ Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc);
  */
 Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json);
 
-/// Inverse of serializeQueryLogItem, convert property tree to QueryLogItem.
+/// Inverse of serializeQueryLogItem, convert JSON to QueryLogItem.
 Status deserializeQueryLogItem(const rapidjson::Document& doc,
                                QueryLogItem& item);
 

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -604,7 +604,7 @@ Status Config::genPack(const std::string& name,
   }
 
   auto clone = response[0][name];
-  if (clone == "") {
+  if (clone.empty()) {
     LOG(WARNING) << "Error reading the query pack named: " << name;
     return Status();
   }

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -206,13 +206,13 @@ void Pack::initialize(const std::string& name,
     if (!q.value.HasMember("snapshot")) {
       query.options["snapshot"] = false;
     } else {
-      query.options["snapshot"] = JSON::valueAsBool(q.value["snapshot"]);
+      query.options["snapshot"] = JSON::valueToBool(q.value["snapshot"]);
     }
 
     if (!q.value.HasMember("removed")) {
       query.options["removed"] = true;
     } else {
-      query.options["removed"] = JSON::valueAsBool(q.value["removed"]);
+      query.options["removed"] = JSON::valueToBool(q.value["removed"]);
     }
     query.options["blacklist"] =
         (q.value.HasMember("blacklist")) ? q.value["blacklist"].GetBool() : true;

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -214,8 +214,9 @@ void Pack::initialize(const std::string& name,
     } else {
       query.options["removed"] = JSON::valueToBool(q.value["removed"]);
     }
-    query.options["blacklist"] =
-        (q.value.HasMember("blacklist")) ? q.value["blacklist"].GetBool() : true;
+    query.options["blacklist"] = (q.value.HasMember("blacklist"))
+                                     ? q.value["blacklist"].GetBool()
+                                     : true;
 
     schedule_[q.name.GetString()] = query;
   }

--- a/osquery/config/parsers/decorators.cpp
+++ b/osquery/config/parsers/decorators.cpp
@@ -177,7 +177,8 @@ void DecoratorsConfigParserPlugin::updateDecorations(const std::string& source,
   if (doc.doc().HasMember(interval_key)) {
     const auto& interval = doc.doc()[interval_key];
     for (const auto& item : interval.GetObject()) {
-      size_t rate = std::stoll(item.name.GetString());
+      auto rate = doc.valueToSize(item.name);
+      //      size_t rate = std::stoll(item.name.GetString());
       if (rate % 60 != 0) {
         LOG(WARNING) << "Invalid decorator interval rate " << rate
                      << " in config source: " << source;

--- a/osquery/config/parsers/events_parser.cpp
+++ b/osquery/config/parsers/events_parser.cpp
@@ -31,17 +31,18 @@ class EventsConfigParserPlugin : public ConfigParserPlugin {
 Status EventsConfigParserPlugin::setUp() {
   auto obj = data_.getObject();
   data_.add("events", obj);
-  return Status(0, "OK");
+  return Status();
 }
 
 Status EventsConfigParserPlugin::update(const std::string& source,
                                         const ParserConfig& config) {
-  if (config.count("events") > 0) {
+  auto events = config.find("events");
+  if (events != config.end()) {
     auto obj = data_.getObject();
-    obj.CopyFrom(config.at("events").doc(), data_.doc().GetAllocator());
+    data_.copyFrom(events->second.doc(), obj);
     data_.add("events", obj, data_.doc());
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 REGISTER_INTERNAL(EventsConfigParserPlugin, "config_parser", "events");

--- a/osquery/config/parsers/events_parser.cpp
+++ b/osquery/config/parsers/events_parser.cpp
@@ -29,15 +29,17 @@ class EventsConfigParserPlugin : public ConfigParserPlugin {
 };
 
 Status EventsConfigParserPlugin::setUp() {
-  data_.put_child("events", pt::ptree());
+  auto obj = data_.getObject();
+  data_.add("events", obj);
   return Status(0, "OK");
 }
 
 Status EventsConfigParserPlugin::update(const std::string& source,
                                         const ParserConfig& config) {
   if (config.count("events") > 0) {
-    data_ = pt::ptree();
-    data_.put_child("events", config.at("events"));
+    auto obj = data_.getObject();
+    obj.CopyFrom(config.at("events").doc(), data_.doc().GetAllocator());
+    data_.add("events", obj, data_.doc());
   }
   return Status(0, "OK");
 }

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -77,6 +77,7 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     data_.add("file_accesses", arr);
   }
 
+  // We know this top-level is an Object.
   const auto& file_paths = config.at("file_paths").doc();
   for (const auto& category : file_paths.GetObject()) {
     if (category.value.IsArray()) {
@@ -93,6 +94,7 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     }
   }
 
+  // We know this top-level is an Object.
   if (config.count("exclude_paths") > 0) {
     auto obj = data_.getObject();
     const auto& exclude_paths = config.at("exclude_paths").doc();

--- a/osquery/config/parsers/kafka_topics.cpp
+++ b/osquery/config/parsers/kafka_topics.cpp
@@ -25,10 +25,10 @@ std::vector<std::string> KafkaTopicsConfigParserPlugin::keys() const {
 
 Status KafkaTopicsConfigParserPlugin::update(const std::string& source,
                                              const ParserConfig& config) {
-  if (config.count(kKafkaTopicParserRootKey) > 0) {
+  auto topics = config.find(kKafkaTopicParserRootKey);
+  if (topics != config.end()) {
     auto obj = data_.getObject();
-    obj.CopyFrom(config.at(kKafkaTopicParserRootKey).doc(),
-                 data_.doc().GetAllocator());
+    data_.copyFrom(topics->second.doc(), obj);
     data_.add(kKafkaTopicParserRootKey, obj);
   }
   return Status();

--- a/osquery/config/parsers/kafka_topics.cpp
+++ b/osquery/config/parsers/kafka_topics.cpp
@@ -27,7 +27,8 @@ Status KafkaTopicsConfigParserPlugin::update(const std::string& source,
                                              const ParserConfig& config) {
   if (config.count(kKafkaTopicParserRootKey) > 0) {
     auto obj = data_.getObject();
-    obj.CopyFrom(config.at(kKafkaTopicParserRootKey).doc(), data_.doc().GetAllocator());
+    obj.CopyFrom(config.at(kKafkaTopicParserRootKey).doc(),
+                 data_.doc().GetAllocator());
     data_.add(kKafkaTopicParserRootKey, obj);
   }
   return Status();

--- a/osquery/config/parsers/kafka_topics.cpp
+++ b/osquery/config/parsers/kafka_topics.cpp
@@ -23,20 +23,14 @@ std::vector<std::string> KafkaTopicsConfigParserPlugin::keys() const {
   return {kKafkaTopicParserRootKey};
 }
 
-Status KafkaTopicsConfigParserPlugin::setUp() {
-  data_.put_child(kKafkaTopicParserRootKey, boost::property_tree::ptree());
-  return Status(0, "OK");
-}
-
 Status KafkaTopicsConfigParserPlugin::update(const std::string& source,
                                              const ParserConfig& config) {
   if (config.count(kKafkaTopicParserRootKey) > 0) {
-    data_ = boost::property_tree::ptree();
-    data_.put_child(kKafkaTopicParserRootKey,
-                    config.at(kKafkaTopicParserRootKey));
+    auto obj = data_.getObject();
+    obj.CopyFrom(config.at(kKafkaTopicParserRootKey).doc(), data_.doc().GetAllocator());
+    data_.add(kKafkaTopicParserRootKey, obj);
   }
-
-  return Status(0, "OK");
+  return Status();
 }
 
 REGISTER_INTERNAL(KafkaTopicsConfigParserPlugin,

--- a/osquery/config/parsers/kafka_topics.h
+++ b/osquery/config/parsers/kafka_topics.h
@@ -25,7 +25,6 @@ extern const std::string kKafkaTopicParserRootKey;
 class KafkaTopicsConfigParserPlugin : public ConfigParserPlugin {
  public:
   std::vector<std::string> keys() const override;
-  Status setUp() override;
   Status update(const std::string& source, const ParserConfig& config) override;
 };
 } // namespace osquery

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -14,7 +14,7 @@
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 
-namespace pt = boost::property_tree;
+namespace rj = rapidjson;
 
 namespace osquery {
 
@@ -46,38 +46,50 @@ class OptionsConfigParserPlugin : public ConfigParserPlugin {
     return {"options"};
   }
 
-  Status setUp() override;
-
   Status update(const std::string& source, const ParserConfig& config) override;
 };
-
-Status OptionsConfigParserPlugin::setUp() {
-  data_.put_child("options", pt::ptree());
-  return Status(0, "OK");
-}
 
 Status OptionsConfigParserPlugin::update(const std::string& source,
                                          const ParserConfig& config) {
   if (config.count("options") > 0) {
-    data_ = pt::ptree();
-    data_.put_child("options", config.at("options"));
+    if (!data_.doc().HasMember("options")) {
+      auto obj = data_.getObject();
+      data_.add("options", obj);
+    }
+
+    if (config.at("options").doc().IsObject()) {
+      auto obj = data_.getObject();
+      obj.CopyFrom(config.at("options").doc(), data_.doc().GetAllocator());
+      data_.mergeObject(data_.doc()["options"], obj);
+    }
   }
 
-  const auto& options = data_.get_child("options");
-  for (const auto& option : options) {
-    std::string value = options.get<std::string>(option.first, "");
-    if (value.empty()) {
+  const auto& options = data_.doc()["options"];
+  for (const auto& option : options.GetObject()) {
+    std::string name = option.name.GetString();
+    std::string value;
+    if (option.value.IsString()) {
+      value = option.value.GetString();
+    } else if (option.value.IsBool()) {
+      value = (option.value.GetBool()) ? "true" : "false";
+    } else if (option.value.IsInt()) {
+      value = std::to_string(option.value.GetInt());
+    } else if (option.value.IsNumber()) {
+      value = std::to_string(option.value.GetUint64());
+    }
+
+    if (value.empty() || name.empty()) {
       continue;
     }
 
-    bool is_custom = option.first.find("custom_") == 0;
-    if (!is_custom && Flag::getType(option.first).empty()) {
-      LOG(WARNING) << "Cannot set unknown or invalid flag: " << option.first;
+    bool is_custom = name.find("custom_") == 0;
+    if (!is_custom && Flag::getType(name).empty()) {
+      LOG(WARNING) << "Cannot set unknown or invalid flag: " << name;
     }
 
-    Flag::updateValue(option.first, value);
+    Flag::updateValue(name, value);
     // There is a special case for supported Gflags-reserved switches.
-    if (kVerboseOptions.count(option.first)) {
+    if (kVerboseOptions.count(name)) {
       setVerboseLevel();
       if (Flag::getValue("verbose") == "true") {
         VLOG(1) << "Verbose logging enabled by config option";

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -51,17 +51,20 @@ class OptionsConfigParserPlugin : public ConfigParserPlugin {
 
 Status OptionsConfigParserPlugin::update(const std::string& source,
                                          const ParserConfig& config) {
-  if (config.count("options") > 0) {
-    if (!data_.doc().HasMember("options")) {
-      auto obj = data_.getObject();
-      data_.add("options", obj);
-    }
+  auto co = config.find("options");
+  if (co == config.end()) {
+    return Status();
+  }
 
-    if (config.at("options").doc().IsObject()) {
-      auto obj = data_.getObject();
-      obj.CopyFrom(config.at("options").doc(), data_.doc().GetAllocator());
-      data_.mergeObject(data_.doc()["options"], obj);
-    }
+  if (!data_.doc().HasMember("options")) {
+    auto obj = data_.getObject();
+    data_.add("options", obj);
+  }
+
+  if (co->second.doc().IsObject()) {
+    auto obj = data_.getObject();
+    data_.copyFrom(co->second.doc(), obj);
+    data_.mergeObject(data_.doc()["options"], obj);
   }
 
   const auto& options = data_.doc()["options"];
@@ -97,7 +100,7 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
     }
   }
 
-  return Status(0, "OK");
+  return Status();
 }
 
 REGISTER_INTERNAL(OptionsConfigParserPlugin, "config_parser", "options");

--- a/osquery/config/parsers/prometheus_targets.cpp
+++ b/osquery/config/parsers/prometheus_targets.cpp
@@ -27,7 +27,8 @@ Status PrometheusMetricsConfigParserPlugin::update(const std::string& source,
                                                    const ParserConfig& config) {
   if (config.count(kPrometheusParserRootKey) > 0) {
     auto obj = data_.getObject();
-    obj.CopyFrom(config.at(kPrometheusParserRootKey).doc(), data_.doc().GetAllocator());
+    obj.CopyFrom(config.at(kPrometheusParserRootKey).doc(),
+                 data_.doc().GetAllocator());
     data_.add(kPrometheusParserRootKey, obj);
   }
 

--- a/osquery/config/parsers/prometheus_targets.cpp
+++ b/osquery/config/parsers/prometheus_targets.cpp
@@ -17,23 +17,21 @@
 
 namespace osquery {
 
-std::vector<std::string> PrometheusMetricsConfigParserPlugin::keys() const {
-  return {kConfigParserRootKey};
-}
+const std::string kPrometheusParserRootKey("prometheus_targets");
 
-Status PrometheusMetricsConfigParserPlugin::setUp() {
-  data_.put_child(kConfigParserRootKey, boost::property_tree::ptree());
-  return Status(0, "OK");
+std::vector<std::string> PrometheusMetricsConfigParserPlugin::keys() const {
+  return {kPrometheusParserRootKey};
 }
 
 Status PrometheusMetricsConfigParserPlugin::update(const std::string& source,
                                                    const ParserConfig& config) {
-  if (config.count(kConfigParserRootKey) > 0) {
-    data_ = boost::property_tree::ptree();
-    data_.put_child(kConfigParserRootKey, config.at(kConfigParserRootKey));
+  if (config.count(kPrometheusParserRootKey) > 0) {
+    auto obj = data_.getObject();
+    obj.CopyFrom(config.at(kPrometheusParserRootKey).doc(), data_.doc().GetAllocator());
+    data_.add(kPrometheusParserRootKey, obj);
   }
 
-  return Status(0, "OK");
+  return Status();
 }
 
 REGISTER_INTERNAL(PrometheusMetricsConfigParserPlugin,

--- a/osquery/config/parsers/prometheus_targets.cpp
+++ b/osquery/config/parsers/prometheus_targets.cpp
@@ -25,10 +25,10 @@ std::vector<std::string> PrometheusMetricsConfigParserPlugin::keys() const {
 
 Status PrometheusMetricsConfigParserPlugin::update(const std::string& source,
                                                    const ParserConfig& config) {
-  if (config.count(kPrometheusParserRootKey) > 0) {
+  auto prometheus_targets = config.find(kPrometheusParserRootKey);
+  if (prometheus_targets != config.end()) {
     auto obj = data_.getObject();
-    obj.CopyFrom(config.at(kPrometheusParserRootKey).doc(),
-                 data_.doc().GetAllocator());
+    data_.copyFrom(prometheus_targets->second.doc(), obj);
     data_.add(kPrometheusParserRootKey, obj);
   }
 

--- a/osquery/config/parsers/prometheus_targets.h
+++ b/osquery/config/parsers/prometheus_targets.h
@@ -16,12 +16,11 @@
 
 namespace osquery {
 
-const std::string kConfigParserRootKey("prometheus_targets");
+extern const std::string kPrometheusParserRootKey;
 
 class PrometheusMetricsConfigParserPlugin : public ConfigParserPlugin {
  public:
   std::vector<std::string> keys() const override;
-  Status setUp() override;
   Status update(const std::string& source, const ParserConfig& config) override;
 };
 }

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -92,10 +92,10 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_interval) {
   std::string log_line;
   serializeQueryLogItemJSON(item, log_line);
   std::string expected =
-      "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"\","
-      "\"hostIdentifier\":\"\",\"calendarTime\":\"\",\"unixTime\":\"0\","
-      "\"epoch\":\"0\",\"counter\":\"0\","
-      "\"decorations\":{\"internal_60_test\":\"test\",\"one\":\"1\"}}\n";
+      "{\"snapshot\":[],\"action\":\"snapshot\",\"name\":\"\","
+      "\"hostIdentifier\":\"\",\"calendarTime\":\"\",\"unixTime\":0,"
+      "\"epoch\":0,\"counter\":0,"
+      "\"decorations\":{\"internal_60_test\":\"test\",\"one\":\"1\"}}";
   EXPECT_EQ(log_line, expected);
 
   // Now clear and run again.
@@ -121,11 +121,11 @@ TEST_F(DecoratorsConfigParserPluginTests, test_decorators_run_load_top_level) {
   ASSERT_EQ(item.decorations.size(), 3U);
   EXPECT_EQ(item.decorations["load_test"], "test");
 
-  // searialize the QueryLogItem and make sure decorations go top level
-  pt::ptree tree;
-  auto status = serializeQueryLogItem(item, tree);
+  // serialize the QueryLogItem and make sure decorations go top level
+  auto doc = JSON::newObject();
+  auto status = serializeQueryLogItem(item, doc);
   std::string expected = "test";
-  std::string result = tree.get("load_test", "none");
+  std::string result = doc.doc()["load_test"].GetString();
   EXPECT_EQ(result, expected);
 
   // disable top level decorations

--- a/osquery/config/parsers/tests/events_tests.cpp
+++ b/osquery/config/parsers/tests/events_tests.cpp
@@ -42,10 +42,13 @@ TEST_F(EventsConfigParserPluginTests, test_get_event) {
   EXPECT_TRUE(plugin != nullptr);
   const auto& data = plugin->getData();
 
-  EXPECT_EQ(data.count("events"), 1U);
-  EXPECT_GT(data.get_child("events").count("environment_variables"), 0U);
-  for (const auto& var : data.get_child("events.environment_variables")) {
-    EXPECT_TRUE(var.second.data() == "foo" || var.second.data() == "bar");
+  ASSERT_TRUE(data.doc().HasMember("events"));
+  ASSERT_TRUE(data.doc()["events"].HasMember("environment_variables"));
+  ASSERT_TRUE(data.doc()["events"]["environment_variables"].IsArray());
+  for (const auto& var :
+       data.doc()["events"]["environment_variables"].GetArray()) {
+    std::string value = var.GetString();
+    EXPECT_TRUE(value == "foo" || value == "bar");
   }
 
   // Reset the configuration.

--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -68,8 +68,14 @@ TEST_F(FilePathsConfigParserPluginTests, test_get_files) {
 TEST_F(FilePathsConfigParserPluginTests, test_get_file_accesses) {
   Config::get().update(config_data_);
   auto parser = Config::getParser("file_paths");
-  auto& accesses = parser->getData().get_child("file_accesses");
-  EXPECT_EQ(accesses.size(), 2U);
+  const auto& doc = parser->getData();
+
+  size_t accesses = 0_sz;
+  if (doc.doc().HasMember("file_accesses") &&
+      doc.doc()["file_accesses"].IsArray()) {
+    accesses = doc.doc()["file_accesses"].Size();
+  }
+  EXPECT_EQ(accesses, 2_sz);
 }
 
 TEST_F(FilePathsConfigParserPluginTests, test_remove_source) {

--- a/osquery/config/parsers/views.cpp
+++ b/osquery/config/parsers/views.cpp
@@ -17,7 +17,7 @@
 
 #include "osquery/core/conversions.h"
 
-namespace pt = boost::property_tree;
+namespace rj = rapidjson;
 
 namespace osquery {
 
@@ -30,26 +30,23 @@ class ViewsConfigParserPlugin : public ConfigParserPlugin {
     return {"views"};
   }
 
-  Status setUp() override;
-
   Status update(const std::string& source, const ParserConfig& config) override;
 
  private:
   const std::string kConfigViews = "config_views.";
 };
 
-Status ViewsConfigParserPlugin::setUp() {
-  data_.put_child("views", pt::ptree());
-  return Status(0, "OK");
-}
-
 Status ViewsConfigParserPlugin::update(const std::string& source,
                                        const ParserConfig& config) {
-  if (config.count("views") > 0) {
-    data_ = pt::ptree();
-    data_.put_child("views", config.at("views"));
+  if (config.count("views") == 0) {
+    return Status(1);
   }
-  const auto& views = data_.get_child("views");
+
+  auto obj = data_.getObject();
+  obj.CopyFrom(config.at("views").doc(), data_.doc().GetAllocator());
+  data_.add("views", obj);
+
+  const auto& views = data_.doc()["views"];
 
   // We use a restricted scope below to change the data structure from
   // an array to a set. This lets us do deletes much more efficiently
@@ -62,13 +59,15 @@ Status ViewsConfigParserPlugin::update(const std::string& source,
       erase_views.insert(view.substr(kConfigViews.size()));
     }
   }
+
   QueryData r;
-  for (const auto& view : views) {
-    const auto& name = view.first;
-    std::string query = views.get<std::string>(view.first, "");
+  for (const auto& view : views.GetObject()) {
+    std::string name = view.name.GetString();
+    std::string query = view.value.GetString();
     if (query.empty()) {
       continue;
     }
+
     std::string old_query = "";
     getDatabaseValue(kQueries, kConfigViews + name, old_query);
     erase_views.erase(name);
@@ -85,6 +84,7 @@ Status ViewsConfigParserPlugin::update(const std::string& source,
       LOG(INFO) << "Error creating view (" << name << "): " << s.getMessage();
     }
   }
+
   // Any views left are views that don't exist in the new configuration file
   // so we tear them down and remove them from the database.
   for (const auto& old_view : erase_views) {

--- a/osquery/config/parsers/views.cpp
+++ b/osquery/config/parsers/views.cpp
@@ -38,12 +38,13 @@ class ViewsConfigParserPlugin : public ConfigParserPlugin {
 
 Status ViewsConfigParserPlugin::update(const std::string& source,
                                        const ParserConfig& config) {
-  if (config.count("views") == 0) {
+  auto cv = config.find("views");
+  if (cv == config.end()) {
     return Status(1);
   }
 
   auto obj = data_.getObject();
-  obj.CopyFrom(config.at("views").doc(), data_.doc().GetAllocator());
+  data_.copyFrom(cv->second.doc(), obj);
   data_.add("views", obj);
 
   const auto& views = data_.doc()["views"];

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -355,7 +355,7 @@ class TestConfigParserPlugin : public ConfigParserPlugin {
     // Copy all expected keys into the parser's data.
     for (const auto& key : config) {
       auto obj = data_.getObject();
-      obj.CopyFrom(key.second.doc(), data_.doc().GetAllocator());
+      data_.copyFrom(key.second.doc(), obj);
       data_.add(key.first, obj, data_.doc());
     }
 

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -271,7 +271,8 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
   std::vector<ScheduledQuery> queries;
   get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
   get().scheduledQueries(
-      ([&queries](const std::string&, const ScheduledQuery& query) {
+      ([&queries, &query_names](const std::string& name, const ScheduledQuery& query) {
+        query_names.push_back(name);
         queries.push_back(query);
       }));
 
@@ -290,7 +291,7 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
 
   // When the blacklist is edited externally, the config must re-read.
   get().reset();
-  get().addPack("unrestricted_pack", "", getUnrestrictedPack());
+  get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
 
   // Clear the query names in the scheduled queries and request again.
   query_names.clear();
@@ -327,7 +328,7 @@ TEST_F(ConfigTests, test_nonblacklist_query) {
   saveScheduleBlacklist(blacklist);
 
   get().reset();
-  get().addPack("unrestricted_pack", "", getUnrestrictedPack());
+  get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
 
   std::map<std::string, ScheduledQuery> queries;
   get().scheduledQueries(

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -271,7 +271,8 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
   std::vector<ScheduledQuery> queries;
   get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
   get().scheduledQueries(
-      ([&queries, &query_names](const std::string& name, const ScheduledQuery& query) {
+      ([&queries, &query_names](const std::string& name,
+                                const ScheduledQuery& query) {
         query_names.push_back(name);
         queries.push_back(query);
       }));

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -100,10 +100,8 @@ class TestConfigPlugin : public ConfigPlugin {
                  const std::string& value,
                  std::string& pack) override {
     gen_pack_count_++;
-    std::stringstream ss;
-    pt::write_json(ss, getUnrestrictedPack(), false);
-    pack = ss.str();
-    return Status(0, "OK");
+    getUnrestrictedPack().toString(pack);
+    return Status();
   }
 
  public:
@@ -201,10 +199,10 @@ TEST_F(ConfigTests, test_pack_noninline) {
 }
 
 TEST_F(ConfigTests, test_pack_restrictions) {
-  auto tree = getExamplePacksConfig();
-  auto packs = tree.get_child("packs");
-  for (const auto& pack : packs) {
-    get().addPack(pack.first, "", pack.second);
+  auto doc = getExamplePacksConfig();
+  auto& packs = doc.doc()["packs"];
+  for (const auto& pack : packs.GetObject()) {
+    get().addPack(pack.name.GetString(), "", pack.value);
   }
 
   std::map<std::string, bool> results = {
@@ -234,7 +232,7 @@ TEST_F(ConfigTests, test_pack_removal) {
   EXPECT_EQ(pack_count, 0U);
 
   pack_count = 0;
-  get().addPack("unrestricted_pack", "", getUnrestrictedPack());
+  get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
   get().packs(([&pack_count](std::shared_ptr<Pack>& pack) { pack_count++; }));
   EXPECT_EQ(pack_count, 1U);
 
@@ -271,14 +269,13 @@ TEST_F(ConfigTests, test_content_update) {
 TEST_F(ConfigTests, test_get_scheduled_queries) {
   std::vector<std::string> query_names;
   std::vector<ScheduledQuery> queries;
-  get().addPack("unrestricted_pack", "", getUnrestrictedPack());
-  get().scheduledQueries(([&queries, &query_names](
-      const std::string& name, const ScheduledQuery& query) {
-    query_names.push_back(name);
-    queries.push_back(query);
-  }));
+  get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
+  get().scheduledQueries(
+      ([&queries](const std::string&, const ScheduledQuery& query) {
+        queries.push_back(query);
+      }));
 
-  auto expected_size = getUnrestrictedPack().get_child("queries").size();
+  auto expected_size = getUnrestrictedPack().doc()["queries"].MemberCount();
   EXPECT_EQ(queries.size(), expected_size)
       << "The number of queries in the schedule (" << queries.size()
       << ") should equal " << expected_size;
@@ -357,12 +354,16 @@ class TestConfigParserPlugin : public ConfigParserPlugin {
     update_called = true;
     // Copy all expected keys into the parser's data.
     for (const auto& key : config) {
-      data_.put_child(key.first, key.second);
+      auto obj = data_.getObject();
+      obj.CopyFrom(key.second.doc(), data_.doc().GetAllocator());
+      data_.add(key.first, obj, data_.doc());
     }
 
     // Set parser-rendered additional data.
-    data_.put("dictionary3.key2", "value2");
-    return Status(0, "OK");
+    auto obj2 = data_.getObject();
+    data_.addRef("key2", "value2", obj2);
+    data_.add("dictionary3", obj2, data_.doc());
+    return Status();
   }
 
   // Flag tracking that the update method was called.
@@ -390,10 +391,10 @@ TEST_F(ConfigTests, test_get_parser) {
 
   const auto& parser =
       std::dynamic_pointer_cast<TestConfigParserPlugin>(plugin);
-  const auto& data = parser->getData();
+  const auto& doc = parser->getData();
 
-  EXPECT_EQ(data.count("list"), 1U);
-  EXPECT_EQ(data.count("dictionary"), 1U);
+  EXPECT_TRUE(doc.doc().HasMember("list"));
+  EXPECT_TRUE(doc.doc().HasMember("dictionary"));
   rf.registry("config_parser")->remove("test");
 }
 
@@ -403,7 +404,7 @@ class PlaceboConfigParserPlugin : public ConfigParserPlugin {
     return {};
   }
   Status update(const std::string&, const ParserConfig&) override {
-    return Status(0);
+    return Status();
   }
 
   /// Make sure configure is called.
@@ -458,7 +459,7 @@ TEST_F(ConfigTests, test_pack_file_paths) {
     count += files.size();
   };
 
-  get().addPack("unrestricted_pack", "", getUnrestrictedPack());
+  get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
   get().files(fileCounter);
   EXPECT_EQ(count, 2U);
 
@@ -468,7 +469,7 @@ TEST_F(ConfigTests, test_pack_file_paths) {
   EXPECT_EQ(count, 0U);
 
   count = 0;
-  get().addPack("restricted_pack", "", getRestrictedPack());
+  get().addPack("restricted_pack", "", getRestrictedPack().doc());
   get().files(fileCounter);
   EXPECT_EQ(count, 0U);
 

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -26,41 +26,41 @@ extern size_t getMachineShard(const std::string& hostname = "",
 class PacksTests : public testing::Test {};
 
 TEST_F(PacksTests, test_parse) {
-  auto tree = getExamplePacksConfig();
-  EXPECT_EQ(tree.count("packs"), 1U);
+  auto doc = getExamplePacksConfig();
+  EXPECT_TRUE(doc.doc().HasMember("packs"));
 }
 
 TEST_F(PacksTests, test_should_pack_execute) {
-  Pack kpack("unrestricted_pack", getUnrestrictedPack());
+  Pack kpack("unrestricted_pack", getUnrestrictedPack().doc());
   EXPECT_TRUE(kpack.shouldPackExecute());
 
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_FALSE(fpack.shouldPackExecute());
 }
 
 TEST_F(PacksTests, test_get_discovery_queries) {
   std::vector<std::string> expected;
 
-  Pack kpack("unrestricted_pack", getUnrestrictedPack());
+  Pack kpack("unrestricted_pack", getUnrestrictedPack().doc());
   EXPECT_EQ(kpack.getDiscoveryQueries(), expected);
 
   expected = {"select pid from processes where name = 'foobar';"};
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_EQ(fpack.getDiscoveryQueries(), expected);
 }
 
 TEST_F(PacksTests, test_platform) {
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_EQ(fpack.getPlatform(), "all");
 }
 
 TEST_F(PacksTests, test_version) {
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_EQ(fpack.getVersion(), "1.5.0");
 }
 
 TEST_F(PacksTests, test_name) {
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   fpack.setName("also_discovery_pack");
   EXPECT_EQ(fpack.getName(), "also_discovery_pack");
 }
@@ -77,7 +77,7 @@ TEST_F(PacksTests, test_sharding) {
 }
 
 TEST_F(PacksTests, test_check_platform) {
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_TRUE(fpack.checkPlatform());
 
   // Depending on the current build platform, this check will be true or false.
@@ -110,18 +110,18 @@ TEST_F(PacksTests, test_check_platform) {
 }
 
 TEST_F(PacksTests, test_check_version) {
-  Pack zpack("fake_version_pack", getPackWithFakeVersion());
+  Pack zpack("fake_version_pack", getPackWithFakeVersion().doc());
   EXPECT_FALSE(zpack.checkVersion());
 
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   EXPECT_TRUE(fpack.checkVersion());
 }
 
 TEST_F(PacksTests, test_restriction_population) {
   // Require that all potential restrictions are populated before being checked.
-  auto tree = getExamplePacksConfig();
-  auto packs = tree.get_child("packs");
-  Pack fpack("fake_pack", packs.get_child("restricted_pack"));
+  auto doc = getExamplePacksConfig();
+  const auto& packs = doc.doc()["packs"];
+  Pack fpack("fake_pack", packs["restricted_pack"]);
 
   ASSERT_FALSE(fpack.getPlatform().empty());
   ASSERT_FALSE(fpack.getVersion().empty());
@@ -129,7 +129,7 @@ TEST_F(PacksTests, test_restriction_population) {
 }
 
 TEST_F(PacksTests, test_schedule) {
-  Pack fpack("discovery_pack", getPackWithDiscovery());
+  Pack fpack("discovery_pack", getPackWithDiscovery().doc());
   // Expect a single query in the schedule since one query has an explicit
   // invalid/fake platform requirement.
   EXPECT_EQ(fpack.getSchedule().size(), 1U);
@@ -138,7 +138,7 @@ TEST_F(PacksTests, test_schedule) {
 TEST_F(PacksTests, test_discovery_cache) {
   Config c;
   // This pack and discovery query are valid, expect the SQL to execute.
-  c.addPack("valid_discovery_pack", "", getPackWithValidDiscovery());
+  c.addPack("valid_discovery_pack", "", getPackWithValidDiscovery().doc());
   size_t query_count = 0U;
   size_t query_attemts = 5U;
   for (size_t i = 0; i < query_attemts; i++) {
@@ -164,17 +164,11 @@ TEST_F(PacksTests, test_discovery_cache) {
 
 TEST_F(PacksTests, test_multi_pack) {
   std::string multi_pack_content = "{\"first\": {}, \"second\": {}}";
-  pt::ptree multi_pack;
-
-  {
-    // Convert the content into the expected pack form (ptree).
-    std::stringstream json_stream;
-    json_stream << multi_pack_content;
-    pt::read_json(json_stream, multi_pack);
-  }
+  auto multi_pack = JSON::newObject();
+  multi_pack.fromString(multi_pack_content);
 
   Config c;
-  c.addPack("*", "", multi_pack);
+  c.addPack("*", "", multi_pack.doc());
 
   std::vector<std::string> pack_names;
   c.packs(([&pack_names](std::shared_ptr<Pack>& p) {
@@ -187,7 +181,7 @@ TEST_F(PacksTests, test_multi_pack) {
 }
 
 TEST_F(PacksTests, test_discovery_zero_state) {
-  Pack pack("discovery_pack", getPackWithDiscovery());
+  Pack pack("discovery_pack", getPackWithDiscovery().doc());
   auto stats = pack.getStats();
   EXPECT_EQ(stats.total, 0U);
   EXPECT_EQ(stats.hits, 0U);

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -218,6 +218,19 @@ void JSON::mergeArray(rj::Value& target_arr, rj::Value& source_arr) {
   }
 }
 
+JSON JSON::newFromValue(const rapidjson::Value& value) {
+  assert(value.IsObject() || value.IsArray());
+
+  JSON doc;
+  doc.type_ = (value.IsArray()) ? rj::kArrayType : rj::kObjectType;
+  doc.copyFrom(value, doc.doc());
+  return doc;
+}
+
+void JSON::copyFrom(const rapidjson::Value& value, rj::Value& target) {
+  target.CopyFrom(value, doc().GetAllocator());
+}
+
 rj::Document& JSON::doc() {
   return doc_;
 }

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -51,6 +51,7 @@ class JSON : private only_movable {
   explicit JSON(decltype(rapidjson::kObjectType) type);
 
  public:
+  JSON();
   JSON(JSON&&) = default;
   JSON& operator=(JSON&&) = default;
 
@@ -68,7 +69,22 @@ class JSON : private only_movable {
   rapidjson::Document getArray() const;
 
   /// Add a JSON object or array to a list.
-  void push(rapidjson::Document& line);
+  void push(rapidjson::Value& value);
+
+  /// Add a JSON object or array to a list.
+  void push(rapidjson::Value& value, rapidjson::Value& arr);
+
+  /// Add a size_t to a JSON array.
+  void push(size_t value);
+
+  /// Add a size_t to a JSON array.
+  void push(size_t value, rapidjson::Value& arr);
+
+  /// Add a size_t to a JSON array.
+  void pushCopy(const std::string& value);
+
+  /// Add a size_t to a JSON array.
+  void pushCopy(const std::string& value, rapidjson::Value& arr);
 
   /**
    * @brief Add a string value to a JSON object by copying the contents.
@@ -78,7 +94,7 @@ class JSON : private only_movable {
    */
   void addCopy(const std::string& key,
                const std::string& value,
-               rapidjson::Document& line);
+               rapidjson::Value& obj);
 
   /**
    * @brief Add a string value to a JSON object by copying the contents.
@@ -98,7 +114,7 @@ class JSON : private only_movable {
    */
   void addRef(const std::string& key,
               const std::string& value,
-              rapidjson::Document& line);
+              rapidjson::Value& obj);
 
   /**
    * @brief Add a string value to a JSON object by referencing the contents.
@@ -116,7 +132,7 @@ class JSON : private only_movable {
    * This will add the key and value to an input document.
    * The input document must be an object type.
    */
-  void add(const std::string& key, size_t value, rapidjson::Document& line);
+  void add(const std::string& key, size_t value, rapidjson::Value& obj);
 
   /**
    * @brief Add a size_t value to a JSON object by copying the contents.
@@ -132,7 +148,7 @@ class JSON : private only_movable {
    * This will add the key and value to an input document.
    * The input document must be an object type.
    */
-  void add(const std::string& key, int value, rapidjson::Document& line);
+  void add(const std::string& key, int value, rapidjson::Value& obj);
 
   /**
    * @brief Add a int value to a JSON object by copying the contents.
@@ -142,11 +158,37 @@ class JSON : private only_movable {
    */
   void add(const std::string& key, int value);
 
+  /// Add a JSON document as a member.
+  void add(const std::string& key, rapidjson::Value& value);
+
+  /// Add a JSON document as a member of another document.
+  void add(const std::string& key,
+           rapidjson::Value& value,
+           rapidjson::Value& obj);
+
   /// Convert this document to a JSON string.
   Status toString(std::string& str) const;
 
+  /// Helper to convert a string into JSON.
+  Status fromString(const std::string& str);
+
+  /// Merge members of source into target, must both be objects.
+  void mergeObject(rapidjson::Value& target_obj, rapidjson::Value& source_obj);
+
+  void mergeArray(rapidjson::Value& target_arr, rapidjson::Value& source_arr);
+
   /// Access the internal document containing the allocator.
   rapidjson::Document& doc();
+
+  /// Access the internal document containing the allocator.
+  const rapidjson::Document& doc() const;
+
+ public:
+  /// Get the value as a 'size' or 0.
+  static size_t valueToSize(const rapidjson::Value& value);
+
+  /// Get the value as a 'bool' or false.
+  static bool valueToBool(const rapidjson::Value& value);
 
  private:
   rapidjson::Document doc_;

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -61,6 +61,9 @@ class JSON : private only_movable {
   /// Create a JSON wrapper for an Array (list).
   static JSON newArray();
 
+  /// Create a JSON wrapper from an existing value.
+  static JSON newFromValue(const rapidjson::Value& value);
+
  public:
   /// Make a JSON object (map).
   rapidjson::Document getObject() const;
@@ -165,6 +168,13 @@ class JSON : private only_movable {
   void add(const std::string& key,
            rapidjson::Value& value,
            rapidjson::Value& obj);
+
+  /**
+   * @brief Copy a JSON object/array into the document.
+   *
+   * The type of the base document may change, be careful.
+   */
+  void copyFrom(const rapidjson::Value& value, rapidjson::Value& target);
 
   /// Convert this document to a JSON string.
   Status toString(std::string& str) const;

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -80,10 +80,10 @@ class JSON : private only_movable {
   /// Add a size_t to a JSON array.
   void push(size_t value, rapidjson::Value& arr);
 
-  /// Add a size_t to a JSON array.
+  /// Add a copy of a string to a JSON array.
   void pushCopy(const std::string& value);
 
-  /// Add a size_t to a JSON array.
+  /// Add a reference to a string to a JSON array.
   void pushCopy(const std::string& value, rapidjson::Value& arr);
 
   /**
@@ -143,7 +143,7 @@ class JSON : private only_movable {
   void add(const std::string& key, size_t value);
 
   /**
-   * @brief Add a int value to a JSON object by copying the contents.
+   * @brief Add an int value to a JSON object by copying the contents.
    *
    * This will add the key and value to an input document.
    * The input document must be an object type.
@@ -151,7 +151,7 @@ class JSON : private only_movable {
   void add(const std::string& key, int value, rapidjson::Value& obj);
 
   /**
-   * @brief Add a int value to a JSON object by copying the contents.
+   * @brief Add an int value to a JSON object by copying the contents.
    *
    * This will add the key and value to the JSON document.
    * The document must be an object type.

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -19,7 +19,6 @@
 
 #include "osquery/core/json.h"
 
-namespace pt = boost::property_tree;
 namespace rj = rapidjson;
 
 namespace osquery {
@@ -271,16 +270,6 @@ Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
 }
 
 Status deserializeQueryDataJSON(const std::string& json, QueryDataSet& qd) {
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << json;
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, e.what());
-  }
-  return deserializeQueryData(tree, qd);
-
   rj::Document doc;
   if (doc.Parse(json.c_str()).HasParseError()) {
     return Status(1, "Error serializing JSON");

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -387,8 +387,7 @@ inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
   }
 }
 
-inline void getLegacyFieldsAndDecorations(const JSON& doc,
-                                          QueryLogItem& item) {
+inline void getLegacyFieldsAndDecorations(const JSON& doc, QueryLogItem& item) {
   if (doc.doc().HasMember("decorations")) {
     if (doc.doc()["decorations"].IsObject()) {
       for (const auto& i : doc.doc()["decorations"].GetObject()) {
@@ -489,12 +488,14 @@ Status deserializeQueryLogItem(const JSON& doc, QueryLogItem& item) {
   }
 
   if (doc.doc().HasMember("diffResults")) {
-    auto status = deserializeDiffResults(doc.doc()["diffResults"], item.results);
+    auto status =
+        deserializeDiffResults(doc.doc()["diffResults"], item.results);
     if (!status.ok()) {
       return status;
     }
   } else if (doc.doc().HasMember("snapshot")) {
-    auto status = deserializeQueryData(doc.doc()["snapshot"], item.snapshot_results);
+    auto status =
+        deserializeQueryData(doc.doc()["snapshot"], item.snapshot_results);
     if (!status.ok()) {
       return status;
     }

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -322,7 +322,7 @@ Status deserializeDiffResults(const rj::Value& doc, DiffResults& dr) {
     }
   }
 
-  if (doc.HasMember("added") > 0) {
+  if (doc.HasMember("added")) {
     auto status = deserializeQueryData(doc["added"], dr.added);
     if (!status.ok()) {
       return status;

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -168,237 +168,105 @@ Status Query::addNewResults(QueryData current_qd,
   return Status(0, "OK");
 }
 
-Status serializeRow(const Row& r, pt::ptree& tree) {
-  try {
-    for (auto& i : r) {
-      tree.put<std::string>(i.first, i.second);
-    }
-  } catch (const std::exception& e) {
-    return Status(1, e.what());
+Status serializeRow(const Row& r, JSON& doc, rj::Document& obj) {
+  for (auto& i : r) {
+    doc.addRef(i.first, i.second, obj);
   }
-  return Status(0, "OK");
+  return Status();
 }
 
-Status serializeRowRJ(const Row& r, rj::Document& d) {
-  try {
-    for (auto& i : r) {
-      d.AddMember(rj::Value(i.first.c_str(), d.GetAllocator()).Move(),
-                  rj::Value(i.second.c_str(), d.GetAllocator()).Move(),
-                  d.GetAllocator());
-    }
-  } catch (const std::exception& e) {
-    return Status(1, e.what());
-  }
-  return Status(0, "OK");
-}
-
-Status serializeRow(const Row& r, const ColumnNames& cols, pt::ptree& tree) {
+Status serializeRow(const Row& r,
+                    const ColumnNames& cols,
+                    JSON& doc,
+                    rj::Document& obj) {
   try {
     for (auto& c : cols) {
-      tree.add<std::string>(c, r.at(c));
+      doc.addRef(c, r.at(c), obj);
     }
   } catch (const std::exception& e) {
     return Status(1, e.what());
   }
-  return Status(0, "OK");
-}
-
-Status serializeRowRJ(const Row& r, const ColumnNames& cols, rj::Document& d) {
-  try {
-    for (auto& c : cols) {
-      d.AddMember(rj::Value(c.c_str(), d.GetAllocator()).Move(),
-                  rj::Value(r.at(c).c_str(), d.GetAllocator()).Move(),
-                  d.GetAllocator());
-    }
-  } catch (const std::exception& e) {
-    return Status(1, e.what());
-  }
-  return Status(0, "OK");
+  return Status();
 }
 
 Status serializeRowJSON(const Row& r, std::string& json) {
-  pt::ptree tree;
-  auto status = serializeRow(r, tree);
+  auto doc = JSON::newObject();
+  auto status = serializeRow(r, doc, doc.doc());
   if (!status.ok()) {
     return status;
   }
-
-  std::ostringstream output;
-  try {
-    pt::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
-    return Status(1, e.what());
-  }
-  json = output.str();
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
-Status serializeRowJSONRJ(const Row& r, std::string& json) {
-  rj::Document d(rj::kObjectType);
-  auto status = serializeRowRJ(r, d);
-  if (!status.ok()) {
-    return status;
-  }
-
-  rj::StringBuffer sb;
-  rj::Writer<rj::StringBuffer> writer(sb);
-  d.Accept(writer);
-  json = sb.GetString();
-  return Status(0, "OK");
-}
-
-Status deserializeRow(const pt::ptree& tree, Row& r) {
-  for (const auto& i : tree) {
-    if (i.first.length() > 0) {
-      r[i.first] = i.second.data();
-    }
-  }
-  return Status(0, "OK");
-}
-
-Status deserializeRowRJ(const rj::Value& v, Row& r) {
-  if (!v.IsObject()) {
+Status deserializeRow(const rj::Value& doc, Row& r) {
+  if (!doc.IsObject()) {
     return Status(1, "Row not an object");
   }
-  for (const auto& i : v.GetObject()) {
+
+  for (const auto& i : doc.GetObject()) {
     std::string name(i.name.GetString());
-    std::string value(i.value.GetString());
-    if (name.length() > 0) {
-      r[name] = value;
+    if (!name.empty()) {
+      r[name] = i.value.GetString();
     }
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 Status deserializeRowJSON(const std::string& json, Row& r) {
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << json;
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, e.what());
-  }
-  return deserializeRow(tree, r);
-}
-
-Status deserializeRowJSONRJ(const std::string& json, Row& r) {
-  rj::Document d;
-  if (d.Parse(json.c_str()).HasParseError()) {
+  rj::Document doc;
+  if (doc.Parse(json.c_str()).HasParseError()) {
     return Status(1, "Error serializing JSON");
   }
-  return deserializeRowRJ(d, r);
-}
-
-Status serializeQueryData(const QueryData& q, pt::ptree& tree) {
-  for (const auto& r : q) {
-    pt::ptree serialized;
-    auto status = serializeRow(r, serialized);
-    if (!status.ok()) {
-      return status;
-    }
-    tree.push_back(std::make_pair("", serialized));
-  }
-  return Status(0, "OK");
-}
-
-Status serializeQueryData(const QueryData& q,
-                          const ColumnNames& cols,
-                          pt::ptree& tree) {
-  for (const auto& r : q) {
-    pt::ptree serialized;
-    auto status = serializeRow(r, cols, serialized);
-    if (!status.ok()) {
-      return status;
-    }
-    tree.push_back(std::make_pair("", serialized));
-  }
-  return Status(0, "OK");
+  return deserializeRow(doc, r);
 }
 
 Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
-  pt::ptree tree;
-  auto status = serializeQueryData(q, tree);
+  auto doc = JSON::newArray();
+  auto status = serializeQueryData(q, doc, doc.doc());
   if (!status.ok()) {
     return status;
   }
-
-  std::ostringstream output;
-  try {
-    pt::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
-    return Status(1, e.what());
-  }
-  json = output.str();
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
-Status serializeQueryDataJSONRJ(const QueryData& q, std::string& json) {
-  rj::Document d;
-  d.SetArray();
-  auto status = serializeQueryDataRJ(q, d);
-  if (!status.ok()) {
-    return status;
+Status deserializeQueryData(const rj::Value& v, QueryData& qd) {
+  if (!v.IsArray()) {
+    return Status(1, "Not an array");
   }
 
-  rj::StringBuffer sb;
-  rj::Writer<rj::StringBuffer> writer(sb);
-  d.Accept(writer);
-  json = sb.GetString();
-  return Status(0, "OK");
-}
-
-Status deserializeQueryData(const pt::ptree& tree, QueryDataSet& qd) {
-  for (const auto& i : tree) {
+  for (const auto& i : v.GetArray()) {
     Row r;
-    auto status = deserializeRow(i.second, r);
+    auto status = deserializeRow(i, r);
+    if (!status.ok()) {
+      return status;
+    }
+    qd.push_back(r);
+  }
+  return Status();
+}
+
+Status deserializeQueryData(const rj::Value& v, QueryDataSet& qd) {
+  if (!v.IsArray()) {
+    return Status(1, "Not an array");
+  }
+
+  for (const auto& i : v.GetArray()) {
+    Row r;
+    auto status = deserializeRow(i, r);
     if (!status.ok()) {
       return status;
     }
     qd.insert(std::move(r));
   }
-  return Status(0, "OK");
-}
-
-Status deserializeQueryData(const pt::ptree& tree, QueryData& qd) {
-  for (const auto& i : tree) {
-    Row r;
-    auto status = deserializeRow(i.second, r);
-    if (!status.ok()) {
-      return status;
-    }
-    qd.push_back(r);
-  }
-  return Status(0, "OK");
-}
-
-Status deserializeQueryDataRJ(const rj::Value& v, QueryData& qd) {
-  if (!v.IsArray()) {
-    return Status(1, "Not an array");
-  }
-  for (const auto& i : v.GetArray()) {
-    Row r;
-    auto status = deserializeRowRJ(i, r);
-    if (!status.ok()) {
-      return status;
-    }
-    qd.push_back(r);
-  }
-  return Status(0, "OK");
+  return Status();
 }
 
 Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << json;
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, e.what());
+  rj::Document doc;
+  if (doc.Parse(json.c_str()).HasParseError()) {
+    return Status(1, "Error serializing JSON");
   }
-  return deserializeQueryData(tree, qd);
+  return deserializeQueryData(doc, qd);
 }
 
 Status deserializeQueryDataJSON(const std::string& json, QueryDataSet& qd) {
@@ -411,62 +279,65 @@ Status deserializeQueryDataJSON(const std::string& json, QueryDataSet& qd) {
     return Status(1, e.what());
   }
   return deserializeQueryData(tree, qd);
+
+  rj::Document doc;
+  if (doc.Parse(json.c_str()).HasParseError()) {
+    return Status(1, "Error serializing JSON");
+  }
+  return deserializeQueryData(doc, qd);
 }
 
-Status serializeDiffResults(const DiffResults& d, pt::ptree& tree) {
+Status serializeDiffResults(const DiffResults& d,
+                            JSON& doc,
+                            rj::Document& obj) {
   // Serialize and add "removed" first.
   // A property tree is somewhat ordered, this provides a loose contract to
   // the logger plugins and their aggregations, allowing them to parse chunked
   // lines. Note that the chunking is opaque to the database functions.
-  pt::ptree removed;
-  auto status = serializeQueryData(d.removed, removed);
+  auto removed_arr = doc.getArray();
+  auto status = serializeQueryData(d.removed, doc, removed_arr);
   if (!status.ok()) {
     return status;
   }
-  tree.add_child("removed", removed);
+  doc.add("removed", removed_arr, obj);
 
-  pt::ptree added;
-  status = serializeQueryData(d.added, added);
+  auto added_arr = doc.getArray();
+  status = serializeQueryData(d.added, doc, added_arr);
   if (!status.ok()) {
     return status;
   }
-  tree.add_child("added", added);
-  return Status(0, "OK");
+  doc.add("added", added_arr, obj);
+  return Status();
 }
 
-Status deserializeDiffResults(const pt::ptree& tree, DiffResults& dr) {
-  if (tree.count("removed") > 0) {
-    auto status = deserializeQueryData(tree.get_child("removed"), dr.removed);
+Status deserializeDiffResults(const rj::Value& doc, DiffResults& dr) {
+  if (!doc.IsObject()) {
+    return Status(1);
+  }
+
+  if (doc.HasMember("removed")) {
+    auto status = deserializeQueryData(doc["removed"], dr.removed);
     if (!status.ok()) {
       return status;
     }
   }
 
-  if (tree.count("added") > 0) {
-    auto status = deserializeQueryData(tree.get_child("added"), dr.added);
+  if (doc.HasMember("added") > 0) {
+    auto status = deserializeQueryData(doc["added"], dr.added);
     if (!status.ok()) {
       return status;
     }
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 Status serializeDiffResultsJSON(const DiffResults& d, std::string& json) {
-  pt::ptree tree;
-  auto status = serializeDiffResults(d, tree);
+  auto doc = JSON::newObject();
+  auto status = serializeDiffResults(d, doc, doc.doc());
   if (!status.ok()) {
     return status;
   }
-
-  std::ostringstream output;
-  try {
-    pt::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
-    return Status(1, e.what());
-  }
-  json = output.str();
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
 DiffResults diff(QueryDataSet& old, QueryData& current) {
@@ -489,240 +360,195 @@ DiffResults diff(QueryDataSet& old, QueryData& current) {
 }
 
 inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
-                                          pt::ptree& tree) {
+                                          JSON& doc,
+                                          rj::Document& obj) {
   // Apply legacy fields.
-  tree.put<std::string>("name", item.name);
-  tree.put<std::string>("hostIdentifier", item.identifier);
-  tree.put<std::string>("calendarTime", item.calendar_time);
-  tree.put<size_t>("unixTime", item.time);
-  tree.put<uint64_t>("epoch", item.epoch);
-  tree.put<uint64_t>("counter", item.counter);
+  doc.addRef("name", item.name, obj);
+  doc.addRef("hostIdentifier", item.identifier, obj);
+  doc.addRef("calendarTime", item.calendar_time, obj);
+  doc.add("unixTime", item.time, obj);
+  doc.add("epoch", static_cast<size_t>(item.epoch), obj);
+  doc.add("counter", static_cast<size_t>(item.counter), obj);
 
   // Append the decorations.
-  if (item.decorations.size() > 0) {
-    auto decorator_parent = std::ref(tree);
-    if (!FLAGS_decorations_top_level) {
-      tree.add_child("decorations", pt::ptree());
-      decorator_parent = tree.get_child("decorations");
+  if (!item.decorations.empty()) {
+    auto dec_obj = doc.getObject();
+    auto target_obj = std::ref(dec_obj);
+    if (FLAGS_decorations_top_level) {
+      target_obj = std::ref(obj);
     }
     for (const auto& name : item.decorations) {
-      decorator_parent.get().put<std::string>(name.first, name.second);
+      doc.addRef(name.first, name.second, target_obj);
+    }
+    if (!FLAGS_decorations_top_level) {
+      doc.add("decorations", dec_obj, obj);
     }
   }
 }
 
-inline void getLegacyFieldsAndDecorations(const pt::ptree& tree,
+inline void getLegacyFieldsAndDecorations(const rj::Document& doc,
                                           QueryLogItem& item) {
-  if (tree.count("decorations") > 0) {
-    auto& decorations = tree.get_child("decorations");
-    for (const auto& name : decorations) {
-      item.decorations[name.first] = name.second.data();
+  if (doc.HasMember("decorations")) {
+    for (const auto& i : doc["decorations"].GetObject()) {
+      item.decorations[i.name.GetString()] = i.value.GetString();
     }
   }
 
-  item.name = tree.get<std::string>("name", "");
-  item.identifier = tree.get<std::string>("hostIdentifier", "");
-  item.calendar_time = tree.get<std::string>("calendarTime", "");
-  item.time = tree.get<int>("unixTime", 0);
+  item.name = doc["name"].GetString();
+  item.identifier = doc["hostIdentifier"].GetString();
+  item.calendar_time = doc["calendarTime"].GetString();
+  item.time = doc["unixTime"].GetUint64();
 }
 
-Status serializeQueryLogItem(const QueryLogItem& item, pt::ptree& tree) {
-  pt::ptree results;
+Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc) {
   if (item.results.added.size() > 0 || item.results.removed.size() > 0) {
-    auto status = serializeDiffResults(item.results, results);
+    auto obj = doc.getObject();
+    auto status = serializeDiffResults(item.results, doc, obj);
     if (!status.ok()) {
       return status;
     }
-    tree.add_child("diffResults", results);
+
+    doc.add("diffResults", obj);
   } else {
-    auto status = serializeQueryData(item.snapshot_results, results);
+    auto arr = doc.getArray();
+    auto status = serializeQueryData(item.snapshot_results, doc, arr);
     if (!status.ok()) {
       return status;
     }
-    tree.add_child("snapshot", results);
-    tree.put<std::string>("action", "snapshot");
+
+    doc.add("snapshot", arr);
+    doc.addRef("action", "snapshot");
   }
 
-  addLegacyFieldsAndDecorations(item, tree);
-  return Status(0, "OK");
+  addLegacyFieldsAndDecorations(item, doc, doc.doc());
+  return Status();
 }
 
-static inline Status serializeEvent(const QueryLogItem& item,
-                                    const pt::ptree& event,
-                                    pt::ptree& tree) {
-  addLegacyFieldsAndDecorations(item, tree);
-  pt::ptree columns;
-  for (const auto& i : event) {
+Status serializeEvent(const QueryLogItem& item,
+                      const rj::Value& event_obj,
+                      JSON& doc,
+                      rj::Document& obj) {
+  addLegacyFieldsAndDecorations(item, doc, obj);
+
+  auto columns_obj = doc.getObject();
+  for (const auto& i : event_obj.GetObject()) {
     // Yield results as a "columns." map to avoid namespace collisions.
-    columns.put<std::string>(i.first, i.second.get_value<std::string>());
+    doc.addCopy(i.name.GetString(), i.value.GetString(), columns_obj);
   }
 
-  tree.add_child("columns", columns);
+  doc.add("columns", columns_obj, obj);
   return Status(0, "OK");
 }
 
-Status serializeQueryLogItemAsEvents(const QueryLogItem& item,
-                                     pt::ptree& tree) {
-  pt::ptree results;
+Status serializeQueryLogItemAsEvents(const QueryLogItem& item, JSON& doc) {
+  auto temp_doc = JSON::newObject();
   if (!item.results.added.empty() || !item.results.removed.empty()) {
-    auto status = serializeDiffResults(item.results, results);
+    auto status = serializeDiffResults(item.results, temp_doc, temp_doc.doc());
     if (!status.ok()) {
       return status;
     }
   } else if (!item.snapshot_results.empty()) {
-    pt::ptree snapshot_results;
-    auto status = serializeQueryData(item.snapshot_results, snapshot_results);
+    auto arr = doc.getArray();
+    auto status = serializeQueryData(item.snapshot_results, temp_doc, arr);
     if (!status.ok()) {
       return status;
     }
-    results.add_child("snapshot", snapshot_results);
+    temp_doc.add("snapshot", arr);
   } else {
     // This error case may also be represented in serializeQueryLogItem.
     return Status(1, "No diff results or snapshot results");
   }
 
-  for (const auto& action : results) {
-    for (const auto& row : action.second) {
-      pt::ptree event;
-      serializeEvent(item, row.second, event);
-      event.put<std::string>("action", action.first);
-      tree.push_back(std::make_pair("", event));
+  for (auto& action : temp_doc.doc().GetObject()) {
+    for (auto& row : action.value.GetArray()) {
+      auto obj = doc.getObject();
+      serializeEvent(item, row, doc, obj);
+      doc.addCopy("action", action.name.GetString(), obj);
+      doc.push(obj);
     }
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 Status serializeQueryLogItemJSON(const QueryLogItem& i, std::string& json) {
-  pt::ptree tree;
-  auto status = serializeQueryLogItem(i, tree);
+  auto doc = JSON::newObject();
+  auto status = serializeQueryLogItem(i, doc);
   if (!status.ok()) {
     return status;
   }
 
-  std::ostringstream output;
-  try {
-    pt::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    // The content could not be represented as JSON.
-    return Status(1, e.what());
-  }
-  json = output.str();
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
-Status deserializeQueryLogItem(const pt::ptree& tree, QueryLogItem& item) {
-  if (tree.count("diffResults") > 0) {
-    auto status =
-        deserializeDiffResults(tree.get_child("diffResults"), item.results);
+Status deserializeQueryLogItem(const rj::Document& doc, QueryLogItem& item) {
+  if (doc.HasMember("diffResults")) {
+    auto status = deserializeDiffResults(doc["diffResults"], item.results);
     if (!status.ok()) {
       return status;
     }
-  } else if (tree.count("snapshot") > 0) {
-    auto status =
-        deserializeQueryData(tree.get_child("snapshot"), item.snapshot_results);
+  } else if (doc.HasMember("snapshot")) {
+    auto status = deserializeQueryData(doc["snapshot"], item.snapshot_results);
     if (!status.ok()) {
       return status;
     }
   }
 
-  getLegacyFieldsAndDecorations(tree, item);
-  return Status(0, "OK");
+  getLegacyFieldsAndDecorations(doc, item);
+  return Status();
 }
 
 Status deserializeQueryLogItemJSON(const std::string& json,
                                    QueryLogItem& item) {
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << json;
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& e) {
-    return Status(1, e.what());
+  rj::Document doc;
+  if (doc.Parse(json.c_str()).HasParseError()) {
+    return Status(1, "Cannot parse JSON");
   }
-  return deserializeQueryLogItem(tree, item);
+  return deserializeQueryLogItem(doc, item);
 }
 
 Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& i,
                                          std::vector<std::string>& items) {
-  pt::ptree tree;
-  auto status = serializeQueryLogItemAsEvents(i, tree);
+  auto doc = JSON::newArray();
+  auto status = serializeQueryLogItemAsEvents(i, doc);
   if (!status.ok()) {
     return status;
   }
 
-  for (auto& event : tree) {
-    std::ostringstream output;
-    try {
-      pt::write_json(output, event.second, false);
-    } catch (const pt::json_parser::json_parser_error& e) {
-      return Status(1, e.what());
-    }
-    items.push_back(output.str());
+  // return doc.toString()
+  for (auto& event : doc.doc().GetArray()) {
+    rj::StringBuffer sb;
+    rj::Writer<rj::StringBuffer> writer(sb);
+    event.Accept(writer);
+    items.push_back(sb.GetString());
   }
-  return Status(0, "OK");
+  return Status();
 }
 
-Status serializeQueryDataRJ(const QueryData& q, rj::Document& d) {
-  if (!d.IsArray()) {
-    return Status(1, "Document is not an array");
-  }
+Status serializeQueryData(const QueryData& q, JSON& doc, rj::Document& arr) {
   for (const auto& r : q) {
-    rj::Document serialized;
-    serialized.SetObject();
-    auto status = serializeRowRJ(r, serialized);
+    auto row_obj = doc.getObject();
+    auto status = serializeRow(r, doc, row_obj);
     if (!status.ok()) {
       return status;
     }
-    if (serialized.GetObject().MemberCount()) {
-      d.PushBack(rj::Value(serialized, d.GetAllocator()).Move(),
-                 d.GetAllocator());
-    }
+    doc.push(row_obj, arr);
   }
-  return Status(0, "OK");
+  return Status();
 }
 
-Status serializeQueryDataRJ(const QueryData& q,
-                            const ColumnNames& cols,
-                            rj::Document& d) {
+Status serializeQueryData(const QueryData& q,
+                          const ColumnNames& cols,
+                          JSON& doc,
+                          rj::Document& arr) {
   for (const auto& r : q) {
-    rj::Document serialized;
-    serialized.SetObject();
-    auto status = serializeRowRJ(r, cols, serialized);
+    auto row_obj = doc.getObject();
+    auto status = serializeRow(r, cols, doc, row_obj);
     if (!status.ok()) {
       return status;
     }
-    if (serialized.GetObject().MemberCount()) {
-      d.PushBack(rj::Value(serialized, d.GetAllocator()).Move(),
-                 d.GetAllocator());
-    }
+    doc.push(row_obj, arr);
   }
-  return Status(0, "OK");
-}
-
-Status serializeDiffResultsRJ(const DiffResults& d, rj::Document& doc) {
-  // Serialize and add "removed" first.
-  // A property tree is somewhat ordered, this provides a loose contract to
-  // the logger plugins and their aggregations, allowing them to parse chunked
-  // lines. Note that the chunking is opaque to the database functions.
-  rj::Document removed;
-  auto status = serializeQueryDataRJ(d.removed, removed);
-  if (!status.ok()) {
-    return status;
-  }
-
-  doc.AddMember(rj::Value("removed", doc.GetAllocator()).Move(),
-                rj::Value(removed, doc.GetAllocator()).Move(),
-                doc.GetAllocator());
-
-  rj::Document added;
-  status = serializeQueryDataRJ(d.added, added);
-  if (!status.ok()) {
-    return status;
-  }
-  doc.AddMember(rj::Value("added", doc.GetAllocator()).Move(),
-                rj::Value(added, doc.GetAllocator()).Move(),
-                doc.GetAllocator());
-  return Status(0, "OK");
+  return Status();
 }
 
 bool addUniqueRowToQueryData(QueryData& q, const Row& r) {

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -138,6 +138,46 @@ TEST_F(ConversionsTests, test_json_object) {
   EXPECT_EQ(expected, result);
 }
 
+TEST_F(ConversionsTests, test_json_from_string) {
+  std::string json = "{\"key\":\"value\",\"key2\":{\"key3\":3}}";
+  auto doc = JSON::newObject();
+
+  EXPECT_TRUE(doc.fromString(json).ok());
+
+  std::string result;
+  EXPECT_TRUE(doc.toString(result));
+  EXPECT_EQ(json, result);
+
+  json += ';';
+  EXPECT_FALSE(doc.fromString(json).ok());
+}
+
+TEST_F(ConversionsTests, test_json_add_object) {
+  std::string json = "{\"key\":\"value\", \"key2\":{\"key3\":[3,2,1]}}";
+  auto doc = JSON::newObject();
+
+  ASSERT_TRUE(doc.fromString(json));
+  auto doc2 = JSON::newObject();
+  doc2.add("key2", doc.doc()["key2"]);
+  EXPECT_TRUE(doc2.doc().HasMember("key2"));
+  EXPECT_TRUE(doc2.doc()["key2"].IsObject());
+  EXPECT_TRUE(doc2.doc()["key2"].HasMember("key3"));
+
+  auto doc3 = JSON::newFromValue(doc.doc()["key2"]);
+  ASSERT_TRUE(doc3.doc().IsObject());
+  EXPECT_TRUE(doc3.doc().HasMember("key3"));
+
+  auto doc4 = JSON::newArray();
+  auto arr = doc4.getArray();
+  doc4.copyFrom(doc.doc()["key2"]["key3"], arr);
+  doc4.push(arr);
+
+  std::string expected = "[[3,2,1]]";
+  std::string output;
+  ASSERT_TRUE(doc4.toString(output).ok());
+  EXPECT_EQ(expected, output);
+}
+
 TEST_F(ConversionsTests, test_json_strings) {
   auto doc = JSON::newObject();
 

--- a/osquery/database/benchmarks/database_benchmarks.cpp
+++ b/osquery/database/benchmarks/database_benchmarks.cpp
@@ -60,53 +60,23 @@ ColumnNames getExampleColumnNames(size_t x) {
 static void DATABASE_serialize(benchmark::State& state) {
   auto qd = getExampleQueryData(state.range_x(), state.range_y());
   while (state.KeepRunning()) {
-    boost::property_tree::ptree tree;
-    serializeQueryData(qd, tree);
+    auto doc = JSON::newArray();
+    serializeQueryData(qd, doc, doc.doc());
   }
 }
 
 BENCHMARK(DATABASE_serialize)->ArgPair(1, 1)->ArgPair(10, 10)->ArgPair(10, 100);
 
-static void DATABASE_serializeRJ(benchmark::State& state) {
-  auto qd = getExampleQueryData(state.range_x(), state.range_y());
-  while (state.KeepRunning()) {
-    rapidjson::Document d;
-    d.SetArray();
-    serializeQueryDataRJ(qd, d);
-  }
-}
-
-BENCHMARK(DATABASE_serializeRJ)
-    ->ArgPair(1, 1)
-    ->ArgPair(10, 10)
-    ->ArgPair(10, 100);
-
 static void DATABASE_serialize_column_order(benchmark::State& state) {
   auto qd = getExampleQueryData(state.range_x(), state.range_y());
   auto cn = getExampleColumnNames(state.range_x());
   while (state.KeepRunning()) {
-    boost::property_tree::ptree tree;
-    serializeQueryData(qd, cn, tree);
+    auto doc = JSON::newArray();
+    serializeQueryData(qd, cn, doc, doc.doc());
   }
 }
 
 BENCHMARK(DATABASE_serialize_column_order)
-    ->ArgPair(1, 1)
-    ->ArgPair(10, 10)
-    ->ArgPair(10, 100)
-    ->ArgPair(100, 100);
-
-static void DATABASE_serializeRJ_column_order(benchmark::State& state) {
-  auto qd = getExampleQueryData(state.range_x(), state.range_y());
-  auto cn = getExampleColumnNames(state.range_x());
-  while (state.KeepRunning()) {
-    rapidjson::Document d;
-    d.SetArray();
-    serializeQueryDataRJ(qd, cn, d);
-  }
-}
-
-BENCHMARK(DATABASE_serializeRJ_column_order)
     ->ArgPair(1, 1)
     ->ArgPair(10, 10)
     ->ArgPair(10, 100)
@@ -121,19 +91,6 @@ static void DATABASE_serialize_json(benchmark::State& state) {
 }
 
 BENCHMARK(DATABASE_serialize_json)
-    ->ArgPair(1, 1)
-    ->ArgPair(10, 10)
-    ->ArgPair(10, 100);
-
-static void DATABASE_serializeRJ_json(benchmark::State& state) {
-  auto qd = getExampleQueryData(state.range_x(), state.range_y());
-  while (state.KeepRunning()) {
-    std::string content;
-    serializeQueryDataJSONRJ(qd, content);
-  }
-}
-
-BENCHMARK(DATABASE_serializeRJ_json)
     ->ArgPair(1, 1)
     ->ArgPair(10, 10)
     ->ArgPair(10, 100);
@@ -201,21 +158,6 @@ static void DATABASE_store_large(benchmark::State& state) {
 
 BENCHMARK(DATABASE_store_large);
 
-static void DATABASE_store_largeRJ(benchmark::State& state) {
-  // Serialize the example result set into a string.
-  std::string content;
-  auto qd = getExampleQueryData(20, 100);
-  serializeQueryDataJSONRJ(qd, content);
-
-  while (state.KeepRunning()) {
-    setDatabaseValue(kPersistentSettings, "benchmark", content);
-  }
-  // All benchmarks will share a single database handle.
-  deleteDatabaseValue(kPersistentSettings, "benchmark");
-}
-
-BENCHMARK(DATABASE_store_largeRJ);
-
 static void DATABASE_store_append(benchmark::State& state) {
   // Serialize the example result set into a string.
   std::string content;
@@ -236,25 +178,4 @@ static void DATABASE_store_append(benchmark::State& state) {
 }
 
 BENCHMARK(DATABASE_store_append);
-
-static void DATABASE_store_appendRJ(benchmark::State& state) {
-  // Serialize the example result set into a string.
-  std::string content;
-  auto qd = getExampleQueryData(20, 100);
-  serializeQueryDataJSONRJ(qd, content);
-
-  size_t k = 0;
-  while (state.KeepRunning()) {
-    setDatabaseValue(kPersistentSettings, "key" + std::to_string(k), content);
-    deleteDatabaseValue(kPersistentSettings, "key" + std::to_string(k));
-    k++;
-  }
-
-  // All benchmarks will share a single database handle.
-  for (size_t i = 0; i < k; ++i) {
-    deleteDatabaseValue(kPersistentSettings, "key" + std::to_string(i));
-  }
-}
-
-BENCHMARK(DATABASE_store_appendRJ);
 }

--- a/osquery/database/tests/results_tests.cpp
+++ b/osquery/database/tests/results_tests.cpp
@@ -41,21 +41,12 @@ TEST_F(ResultsTests, test_simple_diff) {
 
 TEST_F(ResultsTests, test_serialize_row) {
   auto results = getSerializedRow();
-  pt::ptree tree;
-  auto s = serializeRow(results.second, tree);
+  auto doc = JSON::newObject();
+  auto s = serializeRow(results.second, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(results.first, tree);
-}
-
-TEST_F(ResultsTests, test_serializeRJ_row) {
-  auto results = getSerializedRow();
-  rapidjson::Document d(rapidjson::kObjectType);
-  auto s = serializeRowRJ(results.second, d);
-  EXPECT_TRUE(s.ok());
-  EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(d["meaning_of_life"], "meaning_of_life_value");
-  EXPECT_EQ(d["alphabetical"], "alphabetical_value");
+  EXPECT_EQ(doc.doc()["meaning_of_life"], "meaning_of_life_value");
+  EXPECT_EQ(doc.doc()["alphabetical"], "alphabetical_value");
 }
 
 TEST_F(ResultsTests, test_deserialize_row_json) {
@@ -71,34 +62,27 @@ TEST_F(ResultsTests, test_deserialize_row_json) {
   EXPECT_EQ(output, results.second);
 }
 
-TEST_F(ResultsTests, test_deserialize_row_jsonRJ) {
-  auto results = getSerializedRow();
-  std::string input;
-  serializeRowJSONRJ(results.second, input);
-
-  // Pull the serialized JSON back into a Row output container.
-  Row output;
-  auto s = deserializeRowJSONRJ(input, output);
-  EXPECT_TRUE(s.ok());
-}
-
 TEST_F(ResultsTests, test_serialize_query_data) {
   auto results = getSerializedQueryData();
-  pt::ptree tree;
-  auto s = serializeQueryData(results.second, tree);
+  //  pt::ptree tree;
+
+  auto doc = JSON::newArray();
+  auto s = serializeQueryData(results.second, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(results.first, tree);
+  EXPECT_EQ(results.first.doc(), doc.doc());
 }
 
 TEST_F(ResultsTests, test_serialize_query_data_in_column_order) {
   auto results = getSerializedQueryDataWithColumnOrder();
   auto column_names = getSerializedRowColumnNames(true);
-  pt::ptree tree;
-  auto s = serializeQueryData(results.second, column_names, tree);
+  //  pt::ptree tree;
+
+  auto doc = JSON::newArray();
+  auto s = serializeQueryData(results.second, column_names, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(results.first, tree);
+  EXPECT_EQ(results.first.doc(), doc.doc());
 }
 
 TEST_F(ResultsTests, test_serialize_query_data_json) {
@@ -123,11 +107,12 @@ TEST_F(ResultsTests, test_deserialize_query_data_json) {
 
 TEST_F(ResultsTests, test_serialize_diff_results) {
   auto results = getSerializedDiffResults();
-  pt::ptree tree;
-  auto s = serializeDiffResults(results.second, tree);
+  // pt::ptree tree;
+  auto doc = JSON::newObject();
+  auto s = serializeDiffResults(results.second, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(results.first, tree);
+  EXPECT_EQ(results.first.doc(), doc.doc());
 }
 
 TEST_F(ResultsTests, test_serialize_diff_results_json) {
@@ -141,11 +126,12 @@ TEST_F(ResultsTests, test_serialize_diff_results_json) {
 
 TEST_F(ResultsTests, test_serialize_query_log_item) {
   auto results = getSerializedQueryLogItem();
-  pt::ptree tree;
-  auto s = serializeQueryLogItem(results.second, tree);
+  //  pt::ptree tree;
+  auto doc = JSON::newObject();
+  auto s = serializeQueryLogItem(results.second, doc);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
-  EXPECT_EQ(results.first, tree);
+  EXPECT_EQ(results.first.doc(), doc.doc());
 }
 
 TEST_F(ResultsTests, test_serialize_query_log_item_json) {

--- a/osquery/database/tests/results_tests.cpp
+++ b/osquery/database/tests/results_tests.cpp
@@ -64,8 +64,6 @@ TEST_F(ResultsTests, test_deserialize_row_json) {
 
 TEST_F(ResultsTests, test_serialize_query_data) {
   auto results = getSerializedQueryData();
-  //  pt::ptree tree;
-
   auto doc = JSON::newArray();
   auto s = serializeQueryData(results.second, doc, doc.doc());
   EXPECT_TRUE(s.ok());
@@ -76,8 +74,6 @@ TEST_F(ResultsTests, test_serialize_query_data) {
 TEST_F(ResultsTests, test_serialize_query_data_in_column_order) {
   auto results = getSerializedQueryDataWithColumnOrder();
   auto column_names = getSerializedRowColumnNames(true);
-  //  pt::ptree tree;
-
   auto doc = JSON::newArray();
   auto s = serializeQueryData(results.second, column_names, doc, doc.doc());
   EXPECT_TRUE(s.ok());
@@ -107,7 +103,6 @@ TEST_F(ResultsTests, test_deserialize_query_data_json) {
 
 TEST_F(ResultsTests, test_serialize_diff_results) {
   auto results = getSerializedDiffResults();
-  // pt::ptree tree;
   auto doc = JSON::newObject();
   auto s = serializeDiffResults(results.second, doc, doc.doc());
   EXPECT_TRUE(s.ok());
@@ -126,7 +121,6 @@ TEST_F(ResultsTests, test_serialize_diff_results_json) {
 
 TEST_F(ResultsTests, test_serialize_query_log_item) {
   auto results = getSerializedQueryLogItem();
-  //  pt::ptree tree;
   auto doc = JSON::newObject();
   auto s = serializeQueryLogItem(results.second, doc);
   EXPECT_TRUE(s.ok());

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -246,6 +246,7 @@ static const char* zShellStatic = nullptr;
 void shellstaticFunc(sqlite3_context* context,
                      int argc,
                      sqlite3_value** /* argv */) {
+  (void)argc;
   assert(0 == argc);
   assert(zShellStatic);
   sqlite3_result_text(context, zShellStatic, -1, SQLITE_STATIC);

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -90,37 +90,22 @@ size_t Distributed::getCompletedCount() {
 }
 
 Status Distributed::serializeResults(std::string& json) {
-  rj::Document results;
-  results.SetObject();
-  rj::Value queries(rj::kObjectType);
-  rj::Value statuses(rj::kObjectType);
+  auto doc = JSON::newObject();
+  auto queries_obj = doc.getObject();
+  auto statuses_obj = doc.getObject();
   for (const auto& result : results_) {
-    rj::Document qd;
-    qd.SetArray();
-    auto s = serializeQueryDataRJ(result.results, result.columns, qd);
+    auto arr = doc.getArray();
+    auto s = serializeQueryData(result.results, result.columns, doc, arr);
     if (!s.ok()) {
       return s;
     }
-    // This is a deep copy of qd which is not ideal, if we can make this a
-    // move, that would be best
-    queries.AddMember(
-        rj::Value(result.request.id.c_str(), results.GetAllocator()).Move(),
-        rj::Value(qd, results.GetAllocator()),
-        results.GetAllocator());
-    statuses.AddMember(
-        rj::Value(result.request.id.c_str(), results.GetAllocator()).Move(),
-        rj::Value(result.status.getCode()).Move(),
-        results.GetAllocator());
+    doc.add(result.request.id, arr, queries_obj);
+    doc.add(result.request.id, result.status.getCode(), statuses_obj);
   }
 
-  results.AddMember("queries", queries, results.GetAllocator());
-  results.AddMember("statuses", statuses, results.GetAllocator());
-
-  rj::StringBuffer sb;
-  rj::Writer<rj::StringBuffer> writer(sb);
-  results.Accept(writer);
-  json = sb.GetString();
-  return Status(0, "OK");
+  doc.add("queries", queries_obj);
+  doc.add("statuses", queries_obj);
+  return doc.toString(json);
 }
 
 void Distributed::addResult(const DistributedQueryResult& result) {
@@ -176,17 +161,17 @@ Status Distributed::flushCompleted() {
 }
 
 Status Distributed::acceptWork(const std::string& work) {
-  rj::Document d;
-  rj::ParseResult pr = d.Parse(rj::StringRef(work.c_str()));
-  if (!pr) {
-    return Status(1,
-                  "Error Parsing JSON: " +
-                      std::string(GetParseError_En(pr.Code()), pr.Offset()));
+  auto doc = JSON::newObject();
+  if (!doc.fromString(work)) {
+    return Status(1, "Error Parsing JSON");
   }
+
   std::set<std::string> queries_to_run;
   // Check for and run discovery queries first
-  if (d.HasMember("discovery")) {
-    const rj::Value& queries = d["discovery"];
+  if (doc.doc().HasMember("discovery")) {
+    const auto& queries = doc.doc()["discovery"];
+    assert(queries.IsObject());
+
     for (const auto& query_entry : queries.GetObject()) {
       auto name = std::string(query_entry.name.GetString());
       auto query = std::string(query_entry.value.GetString());
@@ -195,6 +180,7 @@ Status Distributed::acceptWork(const std::string& work) {
         return Status(
             1, "Distributed discovery query does not have complete attributes");
       }
+
       SQL sql(query);
       if (!sql.getStatus().ok()) {
         return Status(1, "Distributed discovery query has an SQL error");
@@ -204,8 +190,11 @@ Status Distributed::acceptWork(const std::string& work) {
       }
     }
   }
-  if (d.HasMember("queries")) {
-    const rj::Value& queries = d["queries"];
+
+  if (doc.doc().HasMember("queries")) {
+    const auto& queries = doc.doc()["queries"];
+    assert(queries.IsObject());
+
     for (const auto& query_entry : queries.GetObject()) {
       auto name = std::string(query_entry.name.GetString());
       auto query = std::string(query_entry.value.GetString());
@@ -218,9 +207,9 @@ Status Distributed::acceptWork(const std::string& work) {
     }
   }
 
-  if (d.HasMember("accelerate")) {
-    auto new_time = std::string(d["accelerate"].GetString());
-    unsigned long duration;
+  if (doc.doc().HasMember("accelerate")) {
+    auto new_time = std::string(doc.doc()["accelerate"].GetString());
+    unsigned long duration = 0;
     Status conversion = safeStrtoul(new_time, 10, duration);
     if (conversion.ok()) {
       LOG(INFO) << "Accelerating distributed query checkins for " << duration
@@ -232,7 +221,7 @@ Status Distributed::acceptWork(const std::string& work) {
       LOG(WARNING) << "Failed to Accelerate: Timeframe is not an integer";
     }
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 DistributedQueryRequest Distributed::popRequest() {
@@ -258,94 +247,79 @@ void Distributed::setCurrentRequestId(const std::string& cReqId) {
 }
 
 Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,
-                                        rj::Document& d) {
-  d.AddMember(rj::Value("query", d.GetAllocator()).Move(),
-              rj::Value(r.query.c_str(), d.GetAllocator()),
-              d.GetAllocator());
-
-  d.AddMember(rj::Value("id", d.GetAllocator()).Move(),
-              rj::Value(r.id.c_str(), d.GetAllocator()),
-              d.GetAllocator());
-
-  return Status(0, "OK");
+                                        JSON& doc,
+                                        rj::Value& obj) {
+  assert(obj.IsObject());
+  doc.addCopy("query", r.query, obj);
+  doc.addCopy("id", r.id, obj);
+  return Status();
 }
 
 Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
                                             std::string& json) {
-  rj::Document d;
-  auto s = serializeDistributedQueryRequest(r, d);
+  // rj::Document d;
+  auto doc = JSON::newObject();
+  auto s = serializeDistributedQueryRequest(r, doc, doc.doc());
   if (!s.ok()) {
     return s;
   }
 
-  rj::StringBuffer sb;
-  rj::Writer<rj::StringBuffer> writer(sb);
-  d.Accept(writer);
-  json = sb.GetString();
-
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
 Status deserializeDistributedQueryRequest(const rj::Value& d,
                                           DistributedQueryRequest& r) {
-  if (!(d.HasMember("query") && d.HasMember("id") && d["query"].IsString() &&
-        d["id"].IsString())) {
+  if (!d.HasMember("query") || !d.HasMember("id") || !d["query"].IsString() || !d["id"].IsString()) {
     return Status(1, "Malformed distributed query request");
   }
-  r.query = std::string(d["query"].GetString());
-  r.id = std::string(d["id"].GetString());
-  return Status(0, "OK");
+
+  r.query = d["query"].GetString();
+  r.id = d["id"].GetString();
+  return Status();
 }
 
 Status deserializeDistributedQueryRequestJSON(const std::string& json,
                                               DistributedQueryRequest& r) {
-  rj::Document d;
-  if (d.Parse(json.c_str()).HasParseError()) {
+  auto doc = JSON::newObject();
+  if (!doc.fromString(json)) {
     return Status(1, "Error serializing JSON");
   }
-  return deserializeDistributedQueryRequest(d, r);
+  return deserializeDistributedQueryRequest(doc.doc(), r);
 }
 
 Status serializeDistributedQueryResult(const DistributedQueryResult& r,
-                                       rj::Document& d) {
-  rj::Document request;
-  request.SetObject();
-  auto s = serializeDistributedQueryRequest(r.request, request);
+                                       JSON& doc,
+                                       rj::Value& obj) {
+  auto request_obj = doc.getObject();
+  auto s = serializeDistributedQueryRequest(r.request, doc, request_obj);
   if (!s.ok()) {
     return s;
   }
 
-  rj::Document results;
-  results.SetArray();
-  s = serializeQueryDataRJ(r.results, r.columns, results);
+  auto results_arr = doc.getArray();
+  s = serializeQueryData(r.results, r.columns, doc, results_arr);
   if (!s.ok()) {
     return s;
   }
 
-  d.AddMember(
-      "request", rj::Value(request, d.GetAllocator()).Move(), d.GetAllocator());
-  d.AddMember(
-      "results", rj::Value(results, d.GetAllocator()).Move(), d.GetAllocator());
+  doc.add("request", request_obj);
+  doc.add("results", results_arr);
   return Status(0, "OK");
 }
 
 Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
                                            std::string& json) {
-  rj::Document d;
-  auto s = serializeDistributedQueryResult(r, d);
+  // rj::Document d;
+  auto doc = JSON::newObject();
+  auto s = serializeDistributedQueryResult(r, doc, doc.doc());
   if (!s.ok()) {
     return s;
   }
 
-  rj::StringBuffer sb;
-  rj::Writer<rj::StringBuffer> writer(sb);
-  d.Accept(writer);
-  json = sb.GetString();
-
-  return Status(0, "OK");
+  return doc.toString(json);
 }
 
-Status deserializeDistributedQueryResult(const rj::Document& d,
+Status deserializeDistributedQueryResult(const rj::Value& d,
                                          DistributedQueryResult& r) {
   DistributedQueryRequest request;
   auto s = deserializeDistributedQueryRequest(d["request"], request);
@@ -354,7 +328,7 @@ Status deserializeDistributedQueryResult(const rj::Document& d,
   }
 
   QueryData results;
-  s = deserializeQueryDataRJ(d["results"], results);
+  s = deserializeQueryData(d["results"], results);
   if (!s.ok()) {
     return s;
   }
@@ -367,10 +341,10 @@ Status deserializeDistributedQueryResult(const rj::Document& d,
 
 Status deserializeDistributedQueryResultJSON(const std::string& json,
                                              DistributedQueryResult& r) {
-  rj::Document d;
-  if (d.Parse(json.c_str()).HasParseError()) {
+  auto doc = JSON::newObject();
+  if (!doc.fromString(json)) {
     return Status(1, "Error serializing JSON");
   }
-  return deserializeDistributedQueryResult(d, r);
+  return deserializeDistributedQueryResult(doc.doc(), r);
 }
 }

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -257,7 +257,6 @@ Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,
 
 Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
                                             std::string& json) {
-  // rj::Document d;
   auto doc = JSON::newObject();
   auto s = serializeDistributedQueryRequest(r, doc, doc.doc());
   if (!s.ok()) {
@@ -269,7 +268,8 @@ Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
 
 Status deserializeDistributedQueryRequest(const rj::Value& d,
                                           DistributedQueryRequest& r) {
-  if (!d.HasMember("query") || !d.HasMember("id") || !d["query"].IsString() || !d["id"].IsString()) {
+  if (!d.HasMember("query") || !d.HasMember("id") || !d["query"].IsString() ||
+      !d["id"].IsString()) {
     return Status(1, "Malformed distributed query request");
   }
 
@@ -309,7 +309,6 @@ Status serializeDistributedQueryResult(const DistributedQueryResult& r,
 
 Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
                                            std::string& json) {
-  // rj::Document d;
   auto doc = JSON::newObject();
   auto s = serializeDistributedQueryResult(r, doc, doc.doc());
   if (!s.ok()) {

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -136,12 +136,12 @@ BENCHMARK(EVENTS_add_events);
 static void EVENTS_retrieve_events(benchmark::State& state) {
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
 
-  for (int i = 0; i < state.range_y(); i++) {
+  for (int i = 0; i < state.range(1); i++) {
     sub->benchmarkAdd(i++);
   }
 
   while (state.KeepRunning()) {
-    sub->benchmarkGet(state.range_x(), state.range_y());
+    sub->benchmarkGet(state.range(0), state.range(1));
   }
 
   sub->clearRows();
@@ -155,7 +155,7 @@ BENCHMARK(EVENTS_retrieve_events)
 static void EVENTS_gentable(benchmark::State& state) {
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
 
-  for (int i = 0; i < state.range_y(); i++) {
+  for (int i = 0; i < state.range(1); i++) {
     sub->benchmarkAdd(i++);
   }
 
@@ -175,7 +175,7 @@ static void EVENTS_add_and_gentable(benchmark::State& state) {
   auto sub = std::make_shared<BenchmarkEventSubscriber>();
 
   while (state.KeepRunning()) {
-    for (int i = 0; i < state.range_y(); i++) {
+    for (int i = 0; i < state.range(1); i++) {
       sub->benchmarkAdd(i++);
     }
 

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -192,10 +192,15 @@ void FSEventsEventPublisher::buildExcludePathsSet() {
 
   WriteLock lock(subscription_lock_);
   exclude_paths_.clear();
-  for (const auto& excl_category :
-       parser->getData().get_child("exclude_paths")) {
-    for (const auto& excl_path : excl_category.second) {
-      auto pattern = excl_path.second.get_value<std::string>("");
+
+  const auto& doc = parser->getData();
+  if (!doc.doc().HasMember("exclude_paths")) {
+    return;
+  }
+
+  for (const auto& category : doc.doc()["exclude_paths"].GetObject()) {
+    for (const auto& excl_path : category.value.GetArray()) {
+      std::string pattern = excl_path.GetString();
       if (pattern.empty()) {
         continue;
       }

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -856,20 +856,21 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
 
   auto plugin = Config::get().getParser("events");
   if (plugin != nullptr && plugin.get() != nullptr) {
-    const auto& data = plugin->getData();
+    const auto& data = plugin->getData().doc();
     // First perform explicit enabling.
-    if (data.get_child("events").count("enable_subscribers") > 0) {
-      for (const auto& item : data.get_child("events.enable_subscribers")) {
-        if (item.second.data() == name) {
+    if (data["events"].HasMember("enable_subscribers")) {
+      for (const auto& item : data["events"]["enable_subscribers"].GetArray()) {
+        if (item.GetString() == name) {
           VLOG(1) << "Enabling event subscriber: " << name;
           specialized_sub->disabled = false;
         }
       }
     }
     // Then use explicit disabling as an ultimate override.
-    if (data.get_child("events").count("disable_subscribers") > 0) {
-      for (const auto& item : data.get_child("events.disable_subscribers")) {
-        if (item.second.data() == name) {
+    if (data["events"].HasMember("disable_subscribers")) {
+      for (const auto& item :
+           data["events"]["disable_subscribers"].GetArray()) {
+        if (item.GetString() == name) {
           VLOG(1) << "Disabling event subscriber: " << name;
           specialized_sub->disabled = true;
         }

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -134,15 +134,17 @@ void INotifyEventPublisher::buildExcludePathsSet() {
   exclude_paths_.clear();
 
   const auto& doc = parser->getData();
-  if (doc.doc().HasMember("exclude_paths")) {
-    for (const auto& category : doc.doc()["exclude_paths"].GetObject()) {
-      for (const auto& excl_path : category.value.GetArray()) {
-        std::string pattern = excl_path.GetString();
-        if (pattern.empty()) {
-          continue;
-        }
-        exclude_paths_.insert(pattern);
+  if (!doc.doc().HasMember("exclude_paths")) {
+    return;
+  }
+
+  for (const auto& category : doc.doc()["exclude_paths"].GetObject()) {
+    for (const auto& excl_path : category.value.GetArray()) {
+      std::string pattern = excl_path.GetString();
+      if (pattern.empty()) {
+        continue;
       }
+      exclude_paths_.insert(pattern);
     }
   }
 }

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -132,14 +132,17 @@ void INotifyEventPublisher::buildExcludePathsSet() {
 
   WriteLock lock(subscription_lock_);
   exclude_paths_.clear();
-  for (const auto& excl_category :
-       parser->getData().get_child("exclude_paths")) {
-    for (const auto& excl_path : excl_category.second) {
-      auto pattern = excl_path.second.get_value<std::string>("");
-      if (pattern.empty()) {
-        continue;
+
+  const auto& doc = parser->getData();
+  if (doc.doc().HasMember("exclude_paths")) {
+    for (const auto& category : doc.doc()["exclude_paths"].GetObject()) {
+      for (const auto& excl_path : category.value.GetArray()) {
+        std::string pattern = excl_path.GetString();
+        if (pattern.empty()) {
+          continue;
+        }
+        exclude_paths_.insert(pattern);
       }
-      exclude_paths_.insert(pattern);
     }
   }
 }
@@ -434,8 +437,8 @@ Status INotifyEventPublisher::addSubscription(
         inotify_sc->mark_for_deletion = false;
         return Status(0);
       }
-      // Returing non zero signals EventSubscriber::subscribe
-      // dont bumpup subscription_count_.
+      // Returning non zero signals EventSubscriber::subscribe
+      // do not bump up subscription_count_.
       return Status(1);
     }
   }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -608,11 +608,8 @@ Status logQueryLogItem(const QueryLogItem& results,
     return status;
   }
 
-  for (auto& json : json_items) {
-    if (!json.empty() && json.back() == '\n') {
-      json.pop_back();
-      status = logString(json, "event", receiver);
-    }
+  for (const auto& json : json_items) {
+    status = logString(json, "event", receiver);
   }
   return status;
 }
@@ -635,11 +632,7 @@ Status logSnapshotQuery(const QueryLogItem& item) {
     return status;
   }
 
-  for (auto& json : json_items) {
-    if (!json.empty() && json.back() == '\n') {
-      json.pop_back();
-    }
-
+  for (const auto& json : json_items) {
     auto receiver = RegistryFactory::get().getActive("logger");
     for (const auto& logger : osquery::split(receiver, ",")) {
       if (FLAGS_logger_secondary_status_only &&

--- a/osquery/logger/plugins/kafka_producer.cpp
+++ b/osquery/logger/plugins/kafka_producer.cpp
@@ -298,12 +298,10 @@ bool KafkaProducerPlugin::configureTopics() {
   auto parser = Config::getParser("kafka_topics");
 
   if (parser != nullptr || parser.get() != nullptr) {
-    const auto& root =
-        parser->getData().get_child_optional(kKafkaTopicParserRootKey);
-    if (root) {
-      const auto& config = root.get();
-      for (const auto& t : config) {
-        auto topic = initTopic(t.first);
+    const auto& root = parser->getData().doc()[kKafkaTopicParserRootKey];
+    if (!root.IsNull()) {
+      for (const auto& t : root.GetObject()) {
+        auto topic = initTopic(t.name.GetString());
         if (topic == nullptr) {
           continue;
         }
@@ -314,15 +312,15 @@ bool KafkaProducerPlugin::configureTopics() {
                 topic, delKafkaTopic));
 
         // Configure queryToTopics_
-        for (const auto& n :
-             config.get_child(t.first, boost::property_tree::ptree())) {
-          if (!n.first.empty()) {
+        for (const auto& n : t.value.GetArray()) {
+          std::string name = n.GetString();
+          if (name.empty()) {
             LOG(WARNING)
                 << "Query names for a topic must be in JSON array format";
             continue;
           }
 
-          queryToTopics_[n.second.data()] = topic;
+          queryToTopics_[name] = topic;
         }
       }
     }

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -159,12 +159,12 @@ TEST_F(FilesystemLoggerTests, test_log_snapshot) {
   EXPECT_TRUE(readFile(snapshot_path.string(), content));
 
   std::string expected =
-      "{\"snapshot\":\"\",\"action\":\"snapshot\",\"name\":\"test\","
+      "{\"snapshot\":[],\"action\":\"snapshot\",\"name\":\"test\","
       "\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":\"0\",\"epoch\":\"0\",\"counter\":\"0\"}\n"
-      "{\"snapshot\":\"\",\"action\":\"snapshot\","
+      "\"unixTime\":0,\"epoch\":0,\"counter\":0}\n"
+      "{\"snapshot\":[],\"action\":\"snapshot\","
       "\"name\":\"test\",\"hostIdentifier\":\"test\",\"calendarTime\":\"test\","
-      "\"unixTime\":\"0\",\"epoch\":\"0\",\"counter\":\"0\"}\n";
+      "\"unixTime\":0,\"epoch\":0,\"counter\":0}\n";
   EXPECT_EQ(content, expected);
 }
 }

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -383,13 +383,13 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
 
   // Now the two removed will be individual events.
   logQueryLogItem(item);
-  EXPECT_EQ(4U, LoggerTests::log_lines.size());
+  ASSERT_EQ(4U, LoggerTests::log_lines.size());
 
   // Make sure the JSON output does not have a newline.
   std::string expected =
       "{\"name\":\"test_query\",\"hostIdentifier\":\"unknown_test_host\","
-      "\"calendarTime\":\"no_time\",\"unixTime\":\"0\",\"epoch\":\"0\","
-      "\"counter\":\"0\",\"columns\":{\"test_column\":\"test_value\"},"
+      "\"calendarTime\":\"no_time\",\"unixTime\":0,\"epoch\":0,"
+      "\"counter\":0,\"columns\":{\"test_column\":\"test_value\"},"
       "\"action\":\"added\"}";
   EXPECT_EQ(LoggerTests::log_lines.back(), expected);
 }

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -79,22 +79,17 @@ QueryData genPrometheusMetrics(QueryContext& context) {
   /* Add a specific value to the default property tree to differentiate it from
    * the scenario where the user does not provide any prometheus_targets config.
    */
-  const auto& root = parser->getData().get_child_optional(kConfigParserRootKey);
-  if (!root) {
+  const auto& root = parser->getData().doc();
+  if (!root.HasMember(kPrometheusParserRootKey)) {
     LOG(WARNING) << "Could not load prometheus_targets root key: "
-                 << kConfigParserRootKey;
+                 << kPrometheusParserRootKey;
     return result;
   }
 
-  const auto& config = root.get();
-  if (config.count("urls") == 0) {
-    /* Only warn the user if they supplied the config, but did not supply any
-     * urls. */
-    if (!config.empty()) {
-      LOG(WARNING)
-          << "Configuration for prometheus_targets is missing field: urls";
-    }
-
+  const auto& config = root[kPrometheusParserRootKey];
+  if (!config.HasMember("urls")) {
+    LOG(WARNING)
+        << "Configuration for prometheus_targets is missing field: urls";
     return result;
   }
 
@@ -102,21 +97,13 @@ QueryData genPrometheusMetrics(QueryContext& context) {
   /* Below should be unreachable if there were no urls child node, but we set
    * handle with default value for consistency's sake and for added robustness.
    */
-  auto urls = config.get_child("urls");
-  if (urls.empty()) {
-    return result;
-  }
-  for (const auto& url : config.get_child("urls")) {
-    if (!url.first.empty()) {
-      return result;
-    }
-
-    sr[url.second.data()] = PrometheusResponseData{};
+  const auto& urls = config["urls"];
+  for (const auto& url : urls.GetArray()) {
+    sr[url.GetString()] = PrometheusResponseData{};
   }
 
-  size_t timeout = config.get_child("timeout", boost::property_tree::ptree())
-                       .get_value<size_t>(1);
-
+  size_t timeout =
+      (!config.HasMember("timeout")) ? 1 : config["timeout"].GetUint64();
   scrapeTargets(sr, timeout);
   parseScrapeResults(sr, result);
 

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -76,10 +76,8 @@ TEST_F(FileEventsTableTests, test_table_empty) {
 class FileEventsTestsConfigPlugin : public ConfigPlugin {
  public:
   Status genConfig(std::map<std::string, std::string>& config) override {
-    std::stringstream ss;
-    pt::write_json(ss, getUnrestrictedPack(), false);
-    config["data"] = ss.str();
-    return Status(0);
+    auto doc = getUnrestrictedPack();
+    return doc.toString(config["data"]);
   }
 };
 

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -170,7 +170,6 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
   const auto& yara_paths = yara_config["file_paths"];
   const auto group_iter = yara_paths.FindMember(category);
   if (group_iter != yara_paths.MemberEnd()) {
-    //  const auto& sig_groups = yara_paths.find(category);
     for (const auto& rule : group_iter->value.GetArray()) {
       std::string group = rule.GetString();
       int result = yr_rules_scan_file(rules[group],

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -48,7 +48,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
 
   bool compiled = false;
   YR_RULES* tmp_rules;
-  VLOG(1) << "Loading " << file;
+  VLOG(1) << "Loading YARA signature file: " << file;
 
   // First attempt to load the file, in case it is saved (pre-compiled)
   // rules.

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -107,7 +107,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
  * in the map under the given category.
  */
 Status handleRuleFiles(const std::string& category,
-                       const pt::ptree& rule_files,
+                       const rapidjson::Value& rule_files,
                        std::map<std::string, YR_RULES*>& rules) {
   YR_COMPILER* compiler = nullptr;
   int result = yr_compiler_create(&compiler);
@@ -119,9 +119,9 @@ Status handleRuleFiles(const std::string& category,
   yr_compiler_set_callback(compiler, YARACompilerCallback, nullptr);
 
   bool compiled = false;
-  for (const auto& item : rule_files) {
+  for (const auto& item : rule_files.GetArray()) {
     YR_RULES* tmp_rules = nullptr;
-    auto rule = item.second.get("", "");
+    std::string rule = item.GetString();
     if (rule[0] != '/') {
       rule = kYARAHome + rule;
     }
@@ -247,21 +247,24 @@ Status YARAConfigParserPlugin::setUp() {
     return Status(1, "Unable to initialize YARA");
   }
 
-  return Status(0, "OK");
+  return Status();
 }
 
 Status YARAConfigParserPlugin::update(const std::string& source,
                                       const ParserConfig& config) {
   // The YARA config parser requested the "yara" top-level key in the config.
-  const auto& yara_config = config.at("yara");
+  const auto& yara_config = config.at("yara").doc();
 
   // Look for a "signatures" key with the group/file content.
-  if (yara_config.count("signatures") > 0) {
-    const auto& signatures = yara_config.get_child("signatures");
-    data_.add_child("signatures", signatures);
-    for (const auto& element : signatures) {
-      VLOG(1) << "Compiling YARA signature group: " << element.first;
-      auto status = handleRuleFiles(element.first, element.second, rules_);
+  if (yara_config.HasMember("signatures")) {
+    auto obj = data_.getObject();
+    obj.CopyFrom(yara_config["signatures"], data_.doc().GetAllocator());
+    data_.add("signatures", obj);
+
+    for (const auto& element : data_.doc()["signatures"].GetObject()) {
+      std::string category = element.name.GetString();
+      VLOG(1) << "Compiling YARA signature group: " << category;
+      auto status = handleRuleFiles(category, element.value, rules_);
       if (!status.ok()) {
         VLOG(1) << "YARA rule compile error: " << status.getMessage();
         return status;
@@ -271,11 +274,12 @@ Status YARAConfigParserPlugin::update(const std::string& source,
 
   // The "file_paths" set maps the rule groups to the "file_paths" top level
   // configuration key. That similar key keeps the groups of file paths.
-  if (yara_config.count("file_paths") > 0) {
-    const auto& file_paths = yara_config.get_child("file_paths");
-    data_.add_child("file_paths", file_paths);
+  if (yara_config.HasMember("file_paths")) {
+    auto obj = data_.getObject();
+    obj.CopyFrom(yara_config["file_paths"], data_.doc().GetAllocator());
+    data_.add("file_paths", obj);
   }
-  return Status(0, "OK");
+  return Status();
 }
 
 /// Call the simple YARA ConfigParserPlugin "yara".

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -257,17 +257,20 @@ Status YARAConfigParserPlugin::update(const std::string& source,
 
   // Look for a "signatures" key with the group/file content.
   if (yara_config.HasMember("signatures")) {
-    auto obj = data_.getObject();
-    obj.CopyFrom(yara_config["signatures"], data_.doc().GetAllocator());
-    data_.add("signatures", obj);
+    auto& signatures = yara_config["signatures"];
+    if (signatures.IsObject()) {
+      auto obj = data_.getObject();
+      data_.copyFrom(signatures, obj);
+      data_.add("signatures", obj);
 
-    for (const auto& element : data_.doc()["signatures"].GetObject()) {
-      std::string category = element.name.GetString();
-      VLOG(1) << "Compiling YARA signature group: " << category;
-      auto status = handleRuleFiles(category, element.value, rules_);
-      if (!status.ok()) {
-        VLOG(1) << "YARA rule compile error: " << status.getMessage();
-        return status;
+      for (const auto& element : data_.doc()["signatures"].GetObject()) {
+        std::string category = element.name.GetString();
+        VLOG(1) << "Compiling YARA signature group: " << category;
+        auto status = handleRuleFiles(category, element.value, rules_);
+        if (!status.ok()) {
+          VLOG(1) << "YARA rule compile error: " << status.getMessage();
+          return status;
+        }
       }
     }
   }
@@ -275,9 +278,12 @@ Status YARAConfigParserPlugin::update(const std::string& source,
   // The "file_paths" set maps the rule groups to the "file_paths" top level
   // configuration key. That similar key keeps the groups of file paths.
   if (yara_config.HasMember("file_paths")) {
-    auto obj = data_.getObject();
-    obj.CopyFrom(yara_config["file_paths"], data_.doc().GetAllocator());
-    data_.add("file_paths", obj);
+    auto& file_paths = yara_config["file_paths"];
+    if (file_paths.IsObject()) {
+      auto obj = data_.getObject();
+      data_.copyFrom(file_paths, obj);
+      data_.add("file_paths", obj);
+    }
   }
   return Status();
 }

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -143,46 +143,31 @@ JSON getExamplePacksConfig() {
 /// no discovery queries, no platform restriction
 JSON getUnrestrictedPack() {
   auto doc = getExamplePacksConfig();
-  auto pack_doc = JSON::newObject();
-  pack_doc.doc().CopyFrom(doc.doc()["packs"]["unrestricted_pack"],
-                          pack_doc.doc().GetAllocator());
-  return pack_doc;
+  return JSON::newFromValue(doc.doc()["packs"]["unrestricted_pack"]);
 }
 
 // several restrictions (version, platform, shard)
 JSON getRestrictedPack() {
   auto doc = getExamplePacksConfig();
-  auto pack_doc = JSON::newObject();
-  pack_doc.doc().CopyFrom(doc.doc()["packs"]["restricted_pack"],
-                          pack_doc.doc().GetAllocator());
-  return pack_doc;
+  return JSON::newFromValue(doc.doc()["packs"]["restricted_pack"]);
 }
 
 /// 1 discovery query, darwin platform restriction
 JSON getPackWithDiscovery() {
   auto doc = getExamplePacksConfig();
-  auto pack_doc = JSON::newObject();
-  pack_doc.doc().CopyFrom(doc.doc()["packs"]["discovery_pack"],
-                          pack_doc.doc().GetAllocator());
-  return pack_doc;
+  return JSON::newFromValue(doc.doc()["packs"]["discovery_pack"]);
 }
 
 /// 1 discovery query which will always pass
 JSON getPackWithValidDiscovery() {
   auto doc = getExamplePacksConfig();
-  auto pack_doc = JSON::newObject();
-  pack_doc.doc().CopyFrom(doc.doc()["packs"]["valid_discovery_pack"],
-                          pack_doc.doc().GetAllocator());
-  return pack_doc;
+  return JSON::newFromValue(doc.doc()["packs"]["valid_discovery_pack"]);
 }
 
 /// no discovery queries, no platform restriction, fake version string
 JSON getPackWithFakeVersion() {
   auto doc = getExamplePacksConfig();
-  auto pack_doc = JSON::newObject();
-  pack_doc.doc().CopyFrom(doc.doc()["packs"]["fake_version_pack"],
-                          pack_doc.doc().GetAllocator());
-  return pack_doc;
+  return JSON::newFromValue(doc.doc()["packs"]["fake_version_pack"]);
 }
 
 QueryData getTestDBExpectedResults() {
@@ -288,11 +273,11 @@ std::pair<JSON, QueryData> getSerializedQueryData() {
 
   JSON doc = JSON::newArray();
   auto arr1 = doc.getArray();
-  arr1.CopyFrom(r.first.doc(), doc.doc().GetAllocator());
+  doc.copyFrom(r.first.doc(), arr1);
   doc.push(arr1);
 
   auto arr2 = doc.getArray();
-  arr2.CopyFrom(r.first.doc(), doc.doc().GetAllocator());
+  doc.copyFrom(r.first.doc(), arr2);
   doc.push(arr2);
 
   return std::make_pair(std::move(doc), q);
@@ -303,11 +288,11 @@ std::pair<JSON, QueryData> getSerializedQueryDataWithColumnOrder() {
   QueryData q = {r.second, r.second};
   JSON doc = JSON::newArray();
   auto arr1 = doc.getArray();
-  arr1.CopyFrom(r.first.doc(), doc.doc().GetAllocator());
+  doc.copyFrom(r.first.doc(), arr1);
   doc.push(arr1);
 
   auto arr2 = doc.getArray();
-  arr2.CopyFrom(r.first.doc(), doc.doc().GetAllocator());
+  doc.copyFrom(r.first.doc(), arr2);
   doc.push(arr2);
 
   return std::make_pair(std::move(doc), q);

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -14,8 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/property_tree/ptree.hpp>
-
 #include <osquery/config.h>
 #include <osquery/core.h>
 #include <osquery/database.h>
@@ -79,12 +77,12 @@ extern const size_t kExpectedExtensionArgsCount;
 std::map<std::string, std::string> getTestConfigMap(
     const std::string& file = "test_parse_items.conf");
 
-pt::ptree getExamplePacksConfig();
-pt::ptree getUnrestrictedPack();
-pt::ptree getRestrictedPack();
-pt::ptree getPackWithDiscovery();
-pt::ptree getPackWithValidDiscovery();
-pt::ptree getPackWithFakeVersion();
+JSON getExamplePacksConfig();
+JSON getUnrestrictedPack();
+JSON getRestrictedPack();
+JSON getPackWithDiscovery();
+JSON getPackWithValidDiscovery();
+JSON getPackWithFakeVersion();
 
 ScheduledQuery getOsqueryScheduledQuery();
 
@@ -105,27 +103,27 @@ ColumnNames getSerializedRowColumnNames(bool unordered_and_repeated);
 // getSerializedRow() return an std::pair where pair->first is a string which
 // should serialize to pair->second. pair->second should deserialize
 // to pair->first
-std::pair<pt::ptree, Row> getSerializedRow(bool unordered_and_repeated = false);
+std::pair<JSON, Row> getSerializedRow(bool unordered_and_repeated = false);
 
 // getSerializedQueryData() return an std::pair where pair->first is a string
 // which should serialize to pair->second. pair->second should
 // deserialize to pair->first. getSerializedQueryDataWithColumnOrder
 // returns a pair where pair->second is a tree that has a repeated column and
 // the child nodes are not in alphabetical order
-std::pair<pt::ptree, QueryData> getSerializedQueryData();
-std::pair<pt::ptree, QueryData> getSerializedQueryDataWithColumnOrder();
+std::pair<JSON, QueryData> getSerializedQueryData();
+std::pair<JSON, QueryData> getSerializedQueryDataWithColumnOrder();
 std::pair<std::string, QueryData> getSerializedQueryDataJSON();
 
 // getSerializedDiffResults() return an std::pair where pair->first is a string
 // which should serialize to pair->second. pair->second should
 // deserialize to pair->first
-std::pair<pt::ptree, DiffResults> getSerializedDiffResults();
+std::pair<JSON, DiffResults> getSerializedDiffResults();
 std::pair<std::string, DiffResults> getSerializedDiffResultsJSON();
 
 // getSerializedQueryLogItem() return an std::pair where pair->first
 // is a string which should serialize to pair->second. pair->second
 // should deserialize to pair->first
-std::pair<pt::ptree, QueryLogItem> getSerializedQueryLogItem();
+std::pair<JSON, QueryLogItem> getSerializedQueryLogItem();
 std::pair<std::string, QueryLogItem> getSerializedQueryLogItemJSON();
 
 // generate content for a PEM-encoded certificate

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -48,8 +48,8 @@ EXAMPLE_NODE_CONFIG["node"] = True
 
 EXAMPLE_DISTRIBUTED = {
     "queries": {
-        "info": "select * from osquery_info",
-        "flags": "select * from osquery_flags",
+        "info": "select count(1) from osquery_info",
+        "flags": "select count(1) from osquery_flags",
     }
 }
 


### PR DESCRIPTION
There are lots of changes included in this pull request.

The goal is to eventually replace all unneeded uses of `boost::property_tree::ptree` with `rapidjson` (or our wrapper `JSON` document manager).

In the course of this porting I found several places where data input/output was not tested. The expected default state of configuration parsers (before a config is loaded) is a good example. Loggers and the actual config parsers and tables using parsers are also troubling.

This actually represents a 'minimum change'. This data structure is core to osquery and replacing the `Query` methods created a cascading effect leading to `Config` and there into `ConfigParsers` and finally tests, and events.