### PR TITLE
darwin: separate iokit routines from iokit event support

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -13,6 +13,7 @@ if(APPLE)
   set(OSQUERY_CORE_PLATFORM
     ${OSQUERY_CORE_PLATFORM}
     darwin/conversions.cpp
+    darwin/iokit.cpp
   )
 endif()
 

--- a/osquery/core/darwin/iokit.cpp
+++ b/osquery/core/darwin/iokit.cpp
@@ -8,10 +8,10 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <IOKit/IOMessage.h>
+
 #include <osquery/logger.h>
 #include <osquery/tables.h>
-
-#include <IOKit/IOMessage.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/core/darwin/iokit.hpp"
@@ -64,16 +64,18 @@ std::string getIOKitProperty(const CFMutableDictionaryRef& details,
   CFRelease(cfkey);
 
   // Several supported ways of parsing IOKit-encoded data.
-  if (property) {
-    if (CFGetTypeID(property) == CFNumberGetTypeID()) {
-      value = stringFromCFNumber((CFDataRef)property);
-    } else if (CFGetTypeID(property) == CFStringGetTypeID()) {
-      value = stringFromCFString((CFStringRef)property);
-    } else if (CFGetTypeID(property) == CFDataGetTypeID()) {
-      value = stringFromCFData((CFDataRef)property);
-    } else if (CFGetTypeID(property) == CFBooleanGetTypeID()) {
-      value = (CFBooleanGetValue((CFBooleanRef)property)) ? "1" : "0";
-    }
+  if (!property) {
+    return value;
+  }
+
+  if (CFGetTypeID(property) == CFNumberGetTypeID()) {
+    value = stringFromCFNumber((CFDataRef)property);
+  } else if (CFGetTypeID(property) == CFStringGetTypeID()) {
+    value = stringFromCFString((CFStringRef)property);
+  } else if (CFGetTypeID(property) == CFDataGetTypeID()) {
+    value = stringFromCFData((CFDataRef)property);
+  } else if (CFGetTypeID(property) == CFBooleanGetTypeID()) {
+    value = (CFBooleanGetValue((CFBooleanRef)property)) ? "1" : "0";
   }
 
   return value;

--- a/osquery/core/darwin/iokit.cpp
+++ b/osquery/core/darwin/iokit.cpp
@@ -24,7 +24,6 @@ const std::string kIOPlatformExpertDeviceClassName_ = "IOPlatformExpertDevice";
 const std::string kIOACPIPlatformDeviceClassName_ = "IOACPIPlatformDevice";
 const std::string kIOPlatformDeviceClassname_ = "IOPlatformDevice";
 
-
 IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
   auto properties = osquery::split(compatible, " ");
   if (properties.size() < 2) {
@@ -99,5 +98,4 @@ long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
   return 0;
 }
 
-
-}
+} // namespace osquery

--- a/osquery/core/darwin/iokit.cpp
+++ b/osquery/core/darwin/iokit.cpp
@@ -1,0 +1,103 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include <IOKit/IOMessage.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/darwin/iokit.hpp"
+
+namespace osquery {
+
+const std::string kIOUSBDeviceClassName_ = "IOUSBDevice";
+const std::string kIOPCIDeviceClassName_ = "IOPCIDevice";
+const std::string kIOPlatformExpertDeviceClassName_ = "IOPlatformExpertDevice";
+const std::string kIOACPIPlatformDeviceClassName_ = "IOACPIPlatformDevice";
+const std::string kIOPlatformDeviceClassname_ = "IOPlatformDevice";
+
+
+IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
+  auto properties = osquery::split(compatible, " ");
+  if (properties.size() < 2) {
+    return;
+  }
+
+  size_t prop_index = 0;
+  if (properties[1].find("pci") == 0 && properties[1].find("pciclass") != 0) {
+    // There are two sets of PCI definitions.
+    prop_index = 1;
+  } else if (properties[0].find("pci") != 0) {
+    return;
+  }
+
+  auto vendor = osquery::split(properties[prop_index++], ",");
+  vendor_id = vendor[0].substr(3);
+  model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
+
+  if (properties[prop_index].find("pciclass") == 0) {
+    // There is a class definition.
+    pci_class = properties[prop_index++].substr(9);
+  }
+
+  if (properties.size() > prop_index) {
+    // There is a driver/ID.
+    driver = properties[prop_index];
+  }
+}
+
+std::string getIOKitProperty(const CFMutableDictionaryRef& details,
+                             const std::string& key) {
+  std::string value;
+
+  // Get a property from the device.
+  auto cfkey = CFStringCreateWithCString(
+      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
+  auto property = CFDictionaryGetValue(details, cfkey);
+  CFRelease(cfkey);
+
+  // Several supported ways of parsing IOKit-encoded data.
+  if (property) {
+    if (CFGetTypeID(property) == CFNumberGetTypeID()) {
+      value = stringFromCFNumber((CFDataRef)property);
+    } else if (CFGetTypeID(property) == CFStringGetTypeID()) {
+      value = stringFromCFString((CFStringRef)property);
+    } else if (CFGetTypeID(property) == CFDataGetTypeID()) {
+      value = stringFromCFData((CFDataRef)property);
+    } else if (CFGetTypeID(property) == CFBooleanGetTypeID()) {
+      value = (CFBooleanGetValue((CFBooleanRef)property)) ? "1" : "0";
+    }
+  }
+
+  return value;
+}
+
+long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
+                                  const std::string& key) {
+  // Get a property from the device.
+  auto cfkey = CFStringCreateWithCString(
+      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
+  auto property = CFDictionaryGetValue(details, cfkey);
+  CFRelease(cfkey);
+
+  // Several supported ways of parsing IOKit-encoded data.
+  if (property && CFGetTypeID(property) == CFNumberGetTypeID()) {
+    CFNumberType type = CFNumberGetType((CFNumberRef)property);
+    long long int value;
+    CFNumberGetValue((CFNumberRef)property, type, &value);
+    return value;
+  }
+
+  return 0;
+}
+
+
+}

--- a/osquery/core/darwin/iokit.hpp
+++ b/osquery/core/darwin/iokit.hpp
@@ -22,36 +22,35 @@
 
 namespace osquery {
 
-  extern const std::string kIOUSBDeviceClassName_;
-  extern const std::string kIOPCIDeviceClassName_;
-  extern const std::string kIOPlatformExpertDeviceClassName_;
-  extern const std::string kIOACPIPlatformDeviceClassName_;
-  extern const std::string kIOPlatformDeviceClassname_;
+extern const std::string kIOUSBDeviceClassName_;
+extern const std::string kIOPCIDeviceClassName_;
+extern const std::string kIOPlatformExpertDeviceClassName_;
+extern const std::string kIOACPIPlatformDeviceClassName_;
+extern const std::string kIOPlatformDeviceClassname_;
 
-  struct IOKitPCIProperties {
-    std::string vendor_id;
-    std::string model_id;
-    std::string pci_class;
-    std::string driver;
+struct IOKitPCIProperties {
+  std::string vendor_id;
+  std::string model_id;
+  std::string pci_class;
+  std::string driver;
 
-    /// Populate IOKit PCI device properties from the "compatible" property.
-    explicit IOKitPCIProperties(const std::string& compatible);
-  };
+  /// Populate IOKit PCI device properties from the "compatible" property.
+  explicit IOKitPCIProperties(const std::string& compatible);
+};
 
-  std::string getIOKitProperty(const CFMutableDictionaryRef& details,
-                               const std::string& key);
-  long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
-                                    const std::string& key);
+std::string getIOKitProperty(const CFMutableDictionaryRef& details,
+                             const std::string& key);
+long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
+                                  const std::string& key);
 
-  inline void idToHex(std::string& id) {
-    long base = 0;
-    // = AS_LITERAL(int, id);
-    if (safeStrtol(id, 10, base)) {
-      std::stringstream hex_id;
-      hex_id << std::hex << std::setw(4) << std::setfill('0') << (base & 0xFFFF);
-      id = hex_id.str();
-    }
+inline void idToHex(std::string& id) {
+  long base = 0;
+  // = AS_LITERAL(int, id);
+  if (safeStrtol(id, 10, base)) {
+    std::stringstream hex_id;
+    hex_id << std::hex << std::setw(4) << std::setfill('0') << (base & 0xFFFF);
+    id = hex_id.str();
   }
-
-
 }
+
+} // namespace osquery

--- a/osquery/core/darwin/iokit.hpp
+++ b/osquery/core/darwin/iokit.hpp
@@ -13,11 +13,10 @@
 #include <atomic>
 #include <iomanip>
 
-#include <osquery/status.h>
-
 #include <CoreServices/CoreServices.h>
 #include <IOKit/IOKitLib.h>
 
+#include <osquery/status.h>
 #include "osquery/core/conversions.h"
 
 namespace osquery {
@@ -45,7 +44,6 @@ long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
 
 inline void idToHex(std::string& id) {
   long base = 0;
-  // = AS_LITERAL(int, id);
   if (safeStrtol(id, 10, base)) {
     std::stringstream hex_id;
     hex_id << std::hex << std::setw(4) << std::setfill('0') << (base & 0xFFFF);

--- a/osquery/core/darwin/iokit.hpp
+++ b/osquery/core/darwin/iokit.hpp
@@ -16,8 +16,9 @@
 #include <CoreServices/CoreServices.h>
 #include <IOKit/IOKitLib.h>
 
-#include "osquery/core/conversions.h"
 #include <osquery/status.h>
+
+#include "osquery/core/conversions.h"
 
 namespace osquery {
 

--- a/osquery/core/darwin/iokit.hpp
+++ b/osquery/core/darwin/iokit.hpp
@@ -16,8 +16,8 @@
 #include <CoreServices/CoreServices.h>
 #include <IOKit/IOKitLib.h>
 
-#include <osquery/status.h>
 #include "osquery/core/conversions.h"
+#include <osquery/status.h>
 
 namespace osquery {
 

--- a/osquery/core/darwin/iokit.hpp
+++ b/osquery/core/darwin/iokit.hpp
@@ -1,0 +1,57 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <iomanip>
+
+#include <osquery/status.h>
+
+#include <CoreServices/CoreServices.h>
+#include <IOKit/IOKitLib.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+
+  extern const std::string kIOUSBDeviceClassName_;
+  extern const std::string kIOPCIDeviceClassName_;
+  extern const std::string kIOPlatformExpertDeviceClassName_;
+  extern const std::string kIOACPIPlatformDeviceClassName_;
+  extern const std::string kIOPlatformDeviceClassname_;
+
+  struct IOKitPCIProperties {
+    std::string vendor_id;
+    std::string model_id;
+    std::string pci_class;
+    std::string driver;
+
+    /// Populate IOKit PCI device properties from the "compatible" property.
+    explicit IOKitPCIProperties(const std::string& compatible);
+  };
+
+  std::string getIOKitProperty(const CFMutableDictionaryRef& details,
+                               const std::string& key);
+  long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
+                                    const std::string& key);
+
+  inline void idToHex(std::string& id) {
+    long base = 0;
+    // = AS_LITERAL(int, id);
+    if (safeStrtol(id, 10, base)) {
+      std::stringstream hex_id;
+      hex_id << std::hex << std::setw(4) << std::setfill('0') << (base & 0xFFFF);
+      id = hex_id.str();
+    }
+  }
+
+
+}

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -18,12 +18,6 @@
 
 namespace osquery {
 
-const std::string kIOUSBDeviceClassName_ = "IOUSBDevice";
-const std::string kIOPCIDeviceClassName_ = "IOPCIDevice";
-const std::string kIOPlatformExpertDeviceClassName_ = "IOPlatformExpertDevice";
-const std::string kIOACPIPlatformDeviceClassName_ = "IOACPIPlatformDevice";
-const std::string kIOPlatformDeviceClassname_ = "IOPlatformDevice";
-
 REGISTER(IOKitEventPublisher, "event_publisher", "iokit");
 
 struct DeviceTracker : private boost::noncopyable {
@@ -35,79 +29,6 @@ struct DeviceTracker : private boost::noncopyable {
   io_object_t notification{0};
 };
 
-IOKitPCIProperties::IOKitPCIProperties(const std::string& compatible) {
-  auto properties = osquery::split(compatible, " ");
-  if (properties.size() < 2) {
-    return;
-  }
-
-  size_t prop_index = 0;
-  if (properties[1].find("pci") == 0 && properties[1].find("pciclass") != 0) {
-    // There are two sets of PCI definitions.
-    prop_index = 1;
-  } else if (properties[0].find("pci") != 0) {
-    return;
-  }
-
-  auto vendor = osquery::split(properties[prop_index++], ",");
-  vendor_id = vendor[0].substr(3);
-  model_id = (vendor[1].size() == 3) ? "0" + vendor[1] : vendor[1];
-
-  if (properties[prop_index].find("pciclass") == 0) {
-    // There is a class definition.
-    pci_class = properties[prop_index++].substr(9);
-  }
-
-  if (properties.size() > prop_index) {
-    // There is a driver/ID.
-    driver = properties[prop_index];
-  }
-}
-
-std::string getIOKitProperty(const CFMutableDictionaryRef& details,
-                             const std::string& key) {
-  std::string value;
-
-  // Get a property from the device.
-  auto cfkey = CFStringCreateWithCString(
-      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
-  auto property = CFDictionaryGetValue(details, cfkey);
-  CFRelease(cfkey);
-
-  // Several supported ways of parsing IOKit-encoded data.
-  if (property) {
-    if (CFGetTypeID(property) == CFNumberGetTypeID()) {
-      value = stringFromCFNumber((CFDataRef)property);
-    } else if (CFGetTypeID(property) == CFStringGetTypeID()) {
-      value = stringFromCFString((CFStringRef)property);
-    } else if (CFGetTypeID(property) == CFDataGetTypeID()) {
-      value = stringFromCFData((CFDataRef)property);
-    } else if (CFGetTypeID(property) == CFBooleanGetTypeID()) {
-      value = (CFBooleanGetValue((CFBooleanRef)property)) ? "1" : "0";
-    }
-  }
-
-  return value;
-}
-
-long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
-                                  const std::string& key) {
-  // Get a property from the device.
-  auto cfkey = CFStringCreateWithCString(
-      kCFAllocatorDefault, key.c_str(), kCFStringEncodingUTF8);
-  auto property = CFDictionaryGetValue(details, cfkey);
-  CFRelease(cfkey);
-
-  // Several supported ways of parsing IOKit-encoded data.
-  if (property && CFGetTypeID(property) == CFNumberGetTypeID()) {
-    CFNumberType type = CFNumberGetType((CFNumberRef)property);
-    long long int value;
-    CFNumberGetValue((CFNumberRef)property, type, &value);
-    return value;
-  }
-
-  return 0;
-}
 
 void IOKitEventPublisher::restart() {
   static std::vector<const std::string*> device_classes = {

--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -21,13 +21,9 @@
 
 #include "osquery/core/conversions.h"
 
-namespace osquery {
+#include <osquery/core/darwin/iokit.hpp>
 
-extern const std::string kIOUSBDeviceClassName_;
-extern const std::string kIOPCIDeviceClassName_;
-extern const std::string kIOPlatformExpertDeviceClassName_;
-extern const std::string kIOACPIPlatformDeviceClassName_;
-extern const std::string kIOPlatformDeviceClassname_;
+namespace osquery {
 
 struct IOKitSubscriptionContext : public SubscriptionContext {
   std::string model_id;
@@ -54,31 +50,6 @@ struct IOKitEventContext : public EventContext {
   std::string version;
   std::string serial;
 };
-
-struct IOKitPCIProperties {
-  std::string vendor_id;
-  std::string model_id;
-  std::string pci_class;
-  std::string driver;
-
-  /// Populate IOKit PCI device properties from the "compatible" property.
-  explicit IOKitPCIProperties(const std::string& compatible);
-};
-
-std::string getIOKitProperty(const CFMutableDictionaryRef& details,
-                             const std::string& key);
-long long int getNumIOKitProperty(const CFMutableDictionaryRef& details,
-                                  const std::string& key);
-
-inline void idToHex(std::string& id) {
-  long base = 0;
-  // = AS_LITERAL(int, id);
-  if (safeStrtol(id, 10, base)) {
-    std::stringstream hex_id;
-    hex_id << std::hex << std::setw(4) << std::setfill('0') << (base & 0xFFFF);
-    id = hex_id.str();
-  }
-}
 
 using IOKitEventContextRef = std::shared_ptr<IOKitEventContext>;
 using IOKitSubscriptionContextRef = std::shared_ptr<IOKitSubscriptionContext>;

--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -13,15 +13,14 @@
 #include <atomic>
 #include <iomanip>
 
-#include <osquery/events.h>
-#include <osquery/status.h>
-
 #include <CoreServices/CoreServices.h>
 #include <IOKit/IOKitLib.h>
 
-#include "osquery/core/conversions.h"
+#include <osquery/events.h>
+#include <osquery/status.h>
 
-#include <osquery/core/darwin/iokit.hpp>
+#include "osquery/core/conversions.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 

--- a/osquery/tables/system/darwin/block_devices.cpp
+++ b/osquery/tables/system/darwin/block_devices.cpp
@@ -16,7 +16,7 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -20,8 +20,8 @@
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/diskarbitration.h"
 #include "osquery/core/darwin/iokit.hpp"
+#include "osquery/events/darwin/diskarbitration.h"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -21,7 +21,7 @@
 #include <osquery/tables.h>
 
 #include "osquery/events/darwin/diskarbitration.h"
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/iokit_registry.cpp
+++ b/osquery/tables/system/darwin/iokit_registry.cpp
@@ -11,7 +11,7 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -15,7 +15,7 @@
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 #include "osquery/tables/system/efi_misc.h"
 
 namespace osquery {

--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -10,7 +10,7 @@
 
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/sip_config.cpp
+++ b/osquery/tables/system/darwin/sip_config.cpp
@@ -13,7 +13,7 @@
 #include <osquery/sql.h>
 #include <osquery/logger.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -18,7 +18,7 @@
 
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 #include "osquery/tables/system/smbios_utils.h"
 
 namespace osquery {

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -21,7 +21,7 @@
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -12,7 +12,7 @@
 
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/iokit.h"
+#include "osquery/core/darwin/iokit.hpp"
 
 namespace osquery {
 namespace tables {


### PR DESCRIPTION
There are no functional changes here.  The basic iokit routines were intertwined with the iokit event support code.  This commit separates them into separate files, so that tables that don't require event support do not rely on such code.  The only reason I stumbled upon this, is that I have been looking at modularizing various components (events, database, etc.), and found that there are many hidden dependencies that make it difficult.
