### PR TITLE
Fix issue [#4123] MSVC Permissive Error

### DIFF
--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -21,8 +21,9 @@ namespace tables {
 QueryData genBitlockerInfo(QueryContext& context) {
   Row r;
   QueryData results;
-  WmiRequest wmiSystemReq("SELECT * FROM Win32_EncryptableVolume",
-                          (BSTR)L"ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption");
+  WmiRequest wmiSystemReq(
+      "SELECT * FROM Win32_EncryptableVolume",
+      (BSTR)L"ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption");
   std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (!wmiResults.empty()) {
     long protectionstatus = 0;

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -22,7 +22,7 @@ QueryData genBitlockerInfo(QueryContext& context) {
   Row r;
   QueryData results;
   WmiRequest wmiSystemReq("SELECT * FROM Win32_EncryptableVolume",
-                          L"ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption");
+                          (BSTR)L"ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption");
   std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (!wmiResults.empty()) {
     long protectionstatus = 0;


### PR DESCRIPTION
Our new bitlocker table created a regressions with the MSVC permissive flags. The easy fix is to cast the L string to a BSTR.