### PR TITLE
hash: Use the hash-cache by default and document flags

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -119,6 +119,18 @@ Attempt to convert all UNIX calendar times to UTC.
 
 Add a microsecond delay between multiple table calls (when a table is used in a JOIN). A `200` microsecond delay will trade about 20% additional time for a reduced 5% CPU utilization.
 
+`--hash_cache_max=500`
+
+The `hash` table implements a cache that is invalidated when file path inodes are changed. Eviction occurs in chunks if the max-size is reached. This max should remain relatively low since it will persist in the daemon's resident memory.
+
+`--hash_delay=20`
+
+Add a millisecond delay between multiple `hash` attempts (aka when scanning a directory). This adds about 50% additional wall-time for 150 files. This reduces the instantaneous resource need from hashing new files.
+
+`--disable_hash_cache=false`
+
+Set this to true if you would like to disable file hash caching and always regenerate the file hashes every request. The default osquery configuration may report hashes incorrectly if things are editing filesystems outside of the OS's control.
+
 **Windows Only**
 
 Windows builds include a `--install` and `--uninstall` that will create a Windows service using the `osqueryd.exe` binary and preserve an optional `--flagfile` if provided.

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -441,6 +441,11 @@ void Initializer::initShell() const {
     FLAGS_disable_extensions = true;
     FLAGS_disable_database = true;
   }
+
+  if (Flag::isDefault("hash_delay")) {
+    // The hash_delay is designed for daemons only.
+    Flag::updateValue("hash_delay", "0");
+  }
 }
 
 void Initializer::initWatcher() const {

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -24,9 +24,6 @@
 #include "osquery/tests/test_util.h"
 
 namespace osquery {
-
-DECLARE_bool(enable_hash_cache);
-
 namespace tables {
 
 class SystemsTablesTests : public testing::Test {};
@@ -213,7 +210,6 @@ TEST_F(HashTableTest, hashes_are_correct) {
 }
 
 TEST_F(HashTableTest, test_cache_works) {
-  FLAGS_enable_hash_cache = true;
   time_t last_mtime = 0;
   for (int i = 0; i < 2; ++i) {
     SetContent(i);
@@ -231,7 +227,6 @@ TEST_F(HashTableTest, test_cache_works) {
 }
 
 TEST_F(HashTableTest, test_cache_updates) {
-  FLAGS_enable_hash_cache = true;
   SetContent(0);
   // cache the current state
   SQL r1(qry);


### PR DESCRIPTION
Turn the new hash-cache features on by default.

This adds documentation for the new hash-cache related flags. This cache uses inode and modification time reported by the OS and filesystems as "truth" for the content. If you are worried about out of band modifications or would generally like to skip this hash and recalculate hashes for each query use `--disable_hash_cache`.

This also introduces a on-by-default induced delay when using the `hash` table, with or without the cache features. This induced delay protects the OS from osquery trying to hash tons of files as fast as possible (in a single thread). Previously, hashing a download directory was a surefire 1-way ticket to being blacklisted.