### PR TITLE
Adding detection for new "Symantec" Proton variant

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -470,22 +470,27 @@
       "query" : "select * from file \
         where path like '/Users/%/Library/RenderFiles/activity_agent.app/' OR \
         path like '/Users/%/Library/LaunchAgents/fr.handbrake.activity_agent.plist' OR \
-        path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app';",
+        path='/tmp/Updater.app' OR path='/Library/.rand/updateragent.app' OR \
+        path='/Library/LaunchAgents/com.apple.xpcd.plist' OR \
+        path='/Library/.cachedir' OR \
+        path='/Library/.random';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
       "value" : "Artifacts created by this malware"
     },
     "OSX_Proton_Launchd": {
-      "query" : "select * from launchd where name='com.Eltima.UpdaterAgent.plist';",
+      "query" : "select * from launchd where name='com.Eltima.UpdaterAgent.plist' OR name='com.apple.xpcd.plist';",
       "interval" : "3600",
       "version": "1.4.5",
-      "description" : "OSX/Proton bundled with a tampered version of Elmedia Player: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",
+      "description" : "OSX/Proton bundled with a tampered version of Elmedia Player or Fake Symantec Blog: (https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/) and (https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/11/osx-proton-spreading-through-fake-symantec-blog/)",
       "value" : "Artifacts created by this malware"
     },
     "OSX_Proton_Process": {
       "query" : "select * from processes \
-        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent';",
+        where path like '/Users/%/Library/RenderFiles/activity_agent.app/Contents/MacOS/activity_agent' OR \
+        path='/Library/.rand/updateragent.app/Contents/MacOS/updateragent' OR \
+        path='/Library/.random/xpcd.app/Contents/MacOS/xpcd';",
       "interval" : "3600",
       "version": "1.4.5",
       "description" : "OSX/Proton bundled with a tampered version of Handbrake and Elmedia Player: (https://objective-see.com/blog/blog_0x1D.html and https://www.welivesecurity.com/2017/10/20/osx-proton-supply-chain-attack-elmedia/)",


### PR DESCRIPTION
https://blog.malwarebytes.com/threat-analysis/mac-threat-analysis/2017/11/osx-proton-spreading-through-fake-symantec-blog/