### PR TITLE
deps: Include script to auto-build bottles

### DIFF
--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -7,7 +7,24 @@
 #  LICENSE file in the root directory of this source tree. An additional grant
 #  of patent rights can be found in the PATENTS file in the same directory.
 
+DARWIN_SETUP="\
+if [[ ! -f /var/.osquery_build ]]; then \
+touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress; \
+PROD=\$(softwareupdate -l | grep \"\\*.*Command Line\" | \
+  head -n 1 | awk -F\"*\" '{print \$2}' | sed -e 's/^ *//' | tr -d '\n' \
+); \
+softwareupdate -i \"\$PROD\" --verbose; \
+sudo touch /var/.osquery_build; \
+fi; \
+"
+
+function vagrant_setup() {
+  sudo bash -c "$DARWIN_SETUP"
+}
+
 function distro_main() {
   GEM=`which gem`
   do_sudo $GEM install --no-ri --no-rdoc fpm
 }
+
+[ "$0" = "$BASH_SOURCE" ] && vagrant_setup

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -27,4 +27,4 @@ function distro_main() {
   do_sudo $GEM install --no-ri --no-rdoc fpm
 }
 
-[ "$0" = "$BASH_SOURCE" ] && vagrant_setup
+[ "$0" = "$BASH_SOURCE" ] && vagrant_setup || true

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -11,17 +11,6 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-DARWIN_SETUP="\
-if [[ ! -f /var/.osquery_build ]]; then \
-touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress; \
-PROD=\$(softwareupdate -l | grep \"\\*.*Command Line\" | \
-  head -n 1 | awk -F\"*\" '{print \$2}' | sed -e 's/^ *//' | tr -d '\n' \
-); \
-softwareupdate -i \"\$PROD\" --verbose; \
-sudo touch /var/.osquery_build; \
-fi; \
-"
-
 DARWIN_BOX="macos10.12"
 LINUX_BOX="ubuntu16.04"
 
@@ -74,7 +63,7 @@ function main() {
     echo "[+] Vagrant up $DARWIN_BOX"
     OSQUERY_BUILD_CPUS=4 vagrant up $DARWIN_BOX
     echo "[+] Running initial softwareupdate check..."
-    vagrant ssh $DARWIN_BOX -c "$DARWIN_SETUP"
+    vagrant ssh $DARWIN_BOX -c "/vagrant/tools/provision/darwin.sh"
     echo "[+] Running build command for macOS..."
     vagrant ssh $DARWIN_BOX -c "$BUILD_CMD"
     echo "[+] Running package build command for macOS..."

--- a/tools/release/deps_release.sh
+++ b/tools/release/deps_release.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+#  Copyright (c) 2015, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+DARWIN_BOX="macos10.12"
+LINUX_BOX="ubuntu16.04"
+
+function usage() {
+  echo "${BASH_SOURCE[0]} dependency_name"
+}
+
+function install_deps() {
+  BOX=$1
+  DEPS=$2
+
+  echo "[+] Uninstalling and reinstalling dependency(s)..."
+  for DEP in $(echo "$DEPS" | tr "," " ") ; do
+    INSTALL_CMD="cd /vagrant; \
+      ./tools/provision.sh uninstall osquery/osquery-local/$DEP; \
+      ./tools/provision.sh install osquery/osquery-local/$DEP; \
+      ./tools/provision.sh bottle osquery/osquery-local/$DEP; \
+    "
+
+    vagrant ssh $BOX -c "$INSTALL_CMD"
+
+    if [[ "$BOX" = "$DARWIN_BOX" ]]; then
+      vagrant scp "$BOX:/vagrant/*$DEP*.tar.gz" .
+      vagrant scp "$BOX:/vagrant/tools/provision/formula/$DEP.rb" \
+        ./tools/provision/formula/$DEP.rb
+    fi
+  done
+
+}
+
+function main() {
+  if [[ $# < 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  CURRENT_DIR=$(pwd)
+  DEPS=$1
+
+  DEPS_CMD="cd /vagrant; make deps || true"
+
+  echo "[+] Vagrant up $LINUX_BOX"
+  OSQUERY_BUILD_CPUS=4 vagrant up $LINUX_BOX
+  echo "[+] Building linux deps..."
+  vagrant ssh $LINUX_BOX -c "$DEPS_CMD"
+  install_deps $LINUX_BOX "$DEPS"
+  vagrant halt $LINUX_BOX
+
+  echo "[+] Vagrant up $DARWIN_BOX"
+  OSQUERY_BUILD_CPUS=4 vagrant up $DARWIN_BOX
+  echo "[+] Running initial softwareupdate check..."
+  vagrant ssh $DARWIN_BOX -c "/vagrant/tools/provision/darwin.sh"
+  echo "[+] Running build command for macOS..."
+  vagrant ssh $DARWIN_BOX -c "$DEPS_CMD"
+  install_deps $DARWIN_BOX "$DEPS"
+  vagrant halt $DARWIN_BOX
+
+  echo "[+] Finished"
+  cd $CURRENT_DIR
+}
+
+main $@

--- a/tools/release/deps_release.sh
+++ b/tools/release/deps_release.sh
@@ -10,6 +10,7 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+VAGRANT="/vagrant"
 
 DARWIN_BOX="macos10.12"
 LINUX_BOX="ubuntu16.04"
@@ -33,8 +34,8 @@ function install_deps() {
     vagrant ssh $BOX -c "$INSTALL_CMD"
 
     if [[ "$BOX" = "$DARWIN_BOX" ]]; then
-      vagrant scp "$BOX:/vagrant/*$DEP*.tar.gz" .
-      vagrant scp "$BOX:/vagrant/tools/provision/formula/$DEP.rb" \
+      vagrant scp "$BOX:$VAGRANT/*$DEP*.tar.gz" .
+      vagrant scp "$BOX:$VAGRANT/tools/provision/formula/$DEP.rb" \
         ./tools/provision/formula/$DEP.rb
     fi
   done
@@ -50,7 +51,7 @@ function main() {
   CURRENT_DIR=$(pwd)
   DEPS=$1
 
-  DEPS_CMD="cd /vagrant; make deps || true"
+  DEPS_CMD="cd $VAGRANT; make deps || true"
 
   echo "[+] Vagrant up $LINUX_BOX"
   OSQUERY_BUILD_CPUS=4 vagrant up $LINUX_BOX
@@ -62,7 +63,7 @@ function main() {
   echo "[+] Vagrant up $DARWIN_BOX"
   OSQUERY_BUILD_CPUS=4 vagrant up $DARWIN_BOX
   echo "[+] Running initial softwareupdate check..."
-  vagrant ssh $DARWIN_BOX -c "/vagrant/tools/provision/darwin.sh"
+  vagrant ssh $DARWIN_BOX -c "$VAGRANT/tools/provision/darwin.sh"
   echo "[+] Running build command for macOS..."
   vagrant ssh $DARWIN_BOX -c "$DEPS_CMD"
   install_deps $DARWIN_BOX "$DEPS"


### PR DESCRIPTION
"Bottles" in Homebrew-terminology is the distributable version of a dependency. We build and store bottles from our dependencies to improve build time and to support more than just Ubuntu16.04 and MacOS10.12 for build systems.

Building these is difficult so we include a script to generate new bottles when a dependency formula is updated. Run `./tools/provision/deps_release.sh dependency1,dependency2` Where the comma-separated list is the set of dependencies changed. Each of these will be rebuilt. At the end the bottle `.tar.gz`s will be in the osquery repo root, ready to be uploaded to your hosting, and the formula will be updated to include the new bottle hashes.