### PR TITLE
List all sockets (host and containers) in process_open_sockets

### DIFF
--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -16,54 +16,165 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
+#include "osquery/core/conversions.h"
+#include "osquery/filesystem/linux/proc.h"
+
 namespace osquery {
+const char* kLinuxProcPath = "/proc";
 
-const std::string kLinuxProcPath = "/proc";
+Status procGetProcessNamespaces(const std::string& process_id,
+                                ProcessNamespaceList& namespace_list) {
+  namespace_list.clear();
 
-Status procProcesses(std::set<std::string>& processes) {
-  // Iterate over each process-like directory in proc.
-  boost::filesystem::directory_iterator it(kLinuxProcPath), end;
-  try {
-    for (; it != end; ++it) {
-      if (boost::filesystem::is_directory(it->status())) {
-        // See #792: std::regex is incomplete until GCC 4.9
-        if (std::atoll(it->path().leaf().string().c_str()) > 0) {
-          processes.insert(it->path().leaf().string());
-        }
-      }
+  for (std::string namespace_name :
+       {"cgroup", "ipc", "mnt", "net", "pid", "user", "uts"}) {
+    std::string symlink_path = std::string(kLinuxProcPath) + "/" + process_id +
+                               "/ns/" + namespace_name;
+
+    char link_destination[PATH_MAX] = {};
+    auto link_dest_length =
+        readlink(symlink_path.data(), link_destination, PATH_MAX - 1);
+    if (link_dest_length < 0) {
+      return Status(1,
+                    std::string("Failed to retrieve the inode for namespace ") +
+                        namespace_name + " in process " + process_id);
     }
-  } catch (const boost::filesystem::filesystem_error& e) {
-    VLOG(1) << "Exception iterating Linux processes " << e.what();
-    return Status(1, e.what());
+
+    // The link destination must be in the following form: namespace:[inode]
+    if (std::strncmp(link_destination,
+                     namespace_name.data(),
+                     namespace_name.size()) != 0 ||
+        std::strncmp(link_destination + namespace_name.size(), ":[", 2) != 0) {
+      return Status(1,
+                    std::string("Invalid descriptor for namespace ") +
+                        namespace_name + " in process " + process_id);
+    }
+
+    // Parse the inode part of the string; strtoull should return us a pointer
+    // to the
+    // closing square bracket
+    const char* inode_string_ptr = link_destination + namespace_name.size() + 2;
+    char* square_bracket_ptr = nullptr;
+
+    auto inode = static_cast<ino_t>(
+        std::strtoull(inode_string_ptr, &square_bracket_ptr, 10));
+    if (inode == 0 || square_bracket_ptr == nullptr ||
+        *square_bracket_ptr != ']') {
+      return Status(
+          1,
+          std::string("Invalid inode value in descriptor for namespace ") +
+              namespace_name + " in process " + process_id);
+    }
+
+    namespace_list[namespace_name] = inode;
   }
 
   return Status(0, "OK");
 }
 
-Status procDescriptors(const std::string& process,
-                       std::map<std::string, std::string>& descriptors) {
-  auto descriptors_path = kLinuxProcPath + "/" + process + "/fd";
-  try {
-    // Access to the process' /fd may be restricted.
-    boost::filesystem::directory_iterator it(descriptors_path), end;
-    for (; it != end; ++it) {
-      auto fd = it->path().leaf().string();
-      std::string linkname;
-      if (procReadDescriptor(process, fd, linkname).ok()) {
-        descriptors[fd] = linkname;
-      }
+std::string procDecodeAddressFromHex(const std::string& encoded_address,
+                                     int family) {
+  char addr_buffer[INET6_ADDRSTRLEN] = {0};
+  if (family == AF_INET) {
+    struct in_addr decoded;
+    if (encoded_address.length() == 8) {
+      sscanf(encoded_address.c_str(), "%X", &(decoded.s_addr));
+      inet_ntop(AF_INET, &decoded, addr_buffer, INET_ADDRSTRLEN);
     }
-  } catch (boost::filesystem::filesystem_error& e) {
-    return Status(1, "Cannot access descriptors for " + process);
+  } else if (family == AF_INET6) {
+    struct in6_addr decoded;
+    if (encoded_address.length() == 32) {
+      sscanf(encoded_address.c_str(),
+             "%8x%8x%8x%8x",
+             (unsigned int*)&(decoded.s6_addr[0]),
+             (unsigned int*)&(decoded.s6_addr[4]),
+             (unsigned int*)&(decoded.s6_addr[8]),
+             (unsigned int*)&(decoded.s6_addr[12]));
+      inet_ntop(AF_INET6, &decoded, addr_buffer, INET6_ADDRSTRLEN);
+    }
   }
 
-  return Status(0, "OK");
+  return std::string(addr_buffer);
+}
+
+unsigned short procDecodePortFromHex(const std::string& encoded_port) {
+  unsigned short decoded = 0;
+  if (encoded_port.length() == 4) {
+    sscanf(encoded_port.c_str(), "%hX", &decoded);
+  }
+  return decoded;
+}
+
+Status procProcesses(std::set<std::string>& processes) {
+  auto L_procProcessesCallback = [](const std::string& process_id,
+                                    std::set<std::string>& processes) -> bool {
+    processes.insert(process_id);
+    return true;
+  };
+
+  return procProcesses<decltype(processes)>(L_procProcessesCallback, processes);
+}
+
+Status procProcessSockets(std::vector<ProcessSocket>& socket_list,
+                          const std::string& process_id,
+                          int protocol,
+                          int family) {
+  socket_list.clear();
+
+  auto L_procProcessSocketsCallback = [](
+      const ProcessSocket& proc_socket,
+      std::vector<ProcessSocket>& socket_list) -> bool {
+    socket_list.push_back(proc_socket);
+    return true;
+  };
+
+  return procProcessSockets<decltype(socket_list)>(
+      L_procProcessSocketsCallback, socket_list, process_id, protocol, family);
+}
+
+Status procDescriptors(const std::string& process,
+                       std::map<std::string, std::string>& descriptors) {
+  auto L_procDescriptorsCallback = [](
+      const std::string& fd,
+      const std::string& link_name,
+      std::map<std::string, std::string>& descriptors) -> bool {
+
+    descriptors[fd] = link_name;
+    return true;
+  };
+
+  return procDescriptors<decltype(descriptors)>(
+      process, L_procDescriptorsCallback, descriptors);
+}
+
+Status procSocketInodeToFdMap(
+    const std::string& process,
+    std::unordered_map<std::string, std::string>& inode_to_fd_map) {
+  inode_to_fd_map.clear();
+
+  auto L_procDescriptorsCallback = [](
+      const std::string& fd,
+      const std::string& link_name,
+      std::unordered_map<std::string, std::string>& inode_to_fd_map) -> bool {
+
+    if (link_name.find("socket:[") != 0) {
+      return true;
+    }
+
+    auto inode = link_name.substr(8, link_name.size() - 9);
+    inode_to_fd_map[inode] = fd;
+
+    return true;
+  };
+
+  return procDescriptors<decltype(inode_to_fd_map)>(
+      process, L_procDescriptorsCallback, inode_to_fd_map);
 }
 
 Status procReadDescriptor(const std::string& process,
                           const std::string& descriptor,
                           std::string& result) {
-  auto link = kLinuxProcPath + "/" + process + "/fd/" + descriptor;
+  auto link = std::string(kLinuxProcPath) + "/" + process + "/fd/" + descriptor;
 
   char result_path[PATH_MAX] = {0};
   auto size = readlink(link.c_str(), result_path, sizeof(result_path) - 1);

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -1,0 +1,248 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <unordered_map>
+
+#include <arpa/inet.h>
+#include <linux/limits.h>
+#include <unistd.h>
+
+#include <boost/filesystem.hpp>
+
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+
+namespace osquery {
+extern const char* kLinuxProcPath;
+
+struct ProcessSocket final {
+  std::string socket;
+  int family;
+  int protocol;
+
+  std::string local_address;
+  std::uint16_t local_port;
+
+  std::string remote_address;
+  std::uint16_t remote_port;
+
+  std::string unix_socket_path;
+
+  int fd;
+};
+
+// Linux proc protocol define to net stats file name.
+const std::map<int, std::string> kLinuxProtocolNames = {
+    {IPPROTO_ICMP, "icmp"},
+    {IPPROTO_TCP, "tcp"},
+    {IPPROTO_UDP, "udp"},
+    {IPPROTO_UDPLITE, "udplite"},
+    {IPPROTO_RAW, "raw"},
+};
+
+using ProcessNamespaceList = std::map<std::string, ino_t>;
+
+Status procGetProcessNamespaces(const std::string& process_id,
+                                ProcessNamespaceList& namespace_list);
+
+Status procReadDescriptor(const std::string& process,
+                          const std::string& descriptor,
+                          std::string& result);
+
+std::string procDecodeAddressFromHex(const std::string& encoded_address,
+                                     int family);
+
+unsigned short procDecodePortFromHex(const std::string& encoded_port);
+
+Status procSocketInodeToFdMap(
+    const std::string& process,
+    std::unordered_map<std::string, std::string>& inode_to_fd_map);
+
+template <typename UserData>
+Status procProcesses(bool (*callback)(const std::string&, UserData),
+                     UserData data) {
+  boost::filesystem::directory_iterator it(kLinuxProcPath), end;
+
+  try {
+    for (; it != end; ++it) {
+      if (!boost::filesystem::is_directory(it->status())) {
+        continue;
+      }
+
+      // See #792: std::regex is incomplete until GCC 4.9
+      const auto& pid = it->path().leaf().string();
+      if (std::atoll(pid.data()) <= 0) {
+        continue;
+      }
+
+      if (!callback(pid, data)) {
+        break;
+      }
+    }
+
+  } catch (const boost::filesystem::filesystem_error& e) {
+    VLOG(1) << "Exception iterating Linux processes " << e.what();
+    return Status(1, e.what());
+  }
+
+  return Status(0, "OK");
+}
+
+template <typename UserData>
+Status procDescriptors(const std::string& process_id,
+                       bool (*callback)(const std::string&,
+                                        const std::string&,
+                                        UserData),
+                       UserData data) {
+  auto descriptors_path =
+      std::string(kLinuxProcPath) + "/" + process_id + "/fd";
+
+  try {
+    boost::filesystem::directory_iterator it(descriptors_path), end;
+
+    for (; it != end; ++it) {
+      auto fd = it->path().leaf().string();
+
+      std::string linkname;
+      if (!procReadDescriptor(process_id, fd, linkname).ok()) {
+        continue;
+      }
+
+      if (!callback(fd, linkname, data)) {
+        break;
+      }
+    }
+
+    return Status(0, "OK");
+
+  } catch (boost::filesystem::filesystem_error& e) {
+    return Status(1,
+                  std::string("Cannot access descriptors for ") + process_id);
+  }
+}
+
+template <typename UserData>
+Status procProcessSockets(bool (*callback)(const ProcessSocket&, UserData),
+                          UserData user_data,
+                          const std::string& process_id,
+                          int protocol,
+                          int family,
+                          std::unordered_map<std::string, std::string>*
+                              inode_to_fd_map_ptr = nullptr) {
+  if (protocol != IPPROTO_IP &&
+      kLinuxProtocolNames.find(protocol) == kLinuxProtocolNames.end()) {
+    return Status(1, "Invalid protocol specified");
+  }
+
+  if (family != AF_UNIX && family != AF_INET && family != AF_INET6) {
+    return Status(1, "Invalid address family specified");
+  }
+
+  std::unordered_map<std::string, std::string> inode_to_fd_map;
+  if (inode_to_fd_map_ptr != nullptr) {
+    inode_to_fd_map = *inode_to_fd_map_ptr;
+
+  } else {
+    auto status = procSocketInodeToFdMap(process_id, inode_to_fd_map);
+    if (!status.ok()) {
+      return Status(1, "Failed to enumerate the process descriptors");
+    }
+  }
+
+  auto socket_list_path =
+      std::string(kLinuxProcPath) + "/" + process_id + "/net/";
+
+  if (family == AF_UNIX) {
+    socket_list_path += "unix";
+  } else {
+    socket_list_path += kLinuxProtocolNames.at(protocol);
+    socket_list_path += (family == AF_INET6) ? "6" : "";
+  }
+
+  std::string content;
+  if (!osquery::readFile(socket_list_path, content).ok()) {
+    return Status(1, "Could not open socket information from /proc");
+  }
+
+  // The system's socket information is tokenized by line.
+  size_t index = 0;
+
+  for (const auto& line : osquery::split(content, "\n")) {
+    if (++index == 1) {
+      // The first line is a textual header and will be ignored.
+      if (line.find("sl") != 0 && line.find("sk") != 0 &&
+          line.find("Num") != 0) {
+        return Status(1,
+                      std::string("Invalid file header encountered in ") +
+                          socket_list_path);
+      }
+
+      continue;
+    }
+
+    // The socket information is tokenized by spaces, each a field.
+    auto fields = osquery::split(line, " ");
+
+    // UNIX socket reporting has a smaller number of fields.
+    size_t min_fields = (family == AF_UNIX) ? 7 : 10;
+    if (fields.size() < min_fields) {
+      VLOG(1) << "Invalid UNIX socket descriptor found: '" << line
+              << "'. Skipping this entry";
+      continue;
+    }
+
+    ProcessSocket proc_socket = {};
+
+    if (family == AF_UNIX) {
+      proc_socket.socket = fields[6];
+      proc_socket.family = family;
+      proc_socket.protocol = std::atoll(fields[2].data());
+      proc_socket.local_port = proc_socket.remote_port = 0U;
+      proc_socket.unix_socket_path = (fields.size() >= 8) ? fields[7] : "";
+
+    } else {
+      // Two of the fields are the local/remote address/port pairs.
+      auto locals = osquery::split(fields[1], ":");
+      auto remotes = osquery::split(fields[2], ":");
+
+      if (locals.size() != 2 || remotes.size() != 2) {
+        VLOG(1) << "Invalid socket descriptor found: '" << line
+                << "'. Skipping this entry";
+
+        continue;
+      }
+
+      proc_socket.socket = fields[9];
+      proc_socket.family = family;
+      proc_socket.protocol = protocol;
+      proc_socket.local_address = procDecodeAddressFromHex(locals[0], family);
+      proc_socket.local_port = procDecodePortFromHex(locals[1]);
+      proc_socket.remote_address = procDecodeAddressFromHex(remotes[0], family);
+      proc_socket.remote_port = procDecodePortFromHex(remotes[1]);
+    }
+
+    // If this socket has no fd, then it means that it is not owned by
+    // this process
+    auto it = inode_to_fd_map.find(proc_socket.socket);
+    if (it == inode_to_fd_map.end()) {
+      continue;
+    }
+
+    proc_socket.fd = std::atoll(it->second.data());
+    if (!callback(proc_socket, user_data)) {
+      break;
+    }
+  }
+
+  return Status(0, "OK");
+}
+}

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -21,6 +21,8 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
+#include "osquery/core/conversions.h"
+
 namespace osquery {
 extern const char* kLinuxProcPath;
 

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -23,6 +23,7 @@
 #include <osquery/system.h>
 
 #include "osquery/core/process.h"
+#include "osquery/filesystem/linux/proc.h"
 #include "osquery/tests/test_util.h"
 
 namespace fs = boost::filesystem;
@@ -428,6 +429,23 @@ TEST_F(FilesystemTests, test_safe_permissions) {
   }
 }
 
+TEST_F(FilesystemTests, test_user_namespace_parser) {
+  std::string content;
+
+  if (isPlatform(PlatformType::TYPE_LINUX)) {
+    auto temp_path = fs::unique_path().native();
+    EXPECT_EQ(symlink("namespace:[112233]", temp_path.data()), 0);
+
+    ino_t namespace_inode;
+    auto status =
+        procGetNamespaceInode(namespace_inode, "namespace", temp_path);
+    EXPECT_TRUE(status.ok());
+
+    removePath(temp_path);
+    EXPECT_EQ(namespace_inode, static_cast<ino_t>(112233));
+  }
+}
+
 TEST_F(FilesystemTests, test_read_proc) {
   std::string content;
 
@@ -470,4 +488,4 @@ TEST_F(FilesystemTests, test_read_urandom) {
     EXPECT_NE(first, second);
   }
 }
-}
+} // namespace osquery

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -396,7 +396,6 @@ QueryData genContainers(QueryContext& context) {
     if (s.ok()) {
       pid_t process_id = container_details.get<pid_t>("State.Pid", -1);
       r["pid"] = std::to_string(process_id);
-
     } else {
       VLOG(1) << "Failed to retrieve the pid for container " << r["id"];
     }
@@ -408,7 +407,6 @@ QueryData genContainers(QueryContext& context) {
         for (const auto& pair : namespace_list) {
           r[pair.first + "_namespace"] = std::to_string(pair.second);
         }
-
       } else {
         VLOG(1) << "Failed to retrieve the namespace list for container "
                 << r["id"];
@@ -941,5 +939,5 @@ QueryData genImageLabels(QueryContext& context) {
                    false, // Does not support "filters" query string
                    false); // Does not support "all" query string
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -27,7 +27,12 @@
 #include <osquery/tables.h>
 
 #include "osquery/core/json.h"
+
+// When building on linux, the extended schema of docker_containers will
+// add some additional columns to support user namespaces
+#ifdef __linux__
 #include "osquery/filesystem/linux/proc.h"
+#endif
 
 namespace pt = boost::property_tree;
 namespace local = boost::asio::local;
@@ -400,6 +405,9 @@ QueryData genContainers(QueryContext& context) {
       VLOG(1) << "Failed to retrieve the pid for container " << r["id"];
     }
 
+// When building on linux, the extended schema of docker_containers will
+// add some additional columns to support user namespaces
+#ifdef __linux__
     if (r["pid"] != "-1") {
       ProcessNamespaceList namespace_list;
       s = procGetProcessNamespaces(r["pid"], namespace_list);
@@ -412,6 +420,7 @@ QueryData genContainers(QueryContext& context) {
                 << r["id"];
       }
     }
+#endif
 
     results.push_back(r);
   }

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -54,11 +54,12 @@ QueryData genOpenSockets(QueryContext& context) {
 
   CallbackData callback_data = {};
 
-  std::set<ino_t> processed_namespaces;
-
   for (const auto& process_id : pids) {
+    // We are only interested in the 'net' namespace, so we will be filtering
+    // out everything else
     ProcessNamespaceList process_namespaces;
-    auto status = procGetProcessNamespaces(process_id, process_namespaces);
+    auto status =
+        procGetProcessNamespaces(process_id, process_namespaces, {"net"});
     if (!status.ok()) {
       VLOG(1)
           << "The process_open_sockets may be showing partial results. Error: "
@@ -122,5 +123,5 @@ QueryData genOpenSockets(QueryContext& context) {
 
   return callback_data.results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -46,6 +46,7 @@ QueryData genOpenSockets(QueryContext& context) {
     r["fd"] = std::to_string(proc_socket.fd);
     r["pid"] = data.process_id;
     r["net_namespace"] = std::to_string(data.current_network_namespace);
+    r["state"] = proc_socket.state;
 
     data.results.push_back(std::move(r));
     return true;

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -8,146 +8,16 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <arpa/inet.h>
-
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/filesystem/linux/proc.h"
 
 namespace osquery {
 namespace tables {
-
-// Linux proc protocol define to net stats file name.
-const std::map<int, std::string> kLinuxProtocolNames = {
-    {IPPROTO_ICMP, "icmp"},
-    {IPPROTO_TCP, "tcp"},
-    {IPPROTO_UDP, "udp"},
-    {IPPROTO_UDPLITE, "udplite"},
-    {IPPROTO_RAW, "raw"},
-};
-
-// A map of socket handles (inodes) to their pid and file descriptor.
-typedef std::map<std::string, std::pair<std::string, std::string> > InodeMap;
-
-std::string addressFromHex(const std::string &encoded_address, int family) {
-  char addr_buffer[INET6_ADDRSTRLEN] = {0};
-  if (family == AF_INET) {
-    struct in_addr decoded;
-    if (encoded_address.length() == 8) {
-      sscanf(encoded_address.c_str(), "%X", &(decoded.s_addr));
-      inet_ntop(AF_INET, &decoded, addr_buffer, INET_ADDRSTRLEN);
-    }
-  } else if (family == AF_INET6) {
-    struct in6_addr decoded;
-    if (encoded_address.length() == 32) {
-      sscanf(encoded_address.c_str(),
-             "%8x%8x%8x%8x",
-             (unsigned int *)&(decoded.s6_addr[0]),
-             (unsigned int *)&(decoded.s6_addr[4]),
-             (unsigned int *)&(decoded.s6_addr[8]),
-             (unsigned int *)&(decoded.s6_addr[12]));
-      inet_ntop(AF_INET6, &decoded, addr_buffer, INET6_ADDRSTRLEN);
-    }
-  }
-
-  return std::string(addr_buffer);
-}
-
-unsigned short portFromHex(const std::string &encoded_port) {
-  unsigned short decoded = 0;
-  if (encoded_port.length() == 4) {
-    sscanf(encoded_port.c_str(), "%hX", &decoded);
-  }
-  return decoded;
-}
-
-void genSocketsFromProc(const InodeMap &inodes,
-                        int protocol,
-                        int family,
-                        QueryData &results) {
-  std::string path = "/proc/net/";
-  if (family == AF_UNIX) {
-    path += "unix";
-  } else {
-    path += kLinuxProtocolNames.at(protocol);
-    path += (family == AF_INET6) ? "6" : "";
-  }
-
-  std::string content;
-  if (!osquery::readFile(path, content).ok()) {
-    // Could not open socket information from /proc.
-    return;
-  }
-
-  // The system's socket information is tokenized by line.
-  size_t index = 0;
-  for (const auto &line : osquery::split(content, "\n")) {
-    if (++index == 1) {
-      // The first line is a textual header and will be ignored.
-      if (line.find("sl") != 0 && line.find("sk") != 0 &&
-          line.find("Num") != 0) {
-        // Header fields are unknown, stop parsing.
-        break;
-      }
-      continue;
-    }
-
-    // The socket information is tokenized by spaces, each a field.
-    auto fields = osquery::split(line, " ");
-    // UNIX socket reporting has a smaller number of fields.
-    size_t min_fields = (family == AF_UNIX) ? 7 : 10;
-    if (fields.size() < min_fields) {
-      // Unknown/malformed socket information.
-      continue;
-    }
-
-    Row r;
-    if (family == AF_UNIX) {
-      r["socket"] = fields[6];
-      r["family"] = "1";
-      r["protocol"] = fields[2];
-      r["local_address"] = "";
-      r["local_port"] = "0";
-      r["remote_address"] = "";
-      r["remote_port"] = "0";
-      r["path"] = (fields.size() >= 8) ? fields[7] : "";
-    } else {
-      // Two of the fields are the local/remote address/port pairs.
-      auto locals = osquery::split(fields[1], ":");
-      auto remotes = osquery::split(fields[2], ":");
-      if (locals.size() != 2 || remotes.size() != 2) {
-        // Unknown/malformed socket information.
-        continue;
-      }
-
-      r["socket"] = fields[9];
-      r["family"] = INTEGER(family);
-      r["protocol"] = INTEGER(protocol);
-      r["local_address"] = addressFromHex(locals[0], family);
-      r["local_port"] = INTEGER(portFromHex(locals[1]));
-      r["remote_address"] = addressFromHex(remotes[0], family);
-      r["remote_port"] = INTEGER(portFromHex(remotes[1]));
-      // Path is only used for UNIX domain sockets.
-      r["path"] = "";
-    }
-
-    if (inodes.count(r["socket"]) > 0) {
-      r["pid"] = inodes.at(r["socket"]).second;
-      r["fd"] = inodes.at(r["socket"]).first;
-    } else {
-      r["pid"] = "-1";
-      r["fd"] = "-1";
-    }
-
-    results.push_back(r);
-  }
-}
-
-QueryData genOpenSockets(QueryContext &context) {
-  QueryData results;
-
+QueryData genOpenSockets(QueryContext& context) {
   // If a pid is given then set that as the only item in processes.
   std::set<std::string> pids;
   if (context.constraints["pid"].exists(EQUALS)) {
@@ -156,31 +26,100 @@ QueryData genOpenSockets(QueryContext &context) {
     osquery::procProcesses(pids);
   }
 
-  // Generate a map of socket inode to process tid.
-  InodeMap socket_inodes;
-  for (const auto &process : pids) {
-    std::map<std::string, std::string> descriptors;
-    if (osquery::procDescriptors(process, descriptors).ok()) {
-      for (const auto &fd : descriptors) {
-        if (fd.second.find("socket:[") == 0) {
-          // See #792: std::regex is incomplete until GCC 4.9 (skip 8 chars)
-          auto inode = fd.second.substr(8);
-          socket_inodes[inode.substr(0, inode.size() - 1)] =
-              std::make_pair(fd.first, process);
-        }
+  struct CallbackData final {
+    QueryData results;
+    std::string process_id;
+    ino_t current_network_namespace;
+  };
+
+  auto L_genSocketsFromProcCallback = [](const ProcessSocket& proc_socket,
+                                         CallbackData& data) -> bool {
+    Row r;
+    r["socket"] = proc_socket.socket;
+    r["family"] = std::to_string(proc_socket.family);
+    r["protocol"] = std::to_string(proc_socket.protocol);
+    r["local_address"] = proc_socket.local_address;
+    r["local_port"] = std::to_string(proc_socket.local_port);
+    r["remote_address"] = proc_socket.remote_address;
+    r["remote_port"] = std::to_string(proc_socket.remote_port);
+    r["path"] = proc_socket.unix_socket_path;
+    r["fd"] = std::to_string(proc_socket.fd);
+    r["pid"] = data.process_id;
+    r["net_namespace"] = std::to_string(data.current_network_namespace);
+
+    data.results.push_back(std::move(r));
+    return true;
+  };
+
+  CallbackData callback_data = {};
+
+  std::set<ino_t> processed_namespaces;
+
+  for (const auto& process_id : pids) {
+    ProcessNamespaceList process_namespaces;
+    auto status = procGetProcessNamespaces(process_id, process_namespaces);
+    if (!status.ok()) {
+      VLOG(1)
+          << "The process_open_sockets may be showing partial results. Error: "
+          << status.getMessage();
+      continue;
+    }
+
+    callback_data.process_id = process_id;
+    callback_data.current_network_namespace = process_namespaces["net"];
+
+    std::unordered_map<std::string, std::string> inode_to_fd_map;
+    status = procSocketInodeToFdMap(process_id, inode_to_fd_map);
+    if (!status.ok()) {
+      VLOG(1) << "The process_open_sockets may be showing partial results. "
+                 "Error: Failed to enumerate the fd map for the following "
+                 "process: "
+              << process_id;
+    }
+
+    for (const auto& pair : kLinuxProtocolNames) {
+      int protocol = pair.first;
+
+      std::vector<ProcessSocket> socket_list;
+      status = procProcessSockets<CallbackData&>(L_genSocketsFromProcCallback,
+                                                 callback_data,
+                                                 process_id,
+                                                 protocol,
+                                                 AF_INET,
+                                                 &inode_to_fd_map);
+      if (!status.ok()) {
+        VLOG(1) << "The process_open_sockets may be showing partial results. "
+                   "Error: "
+                << status.getMessage();
       }
+
+      status = procProcessSockets<CallbackData&>(L_genSocketsFromProcCallback,
+                                                 callback_data,
+                                                 process_id,
+                                                 protocol,
+                                                 AF_INET6,
+                                                 &inode_to_fd_map);
+      if (!status.ok()) {
+        VLOG(1) << "The process_open_sockets may be showing partial results. "
+                   "Error: "
+                << status.getMessage();
+      }
+    }
+
+    status = procProcessSockets<CallbackData&>(L_genSocketsFromProcCallback,
+                                               callback_data,
+                                               process_id,
+                                               IPPROTO_IP,
+                                               AF_UNIX,
+                                               &inode_to_fd_map);
+    if (!status.ok()) {
+      VLOG(1) << "The process_open_sockets may be showing partial results. "
+                 "Error: "
+              << status.getMessage();
     }
   }
 
-  // This used to use netlink (Ref: #1094) to request socket information.
-  // Use proc messages to query socket information.
-  for (const auto &protocol : kLinuxProtocolNames) {
-    genSocketsFromProc(socket_inodes, protocol.first, AF_INET, results);
-    genSocketsFromProc(socket_inodes, protocol.first, AF_INET6, results);
-  }
-
-  genSocketsFromProc(socket_inodes, IPPROTO_IP, AF_UNIX, results);
-  return results;
+  return callback_data.results;
 }
 }
 }

--- a/osquery/tables/networking/listening_ports.cpp
+++ b/osquery/tables/networking/listening_ports.cpp
@@ -20,13 +20,17 @@ QueryData genListeningPorts(QueryContext& context) {
   auto sockets = SQL::selectAllFrom("process_open_sockets");
 
   for (const auto& socket : sockets) {
-    if (socket.at("remote_port") != "0") {
-      // Listening UDP/TCP ports have a remote_port == "0"
+    // 1  = AF_UNIX
+    if (socket.at("family") == "1" && socket.at("path").empty()) {
+      // Skip anonymous unix domain sockets
       continue;
     }
 
-    if (socket.at("family") == "1" && socket.at("path").empty()) {
-      // Skip anonymous unix domain sockets
+    // 2  = AF_INET
+    // 10 = AF_INET6
+    if ((socket.at("family") == "2" || socket.at("family") == "10") &&
+        socket.at("remote_port") != "0") {
+      // Listening UDP/TCP ports have a remote_port == "0"
       continue;
     }
 

--- a/osquery/tables/networking/listening_ports.cpp
+++ b/osquery/tables/networking/listening_ports.cpp
@@ -11,24 +11,26 @@
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 
+namespace {
+const std::string kAF_UNIX = "1";
+const std::string kAF_INET = "2";
+const std::string kAF_INET6 = "10";
+} // namespace
+
 namespace osquery {
 namespace tables {
-
 QueryData genListeningPorts(QueryContext& context) {
   QueryData results;
 
   auto sockets = SQL::selectAllFrom("process_open_sockets");
 
   for (const auto& socket : sockets) {
-    // 1  = AF_UNIX
-    if (socket.at("family") == "1" && socket.at("path").empty()) {
+    if (socket.at("family") == kAF_UNIX && socket.at("path").empty()) {
       // Skip anonymous unix domain sockets
       continue;
     }
 
-    // 2  = AF_INET
-    // 10 = AF_INET6
-    if ((socket.at("family") == "2" || socket.at("family") == "10") &&
+    if ((socket.at("family") == kAF_INET || socket.at("family") == kAF_INET6) &&
         socket.at("remote_port") != "0") {
       // Listening UDP/TCP ports have a remote_port == "0"
       continue;
@@ -37,7 +39,7 @@ QueryData genListeningPorts(QueryContext& context) {
     Row r;
     r["pid"] = socket.at("pid");
 
-    if (socket.at("family") == "1") {
+    if (socket.at("family") == kAF_UNIX) {
       r["path"] = socket.at("path");
     } else {
       r["address"] = socket.at("local_address");
@@ -55,5 +57,5 @@ QueryData genListeningPorts(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/networking/listening_ports.cpp
+++ b/osquery/tables/networking/listening_ports.cpp
@@ -40,17 +40,37 @@ QueryData genListeningPorts(QueryContext& context) {
     r["pid"] = socket.at("pid");
 
     if (socket.at("family") == kAF_UNIX) {
+      r["port"] = "0";
       r["path"] = socket.at("path");
+      r["socket"] = "0";
     } else {
       r["address"] = socket.at("local_address");
       r["port"] = socket.at("local_port");
+
+      auto socket_it = socket.find("socket");
+      if (socket_it != socket.end()) {
+        r["socket"] = socket_it->second;
+      } else {
+        r["socket"] = "0";
+      }
     }
 
     r["protocol"] = socket.at("protocol");
     r["family"] = socket.at("family");
-    r["net_namespace"] = socket.at("net_namespace");
-    r["fd"] = socket.at("fd");
-    r["socket"] = socket.at("socket");
+
+    auto fd_it = socket.find("fd");
+    if (fd_it != socket.end()) {
+      r["fd"] = fd_it->second;
+    } else {
+      r["fd"] = "0";
+    }
+
+    // When running under linux, we also have the user namespace
+    // column available. It can be used with the docker_containers
+    // table
+    if (isPlatform(PlatformType::TYPE_LINUX)) {
+      r["net_namespace"] = socket.at("net_namespace");
+    }
 
     results.push_back(r);
   }

--- a/specs/listening_ports.table
+++ b/specs/listening_ports.table
@@ -2,10 +2,14 @@ table_name("listening_ports")
 description("Processes with listening (bound) network sockets/ports.")
 schema([
     Column("pid", INTEGER, "Process (or thread) ID"),
-    Column("port", INTEGER, "Transport layer port"),
+    Column("port", TEXT, "Transport layer port"),
     Column("protocol", INTEGER, "Transport protocol (TCP/UDP)"),
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),
     Column("address", TEXT, "Specific address for bind"),
+    Column("net_namespace", TEXT, "The inode number of the network namespace"),
+    Column("fd", BIGINT, "Socket file descriptor number"),
+    Column("socket", BIGINT, "Socket handle or inode number"),
+    Column("path", TEXT, "Path for UNIX domain sockets")
 ])
 attributes(cacheable=True)
 implementation("listening_ports@genListeningPorts")

--- a/specs/listening_ports.table
+++ b/specs/listening_ports.table
@@ -2,14 +2,16 @@ table_name("listening_ports")
 description("Processes with listening (bound) network sockets/ports.")
 schema([
     Column("pid", INTEGER, "Process (or thread) ID"),
-    Column("port", TEXT, "Transport layer port"),
+    Column("port", INTEGER, "Transport layer port"),
     Column("protocol", INTEGER, "Transport protocol (TCP/UDP)"),
     Column("family", INTEGER, "Network protocol (IPv4, IPv6)"),
     Column("address", TEXT, "Specific address for bind"),
-    Column("net_namespace", TEXT, "The inode number of the network namespace"),
     Column("fd", BIGINT, "Socket file descriptor number"),
     Column("socket", BIGINT, "Socket handle or inode number"),
     Column("path", TEXT, "Path for UNIX domain sockets")
+])
+extended_schema(LINUX, [
+    Column("net_namespace", TEXT, "The inode number of the network namespace"),
 ])
 attributes(cacheable=True)
 implementation("listening_ports@genListeningPorts")

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -10,6 +10,8 @@ schema([
     Column("state", TEXT, "Container state (created, restarting, running, removing, paused, exited, dead)"),
     Column("status", TEXT, "Container status information"),
     Column("pid", TEXT, "Identifier of the initial process"),
+])
+extended_schema(LINUX, [
     Column("cgroup_namespace", TEXT, "cgroup namespace"),
     Column("ipc_namespace", TEXT, "IPC namespace"),
     Column("mnt_namespace", TEXT, "Mount namespace"),

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -8,7 +8,15 @@ schema([
     Column("command", TEXT, "Command with arguments"),
     Column("created", BIGINT, "Time of creation as UNIX time"),
     Column("state", TEXT, "Container state (created, restarting, running, removing, paused, exited, dead)"),
-    Column("status", TEXT, "Container status information")
+    Column("status", TEXT, "Container status information"),
+    Column("pid", TEXT, "Identifier of the initial process"),
+    Column("cgroup_namespace", TEXT, "cgroup namespace"),
+    Column("ipc_namespace", TEXT, "IPC namespace"),
+    Column("mnt_namespace", TEXT, "Mount namespace"),
+    Column("net_namespace", TEXT, "Network namespace"),
+    Column("pid_namespace", TEXT, "PID namespace"),
+    Column("user_namespace", TEXT, "User namespace"),
+    Column("uts_namespace", TEXT, "UTS namespace")
 ])
 implementation("applications/docker@genContainers")
 examples([

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -11,8 +11,10 @@ schema([
     Column("local_port", INTEGER, "Socket local port"),
     Column("remote_port", INTEGER, "Socket remote port"),
     Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
+])
+extended_schema(LINUX, [
+    Column("state", TEXT, "TCP socket state"),
     Column("net_namespace", TEXT, "The inode number of the network namespace"),
-    Column("state", TEXT, "TCP socket state")
 ])
 implementation("system/process_open_sockets@genOpenSockets")
 examples([

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -11,7 +11,8 @@ schema([
     Column("local_port", INTEGER, "Socket local port"),
     Column("remote_port", INTEGER, "Socket remote port"),
     Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
-    Column("net_namespace", TEXT, "The inode number of the network namespace")
+    Column("net_namespace", TEXT, "The inode number of the network namespace"),
+    Column("state", TEXT, "TCP socket state")
 ])
 implementation("system/process_open_sockets@genOpenSockets")
 examples([

--- a/specs/process_open_sockets.table
+++ b/specs/process_open_sockets.table
@@ -11,6 +11,7 @@ schema([
     Column("local_port", INTEGER, "Socket local port"),
     Column("remote_port", INTEGER, "Socket remote port"),
     Column("path", TEXT, "For UNIX sockets (family=AF_UNIX), the domain path"),
+    Column("net_namespace", TEXT, "The inode number of the network namespace")
 ])
 implementation("system/process_open_sockets@genOpenSockets")
 examples([


### PR DESCRIPTION
This PR modifies the process_open_sockets to actually show all sockets active inside all processes (both on the host and inside containers). A new column named "net_namespace" has been added, showing the network namespace that owns each socket.

I would like to make one last change: turn the protocol and family column types from integer to text, and use the actual protocol and family labels rather than numbers (which should make the table mor readable).