### PR TITLE
ux: adding verbosity if osquery fails to read system uuid

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -188,6 +188,7 @@ std::string generateHostUUID() {
   }
 
   // Unable to get the hardware UUID, just return a new UUID
+  VLOG(1) << "Failed to read system uuid, returning ephemeral uuid";
   return generateNewUUID();
 }
 


### PR DESCRIPTION
I noticed the other day while troubleshooting with someone internally, that on Linux in particular we tend to hand back an ephemeral UUID as low priv users cannot read the system UUID. This is totally fine and makes sense, however it wasn't something I had thought of, and lead to a couple of lost hours due to realizing the uuid provided to me wouldn't exist in our backend. I'd prefer for this to actually be a `LOG(WARNING)`, however that might be a touch excessive? What do others think? Am I the only one who's fallen for this?