### PR TITLE
Creating a windows-hardening pack and moving queries there

### DIFF
--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -29,19 +29,6 @@
       "description" : "(https://sensorstechforum.com/windows-infected-2-viruses-scam-remove/)",
       "value" : "Artifact used by this malware"
     },
-    "OpenType_Font_Driver_Vulnerability": {
-      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)"
-    },
-    "Protecting_Against_Weak_Crypto_Algo": {
-      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
-      "interval" : "3600",
-      "version": "2.2.1",
-      "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
-      "value" : "Artifact used by this malware"
-    },
     "unTabs_1": {
       "query" : "select * from programs where name like 'unTabs%';",
       "interval" : "3600",

--- a/packs/windows-hardening.conf
+++ b/packs/windows-hardening.conf
@@ -14,9 +14,10 @@
       "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
       "value" : "Artifact used by this malware"
     },
-    "UAC_Settings_Registry": {
+    "UAC_Disabled": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA' AND data=0;",
       "interval": 3600,
+      "version": "2.2.1",
       "description": "Controls UAC. A setting of 0 indicates that UAC is disabled."
     }
   }

--- a/packs/windows-hardening.conf
+++ b/packs/windows-hardening.conf
@@ -1,0 +1,23 @@
+{
+  "platform": "windows",
+  "queries": {
+    "OpenType_Font_Driver_Vulnerability": {
+      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\%' AND name = 'DisableATMFD' AND data != '1';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "Determine if Adobe Type Manager Font Driver is disabled (https://technet.microsoft.com/en-us/library/security/ms15-078)"
+    },
+    "Protecting_Against_Weak_Crypto_Algo": {
+      "query" : "select * from registry where path like 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllCreateCertificateChainEngine\\Config\\Default\\%' AND name IN ('WeakSha1ThirdPartyFlags','WeakMd5ThirdPartyFlags') AND type = 'REG_DWORD' AND data not like '-2%';",
+      "interval" : "3600",
+      "version": "2.2.1",
+      "description" : "Determine if Windows is configured to log certificates with weak crypto (https://technet.microsoft.com/library/dn375961(v=ws.11).aspx)",
+      "value" : "Artifact used by this malware"
+    },
+    "UAC_Settings_Registry": {
+      "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA' AND data=0;",
+      "interval": 3600,
+      "description": "Controls UAC. A setting of 0 indicates that UAC is disabled."
+    }
+  }
+}


### PR DESCRIPTION
As discussed in Slack, windows-attacks.conf should probably be limited to queries that represent actual compromise on a host, rather than security control settings. I've created windows-hardening.conf as a place to put queries related to Windows security settings.