### PR TITLE
logger: Add check to prevent C++ extensions from using glog

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -308,6 +308,15 @@ static void deserializeIntermediateLog(const PluginRequest& request,
   }
 }
 
+inline bool logStderrOnly() {
+  // Do not write logfiles if filesystem is not included as a plugin.
+  if (Registry::get().external()) {
+    return true;
+  }
+  return Flag::getValue("logger_plugin").find("filesystem") ==
+         std::string::npos;
+}
+
 void setVerboseLevel() {
   auto default_level = google::GLOG_INFO;
   if (Initializer::isShell()) {
@@ -341,6 +350,10 @@ void setVerboseLevel() {
   if (!FLAGS_logger_stderr) {
     FLAGS_logtostderr = false;
     FLAGS_alsologtostderr = false;
+  }
+
+  if (logStderrOnly()) {
+    FLAGS_logtostderr = true;
   }
 
   if (FLAGS_disable_logging) {


### PR DESCRIPTION
It is not our intention to allow extensions to use `LOG()` and other GLOG-related functions. These should be shuttled back to the core and logged through the appropriate logger plugin.