### PR TITLE
[#4009] deps: Update Linux and macOS boost to 1.66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,8 +523,10 @@ if(POSIX)
   include_directories("${BUILD_DEPS}/include/openssl")
 endif()
 
-# Including Boost Beast within third-party until it's merged into boot 1.66.
-include_directories("${CMAKE_SOURCE_DIR}/third-party/beast")
+if(NOT LINUX AND NOT APPLE)
+  # Including Boost Beast within third-party until it's merged into boot 1.66.
+  include_directories("${CMAKE_SOURCE_DIR}/third-party/beast")
+endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/third-party/sqlite3")
 include_directories("${CMAKE_SOURCE_DIR}/include")

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -4,16 +4,16 @@ class Boost < AbstractOsqueryFormula
   desc "Collection of portable C++ source libraries"
   homepage "https://www.boost.org/"
   license "BSL-1.0"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.65.0/boost_1_65_0.tar.bz2"
-  sha256 "ea26712742e2fb079c2a566a31f3266973b76e38222b9f88b387e3c8b2f9902c"
+  url "https://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.bz2"
+  sha256 "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9"
   head "https://github.com/boostorg/boost.git"
-  revision 102
+  revision 100
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "623bd56bf62c72bf5e14919cf7d9c7f761b358aeabe7b3d6da59a89d7b1047c0" => :sierra
-    sha256 "720c4e37c3aba17b8965d1bd6c9b399f6a1c8866ff17be8a974efa1172c4a58a" => :x86_64_linux
+    sha256 "2ec00b382e342a74cf57f12955729c6e2db616afdfc3120e3d7f3d41c6a3c559" => :sierra
+    sha256 "8a435ce15fbd0f0e4c10f063a0cd94cbbaa430d3a6d64b01754b1794dae75e3f" => :x86_64_linux
   end
 
   env :userpaths


### PR DESCRIPTION
Our vendored-in version of Boost Beast (v124) is not compatible with Boost version 1.66.

For those platforms using Boost 1.66, the should use the included Beast. For those using Boost <= 1.65, they should use our version in `third-party`. We control this naively by platform. 