### PR TITLE
Allow building as non-root on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ ifeq ($(PLATFORM),Darwin)
 endif
 	@export PYTHONPATH="$DEPS_DIR/lib/python2.7/site-packages"
 
-	@ln -snf $(SOURCE_DIR)/tools/tests $(BUILD_DIR)/test_data
-	@ln -snf $(SOURCE_DIR)/tools/tests $(DEBUG_BUILD_DIR)/test_data
+	@ln -snf "$(SOURCE_DIR)/tools/tests" $(BUILD_DIR)/test_data
+	@ln -snf "$(SOURCE_DIR)/tools/tests" $(DEBUG_BUILD_DIR)/test_data
 
 all: .setup
 ifeq ($(wildcard $(DEPS_DIR)/.*),)

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -307,13 +307,13 @@ function main() {
   if [[ $OS = "freebsd" ]]; then
     PIP="sudo $PIP"
   fi
-  $PIP install --upgrade pip
+  $PIP install --user --upgrade pip
   # Pip may change locations after upgrade.
   PIP=`which pip`
   if [[ $OS = "freebsd" ]]; then
     PIP="sudo $PIP"
   fi
-  $PIP install --no-cache-dir -I -r requirements.txt
+  $PIP install --user --no-cache-dir -I -r requirements.txt
 
   log "running auxiliary initialization"
   initialize $OS

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -304,15 +304,9 @@ function main() {
   # Pip may have just been installed.
   log "upgrading pip and installing python dependencies"
   PIP=`which pip`
-  if [[ $OS = "freebsd" ]]; then
-    PIP="sudo $PIP"
-  fi
   $PIP install --user --upgrade pip
   # Pip may change locations after upgrade.
   PIP=`which pip`
-  if [[ $OS = "freebsd" ]]; then
-    PIP="sudo $PIP"
-  fi
   $PIP install --user --no-cache-dir -I -r requirements.txt
 
   log "running auxiliary initialization"


### PR DESCRIPTION
This was my first time trying to build osquery on my mac and I hit a couple of problems:

1. Cloned osquery inside my personal dropbox directory, which is `~/Dropbox (Personal)/...` and due to the space on the directory name it failed to create a symlink - this one was fixed by adding double quotes in the Makefile in the `ln -s` command

2. During `make deps` it invoked pip, which wanted root to install stuff in the system's PYTHONPATH. I usually refuse to give root to build things, so I changed one of the provisioning scripts to make it call `pip install --user` instead; not sure you want this patch as-is because it may (will, likely) break other builds

Anyway, after these tweaks I was able to build it without root, like this:

```
mkdir -p ~/tmp/osquery_deps
export PYTHONPATH=~/tmp/osquery_deps/lib/python2.7/site-packages
export OSQUERY_DEPS=~/tmp/osquery_deps
make deps
make
```

I don't expect this to be merged, but I hope it'd serve as a heads up for an alternative to not using root to build osquery.