### PR TITLE
packages: Use source repo git describe for packages

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -18,7 +18,8 @@ OSQUERY_DEPS="${OSQUERY_DEPS:-/usr/local/osquery}"
 export PATH="${OSQUERY_DEPS}/bin:$PATH"
 source "$SOURCE_DIR/tools/lib.sh"
 
-PACKAGE_VERSION=`git describe --tags HEAD || echo 'unknown-version'`
+VERSION=`(cd $SOURCE_DIR; git describe --tags HEAD) || echo 'unknown-version'`
+PACKAGE_VERSION=${OSQUERY_BUILD_VERSION:="$VERSION"}
 PACKAGE_ARCH="x86_64"
 PACKAGE_TYPE=""
 PACKAGE_ITERATION=""

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -28,7 +28,8 @@ source "$SOURCE_DIR/tools/lib.sh"
 distro "darwin" BUILD_VERSION
 
 # Binary identifiers
-APP_VERSION=`git describe --tags HEAD`
+VERSION=`(cd $SOURCE_DIR; git describe --tags HEAD) || echo 'unknown-version'`
+APP_VERSION=${OSQUERY_BUILD_VERSION:="$VERSION"}
 APP_IDENTIFIER="com.facebook.osquery"
 KERNEL_APP_IDENTIFIER="com.facebook.osquery.kernel"
 LD_IDENTIFIER="com.facebook.osqueryd"


### PR DESCRIPTION
This fixes an issue brought up in Slack. If you use Vagrant and the `/vagrant` folder is mapped into the VM using NFS, the osquery build will place the build folder in `/tmp`. This accommodates issues with `ldd`. If you run `make packages` the CWD for the scripts on Linux and macOS will be outside of the git repo and the `git describe` commands will fail.

This PR also adds support for the documented `OSQUERY_BUILD_VERSION`. This environment variable is used by CMake and allows the builder/packager to override the version.