### PR TITLE
extensions: Allow option accesses in extensions

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -951,30 +951,46 @@ Status ConfigPlugin::genPack(const std::string& name,
 
 Status ConfigPlugin::call(const PluginRequest& request,
                           PluginResponse& response) {
-  if (request.count("action") == 0) {
-    return Status(1, "Config plugins require an action in PluginRequest");
+  auto action = request.find("action");
+  if (action == request.end()) {
+    return Status(1, "Config plugins require an action");
   }
 
-  if (request.at("action") == "genConfig") {
+  if (action->second == "genConfig") {
     std::map<std::string, std::string> config;
     auto stat = genConfig(config);
     response.push_back(config);
     return stat;
-  } else if (request.at("action") == "genPack") {
-    if (request.count("name") == 0 || request.count("value") == 0) {
+  } else if (action->second == "genPack") {
+    auto name = request.find("name");
+    auto value = request.find("value");
+    if (name == request.end() || value == request.end()) {
       return Status(1, "Missing name or value");
     }
+
     std::string pack;
-    auto stat = genPack(request.at("name"), request.at("value"), pack);
-    response.push_back({{request.at("name"), pack}});
+    auto stat = genPack(name->second, value->second, pack);
+    response.push_back({{name->second, pack}});
     return stat;
-  } else if (request.at("action") == "update") {
-    if (request.count("source") == 0 || request.count("data") == 0) {
+  } else if (action->second == "update") {
+    auto source = request.find("source");
+    auto data = request.find("data");
+    if (source == request.end() || data == request.end()) {
       return Status(1, "Missing source or data");
     }
-    return Config::get().update({{request.at("source"), request.at("data")}});
+
+    return Config::get().update({{source->second, data->second}});
+  } else if (action->second == "option") {
+    auto name = request.find("name");
+    if (name == request.end()) {
+      return Status(1, "Missing option name");
+    }
+
+    response.push_back(
+        {{"name", name->second}, {"value", Flag::getValue(name->second)}});
+    return Status();
   }
-  return Status(1, "Config plugin action unknown: " + request.at("action"));
+  return Status(1, "Config plugin action unknown: " + action->second);
 }
 
 Status ConfigParserPlugin::setUp() {

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <osquery/flags.h>
+#include <osquery/registry.h>
 
 #include "osquery/core/conversions.h"
 
@@ -63,12 +64,27 @@ bool Flag::isDefault(const std::string& name) {
 }
 
 std::string Flag::getValue(const std::string& name) {
-  if (instance().custom_.count(name)) {
-    return instance().custom_.at(name);
+  const auto& custom = instance().custom_;
+  auto custom_flag = custom.find(name);
+  if (custom_flag != custom.end()) {
+    return custom_flag->second;
   }
 
   std::string current_value;
-  flags::GetCommandLineOption(name.c_str(), &current_value);
+  auto found = flags::GetCommandLineOption(name.c_str(), &current_value);
+
+  // If this is an extension and the flag was not found, forward the request.
+  if (Registry::get().external() && !found) {
+    PluginResponse resp;
+    Registry::call("config", {{"name", name}, {"action", "option"}}, resp);
+    if (resp.size() != 0) {
+      auto value = resp[0].find("value");
+      if (value != resp[0].end()) {
+        return value->second;
+      }
+    }
+  }
+
   return current_value;
 }
 


### PR DESCRIPTION
This extends the "config" plugin API to include an "option" call.

Calls to `Flag::getValue` within extensions will be forwarded to osquery core for lookup.

For example, imagine you have this within an extension's table:
```cpp
r["custom_ted_flag"] = Flag::getValue("custom_ted_flag");
```

And the config is:
```json
{
  "options": {
    "custom_ted_flag": "ted says hello"
  }
}
```

This flag is now available.

Caveats:
- Flags in extensions must use the[ "custom_" prefix](https://osquery.readthedocs.io/en/stable/deployment/configuration/#options) (this differentiates them from gflags).
- There's no caching within extensions, so every flag request is a thrift call (+serialization).
- The value is only available as a string, please check and convert within your own code.