### PR TITLE
Fix JSON output from --json

### DIFF
--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -137,7 +137,6 @@ void jsonPrint(const QueryData& q) {
     std::string row_string;
 
     if (serializeRowJSON(q[i], row_string).ok()) {
-      row_string.pop_back();
       printf("  %s", row_string.c_str());
       if (i < q.size() - 1) {
         printf(",\n");

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -191,7 +191,10 @@ class OsqueryiTest(unittest.TestCase):
             ],
             SHELL_TIMEOUT
         )
-        self.assertEqual(proc.stdout, "[\n  {\"0\":\"0\"}\n]\n")
+        if os.name == "nt":
+            self.assertEqual(proc.stdout, "[\r\n  {\"0\":\"0\"}\r\n]\r\n")
+        else:
+            self.assertEqual(proc.stdout, "[\n  {\"0\":\"0\"}\n]\n")
         print(proc.stdout)
         print(proc.stderr)
         self.assertEqual(proc.proc.poll(), 0)

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -181,6 +181,21 @@ class OsqueryiTest(unittest.TestCase):
             result = self.osqueryi.run_command(command)
         pass
 
+    def test_json_output(self):
+        '''Test that the output of --json is valid json'''
+        proc = test_base.TimeoutRunner([
+            self.binary,
+            "select 0",
+            "--disable_extensions",
+            "--json",
+            ],
+            SHELL_TIMEOUT
+        )
+        self.assertEqual(proc.stdout, "[\n  {\"0\":\"0\"}\n]\n")
+        print(proc.stdout)
+        print(proc.stderr)
+        self.assertEqual(proc.proc.poll(), 0)
+
     @test_base.flaky
     def test_time(self):
         '''Demonstrating basic usage of OsqueryWrapper with the time table'''


### PR DESCRIPTION
There is bug in the current implementation of the json printer. The old ptree representation meant we needed to pop the last character of the string to make the JSON valid but now that we have a proper JSON library, it's removing the final brace. 

This diff fixes that.

Existing output:
```
➜  osquery git:(fix_json) ✗ osqueryi --version
osqueryi version 3.1.0-22-ge421c398
➜  osquery git:(fix_json) ✗ osqueryi 'select 0' --json --disable_extensions
[
  {"0":"0"
]
```

Fixed output:
```
➜  osquery git:(fix_json) ✗ ./build/darwin/osquery/osqueryi --version
osqueryi version 3.1.0-25-gd09c3eeb
➜  osquery git:(fix_json) ✗ ./build/darwin/osquery/osqueryi 'select 0' --disable_extensions --json
[
  {"0":"0"}
]
```