### PR TITLE
fix minor leak in darwin disk_encryption generate

### DIFF
--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -86,6 +86,7 @@ Status genUnlockIdent(CFDataRef& uuid) {
     return Status(0, "ok");
   }
 
+  CFRelease(properties);
   return Status(1, "Could not get unlock ident");
 }
 
@@ -412,7 +413,6 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
   results.push_back(r);
   CFRelease(properties);
   IOObjectRelease(service);
-  CFRelease(matching_dict);
 }
 
 bool isAPFS(const QueryData& result) {

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -76,10 +76,12 @@ Status genUnlockIdent(CFDataRef& uuid) {
   if (CFDictionaryGetValueIfPresent(
           properties, CFSTR("efilogin-unlock-ident"), &unlock_ident)) {
     if (CFGetTypeID(unlock_ident) != CFDataGetTypeID()) {
+      CFRelease(properties);
       return Status(1, "Unexpected data type for unlock ident");
     }
     uuid = CFDataCreateCopy(kCFAllocatorDefault, (CFDataRef)unlock_ident);
     if (uuid == nullptr) {
+      CFRelease(properties);
       return Status(1, "Could not get UUID");
     }
     CFRelease(properties);

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -412,6 +412,7 @@ void genFDEStatusForBSDName(const std::string& bsd_name,
   results.push_back(r);
   CFRelease(properties);
   IOObjectRelease(service);
+  CFRelease(matching_dict);
 }
 
 bool isAPFS(const QueryData& result) {


### PR DESCRIPTION
Found this while looking at leaks.  Since issue #3121 is still open, can associate with that issue.
```
tools/analysis/profile.py --leaks --query "SELECT * FROM disk_encryption"
Analyzing leaks in query: SELECT * FROM disk_encryption
  definitely:  28 leaks for 2080 total leaked bytes. 

```