### PR TITLE
watcher: Use min for delay max and delay current

### DIFF
--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -495,7 +495,7 @@ void WatcherRunner::createWorker() {
       size_t delay = getWorkerLimit(WatchdogLimitType::RESPAWN_DELAY);
       // Exponential back off for quickly-respawning clients.
       delay += static_cast<size_t>(pow(2, watcher.workerRestartCount()));
-      delay = std::max(static_cast<size_t>(FLAGS_watchdog_max_delay), delay);
+      delay = std::min(static_cast<size_t>(FLAGS_watchdog_max_delay), delay);
       pauseMilli(delay * 1000);
     }
   }


### PR DESCRIPTION
In #3944 an initial delay was added to autoloaded extensions. We also added a max-delay time for extension and worker process respawns. This should have been implemented as a `min`. Our tests for `test_osqueryd` started showing 10min+ wait times as this max was applied.