### PR TITLE
Fix a crash in the extended_attributes table

### DIFF
--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -236,9 +236,10 @@ QueryData genXattr(QueryContext& context) {
 
   for (const auto& path_string : paths) {
     boost::filesystem::path path = path_string;
+    boost::system::error_code ec;
     // Folders can have extended attributes too
-    if (!(boost::filesystem::is_regular_file(path) ||
-          boost::filesystem::is_directory(path))) {
+    if (!(boost::filesystem::is_regular_file(path, ec) ||
+          boost::filesystem::is_directory(path, ec))) {
       continue;
     }
     getFileData(results, path.string());


### PR DESCRIPTION
The extended_attributes table can crash osquery if it cannot access a file
due to permissions.