### PR TITLE
Augeas table performance imporvements

### DIFF
--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -96,7 +96,8 @@ void matchAugeasPattern(augeas* aug,
       // The caller is responsible for the matching memory.
       free(file);
     } else {
-      // The iterator is currently pointing to a folder so we extract the path from the node.
+      // The iterator is currently pointing to a folder so we extract the path
+      // from the node.
       path = node.substr(6);
     }
 
@@ -112,13 +113,14 @@ void matchAugeasPattern(augeas* aug,
 }
 
 class AugeasHandle {
-public:
+ public:
   augeas* aug;
   bool error;
 
   AugeasHandle() {
     error = false;
-    this->aug = aug_init(nullptr, FLAGS_augeas_lenses.c_str(), AUG_NO_ERR_CLOSE | AUG_NO_LOAD);
+    this->aug = aug_init(
+        nullptr, FLAGS_augeas_lenses.c_str(), AUG_NO_ERR_CLOSE | AUG_NO_LOAD);
     // Handle initialization errors.
     if (this->aug == nullptr) {
       LOG(ERROR) << "An error has occurred while trying to initialize augeas";
@@ -128,7 +130,7 @@ public:
       // Do not use aug_error_details() here since augeas is not fully
       // initialized.
       LOG(ERROR) << "An error has occurred while trying to initialize augeas: "
-              << aug_error_message(this->aug);
+                 << aug_error_message(this->aug);
       aug_close(this->aug);
     }
   }

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -61,6 +61,7 @@ void matchAugeasPattern(augeas* aug,
 
   char** matches = nullptr;
   int len = aug_match(aug, "$matches", &matches);
+  results.reserve(len);
 
   // Handle matching errors.
   if (matches == nullptr) {
@@ -103,7 +104,7 @@ void matchAugeasPattern(augeas* aug,
              {"value", value == nullptr ? "" : value},
              {"path", path},
              {"label", label == nullptr ? "" : label}};
-    results.push_back(r);
+    results[i] = r;
   }
 
   // aug_match() allocates the matches array and expects the caller to free it.

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -101,11 +101,12 @@ void matchAugeasPattern(augeas* aug,
       path = node.substr(6);
     }
 
-    Row r = {{"node", node},
-             {"value", value == nullptr ? "" : value},
-             {"path", path},
-             {"label", label == nullptr ? "" : label}};
-    results[i] = r;
+    results.emplace_back(
+        std::initializer_list<std::pair<const std::string, std::string>>{
+            {"node", node},
+            {"value", value == nullptr ? "" : value},
+            {"path", path},
+            {"label", label == nullptr ? "" : label}});
   }
 
   // aug_match() allocates the matches array and expects the caller to free it.

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -10,8 +10,8 @@
 
 #include <augeas.h>
 
-#include <unordered_set>
 #include <sstream>
+#include <unordered_set>
 
 #include <boost/algorithm/string/join.hpp>
 

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -169,7 +169,7 @@ QueryData genAugeas(QueryContext& context) {
     auto paths = context.constraints["path"].getAll(EQUALS);
     std::ostringstream pattern;
 
-    for (auto path : paths) {
+    for (const auto& path : paths) {
       pattern << "/files/" << path;
       patterns.insert(pattern.str());
 

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -84,6 +84,7 @@ void matchAugeasPattern(augeas* aug,
     char* file = nullptr;
     result = aug_ns_attr(aug, "matches", i, &value, &label, &file);
     if (result == -1) {
+      reportAugeasError(aug);
       return;
     }
 
@@ -115,12 +116,12 @@ QueryData genAugeas(QueryContext& context) {
 
   // Handle initialization errors.
   if (aug == nullptr) {
-    VLOG(1) << "An error has occurred while trying to initialize augeas";
+    LOG(ERROR) << "An error has occurred while trying to initialize augeas";
     return {};
   } else if (aug_error(aug) != AUG_NOERROR) {
     // Do not use aug_error_details() here since augeas is not fully
     // initialized.
-    VLOG(1) << "An error has occurred while trying to initialize augeas: "
+    LOG(ERROR) << "An error has occurred while trying to initialize augeas: "
             << aug_error_message(aug);
     aug_close(aug);
     return {};

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -185,7 +185,6 @@ QueryData genAugeas(QueryContext& context) {
 
   if (patterns.empty()) {
     matchAugeasPattern(aug, "/files//*", results, context);
-    ;
   } else {
     matchAugeasPattern(
         aug, boost::algorithm::join(patterns, "|"), results, context);

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -10,6 +10,7 @@
 
 #include <augeas.h>
 
+#include <unordered_set>
 #include <sstream>
 
 #include <boost/algorithm/string/join.hpp>
@@ -156,7 +157,7 @@ QueryData genAugeas(QueryContext& context) {
   aug_load(aug);
 
   QueryData results;
-  std::set<std::string> patterns;
+  std::unordered_set<std::string> patterns;
 
   if (context.hasConstraint("node", EQUALS)) {
     auto nodes = context.constraints["node"].getAll(EQUALS);

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -61,7 +61,6 @@ void matchAugeasPattern(augeas* aug,
 
   char** matches = nullptr;
   int len = aug_match(aug, "$matches", &matches);
-  results.reserve(len);
 
   // Handle matching errors.
   if (matches == nullptr) {
@@ -72,6 +71,7 @@ void matchAugeasPattern(augeas* aug,
   }
 
   // Emit a row for each match.
+  results.reserve(len);
   for (size_t i = 0; i < static_cast<size_t>(len); i++) {
     if (matches[i] == nullptr) {
       continue;

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -23,6 +23,7 @@ TEST_F(AugeasTests, sanity_test) {
     auto node = row.at("node");
     auto path = row.at("path");
     auto label = row.at("label");
+    ASSERT_FALSE(node.empty()) << "Node is empty!";
     ASSERT_TRUE(node.find(path) != std::string::npos)
         << "Path not in node. Path=" << path
         << " Node=" << node;

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -20,9 +20,19 @@ class AugeasTests : public testing::Test {};
 TEST_F(AugeasTests, sanity_test) {
   auto results = SQL("select * from augeas");
   for (auto row : results.rows()) {
-    ASSERT_TRUE(row.at("node").find(row.at("path")) != std::string::npos)
-        << "Path not in node. Label=" << row.at("path")
-        << " Node=" << row.at("node");
+    auto node = row.at("node");
+    auto path = row.at("path");
+    auto label = row.at("label");
+    ASSERT_TRUE(node.find(path) != std::string::npos)
+        << "Path not in node. Path=" << path
+        << " Node=" << node;
+    // Deal with escaping issues
+    for(size_t pos = 0; (pos = node.find("\\", pos)) != std::string::npos; pos += 1) {
+      node.replace(pos, 1, "");
+    }
+    ASSERT_TRUE(node.find(label) != std::string::npos)
+        << "Label not in node. Label=" << label
+        << " Node=" << node;
   }
 }
 

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -17,6 +17,16 @@ namespace tables {
 
 class AugeasTests : public testing::Test {};
 
+TEST_F(AugeasTests, sanity_test) {
+  auto results = SQL("select * from augeas");
+  ASSERT_EQ(results.rows().size(), len);
+  for (auto row : results.rows()) {
+    ASSERT_TRUE(row.at("node").find(row.at("path")) != std::string::npos)
+        << "Path not in node. Label=" << row.at("path")
+        << " Node=" << row.at("node");
+  }
+}
+
 TEST_F(AugeasTests, select_hosts_by_path_expression) {
   auto results = SQL("select * from augeas where path = '/etc/hosts' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
@@ -28,20 +38,18 @@ TEST_F(AugeasTests, select_hosts_by_path_expression) {
       << "instead";
 }
 
-TEST_F(AugeasTests, select_etc_by_path_expression) {
+TEST_F(AugeasTests, select_etc_folder_by_path_expression) {
   auto results = SQL("select * from augeas where path = '/etc' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
   ASSERT_EQ(results.rows()[0].at("node"), "/files/etc");
   ASSERT_EQ(results.rows()[0].at("label"), "etc");
-  ASSERT_FALSE(results.rows()[0].at("path").empty())
-      << "Filename is not empty. Got " << results.rows()[0].at("filename")
-      << "instead";
+  ASSERT_EQ(results.rows()[0].at("path"), "/etc");
   ASSERT_TRUE(results.rows()[0].at("value").empty())
       << "Value is not empty. Got " << results.rows()[0].at("value")
       << "instead";
 }
 
-TEST_F(AugeasTests, select_by_path_expression_with_or) {
+TEST_F(AugeasTests, select_files_by_path_expression_with_or) {
   auto results =
       SQL("select * from augeas where path = '/etc/hosts' or "
           "path = '/etc/resolv.conf' group by path order by path");

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -19,7 +19,6 @@ class AugeasTests : public testing::Test {};
 
 TEST_F(AugeasTests, sanity_test) {
   auto results = SQL("select * from augeas");
-  ASSERT_EQ(results.rows().size(), len);
   for (auto row : results.rows()) {
     ASSERT_TRUE(row.at("node").find(row.at("path")) != std::string::npos)
         << "Path not in node. Label=" << row.at("path")

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -49,6 +49,16 @@ TEST_F(AugeasTests, select_files_by_path_expression_with_or) {
   ASSERT_EQ(results.rows()[1].at("path"), "/etc/resolv.conf");
 }
 
+TEST_F(AugeasTests, select_files_by_path_or_node) {
+  auto results =
+      SQL("select * from augeas where node = '/files/etc/hosts' or "
+          "path = '/etc/resolv.conf' group by path order by path");
+
+  ASSERT_EQ(results.rows().size(), 2U);
+  ASSERT_EQ(results.rows()[0].at("node"), "/files/etc/hosts");
+  ASSERT_EQ(results.rows()[1].at("path"), "/etc/resolv.conf");
+}
+
 TEST_F(AugeasTests, select_hosts_by_node) {
   auto results = SQL("select * from augeas where node = '/files/etc/hosts'");
   ASSERT_GE(results.rows().size(), 1U);

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -18,7 +18,9 @@ namespace tables {
 class AugeasTests : public testing::Test {};
 
 TEST_F(AugeasTests, select_hosts_by_path_expression) {
-  auto results = SQL("select * from augeas where path = '/etc/hosts' and label = 'hosts' limit 1");
+  auto results =
+      SQL("select * from augeas where path = '/etc/hosts' and label = 'hosts' "
+          "limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
   ASSERT_EQ(results.rows()[0].at("node"), "/files/etc/hosts");
   ASSERT_EQ(results.rows()[0].at("path"), "/etc/hosts");

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -18,7 +18,7 @@ namespace tables {
 class AugeasTests : public testing::Test {};
 
 TEST_F(AugeasTests, select_hosts_by_path_expression) {
-  auto results = SQL("select * from augeas where path = '/etc/hosts' limit 1");
+  auto results = SQL("select * from augeas where path = '/etc/hosts' and label = 'hosts' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);
   ASSERT_EQ(results.rows()[0].at("node"), "/files/etc/hosts");
   ASSERT_EQ(results.rows()[0].at("path"), "/etc/hosts");

--- a/osquery/tables/system/posix/tests/augeas_tests.cpp
+++ b/osquery/tables/system/posix/tests/augeas_tests.cpp
@@ -17,26 +17,6 @@ namespace tables {
 
 class AugeasTests : public testing::Test {};
 
-TEST_F(AugeasTests, sanity_test) {
-  auto results = SQL("select * from augeas");
-  for (auto row : results.rows()) {
-    auto node = row.at("node");
-    auto path = row.at("path");
-    auto label = row.at("label");
-    ASSERT_FALSE(node.empty()) << "Node is empty!";
-    ASSERT_TRUE(node.find(path) != std::string::npos)
-        << "Path not in node. Path=" << path
-        << " Node=" << node;
-    // Deal with escaping issues
-    for(size_t pos = 0; (pos = node.find("\\", pos)) != std::string::npos; pos += 1) {
-      node.replace(pos, 1, "");
-    }
-    ASSERT_TRUE(node.find(label) != std::string::npos)
-        << "Label not in node. Label=" << label
-        << " Node=" << node;
-  }
-}
-
 TEST_F(AugeasTests, select_hosts_by_path_expression) {
   auto results = SQL("select * from augeas where path = '/etc/hosts' limit 1");
   ASSERT_EQ(results.rows().size(), 1U);

--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -12,7 +12,7 @@ class Augeas < AbstractOsqueryFormula
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "3e09566342fbb532676db198d8c3b5c5bacdb3bc633dd751f19ac2a3b184631c" => :sierra
-    sha256 "a0fbaf826489cf8d1f5bce151d49e7b4a1704ed3ebc0b5c7a8d21f14bd615b51" => :x86_64_linux
+    sha256 "38b142641d71776eda481341e4e5d1b7396f30ae9266801416fa6129fcb01c15" => :x86_64_linux
   end
 
   # The autoconfigure requests readline.

--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -4,8 +4,8 @@ class Augeas < AbstractOsqueryFormula
   desc "A configuration editing tool and API"
   homepage "http://augeas.net/"
   url "https://github.com/hercules-team/augeas.git",
-    :revision => "aacc8ac07f6722622b73d9183b9acc666906d2e9"
-  version "1.8.1"
+    :tag => "release-1.9.0"
+  version "1.9.0"
   revision 100
 
   bottle do
@@ -55,9 +55,9 @@ index 5230efe..d639e14 100644
 @@ -91,7 +91,7 @@ AUGEAS_COMPILE_WARNINGS(maximum)
  AUGEAS_CFLAGS=-std=gnu99
  AC_SUBST(AUGEAS_CFLAGS)
- 
+
 -AUGEAS_CHECK_READLINE
 +# AUGEAS_CHECK_READLINE
  AC_CHECK_FUNCS([open_memstream uselocale])
- 
+
  AC_MSG_CHECKING([how to pass version script to the linker ($LD)])

--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -11,7 +11,7 @@ class Augeas < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "3e09566342fbb532676db198d8c3b5c5bacdb3bc633dd751f19ac2a3b184631c" => :sierra
+    sha256 "4d64984c408db64f33e4ba629195caa96ede0e02c1bcb7154fc2c9dc195ff4e9" => :sierra
     sha256 "38b142641d71776eda481341e4e5d1b7396f30ae9266801416fa6129fcb01c15" => :x86_64_linux
   end
 

--- a/tools/provision/formula/augeas.rb
+++ b/tools/provision/formula/augeas.rb
@@ -4,7 +4,7 @@ class Augeas < AbstractOsqueryFormula
   desc "A configuration editing tool and API"
   homepage "http://augeas.net/"
   url "https://github.com/hercules-team/augeas.git",
-    :tag => "release-1.9.0"
+    :revision => "3775c2bf53fef5f694fcf25308cee1dfe00600c4"
   version "1.9.0"
   revision 100
 


### PR DESCRIPTION
Augeas 1.9 was released 5 days ago and contains the new API we needed to make this table return results faster.
Benchmark results:
```
/usr/local/osquery/bin/python tools/analysis/profile.py --compare old.json new.json
 D:3  C:3  U:3  F:0  M:2  posix.augeas: duration: 12.5275700092 cpu_time: 12.09 utilization: 96.468 fds: 4.0 memory: 18239488.0 
 D:3  C:2  U:3  F:0  M:2  posix.augeas: duration: 6.01688480377 cpu_time: 5.84 utilization: 97.0666666667 fds: 4.0 memory: 18624512.0
```
I think that 2X improvement is impressive.

I also made the augeas handle a singleton. If we really need a mutex around it's usage I'll add it.