### PR TITLE
fix MacOS Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -190,7 +190,6 @@ Vagrant.configure("2") do |config|
         build.vm.synced_folder ".", "/vagrant", group: "staff", type: "rsync",
           rsync__exclude: [
             "build",
-            ".git/objects",
             ".git/modules/third-party/objects"
           ]
       end


### PR DESCRIPTION
When using vagrant to build the MacOS binaries, the _make sysprep_ step fails due to vagrant not rsync'ing all the correct repo items.

Before this pull request:
```bash
host$ vagrant up macos10.12
Bringing machine 'macos10.12' up with 'virtualbox' provider...
==> macos10.12: Importing base box 'jhcook/macos-sierra'...
   ....
host$ vagrant ssh macos10.12
Last login: Wed Jan 31 13:40:36 2018 from 10.0.2.2
This-MacBook-Pro:~ vagrant$ cd /vagrant/
This-MacBook-Pro:vagrant vagrant$ git status
fatal: Not a git repository (or any of the parent directories): .git
This-MacBook-Pro:vagrant vagrant$ make sysprep
[+] found darwin provision script: /vagrant/tools/provision/darwin.sh
[+] requesting sudo: /usr/bin/gem install --no-ri --no-rdoc fpm
   ....
[+] running auxiliary initialization
fatal: Not a git repository (or any of the parent directories): .git
make: *** [sysprep] Error 128
This-MacBook-Pro:vagrant vagrant$ 
```
After this pull request:
```bash
host$ vagrant up macos10.12
Bringing machine 'macos10.12' up with 'virtualbox' provider...
==> macos10.12: Importing base box 'jhcook/macos-sierra'...
   ....
host$ vagrant ssh macos10.12
Last login: Wed Jan 31 13:58:20 2018 from 10.0.2.2
This-MacBook-Pro:~ vagrant$ cd /vagrant/
This-MacBook-Pro:vagrant vagrant$ git status
On branch vagrantfile-fix
nothing to commit, working tree clean
This-MacBook-Pro:vagrant vagrant$ make sysprep
[+] found darwin provision script: /vagrant/tools/provision/darwin.sh
[+] requesting sudo: /usr/bin/gem install --no-ri --no-rdoc fpm
   ....
[+] running auxiliary initialization
HEAD is now at 408be33e fix MacOS Vagrant
Submodule 'third-party' (https://github.com/osquery/third-party.git) registered for path 'third-party'
Cloning into '/vagrant/third-party'...
Submodule path 'third-party': checked out '4ef099c31a1165c5e7e3a699f9e4b3eb68c3c3d9'
This-MacBook-Pro:vagrant vagrant$ 
```