### PR TITLE
Tools to generate table and package JSON for the new website

### DIFF
--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""Generate a complete table specification for the website
+
+This script will generate JSON output as expected by the osquery website given
+a directory of osquery schema specifications. Results will be printer to stdout.
+
+Usage:
+    python tools/codegen/genwebsitejson.py --specs=./specs
+"""
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import os
+import re
+import sys
+
+from gentable import *
+
+# In the specs/ directory of the osquery repository, specification files are put
+# in certain directories based on what platforms they are meant to be built on.
+# This data structure represents the directories in specs/ and how they map to
+# the operating systems which support tables found in those directories
+PLATFORM_DIRS = {
+    "specs": ["darwin", "linux"],
+    "utility": ["darwin", "linux", "freebsd", "windows"],
+    "yara": ["darwin", "linux"],
+    "darwin": ["darwin"],
+    "freebsd": ["freebsd"],
+    "kernel": ["darwin"],
+    "linux": ["linux"],
+    "lldpd": ["linux"],
+    "macwin": ["darwin", "windows"],
+    "posix": ["darwin", "linux"],
+    "sleuthkit": ["darwin", "linux"],
+    "windows": ["windows"],
+}
+
+def platform_for_spec(path):
+    """Given a path to a table specification, return a list of what osquery
+    platforms that table will work on. In the event that no match is found, it
+    will be assumed that the table is found on all platforms.
+    """
+    full_path = os.path.abspath(path)
+    directory_list = os.path.dirname(full_path).split("/")
+    directory = directory_list[len(directory_list)-1]
+    try:
+        return PLATFORM_DIRS[directory]
+    except KeyError:
+        return ["darwin", "linux", "freebsd", "windows"]
+
+def url_for_spec(path):
+    """Given a path to a table specification, return the URL that would take you
+    to the specification on GitHub.
+    """
+    full_path = os.path.abspath(path)
+    url = "https://github.com/facebook/osquery/blob/master"
+    osquery_found = False
+    for part in full_path.split("/"):
+        if osquery_found:
+            url = url + "/" + part
+        elif part == "osquery":
+            osquery_found = True
+        else:
+            continue
+    return url
+
+def generate_table_metadata(full_path):
+    """This function generates a dictionary of table metadata for a spec file
+    found at a given path."""
+    with open(full_path, "rU") as file_handle:
+        # Each osquery table specification is a syntactically correct python file
+        # because we imported `from gentable import *`, we imported all of the
+        # functions that you use in an osquery specification. a global "table"
+        # is then modified based on the python that has just executed.
+        tree = ast.parse(file_handle.read())
+        exec(compile(tree, "<string>", "exec"))
+
+        # Now that the `table` variable is accessible, we can access attributes
+        # of the table
+        t = {}
+        t["name"] = table.table_name
+        t["description"] = table.description
+        t["url"] = url_for_spec(full_path)
+        t["platforms"] = platform_for_spec(full_path)
+        t["evented"] = "event_subscriber" in table.attributes
+        t["cacheable"] = "cacheable" in table.attributes
+
+        # Now we must iterate through `table.columns` to collect information
+        # about each column
+        t["columns"] = []
+        for col in table.columns():
+            c = {}
+            c["name"] = col.name
+            c["description"] = col.description
+            c["type"] = col.type.affinity.replace("_TYPE", "").lower()
+
+            hidden = False
+            required = False
+            index = False
+            for option in col.options:
+                if option == "hidden":
+                    hidden = True
+                elif option == "required":
+                    required = True
+                elif option == "index":
+                    index == True
+            c["hidden"] = hidden
+            c["required"] = required
+            c["index"] = index
+
+            t["columns"].append(c)
+    return t
+
+def main(argc, argv):
+    parser = argparse.ArgumentParser(
+        "Generate minmal JSON from a table spec")
+    parser.add_argument("--specs", help="Path to spec directory", required=True)
+    args = parser.parse_args()
+
+    specs_dir = os.path.abspath(args.specs)
+    tables = {}
+
+    for subdir, dirs, files in os.walk(specs_dir):
+        for filename in files:
+            if filename.endswith(".table"):
+                full_path = os.path.join(subdir, filename)
+                metadata = generate_table_metadata(full_path)
+                tables[metadata["name"]] = metadata
+
+    # Print the JSON output to stdout
+    print(json.dumps([value for key, value in sorted(tables.items())], indent=2, separators=(',', ':')))
+
+if __name__ == "__main__":
+    main(len(sys.argv), sys.argv)

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Generate a new website version metadata file based on a new release version
+
+Usage:
+    python tools/codegen/genwebsitemetadata.py --file=~/osquery-site/src/data/osquery_metadata.json
+"""
+
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import io
+import json
+import sys
+
+def main(argc, argv):
+    parser = argparse.ArgumentParser(
+        "Generate a new website version metadata file based on a new release")
+    parser.add_argument("--file", help="Path to metadata file", required=True)
+    parser.add_argument("--version", help="Version identifier", required=True)
+    args = parser.parse_args()
+
+    metadata = json.load(open(args.file))
+    metadata["current_version"] = args.version
+    metadata["all_versions"].append(args.version)
+    with io.open(args.file, 'w', encoding='utf-8') as f:
+        f.write(json.dumps(metadata, indent=2, separators=(',', ':')))
+
+if __name__ == "__main__":
+    main(len(sys.argv), sys.argv)

--- a/tools/release/new_release.sh
+++ b/tools/release/new_release.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )")"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 URL=https://osquery-packages.s3.amazonaws.com
 
@@ -34,6 +34,10 @@ function main() {
   echo "[+] Writing new table API"
   GENJSON="$SCRIPT_DIR/../codegen/genwebsitejson.py"
   /usr/local/osquery/bin/python "$GENJSON" --specs "$OSQUERY/specs" > "$SITE/src/data/osquery_schema_versions/$VERSION.json"
+
+  echo "[+] Writing new version metadata"
+  GENMETADATA="$SCRIPT_DIR/../codegen/genwebsitemetadata.py"
+  /usr/local/osquery/bin/python "$GENMETADATA" --file "$SITE/src/data/osquery_metadata.json" --version "$VERSION"
 
   printf "[+] Downloading and hashing packages...\n"
   PACKAGE="$URL/linux/osquery-${VERSION}_1.linux_x86_64.tar.gz"
@@ -120,6 +124,8 @@ function main() {
 }
 EOF
   echo "[+] Hashes written to $PACKAGES"
+
+
 
   echo "[+] Finished"
 }

--- a/tools/release/new_release.sh
+++ b/tools/release/new_release.sh
@@ -10,7 +10,7 @@
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )")"
 
 URL=https://osquery-packages.s3.amazonaws.com
 
@@ -32,8 +32,8 @@ function main() {
   (cd $OSQUERY; git checkout $VERSION)
 
   echo "[+] Writing new table API"
-  GENAPI="$OSQUERY/tools/codegen/genapi.py"
-  /usr/local/osquery/bin/python "$GENAPI" --tables "$OSQUERY/specs" > "$SITE/schema/$VERSION.json"
+  GENJSON="$SCRIPT_DIR/../codegen/genwebsitejson.py"
+  /usr/local/osquery/bin/python "$GENJSON" --specs "$OSQUERY/specs" > "$SITE/src/data/osquery_schema_versions/$VERSION.json"
 
   printf "[+] Downloading and hashing packages...\n"
   PACKAGE="$URL/linux/osquery-${VERSION}_1.linux_x86_64.tar.gz"
@@ -64,30 +64,62 @@ function main() {
   echo "[+] Downloading $PACKAGE"
   DEBUG_DEB=$(curl $PACKAGE | shasum -a 256 | awk '{print $1}')
 
-  EXISTING=$(cat $OSQUERY/docs/_data/versions.yml)
-  OUTPUT="$OSQUERY/docs/_data/versions.yml"
-  rm -f "${OUTPUT}"
-  cat << EOF >> ${OUTPUT}
-- version: $VERSION
-  linux: $LINUX
-  deb: $DEB
-  darwin: $DARWIN
-  rpm: $RPM
-  debug:
-    deb: $DEBUG_DEB
-    darwin: $DEBUG_DARWIN
-    rpm: $DEBUG_RPM
-
-$EXISTING
+  PACKAGES="$SITE/src/data/osquery_package_versions/${VERSION}.json"
+  rm -f "${PACKAGES}"
+  cat << EOF >> ${PACKAGES}
+{
+  "version": "$VERSION",
+  "downloads": {
+    "official": [
+      {
+        "type": "macOS",
+        "package": "osquery-$VERSION.pkg",
+        "content": "$DARWIN",
+        "url": "https://pkg.osquery.io/darwin/osquery-$VERSION.pkg"
+      },
+      {
+        "type": "Linux",
+        "package": "osquery-$VERSION_1.linux_x86_64.tar.gz",
+        "content": "$LINUX",
+        "url": "https://pkg.osquery.io/linux/osquery-$VERSION_1.linux_x86_64.tar.gz"
+      },
+      {
+        "type": "RPM",
+        "package": "osquery-$VERSION-1.linux.x86_64.rpm",
+        "content": "$RPM",
+        "url": "https://pkg.osquery.io/rpm/osquery-$VERSION-1.linux.x86_64.rpm"
+      },
+      {
+        "type": "Debian",
+        "package": "osquery_$VERSION_1.linux.amd64.deb",
+        "content": "$DEB",
+        "url": "https://pkg.osquery.io/deb/osquery_$VERSION_1.linux.amd64.deb"
+      }
+    ],
+    "debug": [
+      {
+        "type": "macOS",
+        "package": "osquery-debug-$VERSION.pkg",
+        "content": "$DEBUG_DARWIN",
+        "url": "https://pkg.osquery.io/darwin/osquery-debug-$VERSION.pkg"
+      },
+      {
+        "type": "RPM",
+        "package": "osquery-debuginfo-$VERSION-1.linux.x86_64.rpm",
+        "content": "$DEBUG_RPM",
+        "url": "https://pkg.osquery.io/rpm/osquery-debuginfo-$VERSION-1.linux.x86_64.rpm"
+      },
+      {
+        "type": "Debian",
+        "package": "osquery-dbg_2.10.2_1.linux.amd64.deb",
+        "content": "$DEBUG_DEB",
+        "url": "https://pkg.osquery.io/deb/osquery-dbg_$VERSION_1.linux.amd64.deb"
+      }
+    ]
+  }
+}
 EOF
-  echo "[+] Hashes written to $OUTPUT"
-
-  cat << EOF >> $OSQUERY/docs/_schema/$VERSION.md
----
-version: $VERSION
-redirect_from: /docs/tables/$VERSION/index.html
----
-EOF
+  echo "[+] Hashes written to $PACKAGES"
 
   echo "[+] Finished"
 }


### PR DESCRIPTION
When cutting a release, use the `tools/release/new_release.sh` tool as usual, except point it at the new website instead of the `docs/` subdirectory:

```
$ ./tools/release/new_release.sh 3.0.0 ~/git/osquery-packaging ~/git/osquery-site
[+] Checking out version 3.0.0
HEAD is now at 597b60d5... website: Upload dark version of logo for README (#4065)
[+] Writing new table API
[+] Writing new version metadata
[+] Downloading and hashing packages...
[+] Downloading https://osquery-packages.s3.amazonaws.com/linux/osquery-3.0.0_1.linux_x86_64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1054      0 --:--:-- --:--:-- --:--:--  1056
[+] Downloading https://osquery-packages.s3.amazonaws.com/deb/osquery_3.0.0_1.linux.amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1172      0 --:--:-- --:--:-- --:--:--  1168
[+] Downloading https://osquery-packages.s3.amazonaws.com/rpm/osquery-3.0.0-1.linux.x86_64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1170      0 --:--:-- --:--:-- --:--:--  1173
[+] Downloading https://osquery-packages.s3.amazonaws.com/darwin/osquery-3.0.0.pkg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1163      0 --:--:-- --:--:-- --:--:--  1168
[+] Downloading https://osquery-packages.s3.amazonaws.com/darwin/osquery-debug-3.0.0.pkg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1179      0 --:--:-- --:--:-- --:--:--  1185
[+] Downloading https://osquery-packages.s3.amazonaws.com/rpm/osquery-debuginfo-3.0.0-1.linux.x86_64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1154      0 --:--:-- --:--:-- --:--:--  1157
[+] Downloading https://osquery-packages.s3.amazonaws.com/deb/osquery-dbg_3.0.0_1.linux.amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   243    0   243    0     0   1203      0 --:--:-- --:--:-- --:--:--  1202
[+] Hashes written to /Users/marpaia/git/osquery-site/src/data/osquery_package_versions/3.0.0.json
[+] Finished
$
```

Now, in the website repository:

```
$ pwd
/Users/marpaia/git/osquery-site

$ git st
On branch develop
Your branch is up-to-date with 'origin/develop'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   src/data/osquery_metadata.json

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	src/data/osquery_package_versions/3.0.0.json
	src/data/osquery_schema_versions/3.0.0.json

no changes added to commit (use "git add" and/or "git commit -a")

$ git diff src/data/osquery_metadata.json
diff --git a/src/data/osquery_metadata.json b/src/data/osquery_metadata.json
index 3ede9ce..2479839 100644
--- a/src/data/osquery_metadata.json
+++ b/src/data/osquery_metadata.json
@@ -1,12 +1,13 @@
 {
-  "current_version":"2.11.2",
+  "current_version":"3.0.0",
   "all_versions":[
     "2.7.0",
     "2.8.0",
     "2.9.0",
     "2.10.0",
     "2.10.2",
     "2.11.0",
-    "2.11.2"
+    "2.11.2",
+    "3.0.0"
   ]
 }

$
```