### PR TITLE
typo in mac setup instructions

### DIFF
--- a/docs/wiki/installation/install-osx.md
+++ b/docs/wiki/installation/install-osx.md
@@ -30,7 +30,7 @@ Only applies if you have never installed and run **osqueryd** on this Mac.
 After completing the brew installation run the following commands. If you are using the chef recipe to install osquery then these steps are not necessary, the [recipe](http://osquery.readthedocs.io/en/stable/deployment/configuration/#chef-os-x) has this covered.
 
 ```
-sudo ln -s /usr/local/share/osquery /var/osquery
+sudo ln -s /var/osquery /usr/local/share/osquery
 sudo mkdir /var/log/osquery
 sudo chown root /usr/local/Cellar/osquery/1.7.3/bin/osqueryd
 sudo cp /var/osquery/osquery.example.conf /var/osquery/osquery.conf


### PR DESCRIPTION
In testing, the prior cmd line would create a symlink named `/var/osquery` that pointed to `/usr/local/share/osquery` (which was an empty folder) 

- this commit sets the symlink as (i presume) is intended

> 10.12.6 (16G1114)