### PR TITLE
tables: expanding windows programs table to encompass apps without GUID

### DIFF
--- a/specs/windows/programs.table
+++ b/specs/windows/programs.table
@@ -1,9 +1,10 @@
 table_name("programs", aliases=["programs_and_features"])
-description("Rrepresents products as they are installed by Windows Installer. A product generally correlates to one installation package.")
+description("Represents products as they are installed by Windows Installer. A product generally correlates to one installation package on Windows. Some fields may be blank as Windows installation details are left to the discretion of the product author.")
 schema([
     Column("name", TEXT, "Commonly used product name."),
     Column("version", TEXT, "Product version information."),
-    Column("install_source", TEXT, "The installation source directory of the product."),
+    Column("install_location", TEXT, "The installation location directory of the product."),
+    Column("install_source", TEXT, "The installation source of the product."),
     Column("language", TEXT, "The language of the product."),
     Column("publisher", TEXT, "Name of the product supplier."),
     Column("uninstall_string", TEXT, "Path and filename of the uninstaller."),
@@ -13,4 +14,5 @@ schema([
 implementation("programs@genPrograms")
 examples([
   "select * from programs",
+  "select name, install_location from programs where install_location not like 'C:\Program Files%';",
 ])


### PR DESCRIPTION
This should address #3043 in entirety. The current method for parsing our program applications is to enumerate all of the `Uninstall` registry keys on the system, and parse out this data. This works out pretty well, however we're currently missing programs as we're looking for registry keys that leverage a GUID for the key path. This removes that restriction, and ensures we make a best effort to parse any registry keys we find under the uninstall path. I did some number checking against the programs generated by `Get-WmiObject -Query "Select * from Win32_Product"`, and it looks like we're getting all of the same stuff, plus more :3

The below series of python commands are checking that osquerys `programs` table captures all of the same installed programs as the WMI table by checking the `identifying_number` column. As one might've inferred from my notes above, quite a few of our installed applications aren't exposing their `identifying_number`, such as Atom or Sublime Text, and thus osquery has a few more programs listed.
```
...
In [14]: osquery_programs = [x.strip() for x in open('C:\Users\Nicholas\Desktop\osquery_programs.out', 'r').readlines()]

In [15]: osq = set(osquery_programs)

In [16]: len(osq)
Out[16]: 477

In [17]: len(wmi)
Out[17]: 389

In [18]: osq.issuperset(wmi)
Out[18]: True

In [20]: len(osq.difference(wmi))
Out[20]: 88
```

Lastly, worth noting, this PR also brings in the `install_location` field to the table schema, as Windows apparently leaves it to the discretion of the program author what fields to specify. There's numerous entries in the programs table that have no `install_source`, and vice-versa for `install_location`. The hope is that between the various fields we check, one can infer the installation location of the program.