### PR TITLE
deps: Add SKIP_DEPS control to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,20 @@ elseif(CLANGXX_EXECUTABLE)
   set(CMAKE_CXX_COMPILER "clang++")
 endif()
 
+if(CMAKE_CXX_COMPILER MATCHES "clang")
+  set(CLANG TRUE)
+else()
+  set(CLANG FALSE)
+endif()
+
+# We will add a lot of extra flags and options when using the osquery runtime.
+# The "DEPS" environment is the osquery runtime compiler and 3rd-party deps.
+if(NOT DEFINED ENV{SKIP_DEPS})
+  set(DEPS TRUE)
+else()
+  set(DEPS FALSE)
+endif()
+
 if(NOT DEFINED ENV{SKIP_CCACHE})
   find_program(CCACHE_EXECUTABLE ccache ENV PATH)
   if(CCACHE_EXECUTABLE)
@@ -102,7 +116,6 @@ if(APPLE)
     -mmacosx-version-min=${OSX_VERSION_MIN}
   )
 
-  set(CMAKE_CXX_FLAGS "-std=${CXX_STD} -stdlib=libc++" CACHE STRING "" FORCE)
   set(OS_WHOLELINK_PRE "-Wl,-force_load")
   set(OS_WHOLELINK_POST "")
   # Special compile flags for Objective-C++
@@ -124,30 +137,46 @@ else()
     set(FREEBSD TRUE)
     include_directories("/usr/local/include")
     include_directories("/usr/include")
-    set(CMAKE_CXX_FLAGS "-std=${CXX_STD} -stdlib=libc++" CACHE STRING "" FORCE)
   else()
     set(LINUX TRUE)
-    set(CMAKE_CXX_FLAGS "-std=${CXX_STD} -stdlib=libc++" CACHE STRING "" FORCE)
   endif()
   set(POSIX TRUE)
 endif()
 
+# Configure the CXX standard and optionally set the stdlib to LLVM's.
+if(NOT WIN32)
+  if(CLANG)
+    set(CXX_STDLIB "-stdlib=libc++")
+  else()
+    set(CXX_STDLIB "")
+  endif()
+  set(CMAKE_CXX_FLAGS "-std=${CXX_STD} ${CXX_STDLIB}" CACHE STRING "" FORCE)
+endif()
+
 if(POSIX)
+  if(CLANG)
+    add_compile_options(
+      -Qunused-arguments
+      -Wabi-tag
+      -Wno-unused-local-typedef
+      -Wno-deprecated-register
+      -Wno-unknown-warning-option
+      -Wstrict-aliasing
+      -Wno-missing-field-initializers
+      -Wnon-virtual-dtor
+      -Wchar-subscripts
+      -Wpointer-arith
+      -Woverloaded-virtual
+    )
+  else()
+    add_compile_options(
+      -Wno-unknown-pragmas
+    )
+  endif()
   add_compile_options(
-    -Qunused-arguments
-    -Wstrict-aliasing
-    -Wno-missing-field-initializers
-    -Wno-unused-local-typedef
-    -Wno-deprecated-register
-    -Wno-unknown-warning-option
-    -Wnon-virtual-dtor
-    -Wchar-subscripts
-    -Wpointer-arith
-    -Woverloaded-virtual
     -Wformat
     -Wformat-security
     -Werror=format-security
-    -Wabi-tag
     -fpermissive
     -fstack-protector-all
     -pipe
@@ -174,7 +203,7 @@ elseif(WINDOWS)
 endif()
 
 set(TEST_ARGS "")
-if(LINUX AND CMAKE_CXX_COMPILER MATCHES "clang")
+if(LINUX AND CLANG AND DEPS)
   # Use the LLVM versions of ar and ranlib to support LTO builds
   find_program(LLVMRANLIB_EXECUTABLE "llvm-ranlib" ENV PATH)
   find_program(LLVMAR_EXECUTABLE "llvm-ar" ENV PATH)
@@ -243,8 +272,10 @@ else()
   set(DEBUG FALSE)
   if(WINDOWS)
     add_compile_options(/Ot /WX)
-  else()
+  elseif(CLANG)
     add_compile_options(-Oz)
+  else()
+    add_compile_options(-Os)
   endif()
   add_definitions(-DNDEBUG)
   # Do not enable fortify with clang: http://llvm.org/bugs/show_bug.cgi?id=16821
@@ -258,7 +289,7 @@ else()
       -fPIC
       -fpic
     )
-    if (CMAKE_CXX_COMPILER MATCHES "clang" AND NOT FREEBSD)
+    if (CLANG AND DEPS AND NOT FREEBSD)
       # Only enable LTO builds when using clang on Unix, for now
       add_compile_options(-flto=thin)
     endif()
@@ -403,12 +434,10 @@ if(WINDOWS)
   endforeach(flag_var)
 
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG")
-elseif(NOT FREEBSD)
-  if (CMAKE_CXX_COMPILER MATCHES "clang")
-    # Clang on Unix uses LTO; we also need to pass -flto when linking
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=thin")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto=thin")
-  endif()
+elseif(CLANG AND DEPS AND NOT FREEBSD)
+  # Clang on Unix uses LTO; we also need to pass -flto when linking
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -flto=thin")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -flto=thin")
 endif()
 
 if(NOT IS_DIRECTORY "${CMAKE_SOURCE_DIR}/third-party/sqlite3")
@@ -514,19 +543,24 @@ elseif(LINUX)
   include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third-party/sysroots/linux")
 endif()
 
-if(POSIX)
+if(POSIX AND DEPS)
   set(CMAKE_REQUIRED_INCLUDES
     "${BUILD_DEPS}/legacy/include"
     "${BUILD_DEPS}/include"
   )
 
-  include_directories(SYSTEM "${BUILD_DEPS}/include/c++/v1")
+  # The order here matters, please do not reorder.
+  if(CLANG)
+    include_directories(SYSTEM "${BUILD_DEPS}/include/c++/v1")
+  endif()
   include_directories(SYSTEM "${BUILD_DEPS}/legacy/include")
   include_directories(SYSTEM "${BUILD_DEPS}/include")
-  include_directories(SYSTEM "${BUILD_DEPS}/lib/clang/4.0.0/include")
+  if(CLANG)
+    include_directories(SYSTEM "${BUILD_DEPS}/lib/clang/4.0.0/include")
+  endif()
 endif()
 
-if(NOT LINUX AND NOT APPLE AND NOT WINDOWS)
+if(FREEBSD)
   # Including Boost Beast within third-party until it's merged into boot 1.66.
   include_directories("${CMAKE_SOURCE_DIR}/third-party/beast")
 endif()

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -11,7 +11,7 @@ We include a `make deps` command to make it easier for developers to get started
 
 > NOTICE: This will install or build various dependencies on the build host that are not required to "use" osquery, only build osquery binaries and packages.
 
-For our build hosts (CentOS, Ubuntu 12, 14, 16, macOS 10.12, Windows 2016) we use a `sysprep` target to update the host and install these basic dependencies.
+For our build hosts (CentOS, Ubuntu 12, 14, 16, macOS 10.12, Windows 2016) we use a `sysprep` target to update the host and install these basic dependencies. This make target is included to help set up our cont-test hosts, your mileage may vary.
 
 ```sh
 make sysprep
@@ -26,7 +26,7 @@ The complete installation/build steps are as follows:
 ```sh
 $ git clone https://github.com/facebook/osquery.git
 $ cd osquery
-$ # make sysprep
+$ # ./tools/provision/darwin.sh # installs Xcode-Tools
 $ make deps
 $ make
 ```
@@ -45,7 +45,7 @@ $ ls -la ./build/darwin/osquery/
 
 ## Building on Linux
 
-osquery supports almost all distributions of Linux.
+osquery supports almost all distributions of Linux (2011+).
 
 For some distros, we supply vagrant infrastructure for creating native operating system packages. To create a package (e.g. a deb on Ubuntu or an rpm on CentOS), simply spin up a vagrant instance.
 
@@ -113,11 +113,10 @@ The `make deps` command is fairly intense and serves two purposes: (1) to commun
 
 When using `make deps` the environment the resultant binaries will have a minimum set of requirements to run:
 
-- `glibc` version 2.13
-- `libgcc_s`
+- `glibc` version 2.13 or greater
 - `libz`
 
-All other dependencies are built, compiled, and linked statically. This makes for a rather large set of output binaries (15M on Linux and 9M on macOS) but the trade-off for deployment simplicity is very worthwhile.
+All other dependencies are built, compiled, and linked statically. This makes for a rather large set of output binaries (20M+ on Linux and 15M+ on macOS) but the trade-off for deployment simplicity is very worthwhile.
 
 Under the hood the `make deps` script is calling `./tools/provision.sh`, which performs the simplified set of steps:
 
@@ -283,6 +282,7 @@ SQLITE_DEBUG=True # Enable SQLite query debugging (very verbose!)
 There are various features that can be disabled with a customized build. These are also controlled by environment variables to be as cross-platform as possible and take the form: `SKIP_*`. These are converted into CMake variables within the root `CMakeLists.txt`.
 
 ```sh
+SKIP_DEPS=True # Skip adding the header and linking options from make deps
 SKIP_AWS=True # Skip the various AWS integrations
 SKIP_TSK=True # Skip SleuthKit integrations
 SKIP_LLDPD=True # Skip LLDP tables

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -27,7 +27,7 @@ set(OSQUERY_ADDITIONAL_TESTS "")
 set(OSQUERY_TABLES_TESTS "")
 
 # Add all and extra for osquery code.
-if(POSIX)
+if(CLANG AND POSIX)
   add_compile_options(
     -Wall
     -Wextra
@@ -200,7 +200,7 @@ if(LINUX)
   endif()
   # For Ubuntu/CentOS packages add the build SHA1.
   ADD_OSQUERY_LINK_CORE("-Wl,--build-id")
-  if (CMAKE_CXX_COMPILER MATCHES "clang")
+  if (CLANG AND DEPS)
     # If using GCC, libgcc_s may be needed.
     ADD_OSQUERY_LINK_CORE("-fuse-ld=lld")
     ADD_OSQUERY_LINK_CORE("c++")


### PR DESCRIPTION
Introduce a `SKIP_DEPS` environment variable. If you set this then osquery's CMake does not perform bit of magic that assume our dependency runtime installed at `/usr/local/osquery`.

This is helpful for OS package managers.

For example:
```
mkdir -p build/standalone
cd build/standalone
SKIP_DEPS=1 CC=/usr/bin/gcc CXX=/usr/bin/g++ cmake ../..
```

If you do not want to build with `clang`.