### PR TITLE
extensions: adding support for autoloading python extensions on Windows

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -360,6 +360,12 @@ std::string join(const std::vector<std::string>& s, const std::string& tok) {
   return boost::algorithm::join(s, tok);
 }
 
+std::string join(const std::set<std::string>& s, const std::string& tok) {
+  std::vector<std::string> toJoin;
+  toJoin.insert(toJoin.end(), s.begin(), s.end());
+  return boost::algorithm::join(toJoin, tok);
+}
+
 std::string getBufferSHA1(const char* buffer, size_t size) {
   // SHA1 produces 160-bit digests, so allocate (5 * 32) bits.
   uint32_t digest[5] = {0};

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -13,6 +13,7 @@
 #include <limits.h>
 
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -107,6 +108,16 @@ inline void replaceAll(std::string& str,
  * @return the joined string.
  */
 std::string join(const std::vector<std::string>& s, const std::string& tok);
+
+/**
+ * @brief Join a set of strings inserting a token string between elements
+ *
+ * @param s the set of strings to be joined.
+ * @param tok a token glue string to be inserted between elements.
+ *
+ * @return the joined string.
+ */
+std::string join(const std::set<std::string>& s, const std::string& tok);
 
 /**
  * @brief Decode a base64 encoded string.

--- a/osquery/core/windows/process.cpp
+++ b/osquery/core/windows/process.cpp
@@ -14,8 +14,11 @@
 #include <signal.h>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 
 #include "osquery/core/process.h"
+
+namespace fs = boost::filesystem;
 
 namespace osquery {
 
@@ -274,27 +277,35 @@ std::shared_ptr<PlatformProcess> PlatformProcess::launchExtension(
     return std::shared_ptr<PlatformProcess>();
   }
 
-  auto status = ::CreateProcessA(exec_path.c_str(),
-                                 mutable_argv.data(),
-                                 nullptr,
-                                 nullptr,
-                                 TRUE,
-                                 0,
-                                 nullptr,
-                                 nullptr,
-                                 &si,
-                                 &pi);
-  unsetEnvVar("OSQUERY_EXTENSION");
+  auto ext_path = fs::path(exec_path);
 
-  if (!status) {
-    return std::shared_ptr<PlatformProcess>();
+  // We are autoloading a Python extension, so pass off to our helper
+  if (ext_path.extension().string() == ".ext") {
+    return launchTestPythonScript(
+        std::string(mutable_argv.begin(), mutable_argv.end()));
+  } else {
+    auto status = ::CreateProcessA(exec_path.c_str(),
+                                   mutable_argv.data(),
+                                   nullptr,
+                                   nullptr,
+                                   TRUE,
+                                   0,
+                                   nullptr,
+                                   nullptr,
+                                   &si,
+                                   &pi);
+    unsetEnvVar("OSQUERY_EXTENSION");
+
+    if (!status) {
+      return std::shared_ptr<PlatformProcess>();
+    }
+
+    auto process = std::make_shared<PlatformProcess>(pi.hProcess);
+    ::CloseHandle(pi.hThread);
+    ::CloseHandle(pi.hProcess);
+
+    return process;
   }
-
-  auto process = std::make_shared<PlatformProcess>(pi.hProcess);
-  ::CloseHandle(pi.hThread);
-  ::CloseHandle(pi.hProcess);
-
-  return process;
 }
 
 std::shared_ptr<PlatformProcess> PlatformProcess::launchTestPythonScript(


### PR DESCRIPTION
This commit adds support for Windows autoloading Python extensions by adding a check on the file extension. If the file extension is `.ext`, as is the standard for posix platforms, then we attempt to launch this extension using Python. Otherwise the assumption is that the extension is a native Windows binary, and we launch as such. I tested this on a Windows VM, and we seem to launch and query from Python extensions correctly:

```
C:\Users\Nick\work\repos\osquery [win-python-auto-ext]
λ  C:\ProgramData\osquery\osqueryd\osqueryd.exe --flagfile=C:\Users\Nick\work\configs\osquery_extensions\osquery.flags --verbose
I0131 14:58:13.185580 15712 init.cpp:380] osquery initialized [version=3.0.0-17-g10c0c60b]
I0131 14:58:13.264608 15712 system.cpp:344] Found stale process for osqueryd (13792)
I0131 14:58:13.265585 15712 system.cpp:377] Writing osqueryd pid (4748) to C:\Users\Nick\work\configs\osquery_extensions\osquery.pidfile
I0131 14:58:13.268623 15712 extensions.cpp:347] Found autoloadable extension: C:\ProgramData\osquery\extensions\foobar_table.ext
I0131 14:58:13.663625 22520 watcher.cpp:549] osqueryd watcher (4748) executing worker (8628)
I0131 14:58:13.667609 22520 watcher.cpp:591] Created and monitoring extension child (16468): C:\ProgramData\osquery\extensions\foobar_table.ext
I0131 14:58:13.701617 25572 init.cpp:377] osquery worker initialized [watcher=4748]
I0131 14:58:13.707610 25572 rocksdb.cpp:132] Opening RocksDB handle: C:\Users\Nick\work\configs\osquery_extensions\osquery.db
I0131 14:58:13.797616 10964 interface.cpp:338] Extension manager service starting: \\.\pipe\osquery.em
I0131 14:58:13.806617 19248 interface.cpp:89] Thrift message: TPipe ::GetOverlappedResult errored GLE=errno = 109
I0131 14:58:13.809626 19248 interface.cpp:89] Thrift message: TConnectedClient died: TPipe: GetOverlappedResult failed
I0131 14:58:13.806617 10572 interface.cpp:89] Thrift message: TPipe ::GetOverlappedResult errored GLE=errno = 109
I0131 14:58:13.810617 10572 interface.cpp:89] Thrift message: TConnectedClient died: TPipe: GetOverlappedResult failed
I0131 14:58:13.876621 23884 interface.cpp:141] Registering extension (foobar_table, 17003, version=1.0.0, sdk=1.8.0)
I0131 14:58:14.882678 23884 registry.cpp:351] Extension 17003 registered table plugin foobar
...
I0131 14:58:22.535239 23332 scheduler.cpp:75] Executing scheduled query example_extension_query: select * from foobar;
```
We then see the results of our query in the snapshots log:
```
...
{"snapshot":[{"baz":"baz","foo":"bar"},{"baz":"baz","foo":"bar"}],"action":"snapshot","name":"example_extension_query","hostIdentifier":"devbox","calendarTime":"Wed Jan 31 22:58:23 2018 UTC","unixTime":1517439503,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick","version":"3.0.0-17-g10c0c60b"}}
```