### PR TITLE
config: Allow scheduled queries to set blacklist=false

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -306,21 +306,24 @@ Example:
 Each of `schedule`'s value's is also a map, we call these scheduled queries and their key is the `name` which shows up in your results log. In the example above the schedule includes two queries: **users_browser_plugins** and **hashes_of_bin**. While it is common to schedule a `SELECT * FROM your_favorite_table`, one of the powers of osquery is SQL expression and the combination of several table concepts please use `JOIN`s liberally.
 
 The basic scheduled query specification includes:
-* `query`: the SQL query to run
-* `interval`: an interval in seconds to run the query (subject to splay/smoothing)
-* `removed`: a boolean to determine if removed actions should be logged
-* `snapshot`: a boolean to set 'snapshot' mode
-* `platform`: restrict this query to a given platform
-* `version`: only run on osquery versions greater than or equal-to
-* `shard`: restrict this query to a percentage (1-100) of target hosts
+
+- `query`: the SQL query to run
+- `interval`: an interval in seconds to run the query (subject to splay/smoothing)
+- `removed`: a boolean to determine if "removed" actions should be logged, default true
+- `snapshot`: a boolean to set 'snapshot' mode, default false
+- `platform`: restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
+- `version`: only run on osquery versions greater than or equal-to this version string
+- `shard`: restrict this query to a percentage (1-100) of target hosts
+- `blacklist`: a boolean to determine if this query may be blacklisted, default true
 
 The `platform` key can be:
-* `darwin` for MacOS hosts
-* `freebsd` for FreeBSD hosts
-* `linux` for any RedHat or Debian-based hosts
-* `posix` for `linux`, `freebsd`, and `linux` hosts
-* `windows` for any Windows desktop or server hosts
-* `any` or `all` for all, alternatively no platform key selects all
+
+- `darwin` for MacOS hosts
+- `freebsd` for FreeBSD hosts
+- `linux` for any RedHat or Debian-based hosts
+- `posix` for `linux`, `freebsd`, and `linux` hosts
+- `windows` for any Windows desktop or server hosts
+- `any` or `all` for all, alternatively no platform key selects all
 
 The `shard` key works by hashing the hostname then taking the quotient 255 of the first byte. This allows us to select a deterministic 'preview' for the query, this helps when slow-rolling or testing new queries.
 
@@ -328,6 +331,8 @@ The schedule and associated queries generate a timeline of events through the de
 
 Snapshot queries, those with `snapshot: true` will not store differentials and will not emulate an event stream. Snapshots always return the entire results from the query on the given interval. See
 the next section on [logging](../deployment/logging.md) for examples of each log output.
+
+Queries may be "blacklisted" if they cause osquery to take too many system resources. A blacklisted query returns to the schedule after a cool-down period of 1 day. Some queries may be very important and you may request that they continue to run even if they are latent. Set the `blacklist: false` to prevent a query from being blacklisted.
 
 ### Packs
 

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -355,6 +355,7 @@ class Config : private boost::noncopyable {
   friend class SchedulerTests;
   FRIEND_TEST(ConfigTests, test_config_refresh);
   FRIEND_TEST(ConfigTests, test_get_scheduled_queries);
+  FRIEND_TEST(ConfigTests, test_nonblacklist_query);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_get_option);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_add_view);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_swap_view);

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -130,58 +130,29 @@ class Schedule : private boost::noncopyable {
    * next iterator element or skipped.
    */
   struct Step {
-    bool operator()(PackRef& pack) {
-      return pack->shouldPackExecute();
-    }
+    bool operator()(PackRef& pack);
   };
 
   /// Add a pack to the schedule
-  void add(PackRef&& pack) {
-    remove(pack->getName(), pack->getSource());
-    packs_.push_back(pack);
-  }
+  void add(PackRef&& pack);
 
   /// Remove a pack, by name.
-  void remove(const std::string& pack) {
-    remove(pack, "");
-  }
+  void remove(const std::string& pack);
 
   /// Remove a pack by name and source.
-  void remove(const std::string& pack, const std::string& source) {
-    packs_.remove_if([pack, source](PackRef& p) {
-      if (p->getName() == pack && (p->getSource() == source || source == "")) {
-        Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
-        return true;
-      }
-      return false;
-    });
-  }
+  void remove(const std::string& pack, const std::string& source);
 
   /// Remove all packs by source.
-  void removeAll(const std::string& source) {
-    packs_.remove_if(([source](PackRef& p) {
-      if (p->getSource() == source) {
-        Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
-        return true;
-      }
-      return false;
-    }));
-  }
+  void removeAll(const std::string& source);
 
   /// Boost gives us a nice template for maintaining the state of the iterator
   using iterator = boost::filter_iterator<Step, container::iterator>;
 
-  iterator begin() {
-    return iterator(packs_.begin(), packs_.end());
-  }
+  iterator begin();
 
-  iterator end() {
-    return iterator(packs_.end(), packs_.end());
-  }
+  iterator end();
 
-  PackRef& last() {
-    return packs_.back();
-  }
+  PackRef& last();
 
  private:
   /// Underlying storage for the packs
@@ -207,6 +178,51 @@ class Schedule : private boost::noncopyable {
  private:
   friend class Config;
 };
+
+bool Schedule::Step::operator()(PackRef& pack) {
+  return pack->shouldPackExecute();
+}
+
+void Schedule::add(PackRef&& pack) {
+  remove(pack->getName(), pack->getSource());
+  packs_.push_back(pack);
+}
+
+void Schedule::remove(const std::string& pack) {
+  remove(pack, "");
+}
+
+void Schedule::remove(const std::string& pack, const std::string& source) {
+  packs_.remove_if([pack, source](PackRef& p) {
+    if (p->getName() == pack && (p->getSource() == source || source == "")) {
+      Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
+      return true;
+    }
+    return false;
+  });
+}
+
+void Schedule::removeAll(const std::string& source) {
+  packs_.remove_if(([source](PackRef& p) {
+    if (p->getSource() == source) {
+      Config::get().removeFiles(source + FLAGS_pack_delimiter + p->getName());
+      return true;
+    }
+    return false;
+  }));
+}
+
+Schedule::iterator Schedule::begin() {
+  return Schedule::iterator(packs_.begin(), packs_.end());
+}
+
+Schedule::iterator Schedule::end() {
+  return Schedule::iterator(packs_.end(), packs_.end());
+}
+
+PackRef& Schedule::last() {
+  return packs_.back();
+}
 
 /**
  * @brief A thread that periodically reloads configuration state.
@@ -343,6 +359,30 @@ void Config::removeFiles(const std::string& source) {
   }
 }
 
+/**
+ * @brief Return true if the failed query is no longer blacklisted.
+ *
+ * There are two scenarios where a blacklisted query becomes 'unblacklisted'.
+ * The first is simple, the amount of time it was blacklisted for has expired.
+ * The second is more complex, the query failed by the schedule has requested
+ * that the query should not be blacklisted.
+ *
+ * @param blt The time the query was originally blacklisted.
+ * @param query The scheduled query and its options.
+ */
+static inline bool blacklistExpired(size_t blt, const ScheduledQuery& query) {
+  if (getUnixTime() > blt) {
+    return true;
+  }
+
+  auto blo = query.options.find("blacklist");
+  if (blo != query.options.end() && blo->second == false) {
+    // The schedule requested that we do not blacklist this query.
+    return true;
+  }
+  return false;
+}
+
 void Config::scheduledQueries(
     std::function<void(const std::string& name, const ScheduledQuery& query)>
         predicate,
@@ -356,10 +396,11 @@ void Config::scheduledQueries(
         name = "pack" + FLAGS_pack_delimiter + pack->getName() +
                FLAGS_pack_delimiter + it.first;
       }
+
       // They query may have failed and been added to the schedule's blacklist.
       auto blacklisted_query = schedule_->blacklist_.find(name);
       if (blacklisted_query != schedule_->blacklist_.end()) {
-        if (getUnixTime() > blacklisted_query->second) {
+        if (blacklistExpired(blacklisted_query->second, it.second)) {
           // The blacklisted query passed the expiration time (remove).
           schedule_->blacklist_.erase(blacklisted_query);
           saveScheduleBlacklist(schedule_->blacklist_);

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -364,7 +364,7 @@ void Config::removeFiles(const std::string& source) {
  *
  * There are two scenarios where a blacklisted query becomes 'unblacklisted'.
  * The first is simple, the amount of time it was blacklisted for has expired.
- * The second is more complex, the query failed by the schedule has requested
+ * The second is more complex, the query failed but the schedule has requested
  * that the query should not be blacklisted.
  *
  * @param blt The time the query was originally blacklisted.

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -195,6 +195,7 @@ void Pack::initialize(const std::string& name,
     query.splayed_interval = restoreSplayedValue(q.first, query.interval);
     query.options["snapshot"] = q.second.get<bool>("snapshot", false);
     query.options["removed"] = q.second.get<bool>("removed", true);
+    query.options["blacklist"] = q.second.get<bool>("blacklist", true);
     schedule_[q.first] = query;
   }
 }

--- a/packs/osquery-monitoring.conf
+++ b/packs/osquery-monitoring.conf
@@ -4,6 +4,7 @@
       "query": "select name, interval, executions, output_size, wall_time, (user_time/executions) as avg_user_time, (system_time/executions) as avg_system_time, average_memory, last_executed from osquery_schedule;",
       "interval": 7200,
       "removed": false,
+      "blacklist": false,
       "version": "1.6.0",
       "description": "Report performance for every query within packs and the general schedule."
     },
@@ -11,6 +12,7 @@
       "query": "select name, publisher, type, subscriptions, events, active from osquery_events;",
       "interval": 86400,
       "removed": false,
+      "blacklist": false,
       "version": "1.5.3",
       "description": "Report event publisher health and track event counters."
     },
@@ -18,6 +20,7 @@
       "query": "select i.*, p.resident_size, p.user_time, p.system_time, time.minutes as counter from osquery_info i, processes p, time where p.pid = i.pid;",
       "interval": 600,
       "removed": false,
+      "blacklist": false,
       "version": "1.2.2",
       "description": "A heartbeat counter that reports general performance (CPU, memory) and version."
     }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -518,7 +518,7 @@
       "value" : "Artifacts created by this malware"
     },
     "OSX_HiddenLotus": {
-      "query" : "select * from launchd where name = 'com.apple.hidd.shared.plist",
+      "query" : "select * from launchd where name = 'com.apple.hidd.shared.plist';",
       "interval" : "3600",
       "version" : "1.4.5",
       "description" : "Apple added XProtect rules for this sample: (https://www.virustotal.com/en/file/f261815905e77eebdb5c4ec06a7acdda7b68644b1f5155049f133be866d8b179/analysis/1509567775/)",

--- a/tools/tests/test_inline_pack.conf
+++ b/tools/tests/test_inline_pack.conf
@@ -11,6 +11,11 @@
           "interval": 3600,
           "version": "1.5.1-26",
           "removed": false
+        },
+        "process_heartbeat": {
+          "query": "select * from osquery_info",
+          "interval": 3600,
+          "blacklist": false
         }
       },
       "file_paths": {


### PR DESCRIPTION
This adds a new feature to the configuration and extends the scheduled query schema by allowing a new (optional) key in the query details. If you set `blacklist: false` then a this scheduled query will never be blacklisted.