### PR TITLE
Adding symlink loop detection to globbing

### DIFF
--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -499,7 +499,7 @@ TEST_F(INotifyTests, test_inotify_recursion) {
   pub->configure();
 
   // Also expect canonicalized resolution (to prevent loops).
-  EXPECT_EQ(pub->path_descriptors_.size(), 11U);
+  EXPECT_EQ(pub->path_descriptors_.size(), 9U);
   RemoveAll(pub);
 
   // Remove mock directory structure.

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -360,4 +360,14 @@ Status socketExists(const boost::filesystem::path& path,
  * @return boost::filesystem::path containing the OS root location.
  */
 boost::filesystem::path getSystemRoot();
+
+/**
+ * @brief Returns the succesfully and fills d_stat if lstat was successful.
+ *
+ *
+ * On Windows systems this does not touch the structure.
+ *
+ * @return osquery::Status
+ */
+Status platformLstat(const std::string& path, struct stat& d_stat);
 }

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -285,8 +285,9 @@ static void genGlobs(std::string path,
 
     for (auto& result_path : glob_results) {
       results.push_back(result_path);
-      struct stat d_stat;
 
+      #ifndef WIN32
+      struct stat d_stat;
       if (::lstat(result_path.c_str(), &d_stat) < 0) {
         continue;
       }
@@ -311,6 +312,7 @@ static void genGlobs(std::string path,
                      << result_path;
         glob_index = kMaxRecursiveGlobs;
       }
+      #endif
     }
 
     // The end state is a non-recursive ending or empty set of matches.

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -286,7 +286,7 @@ static void genGlobs(std::string path,
     for (auto& result_path : glob_results) {
       results.push_back(result_path);
 
-      #ifndef WIN32
+#ifndef WIN32
       struct stat d_stat;
       if (::lstat(result_path.c_str(), &d_stat) < 0) {
         continue;
@@ -312,7 +312,7 @@ static void genGlobs(std::string path,
                      << result_path;
         glob_index = kMaxRecursiveGlobs;
       }
-      #endif
+#endif
     }
 
     // The end state is a non-recursive ending or empty set of matches.

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -307,10 +307,9 @@ static void genGlobs(std::string path,
       if (dsym_inos.find(d_stat.st_ino) == dsym_inos.end()) {
         dsym_inos.insert(d_stat.st_ino);
       } else {
-        LOG(WARNING) << "Recursive symlink found: " << result_path;
-        results.clear();
+        LOG(WARNING) << "Symlink loop detected possibly involving: "
+                     << result_path;
         glob_index = kMaxRecursiveGlobs;
-        break;
       }
     }
 

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -368,4 +368,11 @@ Status socketExists(const fs::path& path, bool remove_socket) {
 fs::path getSystemRoot() {
   return fs::path("/");
 }
+
+Status platformLstat(const std::string& path, struct stat& d_stat) {
+  if (::lstat(path.c_str(), &d_stat) < 0) {
+    return Status(1);
+  }
+  return Status(0);
+}
 }

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1475,4 +1475,8 @@ fs::path getSystemRoot() {
   GetWindowsDirectory(winDirectory.data(), MAX_PATH);
   return fs::path(std::string(winDirectory.data()));
 }
+
+Status platformLstat(const std::string& path, struct stat& d_stat) {
+  return Status(1);
+}
 }


### PR DESCRIPTION
This adds an extra check for symlink loops. We now keep track of all inodes of directory symlinks. If we ever encounter the same one, we may have found loop so stop globbing.