### PR TITLE
rocksdb: Decrease max open database files to 128 from 256

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -88,7 +88,7 @@ Status RocksDBDatabasePlugin::setUp() {
     options_.log_file_time_to_roll = 0;
     options_.keep_log_file_num = 10;
     options_.max_log_file_size = 1024 * 1024 * 1;
-    options_.max_open_files = 256;
+    options_.max_open_files = 128;
     options_.stats_dump_period_sec = 0;
     options_.max_manifest_file_size = 1024 * 500;
 


### PR DESCRIPTION
This is another attempt to mitigate #3984. When RocksDB's max open files is 256, and macOS's max per-process is at 256, a max + the FDs for stdin/etc will overflow.