### PR TITLE
tables: Remove apt-pkg linking on Linux

### DIFF
--- a/osquery/tables/CMakeLists.txt
+++ b/osquery/tables/CMakeLists.txt
@@ -73,7 +73,7 @@ if(LINUX)
   ADD_OSQUERY_LINK_ADDITIONAL("blkid")
   ADD_OSQUERY_LINK_ADDITIONAL("ip4tc")
 
-  ADD_OSQUERY_LINK_ADDITIONAL("apt-pkg dpkg lzma bz2")
+  ADD_OSQUERY_LINK_ADDITIONAL("dpkg lzma bz2")
   ADD_OSQUERY_LINK_ADDITIONAL("rpm rpmio beecrypt popt db")
 endif()
 


### PR DESCRIPTION
This is my error, I forgot to remove `libapt-pkg` from the required linking list.