### PR TITLE
Fix for sslv3 handshake failure in the file carver

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -238,6 +238,7 @@ Status Carver::carve(const boost::filesystem::path& path) {
 
 Status Carver::postCarve(const boost::filesystem::path& path) {
   auto startRequest = Request<TLSTransport, JSONSerializer>(startUri_);
+  startRequest.setOption("hostname", FLAGS_tls_hostname);
 
   // Perform the start request to get the session id
   PlatformFile pFile(path, PF_OPEN_EXISTING | PF_READ);
@@ -271,6 +272,7 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   }
 
   auto contRequest = Request<TLSTransport, JSONSerializer>(contUri_);
+  contRequest.setOption("hostname", FLAGS_tls_hostname);
   for (size_t i = 0; i < blkCount; i++) {
     std::vector<char> block(FLAGS_carver_block_size, 0);
     auto r = pFile.read(block.data(), FLAGS_carver_block_size);


### PR DESCRIPTION
When attempting to use the file carver with a remote server deployed as a Lambda function, but with a API Gateway in front of it handling TLS termination, after the enrollment has succeeded, the carver shows the following error, when starting and continuing a file carve:

```
osquery> select * from carves where carve=1 and path like '/tmp/testfile';
I0206 00:59:58.977370 19953 tls_enroll.cpp:63] TLSEnrollPlugin requesting a node enroll key from: https://XXXXXXXXXX.us-east-2.amazonaws.com/prod/enroll
I0206 00:59:58.978435 19953 smbios_tables.cpp:132] Could not read SMBIOS memory
I0206 00:59:58.979321 19953 tls.cpp:198] TLS/HTTPS POST request to URI: https://XXXXXXXXXX.us-east-2.amazonaws.com/prod/enroll
{"enroll_secret":"osquery_secret","host_identifier":"vagrant","platform_type":"9","host_details":{"os_version":{"_id":"16.04","codename":"xenial","major":"16","minor":"04","name":"Ubuntu","patch":"0","platform":"ubuntu","platform_like":"debian","version":"16.04.3 LTS (Xenial Xerus)"},"osquery_info":{"build_distro":"xenial","build_platform":"ubuntu","config_hash":"","config_valid":"0","extensions":"active","instance_id":"c8c2b291-a5b0-4c8f-a6f9-68e73322e1ef","pid":"19953","start_time":"1517878796","uuid":"a40c6537-108f-4b05-8f54-2a496c777d86","version":"3.0.0-17-gbf2b464","watcher":"-1"},"system_info":{"computer_name":"vagrant","cpu_brand":"Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000","cpu_logical_cores":"2","cpu_physical_cores":"2","cpu_subtype":"158","cpu_type":"6","hardware_model":"","hostname":"vagrant.vm","local_hostname":"vagrant.vm","physical_memory":"4143591424","uuid":"a40c6537-108f-4b05-8f54-2a496c777d86"}}}

{"node_key": "unique_key", "node_invalid": false}
osquery> I0206 00:59:59.496510 19962 tls.cpp:198] TLS/HTTPS POST request to URI: https://XXXXXXXXXX.us-east-2.amazonaws.com/prod/carve_init
{"block_count":"1","block_size":"100000","carve_size":"2048","carve_id":"e8beb90d-a5b3-4422-97a9-fae7000be462","request_id":"","node_key":"unique_key"}

I0206 00:59:59.519779 19962 carver.cpp:207] Failed to post carve: Request error: sslv3 alert handshake failure
```

```
I0206 01:03:56.935617 20478 tls.cpp:198] TLS/HTTPS POST request to URI: https://XXXXXXXXXX.us-east-2.amazonaws.com/prod/carve_block
{"block_id":"0","session_id":"6645JVSXO4","request_id":"","data":"...BASE64_blob..."}

I0206 01:03:56.963280 20478 carver.cpp:295] Post of carved block 0 failed: Request error: sslv3 alert handshake failure
```

This fix solves the issue and both requests are processed successfully. @jbussing can provide more info about the server-side setup in AWS.