### PR TITLE
deps: Build librdkafka 0.11.3 without clock_gettime

### DIFF
--- a/tools/provision/formula/librdkafka.rb
+++ b/tools/provision/formula/librdkafka.rb
@@ -4,8 +4,8 @@ class Librdkafka < AbstractOsqueryFormula
   desc "The Apache Kafka C/C++ library"
   homepage "https://github.com/edenhill/librdkafka"
   license "BSD-2-Clause"
-  url "https://github.com/edenhill/librdkafka/archive/v0.11.1.tar.gz"
-  sha256 "dd035d57c8f19b0b612dd6eefe6e5eebad76f506e302cccb7c2066f25a83585e"
+  url "https://github.com/edenhill/librdkafka/archive/v0.11.3.tar.gz"
+  sha256 "2b96d7ed71470b0d0027bd9f0b6eb8fb68ed979f8092611c148771eb01abb72c"
   revision 200
 
   depends_on "openssl"
@@ -13,9 +13,12 @@ class Librdkafka < AbstractOsqueryFormula
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "26704f9e73096866a8331653a004725e32a61d166ddcb486bc20c1d6e4c15e6f" => :sierra
-    sha256 "399d36524c08032e79b0d3f9673e6be4bc5f1c20c1e0dcff91316e9966465d68" => :x86_64_linux
+    sha256 "01894340a1b04fdf2a8858a75ffc2025ef621792d3e1c66c5b5d3143e0e7b975" => :sierra
+    sha256 "f366a7b46d6f0c3141a64c059ec03d8d2f5880eb08317ae712747e775e05f914" => :x86_64_linux
   end
+
+  # Do not use clock_gettime on macOS (introduced in 10.12).
+  patch :DATA
 
   def install
     args = [
@@ -34,3 +37,27 @@ class Librdkafka < AbstractOsqueryFormula
     system "make", "install"
   end
 end
+
+__END__
+diff --git a/src/tinycthread.c b/src/tinycthread.c
+index 0049db3..9b186a3 100644
+--- a/src/tinycthread.c
++++ b/src/tinycthread.c
+@@ -921,7 +921,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
+ {
+ #if defined(_TTHREAD_WIN32_)
+   struct _timeb tb;
+-#elif !defined(CLOCK_REALTIME)
++#elif !defined(CLOCK_REALTIME) || defined(__APPLE__)
+   struct timeval tv;
+ #endif
+ 
+@@ -934,7 +934,7 @@ int _tthread_timespec_get(struct timespec *ts, int base)
+   _ftime_s(&tb);
+   ts->tv_sec = (time_t)tb.time;
+   ts->tv_nsec = 1000000L * (long)tb.millitm;
+-#elif defined(CLOCK_REALTIME)
++#elif defined(CLOCK_REALTIME) && !defined(__APPLE__)
+   base = (clock_gettime(CLOCK_REALTIME, ts) == 0) ? base : 0;
+ #else
+   gettimeofday(&tv, NULL);

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -28,14 +28,16 @@ function setup_brew() {
   fi
 
   # Checkout new brew in local deps dir
-  if [[ ! -d "$DEPS/.git" ]]; then
-    log "setting up new brew in $DEPS"
-    git clone $BREW_REPO "$DEPS"
-  elif [[ ! "$ACTION" = "bottle" ]]; then
-    log "checking for updates to brew"
-    git fetch origin > /dev/null
-    git reset --hard origin/master > /dev/null
-    git clean -f
+  if [[ -z "$HOMEBREW_NO_AUTO_UPDATE" ]]; then
+    if [[ ! -d "$DEPS/.git" ]]; then
+      log "setting up new brew in $DEPS"
+      git clone $BREW_REPO "$DEPS"
+    elif [[ ! "$ACTION" = "bottle" ]]; then
+      log "checking for updates to brew"
+      git fetch origin > /dev/null
+      git reset --hard origin/master > /dev/null
+      git clean -f
+    fi
   fi
 
   # Reset to a deterministic checkout of brew.


### PR DESCRIPTION
This updates the version of `librdkafka` to 0.11.3. It also includes a patch to make sure the Darwin/Apple version does not include `clock_gettime`. This API was introduced in 10.12 and would require a weak link (run-time resolved). If this was needed on 10.11 it would throw a SIGILL.