### PR TITLE
extensions: watchdog: Opt-in to monitor extension performance

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -107,6 +107,10 @@ This value is a maximum number of CPU cycles counted as the `processes` table's 
 
 A delay in seconds before the watchdog process starts enforcing memory and CPU utilization limits. The default value `60s` allows the daemon to perform resource intense actions, such as forwarding logs, at startup.
 
+`--enable_extensions_watchdog=false`
+
+By default the watchdog monitors extensions for improper shutdown, but NOT for performance and utilization issues. Enable this flag if you would like extensions to use the same CPU and memory limits as the osquery worker. This means that your extensions or third-party extensions may be asked to stop and restart during execution.
+
 `--utc=true`
 
 Attempt to convert all UNIX calendar times to UTC.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -87,6 +87,11 @@ HIDDEN_FLAG(uint64,
             60 * 10,
             "Max delay in seconds between worker respawns");
 
+CLI_FLAG(bool,
+         enable_extensions_watchdog,
+         false,
+         "Disable userland watchdog for extensions processes");
+
 CLI_FLAG(bool, disable_watchdog, false, "Disable userland watchdog process");
 
 void Watcher::resetWorkerCounters(size_t respawn_time) {
@@ -251,8 +256,9 @@ void WatcherRunner::watchExtensions() {
 
     auto ext_valid = extension.second->isValid();
     auto s = isChildSane(*extension.second);
+
     if (!ext_valid || (!s.ok() && getUnixTime() >= delayedTime())) {
-      if (ext_valid) {
+      if (ext_valid && FLAGS_enable_extensions_watchdog) {
         // The extension was already launched once.
         std::stringstream error;
         error << "osquery extension " << extension.first << " ("


### PR DESCRIPTION
We found that imposing watchdog limits on extensions is not a good default assumption.

There are many use cases for extensions and one include running high-computation workloads. Imposing these limits was a new feature added in 2.10. We'll keep the watchdog on the extensions to help restart if they inappropriately shutdown, but we wont by-default impose memory and CPU limits.