### PR TITLE
only daemon-reload if systemd is running

### DIFF
--- a/tools/deployment/linux_postinstall.sh
+++ b/tools/deployment/linux_postinstall.sh
@@ -12,6 +12,6 @@ case "$1" in
 esac
 
 # If we have a systemd, daemon-reload away now
-if [ -x /bin/systemctl ] ; then
+if [ -x /bin/systemctl ] && pidof systemd ; then
   /bin/systemctl daemon-reload 2>/dev/null 2>&1
 fi


### PR DESCRIPTION
Without this, if you do `apt-get install osquery`, and systemd is *not*
running (for example, if you are trying to install osquery inside a
docker build, in which PID 1 is a bash script), it'll error out like
this:

```
Failed to connect to bus: No such file or directory
```