### PR TITLE
tables: adding type column to users table to differentiate local users

### DIFF
--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -34,6 +34,25 @@ const std::string kRegProfilePath =
     "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows "
     "NT\\CurrentVersion\\ProfileList";
 const char kRegSep = '\\';
+const std::set<std::string> kWellKnownSids = {
+    "S-1-5-1",
+    "S-1-5-2",
+    "S-1-5-3",
+    "S-1-5-4",
+    "S-1-5-6",
+    "S-1-5-7",
+    "S-1-5-8",
+    "S-1-5-9",
+    "S-1-5-10",
+    "S-1-5-11",
+    "S-1-5-12",
+    "S-1-5-13",
+    "S-1-5-18",
+    "S-1-5-19",
+    "S-1-5-20",
+    "S-1-5-21",
+    "S-1-5-32",
+};
 
 namespace tables {
 
@@ -75,6 +94,9 @@ void processRoamingProfiles(const std::set<std::string>& processedSids,
     r["gid"] = INTEGER(getGidFromSid(sid));
     r["uid_signed"] = r["uid"];
     r["gid_signed"] = r["gid"];
+    r["type"] = kWellKnownSids.find(sidString) == kWellKnownSids.end()
+                    ? "roaming"
+                    : "special";
 
     // TODO
     r["shell"] = "C:\\Windows\\system32\\cmd.exe";
@@ -149,6 +171,7 @@ void processLocalAccounts(std::set<std::string>& processedSids,
             wstringToString(LPUSER_INFO_4(userLvl4Buff)->usri4_comment);
         r["directory"] = getUserHomeDir(sidString);
         r["shell"] = "C:\\Windows\\System32\\cmd.exe";
+        r["type"] = "local";
         if (userLvl4Buff != nullptr) {
           NetApiBufferFree(userLvl4Buff);
         }

--- a/specs/users.table
+++ b/specs/users.table
@@ -11,6 +11,9 @@ schema([
     Column("shell", TEXT, "User's configured default shell"),
     Column("uuid", TEXT, "User's UUID (Apple)"),
 ])
+extended_schema(WINDOWS, [
+    Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),
+])
 implementation("users@genUsers")
 examples([
   "select * from users where uid = 1000",


### PR DESCRIPTION
This addresses #3929 by specifying a `type` for Windows users. The attempt is to differentiate roaming profiles from local users from system account profiles. To check for system account profiles, we match the SID of the user being processed against the set of well known SID values from MS. The only remaining type of user will be domain users, or users with a roaming profile that NetUserEnum doesn't process. Of note, I made some decisions here with the values of `type`. Currently they are `local`, `roaming` for domain users and roaming profiles, and `special` for any of the Windows well-known SIDs. I had thought about using `system` for the well-known sids, but figured that'd be confusing with the `SYSTEM` account. I'm definitely open to using different values though, let me know!