### PR TITLE
build: adding helper function to add paths to system path

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -86,13 +86,4 @@ if ($installService) {
 }
 
 # Add osquery binary path to machines path for ease of use.
-$oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
-if (-not ($oldPath -imatch [regex]::escape($targetFolder))) {
-  $newPath = $oldPath
-  if ($oldPath[-1] -eq ';') {
-    $newPath = $newPath + $targetFolder
-  } else {
-    $newPath = $newPath + ';' + $targetFolder
-  }
-  [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
-}
+Add-ToSystemPath $targetFolder

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -472,6 +472,8 @@ function Main {
   }
 
   $out = Install-ChocoPackage 'wixtoolset' '' @('--version', '3.10.3.300701')
+  # Add the WiX binary path to the system path for use
+  Add-ToSystemPath 'C:\Program Files (x86)\WiX Toolset v3.10\bin'
 
   # Convenience variable for accessing Python
   [Environment]::SetEnvironmentVariable("OSQUERY_PYTHON_PATH", $pythonInstall, "Machine")

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -171,6 +171,24 @@ function Get-OsqueryBuildPath {
   return $ret
 }
 
+# Helper function to add to the SYSTEM path
+function Add-ToSystemPath {
+  param(
+    [string] $targetFolder = ''
+  )
+
+  $oldPath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+  if (-not ($oldPath -imatch [regex]::escape($targetFolder))) {
+    $newPath = $oldPath
+    if ($oldPath[-1] -eq ';') {
+      $newPath = $newPath + $targetFolder
+    } else {
+      $newPath = $newPath + ';' + $targetFolder
+    }
+    [System.Environment]::SetEnvironmentVariable('Path', $newPath, 'Machine')
+  }
+}
+
 # A helper function for starting and waiting on processes in powershell
 function Start-OsqueryProcess {
   param(


### PR DESCRIPTION
This adds the WiX toolset binary path to the system `PATH` variable for CLI use. Also this adds a powershell helper for adding paths to the system-wide path