### PR TITLE
tables: Remove ptree from table plugins

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -10,9 +10,7 @@
 
 #pragma once
 
-#include <deque>
 #include <map>
-#include <memory>
 #include <set>
 #include <unordered_map>
 #include <utility>
@@ -30,14 +28,13 @@
 #endif
 
 /// Wrap this include with the above and below ignored warnings for FreeBSD.
-#include <boost/coroutine2/all.hpp>
+#include <boost/coroutine2/coroutine.hpp>
 
 #ifndef WIN32
 #pragma clang diagnostic pop
 #endif
 
 #include <boost/lexical_cast.hpp>
-#include <boost/property_tree/ptree.hpp>
 
 #include <osquery/core.h>
 #include <osquery/query.h>
@@ -431,10 +428,10 @@ struct ConstraintList : private boost::noncopyable {
    *   ]
    * }
    */
-  void serialize(boost::property_tree::ptree& tree) const;
+  void serialize(JSON& doc, rapidjson::Value& obj) const;
 
   /// See ConstraintList::unserialize.
-  void unserialize(const boost::property_tree::ptree& tree);
+  void deserialize(const rapidjson::Value& obj);
 
  private:
   /// List of constraint operator/expressions.

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -15,8 +15,6 @@
 
 #include "osquery/core/json.h"
 
-namespace pt = boost::property_tree;
-
 namespace osquery {
 
 FLAG(bool, disable_caching, false, "Disable scheduled query caching");
@@ -57,50 +55,36 @@ void TablePlugin::removeExternal(const std::string& name) {
 
 void TablePlugin::setRequestFromContext(const QueryContext& context,
                                         PluginRequest& request) {
-  pt::ptree tree;
+  auto doc = JSON::newObject();
+  auto constraints = doc.getArray();
 
   // The QueryContext contains a constraint map from column to type information
   // and the list of operand/expression constraints applied to that column from
   // the query given.
-  pt::ptree constraints;
   for (const auto& constraint : context.constraints) {
-    pt::ptree child;
-    child.put("name", constraint.first);
-    constraint.second.serialize(child);
-    constraints.push_back(std::make_pair("", child));
+    auto child = doc.getObject();
+    doc.addRef("name", constraint.first, child);
+    constraint.second.serialize(doc, child);
+    doc.push(child, constraints);
   }
-  tree.add_child("constraints", constraints);
 
-  // Write the property tree as a JSON string into the PluginRequest.
-  std::ostringstream output;
-  try {
-    pt::write_json(output, tree, false);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
-    // The content could not be represented as JSON.
-  }
-  request["context"] = output.str();
+  doc.add("constraints", constraints);
+  doc.toString(request["context"]);
 }
 
 void TablePlugin::setContextFromRequest(const PluginRequest& request,
                                         QueryContext& context) {
-  if (request.count("context") == 0) {
-    return;
-  }
-
-  // Read serialized context from PluginRequest.
-  pt::ptree tree;
-  try {
-    std::stringstream input;
-    input << request.at("context");
-    pt::read_json(input, tree);
-  } catch (const pt::json_parser::json_parser_error& /* e */) {
+  auto doc = JSON::newObject();
+  doc.fromString(request.at("context"));
+  if (!doc.doc().HasMember("constraints") ||
+      !doc.doc()["constraints"].IsArray()) {
     return;
   }
 
   // Set the context limit and deserialize each column constraint list.
-  for (const auto& constraint : tree.get_child("constraints")) {
-    auto column_name = constraint.second.get<std::string>("name");
-    context.constraints[column_name].unserialize(constraint.second);
+  for (const auto& constraint : doc.doc()["constraints"].GetArray()) {
+    auto column_name = constraint["name"].GetString();
+    context.constraints[column_name].deserialize(constraint);
   }
 }
 
@@ -391,27 +375,36 @@ std::set<std::string> ConstraintList::getAll(ConstraintOperator op) const {
   return set;
 }
 
-void ConstraintList::serialize(boost::property_tree::ptree& tree) const {
-  boost::property_tree::ptree expressions;
+void ConstraintList::serialize(JSON& doc, rapidjson::Value& obj) const {
+  auto expressions = doc.getArray();
   for (const auto& constraint : constraints_) {
-    boost::property_tree::ptree child;
-    child.put("op", constraint.op);
-    child.put("expr", constraint.expr);
-    expressions.push_back(std::make_pair("", child));
+    auto child = doc.getObject();
+    doc.add("op", static_cast<size_t>(constraint.op), child);
+    doc.addRef("expr", constraint.expr, child);
+    doc.push(child, expressions);
   }
-  tree.add_child("list", expressions);
-  tree.put("affinity", columnTypeName(affinity));
+  doc.add("list", expressions, obj);
+  doc.addCopy("affinity", columnTypeName(affinity), obj);
 }
 
-void ConstraintList::unserialize(const boost::property_tree::ptree& tree) {
+void ConstraintList::deserialize(const rapidjson::Value& obj) {
   // Iterate through the list of operand/expressions, then set the constraint
   // type affinity.
-  for (const auto& list : tree.get_child("list")) {
-    Constraint constraint(list.second.get<unsigned char>("op"));
-    constraint.expr = list.second.get<std::string>("expr");
+  if (!obj.IsObject() || !obj.HasMember("list") || !obj["list"].IsArray()) {
+    return;
+  }
+
+  for (const auto& list : obj["list"].GetArray()) {
+    auto op = static_cast<unsigned char>(JSON::valueToSize(list["op"]));
+    Constraint constraint(op);
+    constraint.expr = list["expr"].GetString();
     constraints_.push_back(constraint);
   }
-  affinity = columnTypeName(tree.get<std::string>("affinity", "UNKNOWN"));
+
+  auto affinity_name = (obj.HasMember("affinity") && obj["affinity"].IsString())
+                           ? obj["affinity"].GetString()
+                           : "UNKNOWN";
+  affinity = columnTypeName(affinity_name);
 }
 
 void QueryContext::useCache(bool use_cache) {

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <asm/unistd_64.h>
+#include <fcntl.h>
 
 #include <cstdint>
 #include <iostream>

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -10,6 +10,7 @@
 
 #include <asm/unistd_64.h>
 #include <fcntl.h>
+#include <sys/mman.h>
 
 #include <cstdint>
 #include <iostream>

--- a/osquery/tables/system/linux/intel_me.cpp
+++ b/osquery/tables/system/linux/intel_me.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <sys/ioctl.h>
+#include <fcntl.h>
 
 #include <vector>
 

--- a/osquery/tables/system/linux/intel_me.cpp
+++ b/osquery/tables/system/linux/intel_me.cpp
@@ -8,8 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <sys/ioctl.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 
 #include <vector>
 


### PR DESCRIPTION
This ports the TablePlugin and constraints-related structures to use `JSON` and RapidJSON. We are attempting to remove all `ptree` usage from osquery.