### PR TITLE
Add quarantine_history table for Darwin platform

### DIFF
--- a/osquery/tables/system/darwin/quarantined_history.cpp
+++ b/osquery/tables/system/darwin/quarantined_history.cpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/sql/sqlite_util.h"
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+namespace osquery {
+namespace tables {
+
+// Path (after /Users/foo) where the quarantine events DB will be found
+const std::string kQuarantineEventsDbPath =
+    "Library/Preferences/com.apple.LaunchServices.QuarantineEventsV2";
+
+void genQuarantineEventRow(sqlite3_stmt* const stmt,
+                           std::string username,
+                           Row& r) {
+  for (int i = 0; i < sqlite3_column_count(stmt); i++) {
+    auto column_name = std::string(sqlite3_column_name(stmt, i));
+    auto column_type = sqlite3_column_type(stmt, i);
+    if (column_type == SQLITE_TEXT) {
+      auto value = sqlite3_column_text(stmt, i);
+      if (value != nullptr) {
+        r[column_name] = std::string(reinterpret_cast<const char*>(value));
+      }
+    } else if (column_type == SQLITE_FLOAT) {
+      auto value = sqlite3_column_double(stmt, i);
+      r[column_name] = DOUBLE(value);
+    } else if (column_type == SQLITE_INTEGER) {
+      auto value = sqlite3_column_int(stmt, i);
+      r[column_name] = INTEGER(value);
+    }
+  }
+  r["username"] = TEXT(username);
+}
+
+void genQuarantineHistoryItems(const fs::path& qepath,
+                               std::string username,
+                               QueryData& results) {
+  sqlite3* db = nullptr;
+
+  try {
+    if (!fs::exists(qepath)) {
+      return;
+    }
+  } catch (const boost::filesystem::filesystem_error) {
+    return;
+  }
+
+  auto rc = sqlite3_open_v2(
+      qepath.c_str(),
+      &db,
+      (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
+      nullptr);
+  if (rc != SQLITE_OK || db == nullptr) {
+    VLOG(1) << "Cannot open Quarantine Events DB: " << rc << " "
+            << getStringForSQLiteReturnCode(rc);
+    if (db != nullptr) {
+      sqlite3_close(db);
+    }
+  }
+
+  const std::string query =
+      "SELECT LSQuarantineEventIdentifier as id, LSQuarantineAgentName as "
+      "agent_name, LSQuarantineAgentBundleIdentifier as "
+      "agent_bundle_identifier, LSQuarantineTypeNumber as type,  "
+      "LSQuarantineDataURLString as data_url,LSQuarantineOriginURLString as "
+      "origin_url, LSQuarantineSenderName as sender_name, "
+      "LSQuarantineSenderAddress as sender_address from LSQuarantineEvent";
+  sqlite3_stmt* stmt = nullptr;
+  rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+  while ((sqlite3_step(stmt)) == SQLITE_ROW) {
+    Row r;
+    genQuarantineEventRow(stmt, username, r);
+    results.push_back(r);
+  }
+
+  // Clean up.
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+}
+
+QueryData genQuarantineHistory(QueryContext& context) {
+  QueryData results;
+
+  // Get the quarantine events for each user.
+  auto users = SQL::selectAllFrom("users");
+  for (const auto& user : users) {
+    auto qepath = fs::path(user.at("directory")) / kQuarantineEventsDbPath;
+    genQuarantineHistoryItems(qepath.string(), user.at("username"), results);
+  }
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/quarantined_history.cpp
+++ b/osquery/tables/system/darwin/quarantined_history.cpp
@@ -21,7 +21,6 @@
 #include "osquery/sql/sqlite_util.h"
 
 namespace fs = boost::filesystem;
-namespace pt = boost::property_tree;
 
 namespace osquery {
 namespace tables {

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -86,7 +86,10 @@ QueryData genGroups(QueryContext &context) {
   return results;
 }
 
-void setRow(Row &r, passwd *pwd) {
+void genUser(const struct passwd* pwd, QueryData& results) {
+  Row r;
+  r["uid"] = BIGINT(pwd->pw_uid);
+  r["username"] = std::string(pwd->pw_name);
   r["gid"] = BIGINT(pwd->pw_gid);
   r["uid_signed"] = BIGINT((int32_t)pwd->pw_uid);
   r["gid_signed"] = BIGINT((int32_t)pwd->pw_gid);
@@ -104,6 +107,7 @@ void setRow(Row &r, passwd *pwd) {
 
   uuid_unparse(uuid, uuid_string);
   r["uuid"] = TEXT(uuid_string);
+  results.push_back(r);
 }
 
 QueryData genUsers(QueryContext &context) {
@@ -115,12 +119,16 @@ QueryData genUsers(QueryContext &context) {
       if (pwd == nullptr) {
         continue;
       }
-
-      Row r;
-      r["uid"] = BIGINT(uid);
-      r["username"] = std::string(pwd->pw_name);
-      setRow(r, pwd);
-      results.push_back(r);
+      genUser(pwd, results);
+    }
+  } else if (context.constraints["username"].exists(EQUALS)) {
+    auto usernames = context.constraints["username"].getAll(EQUALS);
+    for (const auto& username : usernames) {
+      struct passwd* pwd = getpwnam(username.c_str());
+      if (pwd == nullptr) {
+        continue;
+      }
+      genUser(pwd, results);
     }
   } else {
     std::set<std::string> usernames;
@@ -130,12 +138,7 @@ QueryData genUsers(QueryContext &context) {
       if (pwd == nullptr) {
         continue;
       }
-
-      Row r;
-      r["uid"] = BIGINT(pwd->pw_uid);
-      r["username"] = username;
-      setRow(r, pwd);
-      results.push_back(r);
+      genUser(pwd, results);
     }
   }
   return results;

--- a/specs/darwin/quarantine_history.table
+++ b/specs/darwin/quarantine_history.table
@@ -9,6 +9,7 @@ schema([
     Column("origin_url", TEXT, "The URL of the resource originally hosting the quarantined item, from the user's point of view"),
     Column("sender_name", TEXT, "The full name or username of the invidual sending the quarantined file when available (for email attachments and files sent via Airdrop)"),
     Column("sender_address", TEXT, "The email address of the invidual sending the quarantined file"),
+    Column("timestamp", DOUBLE, "The time the quarantining agent created the quarantine event"),
     Column("username", TEXT, "The user associated with the quarantine event")
 ])
 implementation("quarantine_history@genQuarantineHistory")

--- a/specs/darwin/quarantine_history.table
+++ b/specs/darwin/quarantine_history.table
@@ -1,0 +1,14 @@
+table_name("quarantine_history")
+description("OS X Quarantine Events (downloaded/streamed files).")
+schema([
+    Column("id", TEXT, "Quarantine event ID (matches ID in quarantined file's extended attributes"),
+    Column("agent_name", TEXT, "The name of the quarantining agent (application or program)"),
+    Column("agent_bundle_identifier", TEXT, "The bundle identifier of the quarantining agent, if available"),
+    Column("type", INTEGER, "A symbolic string identifying the why the item is quarantined, if available. 0 = Web Download, 1 = Other Download, 2 = Email Attachement, 3 = Instant Message Attachment, 4 = Calendar Event Attachment, 5 = Other Attachment, 6 = Airdrop Attachment"),
+    Column("data_url", TEXT, "The URL from which the data for the quarantined item data was actaully streamed or downloaded, if available"),
+    Column("origin_url", TEXT, "The URL of the resource originally hosting the quarantined item, from the user's point of view"),
+    Column("sender_name", TEXT, "The full name or username of the invidual sending the quarantined file when available (for email attachments and files sent via Airdrop)"),
+    Column("sender_address", TEXT, "The email address of the invidual sending the quarantined file"),
+    Column("username", TEXT, "The user associated with the quarantine event")
+])
+implementation("quarantine_history@genQuarantineHistory")

--- a/specs/darwin/quarantine_history.table
+++ b/specs/darwin/quarantine_history.table
@@ -1,7 +1,8 @@
 table_name("quarantine_history")
 description("OS X Quarantine Events (downloaded/streamed files).")
 schema([
-    Column("id", TEXT, "Quarantine event ID (matches ID in quarantined file's extended attributes"),
+    Column("uid", BIGINT, "The user associated with the quarantine event", additional=True),
+    Column("id", TEXT, "Quarantine event ID (matches ID in quarantined file's extended attributes", index=True),
     Column("agent_name", TEXT, "The name of the quarantining agent (application or program)"),
     Column("agent_bundle_identifier", TEXT, "The bundle identifier of the quarantining agent, if available"),
     Column("type", INTEGER, "A symbolic string identifying the why the item is quarantined, if available. 0 = Web Download, 1 = Other Download, 2 = Email Attachement, 3 = Instant Message Attachment, 4 = Calendar Event Attachment, 5 = Other Attachment, 6 = Airdrop Attachment"),
@@ -10,6 +11,10 @@ schema([
     Column("sender_name", TEXT, "The full name or username of the invidual sending the quarantined file when available (for email attachments and files sent via Airdrop)"),
     Column("sender_address", TEXT, "The email address of the invidual sending the quarantined file"),
     Column("timestamp", DOUBLE, "The time the quarantining agent created the quarantine event"),
-    Column("username", TEXT, "The user associated with the quarantine event")
+    ForeignKey(column="uid", table="users"),
 ])
+attributes(user_data=True)
 implementation("quarantine_history@genQuarantineHistory")
+examples([
+    "select * from users join quarantine_history using (uid)",
+])


### PR DESCRIPTION
## What

This PR adds a new macOS virtual table called `quarantine_history` table that enumerates a log of quarantine events. These events describe times when an application (like a web browser or an email client) has added quarantine extended attributes to a file.

Depending on a few factors, a quarantined file will produce a warning after a user opens it but before it actually executes, warning them the file came from the an untrusted source (usually the web).

When agents/apps quarantine a file, macOS maintains an internal log of this event which can include information such as the URL a file was downloaded from, the application that quarantined it, etc. Entries in this log persist even after the file itself has been deleted.

## Why?
The table will enable organizations with security concerns to quickly find macOS workstations that may have downloaded malware from a known location. 

For example, [when Elmedia Player downloads were compromised with Trojan malware last year](https://www.deepdotweb.com/2017/11/02/mac-users-infected-proton-malware-infected-media-player-download/), this table could have been used to determine users who may have downloaded those files during the time the binaries were compromised, without having to enumerate the filesystem. 

This is especially useful because these entries will exist even if the malicious binary was not yet executed or was deleted (either by a human or by the malware itself) and serves as forensic evidence that could help an investigator determine when a workstation was compromised.