### PR TITLE
tests: Allow VERBOSE_TEST=1 to run verbose ctest

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -73,7 +73,7 @@ macro(ADD_OSQUERY_PYTHON_TEST TEST_NAME SOURCE)
   if(NOT DEFINED ENV{SKIP_INTEGRATION_TESTS})
     add_test(NAME python_${TEST_NAME}
       COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/tests/${SOURCE}"
-        --build "${CMAKE_BINARY_DIR}"
+        --verbose --build "${CMAKE_BINARY_DIR}"
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tools/tests/")
   endif()
 endmacro(ADD_OSQUERY_PYTHON_TEST)

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ else
 	DEBUG_BUILD_DIR := build/debug_$(BUILD_NAME)
 endif
 
-ifneq ($(VERBOSE),)
-  VERBOSE = "-V"
+ifneq ($(VERBOSE_TEST),)
+  VERBOSE_TEST = "-V"
 endif
 
 PATH_SET := PATH="$(DEPS_DIR)/bin:/usr/local/bin:$(PATH)"
@@ -260,7 +260,7 @@ sync: .setup
 		$(DEFINES) $(MAKE) sync --no-print-directory $(MAKEFLAGS)
 
 test: .setup
-	@cd build/$(BUILD_NAME) && $(DEFINES) $(CTEST) $(VERBOSE)
+	@cd build/$(BUILD_NAME) && $(DEFINES) $(CTEST) $(VERBOSE_TEST)
 
 .DEFAULT: .setup
 	@$(MAKE) --no-print-directory $(MAKEFLAGS) setup

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ else
 	DEBUG_BUILD_DIR := build/debug_$(BUILD_NAME)
 endif
 
+ifneq ($(VERBOSE),)
+  VERBOSE = "-V"
+endif
 
 PATH_SET := PATH="$(DEPS_DIR)/bin:/usr/local/bin:$(PATH)"
 CMAKE := $(PATH_SET) LDFLAGS="-L$(DEPS_DIR)/legacy/lib -L$(DEPS_DIR)/lib" cmake $(CMAKE_EXTRA) $(SOURCE_DIR)/
@@ -257,7 +260,7 @@ sync: .setup
 		$(DEFINES) $(MAKE) sync --no-print-directory $(MAKEFLAGS)
 
 test: .setup
-	@cd build/$(BUILD_NAME) && $(DEFINES) $(CTEST)
+	@cd build/$(BUILD_NAME) && $(DEFINES) $(CTEST) $(VERBOSE)
 
 .DEFAULT: .setup
 	@$(MAKE) --no-print-directory $(MAKEFLAGS) setup

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -204,7 +204,7 @@ function build() {
 
   if [[ $RUN_TESTS = true ]]; then
     # Run code unit and integration tests.
-    $MAKE test/fast
+    $MAKE test
 
     if [[ $BUILD_KERNEL = 1 ]]; then
       # Run kernel unit and integration tests (optional).

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -619,13 +619,13 @@ def expect(functional, expected, interval=0.01, timeout=4):
 
 class QueryTester(ProcessGenerator, unittest.TestCase):
     def setUp(self):
-        self.binary = os.path.join(ARGS.build, "osquery", "osqueryi")
         self.daemon = self._run_daemon({
             # The set of queries will hammer the daemon process.
             "disable_watchdog": True,
             # Enable the 'hidden' flag "registry_exceptions" to prevent
             # catching.
             "registry_exceptions": True,
+            "ephemeral": True,
         })
         self.assertTrue(self.daemon.isAlive())
 

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -619,6 +619,7 @@ def expect(functional, expected, interval=0.01, timeout=4):
 
 class QueryTester(ProcessGenerator, unittest.TestCase):
     def setUp(self):
+        self.binary = os.path.join(ARGS.build, "osquery", "osqueryi")
         self.daemon = self._run_daemon({
             # The set of queries will hammer the daemon process.
             "disable_watchdog": True,

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -104,9 +104,10 @@ FILE_CARVE_DIR = '/tmp/'
 FILE_CARVE_MAP = {}
 
 def debug(response):
-    print("-- [DEBUG] %s" % str(response))
-    sys.stdout.flush()
-    sys.stderr.flush()
+    if ARGS.verbose:
+        print("-- [DEBUG] %s" % str(response))
+        sys.stdout.flush()
+        sys.stderr.flush()
 
 ENROLL_RESET = {
     "count": 1,
@@ -321,6 +322,9 @@ if __name__ == '__main__':
         "--timeout", default=10, type=int,
         help="If not persisting, exit after a number of seconds"
     )
+    parser.add_argument(
+        '--verbose', default=False, action='store_true',
+        help='Output version/debug messages')
 
     parser.add_argument(
         "--cert", metavar="CERT_FILE",


### PR DESCRIPTION
The goal is to allow `ctest` to output verbose messages when the environment variable `VERBOSE` is defined. We can define this in Jenkins to help debug problems with long-running tests, like `test_osqueryd`. This test is flaky on macOS and is not easily reproduced locally.