### PR TITLE
Add parent PID on process_events from openbsm

### DIFF
--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -33,7 +33,7 @@ static inline void OpenBSM_AUT_SUBJECT32_EX(Row& r, const tokenstr_t& tok) {
   r["euid"] = INTEGER(tok.tt.subj32_ex.euid);
   r["egid"] = INTEGER(tok.tt.subj32_ex.egid);
   char ip_str[INET6_ADDRSTRLEN];
-  if (tok.tt.proc32_ex.tid.type == AU_IPv4) {
+  if (tok.tt.subj32_ex.tid.type == AU_IPv4) {
     struct in_addr ipv4;
     ipv4.s_addr = static_cast<in_addr_t>(*tok.tt.subj32_ex.tid.addr);
     r["address"] =

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -9,6 +9,7 @@
  */
 #include <arpa/inet.h>
 
+#include <bsm/audit_kevents.h>
 #include <bsm/libbsm.h>
 
 #include <osquery/events.h>
@@ -76,8 +77,7 @@ REGISTER(OpenBSMSSHLoginSubscriber, "event_subscriber", "user_events");
 
 void OpenBSMExecVESubscriber::configure() {
   std::vector<size_t> event_ids{
-      23, // execve
-      43190, // AUX_POSIX_SPAWN
+      AUE_EXECVE, AUE_POSIX_SPAWN,
   };
   for (const auto& evid : event_ids) {
     auto sc = createSubscriptionContext();

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -15,6 +15,8 @@
 #include <osquery/events.h>
 #include <osquery/logger.h>
 
+#include <unordered_map>
+
 #include "osquery/events/darwin/openbsm.h"
 
 namespace osquery {
@@ -60,6 +62,10 @@ class OpenBSMProcEvSubscriber : public EventSubscriber<OpenBSMEventPublisher> {
 
  private:
   Status handleExec(const OpenBSMEventContextRef& ec);
+  Status handleFork(const OpenBSMEventContextRef& ec);
+  Status handleExit(const OpenBSMEventContextRef& ec);
+
+  std::unordered_map<uint32_t, uint32_t> ppid_map;
 };
 
 class OpenBSMSSHLoginSubscriber
@@ -80,7 +86,14 @@ REGISTER(OpenBSMSSHLoginSubscriber, "event_subscriber", "user_events");
 
 void OpenBSMProcEvSubscriber::configure() {
   std::vector<size_t> event_ids{
-      AUE_EXECVE, AUE_POSIX_SPAWN,
+      AUE_EXECVE,
+      AUE_POSIX_SPAWN,
+      AUE_FORK,
+      AUE_VFORK,
+      AUE_FORK1,
+      AUE_DARWIN_RFORK,
+      AUE_RFORK,
+      AUE_EXIT,
   };
   for (const auto& evid : event_ids) {
     auto sc = createSubscriptionContext();
@@ -91,11 +104,29 @@ void OpenBSMProcEvSubscriber::configure() {
 
 Status OpenBSMProcEvSubscriber::Callback(
     const OpenBSMEventContextRef& ec, const OpenBSMSubscriptionContextRef& sc) {
-  return handleExec(ec);
+  switch (sc->event_id) {
+  case AUE_EXECVE:
+  case AUE_POSIX_SPAWN:
+    return handleExec(ec);
+
+  case AUE_FORK:
+  case AUE_VFORK:
+  case AUE_FORK1:
+  case AUE_DARWIN_RFORK:
+  case AUE_RFORK:
+    return handleFork(ec);
+
+  case AUE_EXIT:
+    return handleExit(ec);
+  }
+
+  return Status(1, "Unexpected event");
 }
 
 Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
   Row r;
+  uint32_t pid = 0;
+
   for (const auto& tok : ec->tokens) {
     switch (tok.id) {
     case AUT_HEADER32:
@@ -115,6 +146,7 @@ Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
       r["egid"] = INTEGER(tok.tt.subj32.egid);
       r["uid"] = INTEGER(tok.tt.subj32.ruid);
       r["gid"] = INTEGER(tok.tt.subj32.rgid);
+      pid = tok.tt.subj32.pid;
       break;
     case AUT_SUBJECT64:
       r["auid"] = INTEGER(tok.tt.subj64.auid);
@@ -123,6 +155,7 @@ Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
       r["egid"] = INTEGER(tok.tt.subj64.egid);
       r["uid"] = INTEGER(tok.tt.subj64.ruid);
       r["gid"] = INTEGER(tok.tt.subj64.rgid);
+      pid = tok.tt.subj32.pid;
       break;
     case AUT_SUBJECT32_EX:
       OpenBSM_AUT_SUBJECT32_EX(r, tok);
@@ -163,8 +196,104 @@ Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
     }
   }
   r["uptime"] = INTEGER(tables::getUptime());
+
+  auto ppid = ppid_map.find(pid);
+  if (ppid != ppid_map.end()) {
+    r["parent"] = INTEGER(ppid->second);
+  }
+  /* If mapping doesn't exist no fork was captured. Not fatal. Ignoring. */
+
   add(r);
   return Status(0, "OK");
+}
+
+Status OpenBSMProcEvSubscriber::handleFork(const OpenBSMEventContextRef& ec) {
+  uint32_t ppid = 0; // Parent PID
+  uint32_t cpid = 0; // Child PID
+
+  for (const auto& tok : ec->tokens) {
+    switch (tok.id) {
+    /* The parent is the process issuing the syscall. Its PID is given on the
+     * subject token.
+     */
+    case AUT_SUBJECT32:
+      ppid = tok.tt.subj32.pid;
+      break;
+    case AUT_SUBJECT64:
+      ppid = tok.tt.subj64.pid;
+      break;
+    case AUT_SUBJECT32_EX:
+      ppid = tok.tt.subj32_ex.pid;
+      break;
+    case AUT_SUBJECT64_EX:
+      ppid = tok.tt.subj64_ex.pid;
+      break;
+
+    /* Child PID is given as the first argument here. This could also be
+     * extract from the return token as the child PID should be the return
+     * value of the fork syscall given to the parent.
+     */
+    case AUT_ARG32:
+      if (tok.tt.arg32.no == 0) {
+        cpid = tok.tt.arg32.val;
+      }
+      break;
+    case AUT_ARG64:
+      if (tok.tt.arg64.no == 0) {
+        cpid = tok.tt.arg64.val;
+      }
+      break;
+
+    /* Check whether fork succeeded. Upon failure stop processing as no child
+     * is created.
+     */
+    case AUT_RETURN32:
+      if (tok.tt.ret32.status != 0) {
+        return Status(0);
+      }
+      break;
+    case AUT_RETURN64:
+      if (tok.tt.ret64.err != 0) {
+        return Status(0);
+      }
+    }
+  }
+
+  /* If we succeeded to to capture both parent and child PIDs add them to the
+   * mapping. This information should always be available, if not the event is
+   * malformed.
+   */
+  if (ppid != 0 && cpid != 0) {
+    ppid_map[cpid] = ppid;
+    return Status(0);
+  } else {
+    return Status(1, "Malformed event");
+  }
+}
+
+Status OpenBSMProcEvSubscriber::handleExit(const OpenBSMEventContextRef& ec) {
+  /* When the process exits the mapping is no longer relevant as there won't be
+   * more syscalls issued by it. The PID most come in the subject header.
+   */
+  for (const auto& tok : ec->tokens) {
+    switch (tok.id) {
+    case AUT_SUBJECT32:
+      ppid_map.erase(tok.tt.subj32.pid);
+      return Status(0);
+    case AUT_SUBJECT64:
+      ppid_map.erase(tok.tt.subj64.pid);
+      return Status(0);
+    case AUT_SUBJECT32_EX:
+      ppid_map.erase(tok.tt.subj32_ex.pid);
+      return Status(0);
+    case AUT_SUBJECT64_EX:
+      ppid_map.erase(tok.tt.subj64_ex.pid);
+      return Status(0);
+    }
+  }
+
+  /* If the PID wasn't found this event is malformed. */
+  return Status(1, "Malformed event");
 }
 
 void OpenBSMSSHLoginSubscriber::configure() {

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -57,6 +57,9 @@ class OpenBSMProcEvSubscriber : public EventSubscriber<OpenBSMEventPublisher> {
 
   Status Callback(const OpenBSMEventContextRef& ec,
                   const OpenBSMSubscriptionContextRef& sc);
+
+ private:
+  Status handleExec(const OpenBSMEventContextRef& ec);
 };
 
 class OpenBSMSSHLoginSubscriber
@@ -88,6 +91,10 @@ void OpenBSMProcEvSubscriber::configure() {
 
 Status OpenBSMProcEvSubscriber::Callback(
     const OpenBSMEventContextRef& ec, const OpenBSMSubscriptionContextRef& sc) {
+  return handleExec(ec);
+}
+
+Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
   Row r;
   for (const auto& tok : ec->tokens) {
     switch (tok.id) {

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -47,7 +47,7 @@ static inline void OpenBSM_AUT_SUBJECT32_EX(Row& r, const tokenstr_t& tok) {
   }
 }
 
-class OpenBSMExecVESubscriber : public EventSubscriber<OpenBSMEventPublisher> {
+class OpenBSMProcEvSubscriber : public EventSubscriber<OpenBSMEventPublisher> {
  public:
   Status init() override {
     return Status(0);
@@ -72,21 +72,21 @@ class OpenBSMSSHLoginSubscriber
                   const OpenBSMSubscriptionContextRef& sc);
 };
 
-REGISTER(OpenBSMExecVESubscriber, "event_subscriber", "process_events");
+REGISTER(OpenBSMProcEvSubscriber, "event_subscriber", "process_events");
 REGISTER(OpenBSMSSHLoginSubscriber, "event_subscriber", "user_events");
 
-void OpenBSMExecVESubscriber::configure() {
+void OpenBSMProcEvSubscriber::configure() {
   std::vector<size_t> event_ids{
       AUE_EXECVE, AUE_POSIX_SPAWN,
   };
   for (const auto& evid : event_ids) {
     auto sc = createSubscriptionContext();
     sc->event_id = evid;
-    subscribe(&OpenBSMExecVESubscriber::Callback, sc);
+    subscribe(&OpenBSMProcEvSubscriber::Callback, sc);
   }
 }
 
-Status OpenBSMExecVESubscriber::Callback(
+Status OpenBSMProcEvSubscriber::Callback(
     const OpenBSMEventContextRef& ec, const OpenBSMSubscriptionContextRef& sc) {
   Row r;
   for (const auto& tok : ec->tokens) {


### PR DESCRIPTION
Support capturing parent PID for the `process_events` when using openbsm. This is for feature parity with the kernel based version. Parent children relationship is maintained in a map by capturing fork events. This map is queried at the time of the exec call.