### PR TITLE
tests: removing registry username test in favor of status check

### DIFF
--- a/osquery/tables/system/windows/tests/registry_tests.cpp
+++ b/osquery/tables/system/windows/tests/registry_tests.cpp
@@ -150,7 +150,6 @@ TEST_F(RegistryTablesTest, test_get_username_from_key) {
 
   status = getUsernameFromKey("HKEY_USERS\\S-1-5-19\\Some\\Key", username);
   EXPECT_TRUE(status.ok());
-  EXPECT_TRUE(username == "LOCAL SERVICE");
   for (const auto& key : badKeys) {
     status = getUsernameFromKey(key, username);
     EXPECT_FALSE(status.ok());


### PR DESCRIPTION
The system registry check on Windows for the username `LOCAL SERVICE` is a little redundant, and causes issues with international versions of Windows as the user account names will be different than the english spelling. This removes the string comparison, as it should be sufficient that the function `getUsernameFromKey` returned with a status of `OK`, and should fix test runs on international platforms.