### PR TITLE
daemon: set service status to SERVICE_STOPPED on exit

### DIFF
--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -318,6 +318,7 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
         CloseHandle(stopEvent);
       }
     }
+    UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 
     break;
   default:


### PR DESCRIPTION
This addresses #3950. In our current code flow, we register a service control handler, and on receiving a `SERVICE_CONTROL_STOP` signal we update the service to have a `SERVICE_STOP_PENDING` state while we shut down the osquery daemon. There is an expectation that the extent of our `ServiceMain` routine will be executed, but this does not happen via the service control manager. This ensures that we update the state of our service to be `SERVICE_STOPPED` in our SCM status handler.