### PR TITLE
vagrant: Add win10 target for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,7 @@
 targets = {
+  "win10" => {
+    "box" => "inclusivedesign/windows10-eval"
+  },
   "macos10.12" => {
     "box" => "jhcook/macos-sierra"
   },


### PR DESCRIPTION
This adds a Windows box to the vagrant set. There may be better box targets, please let me know!