### PR TITLE
Adding queries to windows-attacks, fix version, nits

### DIFF
--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -72,37 +72,37 @@
       "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: (https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/)"
     },
     "conhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='conhost.exe' AND lower(path)!='c:\\windows\\system32\\conhost.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='conhost.exe' AND LOWER(path)!='c:\\windows\\system32\\conhost.exe' AND path!='';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "dllhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='dllhost.exe' AND lower(path)!='c:\\windows\\system32\\dllhost.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='dllhost.exe' AND LOWER(path)!='c:\\windows\\system32\\dllhost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\dllhost.exe' AND path!='';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "lsass.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='lsass.exe' AND lower(path)!='c:\\windows\\system32\\lsass.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='lsass.exe' AND LOWER(path)!='c:\\windows\\system32\\lsass.exe' AND path!='';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "services.exe_incorrect_parent_process": {
-      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='services.exe') AND lower(name)!='wininit.exe';",
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='services.exe') AND LOWER(name)!='wininit.exe';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "svchost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='svchost.exe' AND lower(path)!='c:\\windows\\system32\\svchost.exe' AND path!='';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='svchost.exe' AND LOWER(path)!='c:\\windows\\system32\\svchost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\svchost.exe' AND path!='';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "svchost.exe_incorrect_parent_process": {
-      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='svchost.exe') AND lower(name)!='services.exe';",
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='svchost.exe') AND LOWER(name)!='services.exe';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Detect processes masquerading as legitimate Windows processes"

--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -59,7 +59,8 @@
         AND sha256 IN (SELECT sha256 FROM hash \
           WHERE path='c:\\windows\\system32\\cmd.exe' \
           OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' \
-          OR path='c:\\windows\\system32\\explorer.exe');",
+          OR path='c:\\windows\\system32\\explorer.exe') \
+          AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"

--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -4,51 +4,98 @@
     "CCleaner_Trojan.Floxif": {
       "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Piriform\\Agomo%';",
       "interval" : "3600",
-      "version": "1.4.5",
+      "version": "2.2.1",
       "description" : "(https://sensorstechforum.com/ccleaner-trojan-floxif-malware-how-to-remove/)",
       "value" : "Artifact used by this malware"
     },
     "Winsecurity_info_1": {
       "query" : "select * from programs where name = 'Winsecurity.info';",
       "interval" : "3600",
-      "version": "1.4.5",
+      "version": "2.2.1",
       "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
       "value" : "Artifact used by this malware"
     },
     "Winsecurity_info_2": {
       "query" : "select * from chrome_extensions join users using (uid) where name = 'Winsecurity.info';",
       "interval" : "3600",
-      "version": "1.4.5",
+      "version": "2.2.1",
       "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
       "value" : "Artifact used by this malware"
     },
     "OpenType_Font_Driver_Vulnerability": {
       "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
       "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://technet.microsoft.com/en-us/library/security/ms15-078)",
-      "value" : "Artifact used by this malware"
+      "version": "2.2.1",
+      "description" : "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)"
     },
     "Protecting_Against_Weak_Crypto_Algo": {
       "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
       "interval" : "3600",
-      "version": "1.4.5",
-      "description" : "(https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
+      "version": "2.2.1",
+      "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
       "value" : "Artifact used by this malware"
     },
     "unTabs_1": {
       "query" : "select * from programs where name like 'unTabs%';",
       "interval" : "3600",
-      "version": "1.4.5",
+      "version": "2.2.1",
       "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
       "value" : "Artifact used by this malware"
     },
     "unTabs_2": {
       "query" : "select * from chrome_extensions join users using (uid) where name like 'unTabs%';",
       "interval" : "3600",
-      "version": "1.4.5",
+      "version": "2.2.1",
       "description" : "(https://sensorstechforum.com/untabs-browser-extension-virus-remove-completely/)",
       "value" : "Artifact used by this malware"
+    },
+    "StickyKeys_File_Replace_Backdoor": {
+      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe');",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"
+    },
+    "StickyKeys_Registry_Backdoor": {
+      "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\%%' and name='Debugger';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: (https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/)"
+    },
+    "conhost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE lower(name)='conhost.exe' AND lower(path)!='c:\\windows\\system32\\conhost.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "dllhost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE lower(name)='dllhost.exe' AND lower(path)!='c:\\windows\\system32\\dllhost.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "lsass.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE lower(name)='lsass.exe' AND lower(path)!='c:\\windows\\system32\\lsass.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "services.exe_incorrect_parent_process": {
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='services.exe') AND lower(name)!='wininit.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "svchost.exe_incorrect_path": {
+      "query": "SELECT * FROM processes WHERE lower(name)='svchost.exe' AND lower(path)!='c:\\windows\\system32\\svchost.exe' AND path!='';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
+    },
+    "svchost.exe_incorrect_parent_process": {
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='svchost.exe') AND lower(name)!='services.exe';",
+      "interval": 3600,
+      "version": "2.2.1",
+      "description": "Detect processes masquerading as legitimate Windows processes"
     }
   }
 }

--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -50,7 +50,16 @@
       "value" : "Artifact used by this malware"
     },
     "StickyKeys_File_Replace_Backdoor": {
-      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe');",
+      "query": "SELECT * FROM hash WHERE \
+        (path='c:\\windows\\system32\\osk.exe' \
+         OR path='c:\\windows\\system32\\sethc.exe' \
+         OR path='c:\\windows\\system32\\narrator.exe' \
+         OR path='c:\\windows\\system32\\magnify.exe' \
+         OR path='c:\\windows\\system32\\displayswitch.exe') \
+        AND sha256 IN (SELECT sha256 FROM hash \
+          WHERE path='c:\\windows\\system32\\cmd.exe' \
+          OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' \
+          OR path='c:\\windows\\system32\\explorer.exe');",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"


### PR DESCRIPTION
- Adding multiple queries. Descriptions should be self-explanatory 
- Bumping the version to 2.2.1 because the oldest osquery Windows version in Chocolatey is 2.2.1
- Adding descriptions for weak crypto and openfont. `Artifact used by this malware` is not relevant to what these queries are checking for.