### PR TITLE
[Fix #3941] Stop renaming worker and extension argv[0]

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -509,7 +509,7 @@ void Initializer::initWatcher() const {
 void Initializer::initWorker(const std::string& name) const {
   // Clear worker's arguments.
   auto original_name = std::string((*argv_)[0]);
-  for (int i = 0; i < *argc_; i++) {
+  for (int i = 1; i < *argc_; i++) {
     if ((*argv_)[i] != nullptr) {
       memset((*argv_)[i], '\0', strlen((*argv_)[i]));
     }

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -508,21 +508,11 @@ void Initializer::initWatcher() const {
 
 void Initializer::initWorker(const std::string& name) const {
   // Clear worker's arguments.
-  size_t name_size = strlen((*argv_)[0]);
   auto original_name = std::string((*argv_)[0]);
   for (int i = 0; i < *argc_; i++) {
     if ((*argv_)[i] != nullptr) {
       memset((*argv_)[i], '\0', strlen((*argv_)[i]));
     }
-  }
-
-  // Set the worker's process name.
-  if (name.size() < name_size) {
-    std::copy(name.begin(), name.end(), (*argv_)[0]);
-    (*argv_)[0][name.size()] = '\0';
-  } else {
-    std::copy(original_name.begin(), original_name.end(), (*argv_)[0]);
-    (*argv_)[0][original_name.size()] = '\0';
   }
 
   // Start a 'watcher watcher' thread to exit the process if the watcher exits.

--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -120,7 +120,6 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     const std::string& exec_path,
-    const std::string& extension,
     const std::string& extensions_socket,
     const std::string& extensions_timeout,
     const std::string& extensions_interval,
@@ -142,9 +141,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
 
     std::vector<const char*> arguments;
     arguments.push_back(exec_path.c_str());
-
-    auto exec_title = "osquery extension: " + extension;
-    arguments.push_back(exec_title.c_str());
+    arguments.push_back(exec_path.c_str());
 
     std::string arg_verbose("--verbose");
     if (verbose) {
@@ -168,7 +165,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     ::execve(arguments[0], argv, ::environ);
 
     // Code should never reach this point
-    VLOG(1) << "Could not start extension process: " << extension;
+    VLOG(1) << "Could not start extension process: " << exec_path;
     Initializer::shutdown(EXIT_FAILURE);
     return std::shared_ptr<PlatformProcess>();
   }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -158,7 +158,6 @@ class PlatformProcess : private boost::noncopyable {
    */
   static std::shared_ptr<PlatformProcess> launchExtension(
       const std::string& exec_path,
-      const std::string& extension,
       const std::string& extensions_socket,
       const std::string& extensions_timeout,
       const std::string& extensions_interval,

--- a/osquery/core/tests/process_tests.cpp
+++ b/osquery/core/tests/process_tests.cpp
@@ -128,7 +128,6 @@ TEST_F(ProcessTests, test_launchExtension) {
   {
     auto process =
         PlatformProcess::launchExtension(kProcessTestExecPath.c_str(),
-                                         "extension-test",
                                          kExpectedExtensionArgs[3],
                                          kExpectedExtensionArgs[5],
                                          kExpectedExtensionArgs[7],
@@ -168,23 +167,4 @@ TEST_F(ProcessTests, test_launchWorker) {
     EXPECT_EQ(code, WORKER_SUCCESS_CODE);
   }
 }
-
-#ifdef WIN32
-TEST_F(ProcessTests, test_launchExtensionQuotes) {
-  {
-    auto process =
-        PlatformProcess::launchExtension(kProcessTestExecPath.c_str(),
-                                         "exten\"sion-te\"st",
-                                         "socket-name",
-                                         "100",
-                                         "5",
-                                         true);
-    EXPECT_NE(nullptr, process.get());
-
-    int code = 0;
-    EXPECT_TRUE(getProcessExitCode(*process, code));
-    EXPECT_EQ(code, EXTENSION_SUCCESS_CODE);
-  }
-}
-#endif
 }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -547,7 +547,6 @@ void WatcherRunner::createExtension(const std::string& extension) {
 
   auto ext_process =
       PlatformProcess::launchExtension(exec_path.string(),
-                                       extension,
                                        Flag::getValue("extensions_socket"),
                                        Flag::getValue("extensions_timeout"),
                                        Flag::getValue("extensions_interval"),

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -239,7 +239,6 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchWorker(
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     const std::string& exec_path,
-    const std::string& extension,
     const std::string& extensions_socket,
     const std::string& extensions_timeout,
     const std::string& extensions_interval,
@@ -252,8 +251,7 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
   // To prevent errant double quotes from altering the intended arguments for
   // argv, we strip them out completely.
   std::stringstream argv_stream;
-  argv_stream << "\"osquery extension: "
-              << boost::replace_all_copy(extension, "\"", "") << "\" ";
+  argv_stream << boost::replace_all_copy(exec_path, "\"", "") << "\" ";
   if (verbose) {
     argv_stream << "--verbose ";
   }

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -35,12 +35,12 @@ const char* kOsqueryTestModuleName = "osquery_tests.exe";
 
 /// These are the expected arguments for our test worker process.
 const char* kExpectedWorkerArgs[] = {
-    "worker-test", "--socket", "fake-socket", nullptr};
+    nullptr, "--socket", "fake-socket", nullptr};
 const size_t kExpectedWorkerArgsCount =
     (sizeof(osquery::kExpectedWorkerArgs) / sizeof(char*)) - 1;
 
 /// These are the expected arguments for our test extensions process.
-const char* kExpectedExtensionArgs[] = {"osquery extension: extension-test",
+const char* kExpectedExtensionArgs[] = {nullptr,
                                         "--verbose",
                                         "--socket",
                                         "socket-name",
@@ -121,13 +121,16 @@ int extensionMain(int argc, char* argv[]) {
 }
 
 int main(int argc, char* argv[]) {
+  osquery::kProcessTestExecPath = argv[0];
+  osquery::kExpectedExtensionArgs[0] = argv[0];
+  osquery::kExpectedWorkerArgs[0] = argv[0];
+
   if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
     return workerMain(argc, argv);
   } else if ((val = osquery::getEnvVar("OSQUERY_EXTENSION"))) {
     return extensionMain(argc, argv);
   }
 
-  osquery::kProcessTestExecPath = argv[0];
   osquery::initTesting();
   testing::InitGoogleTest(&argc, argv);
   // Optionally enable Goggle Logging


### PR DESCRIPTION
It was fun while it lasted but renaming `argv[0]` from `/path/to/osqueryd` to `osqueryd: worker` had odd effects in practice. There are inconsistencies with libraries, such as syslog, and command line reporting in osquery's `processes` table on macOS.

Since this is not standard, and a little hacky, it feels like we should remove it altogether. 