### PR TITLE
 Fix for issue-3953

### DIFF
--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -187,14 +187,16 @@ void Client::sendRequest(STREAM_TYPE& stream,
   req.target((req.remotePath()) ? *req.remotePath() : "/");
   req.version = 11;
 
-  std::string host_header_value = *client_options_.remote_hostname_;
-  if (ssl_connection && (kHTTPSDefaultPort != *client_options_.remote_port_)) {
-    host_header_value += ':' + *client_options_.remote_port_;
-  } else if (kHTTPDefaultPort != *client_options_.remote_port_) {
-    host_header_value += ':' + *client_options_.remote_port_;
+  if (req[beast_http::field::host].empty()) {
+    std::string host_header_value = *client_options_.remote_hostname_;
+    if (ssl_connection && (kHTTPSDefaultPort != *client_options_.remote_port_)) {
+      host_header_value += ':' + *client_options_.remote_port_;
+    } else if (kHTTPDefaultPort != *client_options_.remote_port_) {
+      host_header_value += ':' + *client_options_.remote_port_;
+    }
+    req.set(beast_http::field::host, host_header_value);
   }
 
-  req.set(beast_http::field::host, host_header_value);
   req.prepare_payload();
   req.keep_alive(true);
 

--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -189,7 +189,8 @@ void Client::sendRequest(STREAM_TYPE& stream,
 
   if (req[beast_http::field::host].empty()) {
     std::string host_header_value = *client_options_.remote_hostname_;
-    if (ssl_connection && (kHTTPSDefaultPort != *client_options_.remote_port_)) {
+    if (ssl_connection &&
+        (kHTTPSDefaultPort != *client_options_.remote_port_)) {
       host_header_value += ':' + *client_options_.remote_port_;
     } else if (kHTTPDefaultPort != *client_options_.remote_port_) {
       host_header_value += ':' + *client_options_.remote_port_;


### PR DESCRIPTION
Host header takes part in the signature calculation.
The problem was aws was setting the host and calculating the signature and http_client was resetting the host header un-conditionally.