### PR TITLE
Use schema branch of website instead of master for raw data

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -80,7 +80,7 @@ separators:
   windows: "-"
 
 docs_url: https://osquery.readthedocs.io/en/stable/
-schema_url: https://raw.githubusercontent.com/osquery/osquery-site/master/schema
+schema_url: https://raw.githubusercontent.com/osquery/osquery-site/schema/schema
 packs_url: https://raw.githubusercontent.com/facebook/osquery/master/packs
 slack_url: https://osquery-slack.herokuapp.com
 github_button:


### PR DESCRIPTION
This PR updates the current https://osquery.io to pull raw data files from the schema branch instead of master.