### PR TITLE
Pin CMake version for build stability

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -458,7 +458,7 @@ function Main {
   $out = Install-ChocoPackage 'cppcheck'
   $out = Install-ChocoPackage '7zip.commandline'
   $out = Install-ChocoPackage 'vswhere'
-  $out = Install-ChocoPackage 'cmake.portable'
+  $out = Install-ChocoPackage 'cmake.portable' '3.10.2'
   $out = Install-ChocoPackage 'windows-sdk-10.0'
 
   # Only install python if it's not needed


### PR DESCRIPTION
Removes a line in the osquery/CMakeLists.txt that was setting a profile which was breaking the build on Windows.

I don't know why this wasn't caught in CI, but removing it also hasn't broken the build on macOS.