### PR TITLE
tables: Add cpu_microcode to system_info

### DIFF
--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -71,6 +71,16 @@ QueryData genSystemInfo(QueryContext& context) {
           // Not the most elegant but prevents us from splitting each line.
           r[(line[0] == 'c') ? "cpu_type" : "cpu_subtype"] = details[1];
         }
+      } else if (line.find("microcode") == 0) {
+        auto details = osquery::split(line, ":");
+        if (details.size() == 2) {
+          r["cpu_microcode"] = details[1];
+        }
+      }
+
+      // Minor optimization to not parse every line.
+      if (line.size() == 0) {
+        break;
       }
     }
   }

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -55,7 +55,18 @@ QueryData genSystemInfo(QueryContext& context) {
     r["hardware_vendor"] = "-1";
     r["hardware_model"] = "-1";
   }
-  
+
+  QueryData regResults;
+  queryKey(
+      "HKEY_LOCAL_MACHINE\\HARDWARE\\DESCRIPTION\\System\CentralProcesses\0",
+      regResults);
+  for (const auto& key : regResults) {
+    if (key.at("name") == "Update Revision") {
+      r["cpu_microcode"] = key.at("data");
+      break;
+    }
+  }
+
   WmiRequest wmiBiosReq("select * from Win32_Bios");
   std::vector<WmiResultItem>& wmiBiosResults = wmiBiosReq.results();
   if (wmiBiosResults.size() != 0) {

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -60,11 +60,15 @@ QueryData genSystemInfo(QueryContext& context) {
   QueryData regResults;
   queryKey(
       "HKEY_LOCAL_MACHINE\\"
-      "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0\\Update Revision",
+      "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0\\",
       regResults);
   for (const auto& key : regResults) {
     if (key.at("name") == "Update Revision") {
-      r["cpu_microcode"] = key.at("data");
+      if (key.at("data").size() >= 16) {
+        unsigned long int revision = 0;
+        safeStrtoul(key.at("data").substr(8, 2), 16, revision);
+        r["cpu_microcode"] = std::to_string(revision);
+      }
       break;
     }
   }

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -16,6 +16,7 @@
 
 #include "osquery/core/conversions.h"
 #include "osquery/core/windows/wmi.h"
+#include "osquery/tables/system/windows/registry.h"
 
 namespace osquery {
 namespace tables {
@@ -58,7 +59,8 @@ QueryData genSystemInfo(QueryContext& context) {
 
   QueryData regResults;
   queryKey(
-      "HKEY_LOCAL_MACHINE\\HARDWARE\\DESCRIPTION\\System\CentralProcesses\0",
+      "HKEY_LOCAL_MACHINE\\"
+      "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0\\Update Revision",
       regResults);
   for (const auto& key : regResults) {
     if (key.at("name") == "Update Revision") {

--- a/specs/system_info.table
+++ b/specs/system_info.table
@@ -8,6 +8,7 @@ schema([
     Column("cpu_brand", TEXT, "CPU brand string, contains vendor and model"),
     Column("cpu_physical_cores", INTEGER, "Max number of CPU physical cores"),
     Column("cpu_logical_cores", INTEGER, "Max number of CPU logical cores"),
+    Column("cpu_microcode", TEXT, "Microcode version"),
     Column("physical_memory", BIGINT, "Total physical memory in bytes"),
     Column("hardware_vendor", TEXT, "Hardware or board vendor"),
     Column("hardware_model", TEXT, "Hardware or board model"),


### PR DESCRIPTION
This attempts to list the CPU microcode version on Windows and Linux, it's not clear how to find this on macOS.