### PR TITLE
thrift: Breakout thrift and fbthrift into implementations

### DIFF
--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -12,7 +12,7 @@ if(LINUX OR DARWIN)
     add_custom_command(
       COMMAND
         LD_LIBRARY_PATH=${BUILD_DEPS}/lib:$ENV{LD_LIBRARY_PATH}
-        ${THRIFT_COMPILER} --gen mstch_cpp2:include_prefix=generated --gen py
+        ${THRIFT_COMPILER} --gen mstch_cpp2:stack_arguments,include_prefix=generated --gen py
         --templates "${BUILD_DEPS}/include/thrift/templates"
         -o "${CMAKE_BINARY_DIR}/generated"
         "${CMAKE_SOURCE_DIR}/osquery.thrift"
@@ -34,6 +34,8 @@ if(LINUX OR DARWIN)
     ADD_OSQUERY_LINK_CORE("thriftcpp2 thrift-core thriftprotocol thriftfrozen2")
     ADD_OSQUERY_LINK_CORE("transport server concurrency security protocol async")
     ADD_OSQUERY_LINK_CORE("crypto ssl")
+
+    set(THRIFT_IMPL_FILE impl_fbthrift.cpp)
   else()
     add_custom_command(
       COMMAND
@@ -44,6 +46,8 @@ if(LINUX OR DARWIN)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
       OUTPUT ${THRIFT_GENERATED_FILES}
     )
+
+    set(THRIFT_IMPL_FILE impl_thrift.cpp)
   endif()
 else()
   add_custom_command(
@@ -64,6 +68,7 @@ endif()
 
 ADD_OSQUERY_LIBRARY(TRUE osquery_extensions
   ${THRIFT_GENERATED_FILES}
+  ${THRIFT_IMPL_FILE}
   extensions.cpp
   interface.cpp
 )

--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -7,6 +7,8 @@
 #  You may select, at your option, one of the above-listed licenses.
 
 # Generate the thrift intermediate/interface code.
+set(THRIFT_IMPL_FILE impl_thrift.cpp)
+
 if(LINUX OR DARWIN)
   if(DEFINED ENV{FBTHRIFT})
     add_custom_command(
@@ -46,8 +48,6 @@ if(LINUX OR DARWIN)
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
       OUTPUT ${THRIFT_GENERATED_FILES}
     )
-
-    set(THRIFT_IMPL_FILE impl_thrift.cpp)
   endif()
 else()
   add_custom_command(

--- a/osquery/extensions/impl_fbthrift.cpp
+++ b/osquery/extensions/impl_fbthrift.cpp
@@ -1,0 +1,143 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/system.h>
+
+#include "osquery/extensions/interface.h"
+
+#include <thrift/lib/cpp/async/TAsyncSocket.h>
+#include <thrift/lib/cpp2/async/HeaderClientChannel.h>
+#include <thrift/lib/cpp2/protocol/BinaryProtocol.h>
+#include <thrift/lib/cpp2/server/ThriftServer.h>
+
+using namespace osquery::extensions;
+
+namespace osquery {
+
+using namespace apache::thrift::protocol;
+using namespace apache::thrift::transport;
+using namespace apache::thrift::server;
+using namespace apache::thrift::concurrency;
+
+typedef std::shared_ptr<AsyncProcessorFactory> TProcessorRef;
+using TThreadedServerRef = std::shared_ptr<ThriftServer>;
+
+typedef std::shared_ptr<ExtensionHandler> ExtensionHandlerRef;
+typedef std::shared_ptr<ExtensionManagerHandler> ExtensionManagerHandlerRef;
+
+struct ImpExtensionRunner {
+  TThreadedServerRef server_{nullptr};
+  TProcessorRef processor_{nullptr};
+};
+
+struct ImpExtensionManagerServer {
+  folly::EventBase base_;
+};
+
+ExtensionRunnerImpl::~ExtensionRunnerImpl() {
+  removePath(path_);
+
+  if (raw_socket_ > 0) {
+    close(raw_socket_);
+    raw_socket_ = 0;
+  }
+};
+
+ExtensionRunnerImpl::ExtensionRunnerImpl()
+    : server{std::make_unique<ImpExtensionRunner>()} {}
+
+void ExtensionRunnerImpl::serve() {
+  // Start the Thrift server's run loop.
+  server->server_->serve();
+}
+
+void ExtensionRunnerImpl::connect() {
+  server->server_ = TThreadedServerRef(new ThriftServer());
+  server->server_->setProcessorFactory(server->processor_);
+
+  raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
+  if (bind(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+    throw std::runtime_error("Cannot bind to socket");
+  }
+  server->server_->useExistingSocket(raw_socket_);
+}
+
+void ExtensionRunnerImpl::init(RouteUUID uuid) {
+  // Create the thrift instances.
+  auto handler = ExtensionHandlerRef(new ExtensionHandler(uuid));
+  server->processor_ =
+      std::make_shared<ThriftServerAsyncProcessorFactory<ExtensionHandler>>(
+          handler);
+}
+
+void ExtensionRunnerImpl::initManager() {
+  // Create the thrift instances.
+  auto handler = ExtensionManagerHandlerRef(new ExtensionManagerHandler());
+  server->processor_ = std::make_shared<
+      ThriftServerAsyncProcessorFactory<ExtensionManagerHandler>>(handler);
+}
+
+void ExtensionRunnerImpl::stopServer() {
+  // In most cases the service thread has started before the stop request.
+  if (server->server_ != nullptr) {
+    server->server_->stop();
+  }
+}
+
+void ExtensionRunnerImpl::stopServerManager() {
+  if (server->server_ != nullptr) {
+    removeStalePaths(path_);
+  }
+}
+
+EXInternal::EXInternal(const std::string& path)
+    : path_(path), server{std::make_unique<ImpExtensionManagerServer>()} {
+  raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
+  if (connect(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+    throw std::runtime_error("Cannot connect to socket");
+  }
+}
+
+EXInternal::~EXInternal() = default;
+
+void EXInternal::setTimeouts(size_t timeouts) {}
+
+EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
+  setTimeouts(timeout);
+  //client_ = std::make_shared<_Client>(HeaderClientChannel::newChannel(
+  //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
+}
+
+EXManagerClient::EXManagerClient(const std::string& manager_path,
+                                 size_t timeout)
+    : EXInternal(manager_path) {
+  setTimeouts(timeout);
+  //client_ = std::make_shared<_ManagerClient>(HeaderClientChannel::newChannel(
+  //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
+}
+
+const std::shared_ptr<_Client>& EXClient::get() const {
+  return client_;
+}
+
+const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
+  return client_;
+}
+} // namespace osquery

--- a/osquery/extensions/impl_fbthrift.cpp
+++ b/osquery/extensions/impl_fbthrift.cpp
@@ -121,7 +121,7 @@ void EXInternal::setTimeouts(size_t timeouts) {}
 
 EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
   setTimeouts(timeout);
-  //client_ = std::make_shared<_Client>(HeaderClientChannel::newChannel(
+  // client_ = std::make_shared<_Client>(HeaderClientChannel::newChannel(
   //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
 }
 
@@ -129,7 +129,7 @@ EXManagerClient::EXManagerClient(const std::string& manager_path,
                                  size_t timeout)
     : EXInternal(manager_path) {
   setTimeouts(timeout);
-  //client_ = std::make_shared<_ManagerClient>(HeaderClientChannel::newChannel(
+  // client_ = std::make_shared<_ManagerClient>(HeaderClientChannel::newChannel(
   //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
 }
 

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -161,4 +161,4 @@ const std::shared_ptr<_Client>& EXClient::get() const {
 const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
   return client_;
 }
-}
+} // namespace osquery

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -1,0 +1,164 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/system.h>
+
+#include "osquery/extensions/interface.h"
+
+#include <thrift/concurrency/ThreadManager.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/server/TThreadedServer.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#ifdef WIN32
+#include <thrift/transport/TPipe.h>
+#include <thrift/transport/TPipeServer.h>
+#else
+#include <thrift/transport/TServerSocket.h>
+#include <thrift/transport/TSocket.h>
+#endif
+
+using namespace osquery::extensions;
+
+namespace osquery {
+
+using namespace apache::thrift::protocol;
+using namespace apache::thrift::transport;
+using namespace apache::thrift::server;
+using namespace apache::thrift::concurrency;
+
+#ifdef WIN32
+typedef TPipe TPlatformSocket;
+typedef TPipeServer TPlatformServerSocket;
+typedef std::shared_ptr<TPipe> TPlatformSocketRef;
+#else
+typedef TSocket TPlatformSocket;
+typedef TServerSocket TPlatformServerSocket;
+typedef std::shared_ptr<TSocket> TPlatformSocketRef;
+#endif
+
+typedef std::shared_ptr<TTransport> TTransportRef;
+typedef std::shared_ptr<TProtocol> TProtocolRef;
+typedef std::shared_ptr<TServerTransport> TServerTransportRef;
+typedef std::shared_ptr<TProcessor> TProcessorRef;
+typedef std::shared_ptr<TTransportFactory> TTransportFactoryRef;
+typedef std::shared_ptr<TProtocolFactory> TProtocolFactoryRef;
+using TThreadedServerRef = std::shared_ptr<TThreadedServer>;
+
+typedef std::shared_ptr<ExtensionHandler> ExtensionHandlerRef;
+typedef std::shared_ptr<ExtensionManagerHandler> ExtensionManagerHandlerRef;
+
+struct ImpExtensionRunner {
+  TServerTransportRef transport_{nullptr};
+  TThreadedServerRef server_{nullptr};
+  TProcessorRef processor_{nullptr};
+};
+
+struct ImpExtensionManagerServer {
+  TPlatformSocketRef socket_;
+  TTransportRef transport_;
+  TProtocolRef protocol_;
+};
+
+ExtensionRunnerImpl::~ExtensionRunnerImpl() {
+  removePath(path_);
+};
+
+ExtensionRunnerImpl::ExtensionRunnerImpl()
+    : server{std::make_unique<ImpExtensionRunner>()} {}
+
+void ExtensionRunnerImpl::serve() {
+  // Start the Thrift server's run loop.
+  server->server_->serve();
+}
+
+void ExtensionRunnerImpl::connect() {
+  server->transport_ = TServerTransportRef(new TPlatformServerSocket(path_));
+
+  // Construct the service's transport, protocol, thread pool.
+  auto transport_fac = TTransportFactoryRef(new TBufferedTransportFactory());
+  auto protocol_fac = TProtocolFactoryRef(new TBinaryProtocolFactory());
+
+  server->server_ = TThreadedServerRef(new TThreadedServer(
+      server->processor_, server->transport_, transport_fac, protocol_fac));
+}
+
+void ExtensionRunnerImpl::init(RouteUUID uuid) {
+  // Create the thrift instances.
+  auto handler = ExtensionHandlerRef(new ExtensionHandler(uuid));
+  server->processor_ = TProcessorRef(new ExtensionProcessor(handler));
+}
+
+void ExtensionRunnerImpl::initManager() {
+  // Create the thrift instances.
+  auto handler = ExtensionManagerHandlerRef(new ExtensionManagerHandler());
+  server->processor_ = TProcessorRef(new ExtensionManagerProcessor(handler));
+}
+
+void ExtensionRunnerImpl::stopServer() {
+  // In most cases the service thread has started before the stop request.
+  if (server->server_ != nullptr) {
+    server->server_->stop();
+  }
+}
+
+void ExtensionRunnerImpl::stopServerManager() {
+  if (server->server_ != nullptr) {
+    removeStalePaths(path_);
+  }
+}
+
+EXInternal::EXInternal(const std::string& path)
+    : path_(path), server{std::make_unique<ImpExtensionManagerServer>()} {
+  server->socket_ = std::make_shared<TPlatformSocket>(path);
+  server->transport_ = std::make_shared<TBufferedTransport>(server->socket_);
+  server->protocol_ = std::make_shared<TBinaryProtocol>(server->transport_);
+}
+
+EXInternal::~EXInternal() {
+  try {
+    server->transport_->close();
+  } catch (const std::exception& /* e */) {
+    // The transport/socket may have exited.
+  }
+}
+
+void EXInternal::setTimeouts(size_t timeouts) {
+#if !defined(WIN32)
+  // Windows TPipe does not support timeouts.
+  server->socket_->setRecvTimeout(timeouts);
+  server->socket_->setSendTimeout(timeouts);
+#endif
+}
+
+EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
+  setTimeouts(timeout);
+  client_ = std::make_shared<_Client>(server->protocol_);
+  (void)server->transport_->open();
+}
+
+EXManagerClient::EXManagerClient(const std::string& manager_path,
+                                 size_t timeout)
+    : EXInternal(manager_path) {
+  setTimeouts(timeout);
+  client_ = std::make_shared<_ManagerClient>(server->protocol_);
+  (void)server->transport_->open();
+}
+
+const std::shared_ptr<_Client>& EXClient::get() const {
+  return client_;
+}
+
+const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
+  return client_;
+}
+}

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -37,36 +37,28 @@ void ExtensionHandler::ping(ExtensionStatus& _return) {
   _return.uuid = uuid_;
 }
 
-#ifdef FBTHRIFT
-#define GP(x) *x
-#define GI(x, k) x->k
-#else
-#define GP(x) x
-#define GI(x, k) x.k
-#endif
-
 void ExtensionHandler::call(ExtensionResponse& _return,
-                            _str_param registry,
-                            _str_param item,
-                            _plugin_param request) {
+                            const std::string& registry,
+                            const std::string& item,
+                            const ExtensionPluginRequest& request) {
   // Call will receive an extension or core's request to call the other's
   // internal registry call. It is the ONLY actor that resolves registry
   // item aliases.
-  auto local_item = RegistryFactory::get().getAlias(GP(registry), GP(item));
+  auto local_item = RegistryFactory::get().getAlias(registry, item);
   if (local_item.empty()) {
     // Extensions may not know about active (non-option based registries).
-    local_item = RegistryFactory::get().getActive(GP(registry));
+    local_item = RegistryFactory::get().getActive(registry);
   }
 
   PluginResponse response;
   PluginRequest plugin_request;
-  for (const auto& request_item : GP(request)) {
+  for (const auto& request_item : request) {
     // Create a PluginRequest from an ExtensionPluginRequest.
     plugin_request[request_item.first] = request_item.second;
   }
 
   auto status =
-      RegistryFactory::call(GP(registry), local_item, plugin_request, response);
+      RegistryFactory::call(registry, local_item, plugin_request, response);
   _return.status.code = status.getCode();
   _return.status.message = status.getMessage();
   _return.status.uuid = uuid_;
@@ -98,7 +90,7 @@ void thriftLoggingOutput(const char* msg) {
 }
 
 ExtensionManagerHandler::ExtensionManagerHandler() {
-  GlobalOutput.setOutputFunction(thriftLoggingOutput);
+  apache::thrift::GlobalOutput.setOutputFunction(thriftLoggingOutput);
 }
 
 void ExtensionManagerHandler::extensions(InternalExtensionList& _return) {
@@ -117,12 +109,13 @@ void ExtensionManagerHandler::options(InternalOptionList& _return) {
   }
 }
 
-void ExtensionManagerHandler::registerExtension(ExtensionStatus& _return,
-                                                _info_param info,
-                                                _registry_param registry) {
-  if (exists(GI(info, name))) {
+void ExtensionManagerHandler::registerExtension(
+    ExtensionStatus& _return,
+    const InternalExtensionInfo& info,
+    const ExtensionRegistry& registry) {
+  if (exists(info.name)) {
     LOG(WARNING) << "Refusing to register duplicate extension "
-                 << GI(info, name);
+                 << info.name;
     _return.code = (int)ExtensionCode::EXT_FAILED;
     _return.message = "Duplicate extension registered";
     return;
@@ -130,9 +123,9 @@ void ExtensionManagerHandler::registerExtension(ExtensionStatus& _return,
 
   // Enforce API change requirements.
   for (const auto& change : kSDKVersionChanges) {
-    if (!versionAtLeast(change, GI(info, sdk_version))) {
-      LOG(WARNING) << "Could not add extension " << GI(info, name)
-                   << ": incompatible extension SDK " << GI(info, sdk_version);
+    if (!versionAtLeast(change, info.sdk_version)) {
+      LOG(WARNING) << "Could not add extension " << info.name
+                   << ": incompatible extension SDK " << info.sdk_version;
       _return.code = (int)ExtensionCode::EXT_FAILED;
       _return.message = "Incompatible extension SDK version";
       return;
@@ -146,13 +139,13 @@ void ExtensionManagerHandler::registerExtension(ExtensionStatus& _return,
   }
   // Every call to registerExtension is assigned a new RouteUUID.
   RouteUUID uuid = static_cast<uint16_t>(rand());
-  VLOG(1) << "Registering extension (" << GI(info, name) << ", " << uuid
-          << ", version=" << GI(info, version)
-          << ", sdk=" << GI(info, sdk_version) << ")";
+  VLOG(1) << "Registering extension (" << info.name << ", " << uuid
+          << ", version=" << info.version
+          << ", sdk=" << info.sdk_version << ")";
 
-  auto status = RegistryFactory::get().addBroadcast(uuid, GP(registry));
+  auto status = RegistryFactory::get().addBroadcast(uuid, registry);
   if (!status.ok()) {
-    LOG(WARNING) << "Could not add extension " << GI(info, name) << ": "
+    LOG(WARNING) << "Could not add extension " << info.name << ": "
                  << status.getMessage();
     _return.code = (int)ExtensionCode::EXT_FAILED;
     _return.message = "Failed adding registry: " + status.getMessage();
@@ -160,7 +153,7 @@ void ExtensionManagerHandler::registerExtension(ExtensionStatus& _return,
   }
 
   WriteLock lock(extensions_mutex_);
-  extensions_[uuid] = GP(info);
+  extensions_[uuid] = info;
   _return.code = (int)ExtensionCode::EXT_SUCCESS;
   _return.message = "OK";
   _return.uuid = uuid;
@@ -188,9 +181,9 @@ void ExtensionManagerHandler::deregisterExtension(
 }
 
 void ExtensionManagerHandler::query(ExtensionResponse& _return,
-                                    _str_param sql) {
+                                    const std::string& sql) {
   QueryData results;
-  auto status = osquery::query(GP(sql), results);
+  auto status = osquery::query(sql, results);
   _return.status.code = status.getCode();
   _return.status.message = status.getMessage();
   _return.status.uuid = uuid_;
@@ -203,9 +196,9 @@ void ExtensionManagerHandler::query(ExtensionResponse& _return,
 }
 
 void ExtensionManagerHandler::getQueryColumns(ExtensionResponse& _return,
-                                              _str_param sql) {
+                                              const std::string& sql) {
   TableColumns columns;
-  auto status = osquery::getQueryColumns(GP(sql), columns);
+  auto status = osquery::getQueryColumns(sql, columns);
   _return.status.code = status.getCode();
   _return.status.message = status.getMessage();
   _return.status.uuid = uuid_;
@@ -250,39 +243,7 @@ bool ExtensionManagerHandler::exists(const std::string& name) {
 }
 } // namespace extensions
 
-ExtensionRunner::ExtensionRunner(const std::string& manager_path,
-                                 RouteUUID uuid)
-    : ExtensionRunnerCore(""), uuid_(uuid) {
-  path_ = getExtensionSocket(uuid, manager_path);
-}
-
-ExtensionRunnerCore::~ExtensionRunnerCore() {
-  removePath(path_);
-
-#ifdef FBTHRIFT
-  if (raw_socket_ > 0) {
-    close(raw_socket_);
-    raw_socket_ = 0;
-  }
-#endif
-}
-
-void ExtensionRunnerCore::stop() {
-  {
-    WriteLock lock(service_start_);
-    service_stopping_ = true;
-    if (transport_ != nullptr) {
-      // This is an opportunity to interrupt the transport listens.
-    }
-  }
-
-  // In most cases the service thread has started before the stop request.
-  if (server_ != nullptr) {
-    server_->stop();
-  }
-}
-
-inline void removeStalePaths(const std::string& manager) {
+void removeStalePaths(const std::string& manager) {
   std::vector<std::string> paths;
   // Attempt to remove all stale extension sockets.
   resolveFilePattern(manager + ".*", paths);
@@ -291,7 +252,23 @@ inline void removeStalePaths(const std::string& manager) {
   }
 }
 
-void ExtensionRunnerCore::startServer(TProcessorRef processor) {
+ExtensionRunnerCore::~ExtensionRunnerCore() = default;
+
+ExtensionRunnerCore::ExtensionRunnerCore(const std::string& path)
+    : InternalRunnable("ExtensionRunnerCore"), ExtensionRunnerImpl() {
+  path_ = path;
+}
+
+void ExtensionRunnerCore::stop() {
+  {
+    WriteLock lock(service_start_);
+    service_stopping_ = true;
+  }
+
+  stopServer();
+}
+
+void ExtensionRunnerCore::startServer() {
   {
     WriteLock lock(service_start_);
     // A request to stop the service may occur before the thread starts.
@@ -299,41 +276,22 @@ void ExtensionRunnerCore::startServer(TProcessorRef processor) {
       return;
     }
 
-#if !defined(FBTHRIFT)
-    transport_ = TServerTransportRef(new TPlatformServerSocket(path_));
-#endif
-
     if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
       // Before starting and after stopping the manager, remove stale sockets.
       // This is not relevant in Windows
       removeStalePaths(path_);
     }
 
-#ifdef FBTHRIFT
-    server_ = TThreadedServerRef(new ThriftServer());
-    server_->setProcessorFactory(processor);
-
-    raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
-    struct sockaddr_un addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
-    if (bind(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-      throw std::runtime_error("Cannot bind to socket");
-    }
-    server_->useExistingSocket(raw_socket_);
-#else
-    // Construct the service's transport, protocol, thread pool.
-    auto transport_fac = TTransportFactoryRef(new TBufferedTransportFactory());
-    auto protocol_fac = TProtocolFactoryRef(new TBinaryProtocolFactory());
-
-    server_ = TThreadedServerRef(new TThreadedServer(
-        processor, transport_, transport_fac, protocol_fac));
-#endif
+    connect();
   }
 
-  // Start the Thrift server's run loop.
-  server_->serve();
+  serve();
+}
+
+ExtensionRunner::ExtensionRunner(const std::string& manager_path,
+                                 RouteUUID uuid)
+    : ExtensionRunnerCore(""), uuid_(uuid) {
+  path_ = getExtensionSocket(uuid, manager_path);
 }
 
 RouteUUID ExtensionRunner::getUUID() const {
@@ -341,116 +299,37 @@ RouteUUID ExtensionRunner::getUUID() const {
 }
 
 void ExtensionRunner::start() {
-  // Create the thrift instances.
-  auto handler = ExtensionHandlerRef(new ExtensionHandler(uuid_));
-#ifdef FBTHRIFT
-  auto processor =
-      std::make_shared<ThriftServerAsyncProcessorFactory<ExtensionHandler>>(
-          handler);
-#else
-  auto processor = TProcessorRef(new ExtensionProcessor(handler));
-#endif
+  init(uuid_);
 
   VLOG(1) << "Extension service starting: " << path_;
   try {
-    startServer(processor);
+    startServer();
   } catch (const std::exception& e) {
     LOG(ERROR) << "Cannot start extension handler: " << path_ << " ("
                << e.what() << ")";
   }
 }
 
+ExtensionManagerRunner::ExtensionManagerRunner(const std::string& manager_path)
+    : ExtensionRunnerCore(manager_path) {}
+
 ExtensionManagerRunner::~ExtensionManagerRunner() {
   // Only attempt to remove stale paths if the server was started.
   WriteLock lock(service_start_);
-  if (server_ != nullptr) {
-    removeStalePaths(path_);
-  }
+  stopServerManager();
 }
 
 void ExtensionManagerRunner::start() {
-  // Create the thrift instances.
-  auto handler = ExtensionManagerHandlerRef(new ExtensionManagerHandler());
-#ifdef FBTHRIFT
-  auto processor = std::make_shared<
-      ThriftServerAsyncProcessorFactory<ExtensionManagerHandler>>(handler);
-#else
-  auto processor = TProcessorRef(new ExtensionManagerProcessor(handler));
-#endif
+  initManager();
 
   VLOG(1) << "Extension manager service starting: " << path_;
   try {
-    startServer(processor);
+    startServer(/*processor*/);
   } catch (const std::exception& e) {
     LOG(WARNING) << "Extensions disabled: cannot start extension manager ("
                  << path_ << ") (" << e.what() << ")";
   }
 }
 
-EXInternal::EXInternal(const std::string& path) : path_(path) {
-#ifdef FBTHRIFT
-  raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
-  struct sockaddr_un addr;
-  memset(&addr, 0, sizeof(addr));
-  addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
-  if (connect(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-    throw std::runtime_error("Cannot connect to socket");
-  }
-#else
-  socket_ = std::make_shared<TPlatformSocket>(path);
-  transport_ = std::make_shared<TBufferedTransport>(socket_);
-  protocol_ = std::make_shared<TBinaryProtocol>(transport_);
-#endif
-}
 
-EXInternal::~EXInternal() {
-#if !defined(FBTHRIFT)
-  try {
-    transport_->close();
-  } catch (const std::exception& /* e */) {
-    // The transport/socket may have exited.
-  }
-#endif
-}
-
-void EXInternal::setTimeouts(size_t timeouts) {
-#if !defined(WIN32) && !defined(FBTHRIFT)
-  // Windows TPipe does not support timeouts.
-  socket_->setRecvTimeout(timeouts);
-  socket_->setSendTimeout(timeouts);
-#endif
-}
-
-EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
-  setTimeouts(timeout);
-#ifdef FBTHRIFT
-  client_ = std::make_shared<_Client>(HeaderClientChannel::newChannel(
-      async::TAsyncSocket::newSocket(&base_, raw_socket_)));
-#else
-  client_ = std::make_shared<_Client>(protocol_);
-  (void)transport_->open();
-#endif
-}
-
-EXManagerClient::EXManagerClient(const std::string& manager_path,
-                                 size_t timeout)
-    : EXInternal(manager_path) {
-  setTimeouts(timeout);
-#ifdef FBTHRIFT
-  client_ = std::make_shared<_ManagerClient>(HeaderClientChannel::newChannel(
-      async::TAsyncSocket::newSocket(&base_, raw_socket_)));
-#else
-  client_ = std::make_shared<_ManagerClient>(protocol_);
-  (void)transport_->open();
-#endif
-}
-
-const std::shared_ptr<_Client>& EXClient::get() const {
-  return client_;
-}
-
-const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
-  return client_;
-}
 } // namespace osquery

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -114,8 +114,7 @@ void ExtensionManagerHandler::registerExtension(
     const InternalExtensionInfo& info,
     const ExtensionRegistry& registry) {
   if (exists(info.name)) {
-    LOG(WARNING) << "Refusing to register duplicate extension "
-                 << info.name;
+    LOG(WARNING) << "Refusing to register duplicate extension " << info.name;
     _return.code = (int)ExtensionCode::EXT_FAILED;
     _return.message = "Duplicate extension registered";
     return;
@@ -140,8 +139,8 @@ void ExtensionManagerHandler::registerExtension(
   // Every call to registerExtension is assigned a new RouteUUID.
   RouteUUID uuid = static_cast<uint16_t>(rand());
   VLOG(1) << "Registering extension (" << info.name << ", " << uuid
-          << ", version=" << info.version
-          << ", sdk=" << info.sdk_version << ")";
+          << ", version=" << info.version << ", sdk=" << info.sdk_version
+          << ")";
 
   auto status = RegistryFactory::get().addBroadcast(uuid, registry);
   if (!status.ok()) {


### PR DESCRIPTION
There's no real change here (unless I introduced a regression). This breaks out the FBThrift and Thrift implementations into two files. This way we can sync the FBThrift without references to the older Thrift headers/structures.