### PR TITLE
deps: Fix symlink check in thrift 0.11

### DIFF
--- a/tools/provision/formula/thrift.rb
+++ b/tools/provision/formula/thrift.rb
@@ -6,13 +6,13 @@ class Thrift < AbstractOsqueryFormula
   license "Apache-2.0"
   url "https://github.com/apache/thrift/archive/0.11.0.tar.gz"
   sha256 "0e324569321a1b626381baabbb98000c8dd3a59697292dbcc71e67135af0fefd"
-  revision 102
+  revision 103
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "4933ae81b741c8920389e4da2a383400af2a54bcd0c63ecc72d3b69eecd2984a" => :sierra
-    sha256 "ec9e09e048ec3027c234b5ed1086dffb3df238da6cd2c488acd1685591d91670" => :x86_64_linux
+    sha256 "3a929dc35860bcd64eae47880f450ab54820fe1e299d3fb824a6cd8814ec6a90" => :sierra
+    sha256 "72fb23a35840b8295b120952dca2061211ae7f133e1f93a98d2ce4057c207965" => :x86_64_linux
   end
 
   depends_on "bison" => :build

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -97,7 +97,7 @@ function setup_brew() {
 
 function clean_thrift() {
   TEST_FILE="$DEPS/lib/python2.7/site-packages/thrift"
-  if [ -f "$TEST_FILE/__init__.py" ]; then
+  if [ ! -L "$TEST_FILE/__init__.py" ]; then
     rm -rf "${TEST_FILE}"*
   fi
 }


### PR DESCRIPTION
The thrift 0.11 dependency is not idempotent on Linux and Darwin.