### PR TITLE
build: Set default macOS SDK to 10.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,10 @@ list(GET PLATFORM 1 OSQUERY_BUILD_DISTRO_DEFINE)
 if(APPLE)
   if(DEFINED ENV{OSX_VERSION_MIN})
     set(OSX_VERSION_MIN "$ENV{OSX_VERSION_MIN}")
-  else()
+  elseif(DEFINED ENV{OSX_VERSION_NATIVE})
     set(OSX_VERSION_MIN "${OSQUERY_BUILD_DISTRO}")
+  else()
+    set(OSX_VERSION_MIN "10.11")
   endif()
   add_compile_options(
     -mmacosx-version-min=${OSX_VERSION_MIN}

--- a/docs/_docs/faq.md
+++ b/docs/_docs/faq.md
@@ -5,7 +5,7 @@ redirect_from: /faq/index.html
 ---
 
 ### What operating systems does osquery support?
-Apple macOS 10.10-10.13, any Linux flavor providing a glibc version 2.13 or newer, Windows 8+, and FreeBSD 10+ available through ports. Every supported OS is integrated into the osquery CI build and test processes. Additional operating systems package manager integrations are tested and supported by the osquery community.
+Apple macOS 10.11-10.13, any Linux flavor providing a glibc version 2.13 or newer, Windows 8+, and FreeBSD 10+ available through ports. Every supported OS is integrated into the osquery CI build and test processes. Additional operating systems package manager integrations are tested and supported by the osquery community.
 
 ### What information does osquery provide?
 osquery produces information in the form of [tables](/schema/index.html) and events. Tables are equivalent to SQL/SQLite tables except they generate data at query time. When you run `select * from time;` the result will be the current time! Events are a bit more complicated but essentially log operating system events in real time so tables may emit the real time results when the next appropriate query runs, sort of like flushing a queued buffer.

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -272,6 +272,7 @@ OSQUERY_OSQUERY_DEPS=/usr/local/osquery # Set alternative dependency path
 OSQUERY_NOSUDO=True # If sudo is not available to user building osquery
 SDK_VERSION=9.9.9 # Set a wacky SDK-version string.
 OSX_VERSION_MIN=10.11 # Override the native minimum macOS version ABI
+OSX_VERSION_NATIVE=True # Set the macOS version ABI to the build system ABI
 OSQUERY_DEPS=/path/to/dependencies # Use a custom dependency environment
 FAST=True # Build and link as quick as possible.
 SANITIZE_THREAD=True # Add -fsanitize=thread when using "make sanitize"

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -7,6 +7,10 @@ module SkipRelocation
   end
 end
 
+def macos_minimum_sdk
+  return "10.11"
+end
+
 def llvm_version
   return "5.0.1"
 end
@@ -212,10 +216,10 @@ class AbstractOsqueryFormula < Formula
 
     # macOS compatibility flags.
     if OS.mac?
-      append "CFLAGS", "-mmacosx-version-min=10.11"
-      append "CXXFLAGS", "-mmacosx-version-min=10.11"
-      append "LDFLAGS", "-mmacosx-version-min=10.11"
-      ENV["MACOSX_DEPLOYMENT_TARGET"] = "10.11"
+      append "CFLAGS", "-mmacosx-version-min=#{macos_minimum_sdk}"
+      append "CXXFLAGS", "-mmacosx-version-min=#{macos_minimum_sdk}"
+      append "LDFLAGS", "-mmacosx-version-min=#{macos_minimum_sdk}"
+      ENV["MACOSX_DEPLOYMENT_TARGET"] = "#{macos_minimum_sdk}"
       # We cannot include this for various reasons, e.g., curl provides _connectx.
       # append "LDFLAGS", "-Wl,-no_weak_imports" if OS.mac?
 


### PR DESCRIPTION
The default macOS SDK is set to the version of the build host. We are getting by with this in practice but it is dangerous. If we set the SDK to 10.11 then we will show compiler warnings for newer APIs.

In a follow-up commit we can enforce no weak linking. This will fail the build if any symbols were introduced after 10.11.