### PR TITLE
windows: deps: Install thrift module on Windows only

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -328,6 +328,7 @@ function Install-PipPackage {
   }
   Write-Host " => Installing from requirements.txt" -foregroundcolor DarkYellow
   & "$pipPath\pip.exe" -q install -r $requirements.path
+  & "$pipPath\pip.exe" -q install thrift
   if ($LastExitCode -ne 0) {
     Write-Host "[-] ERROR: Install packages from requirements failed." -foregroundcolor Red
     Exit -1


### PR DESCRIPTION
I removed `thrift` from the set of `requirements.txt` since the osquery-runtime's `thrift` package installs the module to the local site-packages.

This is not the case on Windows.