### PR TITLE
Write support for tables implemented from extensions

### DIFF
--- a/include/osquery/mutex.h
+++ b/include/osquery/mutex.h
@@ -30,4 +30,10 @@ using RecursiveMutex = boost::recursive_mutex;
 /// Helper alias for write locking a recursive mutex.
 using RecursiveLock = boost::unique_lock<boost::recursive_mutex>;
 
+/// Helper alias for upgrade locking a mutex.
+using UpgradeLock = boost::upgrade_lock<Mutex>;
+
+/// Helper alias for write locking an upgrade lock.
+using WriteUpgradeLock = boost::upgrade_to_unique_lock<Mutex>;
+
 } // namespace osquery

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -23,6 +23,7 @@
 #endif
 #endif
 
+#include <boost/core/ignore_unused.hpp>
 #include <boost/coroutine2/coroutine.hpp>
 
 #include <osquery/core.h>
@@ -776,8 +777,8 @@ class TablePlugin : public Plugin {
   /// Callback for DELETE statements
   virtual QueryData delete_(QueryContext& context,
                             const PluginRequest& request) {
-    static_cast<void>(context);
-    static_cast<void>(request);
+    boost::ignore_unused(context);
+    boost::ignore_unused(request);
 
     return {{std::make_pair("status", "readonly")}};
   }
@@ -785,8 +786,8 @@ class TablePlugin : public Plugin {
   /// Callback for INSERT statements
   virtual QueryData insert(QueryContext& context,
                            const PluginRequest& request) {
-    static_cast<void>(context);
-    static_cast<void>(request);
+    boost::ignore_unused(context);
+    boost::ignore_unused(request);
 
     return {{std::make_pair("status", "readonly")}};
   }
@@ -794,8 +795,8 @@ class TablePlugin : public Plugin {
   /// Callback for UPDATE statements
   virtual QueryData update(QueryContext& context,
                            const PluginRequest& request) {
-    static_cast<void>(context);
-    static_cast<void>(request);
+    boost::ignore_unused(context);
+    boost::ignore_unused(request);
 
     return {{std::make_pair("status", "readonly")}};
   }

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -779,7 +779,7 @@ class TablePlugin : public Plugin {
     static_cast<void>(context);
     static_cast<void>(request);
 
-    return {{std::make_pair("status", "failure")}};
+    return {{std::make_pair("status", "readonly")}};
   }
 
   /// Callback for INSERT statements
@@ -788,7 +788,7 @@ class TablePlugin : public Plugin {
     static_cast<void>(context);
     static_cast<void>(request);
 
-    return {{std::make_pair("status", "failure")}};
+    return {{std::make_pair("status", "readonly")}};
   }
 
   /// Callback for UPDATE statements
@@ -797,7 +797,7 @@ class TablePlugin : public Plugin {
     static_cast<void>(context);
     static_cast<void>(request);
 
-    return {{std::make_pair("status", "failure")}};
+    return {{std::make_pair("status", "readonly")}};
   }
 
   /**

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -773,6 +773,33 @@ class TablePlugin : public Plugin {
     return QueryData();
   }
 
+  /// Callback for DELETE statements
+  virtual QueryData delete_(QueryContext& context,
+                            const PluginRequest& request) {
+    static_cast<void>(context);
+    static_cast<void>(request);
+
+    return {{std::make_pair("status", "failure")}};
+  }
+
+  /// Callback for INSERT statements
+  virtual QueryData insert(QueryContext& context,
+                           const PluginRequest& request) {
+    static_cast<void>(context);
+    static_cast<void>(request);
+
+    return {{std::make_pair("status", "failure")}};
+  }
+
+  /// Callback for UPDATE statements
+  virtual QueryData update(QueryContext& context,
+                           const PluginRequest& request) {
+    static_cast<void>(context);
+    static_cast<void>(request);
+
+    return {{std::make_pair("status", "failure")}};
+  }
+
   /**
    * @brief Generate a table representation by yielding each row.
    *
@@ -805,7 +832,7 @@ class TablePlugin : public Plugin {
 
  protected:
   /// An SQL table containing the table definition/syntax.
-  std::string columnDefinition() const;
+  std::string columnDefinition(bool is_extension = false) const;
 
   /// Return the name and column pairs for attaching virtual tables.
   PluginResponse routeInfo() const override;
@@ -922,6 +949,7 @@ class TablePlugin : public Plugin {
  private:
   friend class RegistryFactory;
   FRIEND_TEST(VirtualTableTests, test_tableplugin_columndefinition);
+  FRIEND_TEST(VirtualTableTests, test_extension_tableplugin_columndefinition);
   FRIEND_TEST(VirtualTableTests, test_tableplugin_statement);
   FRIEND_TEST(VirtualTableTests, test_indexing_costs);
   FRIEND_TEST(VirtualTableTests, test_table_results_cache);
@@ -929,11 +957,13 @@ class TablePlugin : public Plugin {
 };
 
 /// Helper method to generate the virtual table CREATE statement.
-std::string columnDefinition(const TableColumns& columns);
+std::string columnDefinition(const TableColumns& columns,
+                             bool is_extension = false);
 
 /// Helper method to generate the virtual table CREATE statement.
 std::string columnDefinition(const PluginResponse& response,
-                             bool aliases = false);
+                             bool aliases = false,
+                             bool is_extension = false);
 
 /// Get the string representation for an SQLite column type.
 inline const std::string& columnTypeName(ColumnType type) {

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1078,10 +1078,14 @@ inline void meta_schema(int nArg, char** azArg) {
     auto status = osquery::Registry::call(
         "table", table, {{"action", "columns"}}, response);
     if (status.ok()) {
-      fprintf(stdout,
-              "CREATE TABLE %s%s;\n",
-              table.c_str(),
-              osquery::columnDefinition(response, true, false).c_str());
+      auto const aliases = true;
+      auto const is_extension = false;
+
+      fprintf(
+          stdout,
+          "CREATE TABLE %s%s;\n",
+          table.c_str(),
+          osquery::columnDefinition(response, aliases, is_extension).c_str());
     }
   }
 }

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -344,7 +344,7 @@ static char* one_input_line(FILE* in, char* zPrior, int isContinuation) {
 
 /*
 ** Pretty print structure
- */
+*/
 struct prettyprint_data {
   osquery::QueryData results;
   std::vector<std::string> columns;
@@ -784,7 +784,7 @@ static int shell_exec(
     /* (not the same as sqlite3_exec) */
     struct callback_data* pArg, /* Pointer to struct callback_data */
     char** pzErrMsg /* Error msg written here */
-    ) {
+) {
   // Grab a lock on the managed DB instance.
   auto dbc = osquery::SQLiteDBManager::get();
   auto db = dbc->db();
@@ -1081,7 +1081,7 @@ inline void meta_schema(int nArg, char** azArg) {
       fprintf(stdout,
               "CREATE TABLE %s%s;\n",
               table.c_str(),
-              osquery::columnDefinition(response, true).c_str());
+              osquery::columnDefinition(response, true, false).c_str());
     }
   }
 }
@@ -1219,7 +1219,7 @@ static int do_meta_command(char* zLine, struct callback_data* p) {
   char* azArg[50];
 
   /* Parse the input line into tokens.
-  */
+   */
   while ((zLine[i] != 0) && nArg < ArraySize(azArg)) {
     while (IsSpace(zLine[i])) {
       i++;
@@ -1255,7 +1255,7 @@ static int do_meta_command(char* zLine, struct callback_data* p) {
   }
 
   /* Process the input line.
-  */
+   */
   if (nArg == 0) {
     return 0; /* no tokens, no error */
   }
@@ -1294,8 +1294,9 @@ static int do_meta_command(char* zLine, struct callback_data* p) {
     rc = 2;
   } else if (c == 'f' && strncmp(azArg[0], "features", n) == 0 && nArg == 1) {
     meta_features(p);
-  } else if (c == 'h' && (strncmp(azArg[0], "header", n) == 0 ||
-                          strncmp(azArg[0], "headers", n) == 0) &&
+  } else if (c == 'h' &&
+             (strncmp(azArg[0], "header", n) == 0 ||
+              strncmp(azArg[0], "headers", n) == 0) &&
              nArg > 1 && nArg < 3) {
     p->showHeader = booleanValue(azArg[1]);
   } else if (c == 'h' && strncmp(azArg[0], "help", n) == 0) {
@@ -1349,8 +1350,9 @@ static int do_meta_command(char* zLine, struct callback_data* p) {
                      "%.*s",
                      static_cast<int>(sizeof(p->separator)) - 1,
                      azArg[1]);
-  } else if (c == 's' && (strncmp(azArg[0], "show", n) == 0 ||
-                          strncmp(azArg[0], "summary", n) == 0) &&
+  } else if (c == 's' &&
+             (strncmp(azArg[0], "show", n) == 0 ||
+              strncmp(azArg[0], "summary", n) == 0) &&
              nArg == 1) {
     meta_show(p);
   } else if (c == 't' && n > 1 && strncmp(azArg[0], "tables", n) == 0 &&

--- a/osquery/examples/example_writable_table.cpp
+++ b/osquery/examples/example_writable_table.cpp
@@ -1,0 +1,298 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/core/conversions.h>
+#include <osquery/sdk.h>
+#include <osquery/system.h>
+
+#include <rapidjson/document.h>
+
+#include <mutex>
+#include <sstream>
+
+using namespace osquery;
+class WritableTable : public TablePlugin {
+ private:
+  /// Simple primary key implementation; this is just the two columns
+  /// concatenated
+  using PrimaryKey = std::string;
+
+  /// A rowid value uniquely identifies a row in a table
+  using RowID = std::string;
+
+  /// Data mutex
+  std::mutex mutex;
+
+  /// This is our data; each row contains a rowid, and the two remaining columns
+  /// ('text' and 'integer')
+  std::unordered_map<PrimaryKey, Row> data;
+
+  /// This is used to map rowids to primary keys
+  std::unordered_map<RowID, PrimaryKey> rowid_to_primary_key;
+
+  /// This is an example implementation for a basic primary key
+  PrimaryKey getPrimaryKey(const Row& row) const {
+    return row.at("text") + row.at("integer");
+  }
+
+  /// Returns true if the given primary key is unique; used to adhere to
+  /// constraints
+  bool isPrimaryKeyUnique(
+      const PrimaryKey& primary_key,
+      const std::string& ignored_rowid = std::string()) const {
+    auto it = data.find(primary_key);
+    if (it == data.end()) {
+      return true;
+    }
+
+    if (ignored_rowid.empty()) {
+      return false;
+    }
+
+    return it->second.at("rowid") == ignored_rowid;
+  }
+
+  /// Generates a new rowid value; used when sqlite3 does not provide one
+  size_t generateRowId() const {
+    static size_t rowid_generator = 0U;
+    return rowid_generator++;
+  }
+
+  /// Saves the given row
+  Status saveRow(const Row& row, PrimaryKey primary_key = std::string()) {
+    // Expect full rows (i.e. must include the rowid column)
+    if (row.size() != 3U) {
+      return Status(1, "Invalid column count");
+    }
+
+    // Compute the primary key if we haven't received one
+    if (primary_key.empty()) {
+      primary_key = getPrimaryKey(row);
+    }
+
+    // Save the row and update the index
+    data.insert({primary_key, row});
+
+    const auto& rowid = row.at("rowid");
+    rowid_to_primary_key.insert({rowid, primary_key});
+
+    return Status(0, "OK");
+  }
+
+  /// Expands a value list returned by osquery into a Row (without the rowid
+  /// column)
+  Status getRowData(Row& row, const std::string& json_value_array) const {
+    row.clear();
+
+    rapidjson::Document document;
+    document.Parse(json_value_array);
+    if (document.HasParseError() || !document.IsArray()) {
+      return Status(1, "Invalid format");
+    }
+
+    if (document.Size() != 2U) {
+      return Status(1, "Wrong column count");
+    }
+
+    row["text"] = document[0].IsNull() ? "" : document[0].GetString();
+    row["integer"] =
+        std::to_string(document[1].IsNull() ? 0 : document[1].GetInt());
+
+    return Status(0, "OK");
+  }
+
+ public:
+  /// Describes the columns available in the table
+  TableColumns columns() const {
+    return {std::make_tuple("text", TEXT_TYPE, ColumnOptions::DEFAULT),
+            std::make_tuple("integer", INTEGER_TYPE, ColumnOptions::DEFAULT)};
+  }
+
+  /// Generates the rows for osquery
+  QueryData generate(QueryContext& context) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    QueryData results;
+    for (const auto& pkey_row_pair : data) {
+      results.push_back(pkey_row_pair.second);
+    }
+
+    return results;
+  }
+
+  /// Callback for INSERT queries
+  QueryData insert(QueryContext& context, const PluginRequest& request) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    // Generate the Row from the json_value_array json
+    const auto& json_value_array = request.at("json_value_array");
+
+    Row row;
+    auto status = getRowData(row, json_value_array);
+    if (!status.ok()) {
+      VLOG(1) << status.getMessage();
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    // Make the 'text' column NOT NULL
+    if (row["text"].empty()) {
+      return {{std::make_pair("status", "constraint")}};
+    }
+
+    // Generate a primary key; do this first so that we avoid generating
+    // rowids for statements that we then may have to discard!
+    auto primary_key = getPrimaryKey(row);
+    if (!isPrimaryKeyUnique(primary_key)) {
+      return {{std::make_pair("status", "constraint")}};
+    }
+
+    // Obtain the new rowid, and add it to our Row
+    if (request.at("auto_rowid") == "false") {
+      auto new_rowid = generateRowId();
+      row["rowid"] = std::to_string(new_rowid);
+
+    } else {
+      unsigned long long int existing_rowid;
+      status = safeStrtoull(request.at("id"), 10, existing_rowid);
+      if (!status.ok()) {
+        VLOG(1) << "Invalid rowid defined by osquery";
+        return {{std::make_pair("status", "failure")}};
+      }
+
+      row["rowid"] = std::to_string(existing_rowid);
+    }
+
+    // Finally, save the row; also pass the primary key we calculated so that
+    // the function doesn't have to compute it again
+    status = saveRow(row, primary_key);
+    if (!status.ok()) {
+      VLOG(1) << status.getMessage();
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    Row result;
+    if (request.at("auto_rowid") == "false") {
+      result["id"] = row["rowid"];
+    }
+
+    result["status"] = "success";
+    return {result};
+  }
+
+  /// Callback for DELETE queries
+  QueryData delete_(QueryContext& context, const PluginRequest& request) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    const auto& rowid = request.at("id");
+
+    auto primary_key_it = rowid_to_primary_key.find(rowid);
+    if (primary_key_it == rowid_to_primary_key.end()) {
+      VLOG(1) << "The rowid is not mapped to an internal rowid";
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    const auto& primary_key = primary_key_it->second;
+
+    auto row_it = data.find(primary_key);
+    if (row_it == data.end()) {
+      VLOG(1) << "Internal error; row id -> primary key mismatch";
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    data.erase(row_it);
+    rowid_to_primary_key.erase(primary_key_it);
+
+    return {{std::make_pair("status", "success")}};
+  }
+
+  // Callback for UPDATE queries
+  QueryData update(QueryContext& context, const PluginRequest& request) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    // Validate the rowid
+    const auto& original_rowid = request.at("id");
+
+    auto orig_primary_key_it = rowid_to_primary_key.find(original_rowid);
+    if (orig_primary_key_it == rowid_to_primary_key.end()) {
+      VLOG(1) << "The rowid is not mapped to an internal rowid";
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    const auto& original_primary_key = orig_primary_key_it->second;
+
+    auto row_it = data.find(original_primary_key);
+    if (row_it == data.end()) {
+      VLOG(1) << "Internal error; row id -> primary key mismatch";
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    // Generate the Row from the json_value_array json
+    const auto& json_value_array = request.at("json_value_array");
+
+    Row row;
+    auto status = getRowData(row, json_value_array);
+    if (!status.ok()) {
+      VLOG(1) << status.getMessage();
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    // Make the 'text' column NOT NULL
+    if (row["text"].empty()) {
+      return {{std::make_pair("status", "constraint")}};
+    }
+
+    // Generate a primary key
+    auto new_primary_key = getPrimaryKey(row);
+    if (!isPrimaryKeyUnique(new_primary_key, original_rowid)) {
+      return {{std::make_pair("status", "constraint")}};
+    }
+
+    // Add the rowid value to our row
+    auto new_rowid_it = request.find("new_id");
+    if (new_rowid_it != request.end()) {
+      // sqlite has generated the new rowid for us, so we'll discard
+      // the one we have
+      const auto& new_rowid = new_rowid_it->second;
+      row["rowid"] = new_rowid;
+
+    } else {
+      // Here we are supposed to keep the rowid we already have
+      row["rowid"] = original_rowid;
+    }
+
+    // Erase the old row and save the new one
+    rowid_to_primary_key.erase(orig_primary_key_it);
+    data.erase(row_it);
+
+    status = saveRow(row, new_primary_key);
+    if (!status.ok()) {
+      VLOG(1) << status.getMessage();
+      return {{std::make_pair("status", "failure")}};
+    }
+
+    return {{std::make_pair("status", "success")}};
+  }
+};
+
+REGISTER_EXTERNAL(WritableTable, "table", "WritableTable");
+
+int main(int argc, char* argv[]) {
+  osquery::Initializer runner(argc, argv, ToolType::EXTENSION);
+
+  auto status = startExtension("WritableTable", "0.0.1");
+  if (!status.ok()) {
+    LOG(ERROR) << status.getMessage();
+    runner.requestShutdown(status.getCode());
+  }
+
+  // Finally wait for a signal / interrupt to shutdown.
+  runner.waitForShutdown();
+  return 0;
+}

--- a/osquery/examples/example_writable_table.cpp
+++ b/osquery/examples/example_writable_table.cpp
@@ -137,8 +137,8 @@ class WritableTable : public TablePlugin {
     Row row;
     auto status = getRowData(row, json_value_array);
     if (!status.ok()) {
-      VLOG(1) << status.getMessage();
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", status.getMessage())}};
     }
 
     // Make the 'text' column NOT NULL
@@ -162,8 +162,9 @@ class WritableTable : public TablePlugin {
       unsigned long long int existing_rowid;
       status = safeStrtoull(request.at("id"), 10, existing_rowid);
       if (!status.ok()) {
-        VLOG(1) << "Invalid rowid defined by osquery";
-        return {{std::make_pair("status", "failure")}};
+        return {
+            {std::make_pair("status", "failure"),
+             std::make_pair("message", "Invalid rowid defined by osquery")}};
       }
 
       row["rowid"] = std::to_string(existing_rowid);
@@ -173,8 +174,8 @@ class WritableTable : public TablePlugin {
     // the function doesn't have to compute it again
     status = saveRow(row, primary_key);
     if (!status.ok()) {
-      VLOG(1) << status.getMessage();
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", status.getMessage())}};
     }
 
     Row result;
@@ -194,16 +195,17 @@ class WritableTable : public TablePlugin {
 
     auto primary_key_it = rowid_to_primary_key.find(rowid);
     if (primary_key_it == rowid_to_primary_key.end()) {
-      VLOG(1) << "The rowid is not mapped to an internal rowid";
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message",
+                              "The rowid is not mapped to an internal rowid")}};
     }
 
     const auto& primary_key = primary_key_it->second;
 
     auto row_it = data.find(primary_key);
     if (row_it == data.end()) {
-      VLOG(1) << "Internal error; row id -> primary key mismatch";
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", "Row id -> primary key mismatch")}};
     }
 
     data.erase(row_it);
@@ -221,16 +223,17 @@ class WritableTable : public TablePlugin {
 
     auto orig_primary_key_it = rowid_to_primary_key.find(original_rowid);
     if (orig_primary_key_it == rowid_to_primary_key.end()) {
-      VLOG(1) << "The rowid is not mapped to an internal rowid";
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message",
+                              "The rowid is not mapped to an internal rowid")}};
     }
 
     const auto& original_primary_key = orig_primary_key_it->second;
 
     auto row_it = data.find(original_primary_key);
     if (row_it == data.end()) {
-      VLOG(1) << "Internal error; row id -> primary key mismatch";
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", "Row id -> primary key mismatch")}};
     }
 
     // Generate the Row from the json_value_array json
@@ -239,8 +242,8 @@ class WritableTable : public TablePlugin {
     Row row;
     auto status = getRowData(row, json_value_array);
     if (!status.ok()) {
-      VLOG(1) << status.getMessage();
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", status.getMessage())}};
     }
 
     // Make the 'text' column NOT NULL
@@ -273,8 +276,8 @@ class WritableTable : public TablePlugin {
 
     status = saveRow(row, new_primary_key);
     if (!status.ok()) {
-      VLOG(1) << status.getMessage();
-      return {{std::make_pair("status", "failure")}};
+      return {{std::make_pair("status", "failure"),
+               std::make_pair("message", status.getMessage())}};
     }
 
     return {{std::make_pair("status", "success")}};

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -15,13 +15,6 @@
 #include "osquery/core/conversions.h"
 
 namespace osquery {
-
-/// Helper alias for upgrade locking a mutex.
-using UpgradeLock = boost::upgrade_lock<Mutex>;
-
-/// Helper alias for write locking an upgrade lock.
-using WriteUpgradeLock = boost::upgrade_to_unique_lock<Mutex>;
-
 void RegistryInterface::remove(const std::string& item_name) {
   if (items_.count(item_name) > 0) {
     items_[item_name]->tearDown();

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -80,7 +80,8 @@ static void SQL_virtual_table_internal(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("benchmark", columnDefinition(res), dbc);
+  attachTableInternal(
+      "benchmark", columnDefinition(res, false, false), dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -100,7 +101,8 @@ static void SQL_virtual_table_internal_yield(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("benchmark_yield", columnDefinition(res), dbc);
+  attachTableInternal(
+      "benchmark_yield", columnDefinition(res, false, false), dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -121,7 +123,8 @@ static void SQL_virtual_table_internal_global(benchmark::State& state) {
   while (state.KeepRunning()) {
     // Get a connection to the persistent database.
     auto dbc = SQLiteDBManager::get();
-    attachTableInternal("benchmark", columnDefinition(res), dbc);
+    attachTableInternal(
+        "benchmark", columnDefinition(res, false, false), dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -141,7 +144,8 @@ static void SQL_virtual_table_internal_unique(benchmark::State& state) {
   while (state.KeepRunning()) {
     // Get a new database connection (to a unique database).
     auto dbc = SQLiteDBManager::getUnique();
-    attachTableInternal("benchmark", columnDefinition(res), dbc);
+    attachTableInternal(
+        "benchmark", columnDefinition(res, false, false), dbc, false);
 
     QueryData results;
     queryInternal("select * from benchmark", results, dbc);
@@ -178,7 +182,8 @@ static void SQL_virtual_table_internal_long(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("long_benchmark", columnDefinition(res), dbc);
+  attachTableInternal(
+      "long_benchmark", columnDefinition(res, false, false), dbc, false);
 
   while (state.KeepRunning()) {
     QueryData results;
@@ -241,7 +246,8 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("wide_benchmark", columnDefinition(res), dbc);
+  attachTableInternal(
+      "wide_benchmark", columnDefinition(res, false, false), dbc, false);
 
   kWideCount = state.range_y();
   while (state.KeepRunning()) {
@@ -267,7 +273,8 @@ static void SQL_virtual_table_internal_wide_yield(benchmark::State& state) {
 
   // Attach a sample virtual table.
   auto dbc = SQLiteDBManager::getUnique();
-  attachTableInternal("wide_benchmark_yield", columnDefinition(res), dbc);
+  attachTableInternal(
+      "wide_benchmark_yield", columnDefinition(res, false, false), dbc, false);
 
   kWideCount = state.range_y();
   while (state.KeepRunning()) {
@@ -302,4 +309,4 @@ static void SQL_select_basic(benchmark::State& state) {
 }
 
 BENCHMARK(SQL_select_basic);
-}
+} // namespace osquery

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -195,12 +195,16 @@ Status SQLiteSQLPlugin::attach(const std::string& name) {
     return status;
   }
 
-  auto statement = columnDefinition(response);
+  bool is_extension = true;
+  auto statement = columnDefinition(response, false, is_extension);
+
   // Attach requests occurring via the plugin/registry APIs must act on the
   // primary database. To allow this, getConnection can explicitly request the
   // primary instance and avoid the contention decisions.
   auto dbc = SQLiteDBManager::getConnection(true);
-  return attachTableInternal(name, statement, dbc);
+
+  // Attach as an extension, allowing read/write tables
+  return attachTableInternal(name, statement, dbc, is_extension);
 }
 
 void SQLiteSQLPlugin::detach(const std::string& name) {

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -81,7 +81,8 @@ struct VirtualTable : private boost::noncopyable {
 /// Attach a table plugin name to an in-memory SQLite database.
 Status attachTableInternal(const std::string& name,
                            const std::string& statement,
-                           const SQLiteDBInstanceRef& instance);
+                           const SQLiteDBInstanceRef& instance,
+                           bool is_extension);
 
 /// Detach (drop) a table.
 Status detachTableInternal(const std::string& name,
@@ -106,4 +107,4 @@ void attachVirtualTables(const SQLiteDBInstanceRef& instance);
  */
 void registerForeignTables();
 #endif
-}
+} // namespace osquery


### PR DESCRIPTION
### Description
This PR adds support for writable extension tables by providing an xUpdate sqlite3 implementation.

### Disclamer
Write support for core/built-in tables is **NOT** implemented, and will not work.

### Demo
This is a small demo for the following example: *osquery/examples/example_writable_table.cpp*
```
osquery> select * from WritableTable;
osquery> insert into WritableTable (text, integer) values ("1", 1);
osquery> insert into WritableTable (text, integer) values ("1", 1);
Error: constraint failed
osquery> insert into WritableTable (text, integer) values ("2", 2);
osquery> select * from WritableTable;
+------+---------+
| text | integer |
+------+---------+
| 2    | 2       |
| 1    | 1       |
+------+---------+
osquery> delete from WritableTable where text = "1";
osquery> select * from WritableTable;
+------+---------+
| text | integer |
+------+---------+
| 2    | 2       |
+------+---------+
osquery> insert into WritableTable (text, integer) values ("3", 3);
osquery> select * from WritableTable;
+------+---------+
| text | integer |
+------+---------+
| 3    | 3       |
| 2    | 2       |
+------+---------+
osquery> update WritableTable set text="2", integer=2 where text="3";
Error: constraint failed
osquery> update WritableTable set text="5", integer=5 where text="3";
osquery> select * from WritableTable;
+------+---------+
| text | integer |
+------+---------+
| 5    | 5       |
| 2    | 2       |
+------+---------+
```