### PR TITLE
Add additional user attributes for macOS platforms

### DIFF
--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -11,8 +11,6 @@
 #import <OpenDirectory/OpenDirectory.h>
 #include <membership.h>
 
-#include "osquery/core/conversions.h"
-#include "osquery/sql/sqlite_util.h"
 #include "osquery/tables/system/user_groups.h"
 
 namespace pt = boost::property_tree;
@@ -190,6 +188,7 @@ QueryData genUsers(QueryContext &context) {
       if (pwd == nullptr) {
         continue;
       }
+
       Row r;
       r["uid"] = BIGINT(uid);
       r["username"] = std::string(pwd->pw_name);
@@ -205,6 +204,7 @@ QueryData genUsers(QueryContext &context) {
       if (pwd == nullptr) {
         continue;
       }
+
       Row r;
       r["uid"] = BIGINT(pwd->pw_uid);
       r["username"] = username;

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -142,29 +142,31 @@ QueryData genGroups(QueryContext &context) {
 }
 
 void setRow(Row& r, passwd* pwd, boost::property_tree::ptree& tree) {
-  boost::optional<std::string> creationTime =
-      tree.get_optional<std::string>("creationTime");
-  boost::optional<std::string> failedLoginCount =
-      tree.get_optional<std::string>("failedLoginCount");
-  boost::optional<std::string> failedLoginTimestamp =
-      tree.get_optional<std::string>("failedLoginTimestamp");
-  boost::optional<std::string> passwordLastSetTime =
-      tree.get_optional<std::string>("passwordLastSetTime");
-
-  r["creation_time"] = creationTime ? creationTime.get() : DOUBLE(0);
-  r["failed_login_count"] =
-      failedLoginCount ? failedLoginCount.get() : BIGINT(0);
-  r["failed_login_timestamp"] =
-      failedLoginTimestamp ? failedLoginTimestamp.get() : DOUBLE(0);
-  r["password_last_set_time"] =
-      passwordLastSetTime ? passwordLastSetTime.get() : DOUBLE(0);
-
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
   r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
   r["description"] = TEXT(pwd->pw_gecos);
   r["directory"] = TEXT(pwd->pw_dir);
   r["shell"] = TEXT(pwd->pw_shell);
+
+  if (auto creationTime = tree.get_optional<std::string>("creationTime")) {
+    r["creation_time"] = creationTime.get();
+  }
+
+  if (auto failedLoginCount =
+          tree.get_optional<std::string>("failedLoginCount")) {
+    r["failed_login_count"] = failedLoginCount.get();
+  }
+
+  if (auto failedLoginTimestamp =
+          tree.get_optional<std::string>("failedLoginTimestamp")) {
+    r["failed_login_timestamp"] = failedLoginTimestamp.get();
+  }
+
+  if (auto passwordLastSetTime =
+          tree.get_optional<std::string>("passwordLastSetTime")) {
+    r["password_last_set_time"] = passwordLastSetTime.get();
+  }
 
   uuid_t uuid = {0};
   uuid_string_t uuid_string = {0};
@@ -180,7 +182,6 @@ void setRow(Row& r, passwd* pwd, boost::property_tree::ptree& tree) {
 
 QueryData genUsers(QueryContext &context) {
   QueryData results;
-  pt::ptree tree;
   if (context.constraints["uid"].exists(EQUALS)) {
     auto uids = context.constraints["uid"].getAll<long long>(EQUALS);
     for (const auto &uid : uids) {
@@ -190,6 +191,7 @@ QueryData genUsers(QueryContext &context) {
       }
 
       Row r;
+      pt::ptree tree;
       r["uid"] = BIGINT(uid);
       r["username"] = std::string(pwd->pw_name);
       genPolicyColumns(uid, tree);
@@ -206,6 +208,7 @@ QueryData genUsers(QueryContext &context) {
       }
 
       Row r;
+      pt::ptree tree;
       r["uid"] = BIGINT(pwd->pw_uid);
       r["username"] = username;
       genPolicyColumns(pwd->pw_uid, tree);

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -64,6 +64,7 @@ void genPolicyColumns(int uid, boost::property_tree::ptree& tree) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory node: "
            << std::string([[err localizedDescription] UTF8String]);
+      return;
     }
 
     ODQuery* q = [ODQuery queryWithNode:root
@@ -92,11 +93,22 @@ void genPolicyColumns(int uid, boost::property_tree::ptree& tree) {
         TLOG << "Error with OpenDirectory attribute: "
              << std::string([[err localizedDescription] UTF8String]);
       } else {
-        NSData* userPlistData =
+        NSArray* userPolicyDataValues =
             [re valuesForAttribute:@"dsAttrTypeNative:accountPolicyData"
-                             error:nil][0];
+                             error:&err];
+
+        if (err != nullptr) {
+          TLOG << "Error with OpenDirectory attribute data: "
+               << std::string([[err localizedDescription] UTF8String]);
+          continue;
+        }
+
+        if (![userPolicyDataValues count]) {
+          continue;
+        }
+
         std::string userPlistString =
-            [[[NSString alloc] initWithData:userPlistData
+            [[[NSString alloc] initWithData:userPolicyDataValues[0]
                                    encoding:NSUTF8StringEncoding] UTF8String];
 
         if (userPlistString.empty()) {

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -77,6 +77,7 @@ void genPolicyColumns(int uid, boost::property_tree::ptree& tree) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory query: "
            << std::string([[err localizedDescription] UTF8String]);
+      return;
     }
 
     // Obtain the results synchronously, not good for very large sets.
@@ -151,22 +152,22 @@ void setRow(Row& r, passwd* pwd, boost::property_tree::ptree& tree) {
   r["shell"] = TEXT(pwd->pw_shell);
 
   if (auto creationTime = tree.get_optional<std::string>("creationTime")) {
-    r["creation_time"] = creationTime.get();
+    r["creation_time"] = DOUBLE(creationTime.get());
   }
 
   if (auto failedLoginCount =
           tree.get_optional<std::string>("failedLoginCount")) {
-    r["failed_login_count"] = failedLoginCount.get();
+    r["failed_login_count"] = BIGINT(failedLoginCount.get());
   }
 
   if (auto failedLoginTimestamp =
           tree.get_optional<std::string>("failedLoginTimestamp")) {
-    r["failed_login_timestamp"] = failedLoginTimestamp.get();
+    r["failed_login_timestamp"] = DOUBLE(failedLoginTimestamp.get());
   }
 
   if (auto passwordLastSetTime =
           tree.get_optional<std::string>("passwordLastSetTime")) {
-    r["password_last_set_time"] = passwordLastSetTime.get();
+    r["password_last_set_time"] = DOUBLE(passwordLastSetTime.get());
   }
 
   uuid_t uuid = {0};

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -84,6 +84,7 @@ void genPolicyColumns(int uid, boost::property_tree::ptree& tree) {
     if (err != nullptr) {
       TLOG << "Error with OpenDirectory results: "
            << std::string([[err localizedDescription] UTF8String]);
+      return;
     }
     for (ODRecord* re in od_results) {
       if (err != nullptr) {

--- a/specs/users.table
+++ b/specs/users.table
@@ -14,6 +14,12 @@ schema([
 extended_schema(WINDOWS, [
     Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),
 ])
+extended_schema(DARWIN, [
+    Column("creation_time", DOUBLE, "When the account was first created (Apple)"),
+    Column("failed_login_count", BIGINT, "The number of times the user failed to login with the correct password. Resets after a correct password is entered (Apple)"),
+    Column("failed_login_timestamp", DOUBLE, "The time of the last failed login attempt. Resets after a correct password is entered (Apple)"),
+    Column("password_last_set_time", DOUBLE, "The time the password was last changed (Apple)"),
+])
 implementation("users@genUsers")
 examples([
   "select * from users where uid = 1000",


### PR DESCRIPTION
This pull request adds additional columns to the users table (using the `extended_schema` capability) for "fully-fledged" users that login to the GUI.

### What is being added?

Here are the new fields in the user table spec

```
extended_schema(DARWIN, [
  Column("creation_time", DOUBLE, "When the account was first created (Apple)"),
  Column("failed_login_count", BIGINT, "The number of times the user failed to login with the correct password. Resets after a correct password is entered (Apple)"),
  Column("failed_login_timestamp", DOUBLE, "The time of the last failed login attempt. Resets after a correct password is entered (Apple)"),
  Column("password_last_set_time", DOUBLE, "The time the password was last changed (Apple)"),
])
```

### Why?
Many of the fields are useful for mac admins looking to detect password rotation on macOS accounts, detect newly created accounts on old computers, and accounts that could be locked out for too many failed password attempts.

