### PR TITLE
fix windows build. Beast needs to be in include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ if(POSIX AND DEPS)
   endif()
 endif()
 
-if(FREEBSD)
+if(FREEBSD OR WINDOWS)
   # Including Boost Beast within third-party until it's merged into boot 1.66.
   include_directories("${CMAKE_SOURCE_DIR}/third-party/beast")
 endif()


### PR DESCRIPTION
On a fresh windows 10 x64 build, I am getting errors due to boost/beast/core.h not being found.
The CMakeLists.txt file already had an entry for FREEBSD to add to include path.  The chocolatey packages shows "boost-msvc-12 1.58.0" , which is pre-1.66 as indicated in the comment.  This fixes those build include errors.