### PR TITLE
Update remote.md

### DIFF
--- a/docs/wiki/deployment/remote.md
+++ b/docs/wiki/deployment/remote.md
@@ -10,7 +10,7 @@ The initial step is called an "enroll step" and in the case of **tls** plugins, 
 
 1. Configure a target `--tls_hostname`, `--enroll_tls_endpoint`.
 2. Configure a proxy `--proxy_hostname` (Optional Step).
-3. Place your server's root certificate authority's PEM-encoded certificate into a file, for example `/path/to/server-root.pem` and configure the client to pin to these roots: `--tls_server_certs=`.
+3. Place your server's, root certificate authority's PEM-encoded certificate into a file, for example `/path/to/server-root.pem` and configure the client to pin to these roots: `--tls_server_certs=`.
 4. Submit an `--enroll_secret_path`, an `--enroll_secret_env`, or use TLS-client authentication, to the enroll endpoint.
 5. Receive a **node_key** and store within the node's persistent storage (RocksDB).
 6. Make config/logger requests while providing **node_key** as identification/authentication.
@@ -239,7 +239,7 @@ We will use an **osqueryd** client and set the required TLS settings. When enfor
 ```
 $ osqueryd --verbose --ephemeral --disable_database \
     --tls_hostname localhost:8080 \
-    --tls_server_certs ./tools/tests/test_server_ca.pem \
+    --tls_server_certs ./tools/tests/test_server.pem \
     --config_plugin tls \
     --config_tls_endpoint /config \
     --logger_tls_endpoint /logger \


### PR DESCRIPTION
Original: The certificate being passed as parameter in the last example of osqueryd CLI flag --tls_sever_certs was test_server_ca.pem.
Change: I replaced it with test_server.pem.
Reason: As it is mentioned that the flag should pin to the root certificate of server and in the toy example, CN=localhost in subject of certificate. However if we open test_server_ca.pem using openssl, CN=osquery-unittests-ca. Hence the certificate passed is wrong and server certificate should be passed.