### PR TITLE
tables: Fix Bookmark and Alias path extraction

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -311,6 +311,16 @@ Status parsePlist(const boost::filesystem::path& path,
  */
 Status parsePlistContent(const std::string& content,
                          boost::property_tree::ptree& tree);
+
+/**
+ * @brief Parse property list alias data into a path string.
+ *
+ * @param data a string container with the raw alias data.
+ * @param result a string containing the POSIX path.
+ *
+ * @return an instance of Status, indicating success or failure.
+ */
+Status pathFromPlistAliasData(const std::string& data, std::string& result);
 #endif
 
 #ifdef __linux__

--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -44,64 +44,6 @@ const std::map<std::string, std::string> kTopLevelStringKeys{
     {"version", "version"},
 };
 
-Status parseApplicationAliasData(const std::string& data, std::string& result) {
-  std::string decoded_data = base64Decode(data);
-  if (decoded_data.empty()) {
-    return Status(1, "Failed to base64 decode data");
-  }
-
-  CFDataRef resourceData = CFDataCreate(
-      nullptr,
-      static_cast<const UInt8*>(static_cast<const void*>(decoded_data.c_str())),
-      decoded_data.length());
-  if (resourceData == nullptr) {
-    return Status(1, "Failed to allocate resource data");
-  }
-
-  auto alias = (CFDataRef)CFPropertyListCreateWithData(kCFAllocatorDefault,
-                                                       resourceData,
-                                                       kCFPropertyListImmutable,
-                                                       nullptr,
-                                                       nullptr);
-  CFRelease(resourceData);
-  if (alias == nullptr) {
-    return Status(1, "Failed to allocate alias data");
-  }
-
-  auto bookmark =
-      CFURLCreateBookmarkDataFromAliasRecord(kCFAllocatorDefault, alias);
-  CFRelease(alias);
-  if (bookmark == nullptr) {
-    return Status(1, "Alias data is not a bookmark");
-  }
-
-  auto url = CFURLCreateByResolvingBookmarkData(
-      kCFAllocatorDefault, bookmark, 0, nullptr, nullptr, nullptr, nullptr);
-  CFRelease(bookmark);
-  if (url == nullptr) {
-    return Status(1, "Alias data is not a URL bookmark");
-  }
-
-  auto replaced = CFURLCreateStringByReplacingPercentEscapes(
-      kCFAllocatorDefault, CFURLGetString(url), CFSTR(""));
-  CFRelease(url);
-  if (replaced == nullptr) {
-    return Status(1, "Failed to replace percent escapes.");
-  }
-
-  // Get the URL-formatted path.
-  result = stringFromCFString(replaced);
-  CFRelease(replaced);
-  if (result.empty()) {
-    return Status(1, "Return result is zero size");
-  }
-  if (result.length() > 6 && result.substr(0, 7) == "file://") {
-    result = result.substr(7);
-  }
-
-  return Status(0, "OK");
-}
-
 Status genALFTreeFromFilesystem(pt::ptree& tree) {
   Status s = osquery::parsePlist(kALFPlistPath, tree);
   if (!s.ok()) {
@@ -156,7 +98,7 @@ QueryData parseALFExceptionsTree(const pt::ptree& tree) {
       std::string path;
       auto alias_data = it.second.get<std::string>("alias", "");
 
-      if (parseApplicationAliasData(alias_data, path).ok()) {
+      if (pathFromPlistAliasData(alias_data, path).ok()) {
         r["path"] = path;
         r["state"] = INTEGER(it.second.get("state", -1));
         results.push_back(r);

--- a/osquery/tables/system/darwin/tests/startup_items_tests.cpp
+++ b/osquery/tables/system/darwin/tests/startup_items_tests.cpp
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+
+#include "osquery/tests/test_util.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+void genLoginItems(const fs::path& sipath, QueryData& results);
+
+class StartupItemsTests : public testing::Test {};
+
+TEST_F(StartupItemsTests, test_parse_startup_items) {
+  auto si_path = kTestDataPath + "test_startup_items.plist";
+
+  // Parse the contents into a launchd table row.
+  QueryData results;
+  genLoginItems(si_path, results);
+  ASSERT_EQ(results.size(), 2U);
+
+  EXPECT_EQ("/Applications/iTunes.app/Contents/MacOS/iTunesHelper.app/",
+            results[0]["path"]);
+
+  // The second entry cannot be parsed with bookmark resolution.
+  EXPECT_EQ("/private/tmp/this_does_not_exist", results[1]["path"]);
+}
+} // namespace tables
+} // namespace osquery

--- a/tools/tests/test_startup_items.plist
+++ b/tools/tests/test_startup_items.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SessionItems</key>
+	<dict>
+		<key>Controller</key>
+		<string>CustomListItems</string>
+		<key>CustomListItems</key>
+		<array>
+			<dict>
+				<key>Alias</key>
+				<data>
+				AAAAAADYAAMAAQAA1MnZcwAASCsAAAAAAAEIfQABCIAA
+				ANQ/KS0AAAAACSD//gAAAAAAAAAA/////wABABAAAQh9
+				AAEIawABCGoAAAA/AA4AIgAQAGkAVAB1AG4AZQBzAEgA
+				ZQBsAHAAZQByAC4AYQBwAHAADwAaAAwATQBhAGMAaQBu
+				AHQAbwBzAGgAIABIAEQAEgA3QXBwbGljYXRpb25zL2lU
+				dW5lcy5hcHAvQ29udGVudHMvTWFjT1MvaVR1bmVzSGVs
+				cGVyLmFwcAAAEwABLwD//wAA
+				</data>
+				<key>CustomItemProperties</key>
+				<dict>
+					<key>com.apple.LSSharedFileList.Binding</key>
+					<data>
+					ZG5pYgAAAAACAAAAAAAAAAAAAAAAAAAAAAAA
+					AEkAAAAAAAAAZmlsZTovL2xvY2FsaG9zdC9B
+					cHBsaWNhdGlvbnMvaVR1bmVzLmFwcC9Db250
+					ZW50cy9NYWNPUy9pVHVuZXNIZWxwZXIuYXBw
+					LxYAAAAAAAAAY29tLmFwcGxlLmlUdW5lc0hl
+					bHBlcnjkpwAAAAAAjkCQFAIAAABifXQZ
+					</data>
+					<key>com.apple.LSSharedFileList.ItemIsHidden</key>
+					<true/>
+				</dict>
+				<key>Flags</key>
+				<integer>1</integer>
+				<key>Name</key>
+				<string>iTunesHelper</string>
+			</dict>
+			<dict>
+				<key>Alias</key>
+				<data>
+				AAAAAAC+AAMAAAAA1MnZcwAASCsAAAAAAAZi5gHZbDMA
+				ANZq9vsAAAAACSD//gAAAAAAAAAA/////wABAAgABmLm
+				AAZhyAAOACgAEwB0AGgAaQBzAF8AZABvAGUAcwBfAG4A
+				bwB0AF8AZQB4AGkAcwB0AA8AGgAMAE0AYQBjAGkAbgB0
+				AG8AcwBoACAASABEABIAH3ByaXZhdGUvdG1wL3RoaXNf
+				ZG9lc19ub3RfZXhpc3QAABMAAS8A//8AAA==
+				</data>
+				<key>CustomItemProperties</key>
+				<dict>
+					<key>com.apple.LSSharedFileList.Binding</key>
+					<data>
+					ZG5pYgAAAAABAAAAAAAAAAAAAAAAAAAAAAAA
+					AAAAAAAAAAAAAAAAAAAAAAAAAAAA
+					</data>
+				</dict>
+				<key>Name</key>
+				<string>this_does_not_exist</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
This addresses #3994.

We unify the two locations where Alias data is parsed: Startup Items, and the ALF. Then that method is changed to fallback to parsing Alias structure, rather naively, looking for the POSIX path tag.