### PR TITLE
Fix typo in augeas table

### DIFF
--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -170,7 +170,7 @@ QueryData genAugeas(QueryContext& context) {
     std::ostringstream pattern;
 
     for (const auto& path : paths) {
-      pattern << "/files/" << path;
+      pattern << "/files" << path;
       patterns.insert(pattern.str());
 
       pattern.clear();


### PR DESCRIPTION
The trailing slash doesn't cause problems now but messes up further development.
If you specify a path query you get the following expression: `/files//etc/whatever|/files/etc/whatever//*` which wasn't intended.
The correct expression is `/files/etc/whatever|/files/etc/whatever//*` 