### PR TITLE
tests: Interrupt subprocesses of osqueryd

### DIFF
--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -665,6 +665,20 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
             print(" (%sms) rows: %d" % (duration_ms, len(result)))
 
 
+class CleanChildProcesses:
+  # SO: 320232/ensuring-subprocesses-are-dead-on-exiting-python-program
+  def __enter__(self):
+    os.setpgrp() # create new process group, become its leader
+  def __exit__(self, type, value, traceback):
+    try:
+      os.killpg(0, signal.SIGINT) # kill all processes in my group
+    except KeyboardInterrupt:
+      # SIGINT is delivered to this process as well as the child processes.
+      # Ignore it so that the existing exception, if any, is returned. This
+      # leaves us with a clean exit code if there was no exception.
+      pass
+
+
 def expectTrue(functional, interval=0.01, timeout=8):
     """Helper function to run a function with expected latency"""
     delay = 0

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -666,17 +666,17 @@ class QueryTester(ProcessGenerator, unittest.TestCase):
 
 
 class CleanChildProcesses:
-  # SO: 320232/ensuring-subprocesses-are-dead-on-exiting-python-program
-  def __enter__(self):
-    os.setpgrp() # create new process group, become its leader
-  def __exit__(self, type, value, traceback):
-    try:
-      os.killpg(0, signal.SIGINT) # kill all processes in my group
-    except KeyboardInterrupt:
-      # SIGINT is delivered to this process as well as the child processes.
-      # Ignore it so that the existing exception, if any, is returned. This
-      # leaves us with a clean exit code if there was no exception.
-      pass
+    # SO: 320232/ensuring-subprocesses-are-dead-on-exiting-python-program
+    def __enter__(self):
+        if os.name != "nt":
+            os.setpgrp()
+    def __exit__(self, type, value, traceback):
+        try:
+            if os.name == "nt":
+                os.killpg(0, signal.SIGINT)
+        except KeyboardInterrupt:
+            # SIGINT is delivered to this process and children.
+            pass
 
 
 def expectTrue(functional, interval=0.01, timeout=8):

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -672,7 +672,7 @@ class CleanChildProcesses:
             os.setpgrp()
     def __exit__(self, type, value, traceback):
         try:
-            if os.name == "nt":
+            if os.name != "nt":
                 os.killpg(0, signal.SIGINT)
         except KeyboardInterrupt:
             # SIGINT is delivered to this process and children.

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -249,4 +249,5 @@ class DaemonTests(test_base.ProcessGenerator, unittest.TestCase):
         daemon.kill()
 
 if __name__ == '__main__':
-    test_base.Tester().run()
+    with test_base.CleanChildProcesses():
+        test_base.Tester().run()


### PR DESCRIPTION
There are a lot of 2HR timeouts for macOS in Jenkins. I've noticed that sometimes an `osqueryd` subprocess is still running. I am assuming the test pauses waiting for all children to exit.