### PR TITLE
deps: Use beast v124 APIs

### DIFF
--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -376,7 +376,7 @@ class HTTP_Response : public T {
 
   /// body of a HTTP response.
   const std::string& body() {
-    return this->T::body;
+    return this->T::body();
   }
 
   /**


### PR DESCRIPTION
This updates the beast checkout in our third-party repo to use version 124. These API changes should be compatible with boost version 1.66.