### PR TITLE
Fix on_disk detection for Linux

### DIFF
--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -54,11 +54,14 @@ inline std::string readProcLink(const std::string& attr,
                                 const std::string& pid) {
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
+  char full_path[PATH_MAX];
 
-  char* link_path = realpath(attr_path.c_str(), nullptr);
+  char* link_path = realpath(attr_path.c_str(), full_path);
   if (link_path != nullptr) {
     std::string result = std::string(link_path);
-    free(link_path);
+    return result;
+  } else if (attr_path.compare(std::string(full_path)) != 0) {
+    std::string result = std::string(full_path);
     return result;
   }
 

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -54,15 +54,13 @@ inline std::string readProcLink(const std::string& attr,
                                 const std::string& pid) {
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
-  char full_path[PATH_MAX];
+  char full_path[PATH_MAX] = {0};
 
   char* link_path = realpath(attr_path.c_str(), full_path);
   if (link_path != nullptr) {
-    std::string result = std::string(link_path);
-    return result;
+    return std::string(link_path);
   } else if (attr_path.compare(std::string(full_path)) != 0) {
-    std::string result = std::string(full_path);
-    return result;
+    return std::string(full_path);
   }
 
   return "";


### PR DESCRIPTION
Proposed changes to processes.cpp to fix error being returned by readProcLink when reporting on_disk status in Linux.  

When realpath is called with a null value for resolved_path the actual path will not be returned if the executable has been deleted.  The resolved_path variable must have a buffer to receive the path of the deleted executable.

Used this repo to test before and after changes: [https://github.com/exFill/onDisk-Tests](https://github.com/exFill/onDisk-Tests)

**Results at current base master:**

```
Checking /vagrant/build/xenial/osquery/osqueryi
Starting test ... 

osqueryi version 2.11.2-10-g099fb39

================================
Checking with executable PRESENT
attr_path=/proc/3267/exe
link_path=/home/ubuntu/onDisk-Tests/doThis
errno=Success (0)
link_path=/home/ubuntu/onDisk-Tests/doThis
full_path=/home/ubuntu/onDisk-Tests/doThis
errno=Success (0)
+------+----------------------------------+---------------------------+----------+---------+
| pid  | path                             | cwd                       | cmdline  | on_disk |
+------+----------------------------------+---------------------------+----------+---------+
| 3267 | /home/ubuntu/onDisk-Tests/doThis | /home/ubuntu/onDisk-Tests | ./doThis | 1       |
+------+----------------------------------+---------------------------+----------+---------+

================================
Checking with executable DELETED
attr_path=/proc/3267/exe
link_path=(null)
errno=No such file or directory (2)
link_path=(null)
full_path=/home/ubuntu/onDisk-Tests/doThis (deleted)
errno=No such file or directory (2)
+------+------+---------------------------+----------+---------+
| pid  | path | cwd                       | cmdline  | on_disk |
+------+------+---------------------------+----------+---------+
| 3267 |      | /home/ubuntu/onDisk-Tests | ./doThis | -1      |
+------+------+---------------------------+----------+---------+

./runThis.sh: line 42:  3267 Terminated              ./doThis
```

**Results after change:**

```
Checking /vagrant/build/xenial/osquery/osqueryi
Starting test ... 

osqueryi version 2.11.2-11-gde7c85e

================================
Checking with executable PRESENT
attr_path=/proc/3862/exe
link_path=/home/ubuntu/onDisk-Tests/doThis
errno=Success (0)
link_path=/home/ubuntu/onDisk-Tests/doThis
full_path=/home/ubuntu/onDisk-Tests/doThis
errno=Success (0)
+------+----------------------------------+---------------------------+----------+---------+
| pid  | path                             | cwd                       | cmdline  | on_disk |
+------+----------------------------------+---------------------------+----------+---------+
| 3862 | /home/ubuntu/onDisk-Tests/doThis | /home/ubuntu/onDisk-Tests | ./doThis | 1       |
+------+----------------------------------+---------------------------+----------+---------+

================================
Checking with executable DELETED
attr_path=/proc/3862/exe
link_path=(null)
errno=No such file or directory (2)
link_path=(null)
full_path=/home/ubuntu/onDisk-Tests/doThis (deleted)
errno=No such file or directory (2)
+------+----------------------------------+---------------------------+----------+---------+
| pid  | path                             | cwd                       | cmdline  | on_disk |
+------+----------------------------------+---------------------------+----------+---------+
| 3862 | /home/ubuntu/onDisk-Tests/doThis | /home/ubuntu/onDisk-Tests | ./doThis | 0       |
+------+----------------------------------+---------------------------+----------+---------+

./runThis.sh: line 42:  3862 Terminated              ./doThis
```