### PR TITLE
Remove duplicate mode column in device_nodes query

### DIFF
--- a/packs/hardware-monitoring.conf
+++ b/packs/hardware-monitoring.conf
@@ -114,7 +114,7 @@
       "description" : "Retrieves all the information for the current windows drivers in the target Windows system."
     },
     "device_nodes": {
-      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, mode, type from file where directory = '/dev/';",
+      "query": "select file.path, uid, gid, mode, 0 as atime, mtime, ctime, block_size, type from file where directory = '/dev/';",
       "interval": "7200",
       "platform": "posix",
       "version": "1.6.0",


### PR DESCRIPTION
Remove duplicate mode column in device_nodes query