### PR TITLE
added IOCs to query for OSX_MaMi malware

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -523,6 +523,20 @@
       "version" : "1.4.5",
       "description" : "Apple added XProtect rules for this sample: (https://www.virustotal.com/en/file/f261815905e77eebdb5c4ec06a7acdda7b68644b1f5155049f133be866d8b179/analysis/1509567775/)",
       "value" : "Artifacts created by this malware"
+    },
+    "OSX_MaMi_DNS_Servers": {
+      "query" : "select * from dns_resolvers where type = 'nameserver' and address in ('82.163.143.135', '82.163.142.137');",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "value" : "DNS Servers set by this malware"
+    },
+    "OSX_MaMi_Certificate": {
+      "query" : "select * from certificates where common_name like '%cloudguard.me%' and not_valid_after = '2352216315';",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
+      "value" : "bogus certificate added to key store by this malware"
     }
   }
 }


### PR DESCRIPTION
I updated the osx-attacks.conf to include detection for OSX/MaMi, as discussed in the #macos channel in slack today.

References:
Discussion in Slack:
https://osquery.slack.com/archives/C08VA8R6F/p1515784469000445
Patrick's original post:
https://objective-see.com/blog/blog_0x26.html
My blog post w/ queries:
https://medium.com/uptycs/finding-osx-mami-with-osquery-72960eee0190
