### PR TITLE
Updating build docs to include make packages

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -73,7 +73,7 @@ $ make
 $ make test
 ```
 
-If you'd like to generate an RPM or DEB package, please view the [Custom Packages] section.(#custom-packages)
+If you'd like to generate an RPM or DEB package, please view the [Custom Packages](#custom-packages) section.
 
 The binaries are built to a distro-specific folder within *build* and symlinked in:
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -73,9 +73,7 @@ $ make
 $ make test
 ```
 
-If you'd like to generate an RPM or DEB package, first ensure you have [fpm](https://github.com/jordansissel/fpm) installed and then run:
-
-`$ make packages`
+If you'd like to generate an RPM or DEB package, please view the [Custom Packages] section.(#custom-packages)
 
 The binaries are built to a distro-specific folder within *build* and symlinked in:
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -73,6 +73,10 @@ $ make
 $ make test
 ```
 
+If you'd like to generate an RPM or DEB package, first ensure you have [fpm](https://github.com/jordansissel/fpm) installed and then run:
+
+`$ make packages`
+
 The binaries are built to a distro-specific folder within *build* and symlinked in:
 
 ```sh


### PR DESCRIPTION
The package instructions are located on the custom-packages page, but I think it's likely people will want to know how to do this while building from source