### PR TITLE
Adding more functionality to macOS' event tapping

### DIFF
--- a/osquery/tables/events/darwin/user_interaction_events.cpp
+++ b/osquery/tables/events/darwin/user_interaction_events.cpp
@@ -12,7 +12,7 @@
 
 namespace osquery {
 
-class EventTapsKeySubscriber
+class UserInteractionSubscriber
     : public EventSubscriber<EventTappingEventPublisher> {
  public:
   Status init() override {
@@ -25,14 +25,16 @@ class EventTapsKeySubscriber
                   const EventTappingSubscriptionContextRef& sc);
 };
 
-REGISTER(EventTapsKeySubscriber, "event_subscriber", "key_events");
+REGISTER(UserInteractionSubscriber,
+         "event_subscriber",
+         "user_interaction_events");
 
-void EventTapsKeySubscriber::configure() {
+void UserInteractionSubscriber::configure() {
   auto sc = createSubscriptionContext();
-  subscribe(&EventTapsKeySubscriber::Callback, sc);
+  subscribe(&UserInteractionSubscriber::Callback, sc);
 }
 
-Status EventTapsKeySubscriber::Callback(
+Status UserInteractionSubscriber::Callback(
     const EventTappingEventContextRef& ec,
     const EventTappingSubscriptionContextRef& sc) {
   Row r;

--- a/specs/darwin/key_events.table
+++ b/specs/darwin/key_events.table
@@ -1,7 +1,0 @@
-table_name("key_events")
-description("Track key events.")
-schema([
-    Column("time", BIGINT, "Time")
-])
-attributes(event_subscriber=True)
-implementation("events/darwin/key_events@key_events::genTable")

--- a/specs/darwin/user_interaction_events.table
+++ b/specs/darwin/user_interaction_events.table
@@ -1,0 +1,7 @@
+table_name("user_interaction_events")
+description("Track user interaction events from macOS' event tapping framework.")
+schema([
+    Column("time", BIGINT, "Time")
+])
+attributes(event_subscriber=True)
+implementation("events/darwin/user_interaction_events@user_interaction_events::genTable")


### PR DESCRIPTION
Before we were only tapping key_down events. This modifies the concept to also tap mouse_down events and put the data into the same table.

Since the table no longer represents only key_events, it has been renamed user_interaction_events.