### PR TITLE
Remove all table AutoReleasePool blocks

### DIFF
--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -238,12 +238,10 @@ Status genAppsFromLaunchServices(std::set<std::string>& apps) {
     return Status(1, "Could not list LaunchServices applications");
   }
 
-  @autoreleasepool {
-    for (id app in (__bridge NSArray*)ls_apps) {
-      if (app != nil && [app isKindOfClass:[NSURL class]]) {
-        apps.insert(std::string([[app path] UTF8String]) +
-                    "/Contents/Info.plist");
-      }
+  for (id app in (__bridge NSArray*)ls_apps) {
+    if (app != nil && [app isKindOfClass:[NSURL class]]) {
+      apps.insert(std::string([[app path] UTF8String]) +
+                  "/Contents/Info.plist");
     }
   }
 

--- a/osquery/tables/system/darwin/authorizations.mm
+++ b/osquery/tables/system/darwin/authorizations.mm
@@ -58,91 +58,86 @@ void authorizations(QueryContext& context, authorizationCallback cb) {
 QueryData genAuthorizationMechanisms(QueryContext& context) {
   QueryData results;
 
-  @autoreleasepool {
-    authorizations(
-        context, ([&results](NSString* label) {
-          CFDictionaryRef rights_ = nullptr;
-          AuthorizationRightGet([label UTF8String], &rights_);
-          if (rights_ == nullptr) {
-            return;
-          }
+  authorizations(
+      context, ([&results](NSString* label) {
+        CFDictionaryRef rights_ = nullptr;
+        AuthorizationRightGet([label UTF8String], &rights_);
+        if (rights_ == nullptr) {
+          return;
+        }
 
-          Row r;
-          NSDictionary* rights = (__bridge NSDictionary*)rights_;
-          NSArray* mechs = [rights objectForKey:@"mechanisms"];
-          if (mechs == nullptr) {
-            CFRelease(rights_);
-            return;
-          }
-
-          for (NSString* mech in mechs) {
-            r["label"] = TEXT([label UTF8String]);
-            r["privileged"] =
-                ([mech rangeOfString:@"privileged"].location != NSNotFound)
-                    ? "true"
-                    : "false";
-            r["entry"] = TEXT([mech UTF8String]);
-            NSRange colon_loc = [mech rangeOfString:@":"];
-            NSRange plugin_loc = NSMakeRange(0, colon_loc.location);
-            NSRange mech_loc =
-                NSMakeRange(colon_loc.location + 1,
-                            [mech length] - (colon_loc.location + 1));
-            r["plugin"] =
-                TEXT([[mech substringWithRange:plugin_loc] UTF8String]);
-            r["mechanism"] = TEXT([[[mech substringWithRange:mech_loc]
-                stringByReplacingOccurrencesOfString:@",privileged"
-                                          withString:@""] UTF8String]);
-            results.push_back(r);
-          }
-
+        Row r;
+        NSDictionary* rights = (__bridge NSDictionary*)rights_;
+        NSArray* mechs = [rights objectForKey:@"mechanisms"];
+        if (mechs == nullptr) {
           CFRelease(rights_);
-        }));
-  }
+          return;
+        }
+
+        for (NSString* mech in mechs) {
+          r["label"] = TEXT([label UTF8String]);
+          r["privileged"] =
+              ([mech rangeOfString:@"privileged"].location != NSNotFound)
+                  ? "true"
+                  : "false";
+          r["entry"] = TEXT([mech UTF8String]);
+          NSRange colon_loc = [mech rangeOfString:@":"];
+          NSRange plugin_loc = NSMakeRange(0, colon_loc.location);
+          NSRange mech_loc = NSMakeRange(
+              colon_loc.location + 1, [mech length] - (colon_loc.location + 1));
+          r["plugin"] = TEXT([[mech substringWithRange:plugin_loc] UTF8String]);
+          r["mechanism"] = TEXT([[[mech substringWithRange:mech_loc]
+              stringByReplacingOccurrencesOfString:@",privileged"
+                                        withString:@""] UTF8String]);
+          results.push_back(r);
+        }
+
+        CFRelease(rights_);
+      }));
+
   return results;
 }
 
 QueryData genAuthorizations(QueryContext& context) {
   QueryData results;
 
-  @autoreleasepool {
-    authorizations(
-        context, ([&results](NSString* label) {
-          CFDictionaryRef rights = nullptr;
-          AuthorizationRightGet([label UTF8String], &rights);
-          if (rights == nullptr) {
-            return;
-          }
+  authorizations(
+      context, ([&results](NSString* label) {
+        CFDictionaryRef rights = nullptr;
+        AuthorizationRightGet([label UTF8String], &rights);
+        if (rights == nullptr) {
+          return;
+        }
 
-          CFIndex count = CFDictionaryGetCount(rights);
-          std::vector<const void*> keys(count);
-          std::vector<const void*> values(count);
-          CFDictionaryGetKeysAndValues(rights, keys.data(), values.data());
-          if (keys.data() == nullptr || values.data() == nullptr) {
-            CFRelease(rights);
-            return;
-          }
-
-          Row r;
-          for (CFIndex i = 0; i < count; i++) {
-            r["label"] = TEXT([label UTF8String]);
-            id value = (__bridge id)values[i];
-            auto key = [[(__bridge NSString*)keys[i]
-                stringByReplacingOccurrencesOfString:@"-"
-                                          withString:@"_"] UTF8String];
-
-            if (CFGetTypeID(values[i]) == CFNumberGetTypeID()) {
-              r[key] = TEXT([value intValue]);
-            } else if (CFGetTypeID(values[i]) == CFStringGetTypeID()) {
-              r[key] = TEXT([value UTF8String]);
-            } else if (CFGetTypeID(values[i]) == CFBooleanGetTypeID()) {
-              r[key] = TEXT(([value boolValue]) ? "true" : "false");
-            }
-          }
-
-          results.push_back(r);
+        CFIndex count = CFDictionaryGetCount(rights);
+        std::vector<const void*> keys(count);
+        std::vector<const void*> values(count);
+        CFDictionaryGetKeysAndValues(rights, keys.data(), values.data());
+        if (keys.data() == nullptr || values.data() == nullptr) {
           CFRelease(rights);
-        }));
-  }
+          return;
+        }
+
+        Row r;
+        for (CFIndex i = 0; i < count; i++) {
+          r["label"] = TEXT([label UTF8String]);
+          id value = (__bridge id)values[i];
+          auto key = [[(__bridge NSString*)keys[i]
+              stringByReplacingOccurrencesOfString:@"-"
+                                        withString:@"_"] UTF8String];
+
+          if (CFGetTypeID(values[i]) == CFNumberGetTypeID()) {
+            r[key] = TEXT([value intValue]);
+          } else if (CFGetTypeID(values[i]) == CFStringGetTypeID()) {
+            r[key] = TEXT([value UTF8String]);
+          } else if (CFGetTypeID(values[i]) == CFBooleanGetTypeID()) {
+            r[key] = TEXT(([value boolValue]) ? "true" : "false");
+          }
+        }
+
+        results.push_back(r);
+        CFRelease(rights);
+      }));
 
   return results;
 }

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -334,25 +334,23 @@ void genFDEStatusForAPFS(Row& r) {
   }
 
   if (cryptoUsers != nullptr) {
-    @autoreleasepool {
-      for (id arrObj in cryptoUsers) {
-        if (![arrObj isKindOfClass:[NSString class]]) {
-          continue;
-        }
+    for (id arrObj in cryptoUsers) {
+      if (![arrObj isKindOfClass:[NSString class]]) {
+        continue;
+      }
 
-        const char* cStr = [(NSString*)arrObj UTF8String];
-        if (cStr == nullptr) {
-          continue;
-        }
-        std::string uuidStr(cStr);
+      const char* cStr = [(NSString*)arrObj UTF8String];
+      if (cStr == nullptr) {
+        continue;
+      }
+      std::string uuidStr(cStr);
 
-        if (kHardcodedDiskUUIDs.count(uuidStr) == 0) {
-          QueryData rows = SQL::selectAllFrom("users");
-          for (const auto& row : rows) {
-            if (row.count("uuid") > 0 && row.at("uuid") == uuidStr) {
-              r["user_uuid"] = row.at("uuid");
-              r["uid"] = row.count("uuid") > 0 ? row.at("uid") : "";
-            }
+      if (kHardcodedDiskUUIDs.count(uuidStr) == 0) {
+        QueryData rows = SQL::selectAllFrom("users");
+        for (const auto& row : rows) {
+          if (row.count("uuid") > 0 && row.at("uuid") == uuidStr) {
+            r["user_uuid"] = row.at("uuid");
+            r["uid"] = row.count("uuid") > 0 ? row.at("uid") : "";
           }
         }
       }

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -21,52 +21,50 @@ namespace tables {
 QueryData genSharedFolders(QueryContext &context) {
   QueryData results;
 
-  @autoreleasepool {
-    ODSession *s = [ODSession defaultSession];
-    NSError *err = nullptr;
-    ODNode *root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+  ODSession* s = [ODSession defaultSession];
+  NSError* err = nullptr;
+  ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory node: "
+         << std::string([[err localizedDescription] UTF8String]);
+  }
+
+  ODQuery* q = [ODQuery queryWithNode:root
+                       forRecordTypes:kODRecordTypeSharePoints
+                            attribute:@"dsAttrTypeNative:directory_path"
+                            matchType:kODMatchEqualTo
+                          queryValues:nil
+                     returnAttributes:kODAttributeTypeNativeOnly
+                       maximumResults:0
+                                error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory query: "
+         << std::string([[err localizedDescription] UTF8String]);
+  }
+
+  // Obtain the results synchronously, not good for very large sets.
+  NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory results: "
+         << std::string([[err localizedDescription] UTF8String]);
+  }
+
+  for (ODRecord* re in od_results) {
+    NSDictionary* recordPath = [re recordDetailsForAttributes:nil error:&err];
+    Row r;
+
     if (err != nullptr) {
-      TLOG << "Error with OpenDirectory node: "
+      TLOG << "Error with OpenDirectory attribute: "
            << std::string([[err localizedDescription] UTF8String]);
-    }
-
-    ODQuery *q = [ODQuery queryWithNode:root
-                         forRecordTypes:kODRecordTypeSharePoints
-                              attribute:@"dsAttrTypeNative:directory_path"
-                              matchType:kODMatchEqualTo
-                            queryValues:nil
-                       returnAttributes:kODAttributeTypeNativeOnly
-                         maximumResults:0
-                                  error:&err];
-    if (err != nullptr) {
-      TLOG << "Error with OpenDirectory query: "
-           << std::string([[err localizedDescription] UTF8String]);
-    }
-
-    // Obtain the results synchronously, not good for very large sets.
-    NSArray *od_results = [q resultsAllowingPartial:NO error:&err];
-    if (err != nullptr) {
-      TLOG << "Error with OpenDirectory results: "
-           << std::string([[err localizedDescription] UTF8String]);
-    }
-
-    for (ODRecord *re in od_results) {
-      NSDictionary *recordPath = [re recordDetailsForAttributes:nil error:&err];
-      Row r;
-
-      if (err != nullptr) {
-        TLOG << "Error with OpenDirectory attribute: "
-             << std::string([[err localizedDescription] UTF8String]);
-      } else {
-        auto nameValue = [[[recordPath valueForKey:@"dsAttrTypeNative:smb_name"]
-            lastObject] UTF8String];
-        auto pathValue =
-            [[[recordPath valueForKey:@"dsAttrTypeNative:directory_path"]
-                lastObject] UTF8String];
-        r["name"] = nameValue;
-        r["path"] = pathValue;
-        results.push_back(r);
-      }
+    } else {
+      auto nameValue = [[[recordPath valueForKey:@"dsAttrTypeNative:smb_name"]
+          lastObject] UTF8String];
+      auto pathValue =
+          [[[recordPath valueForKey:@"dsAttrTypeNative:directory_path"]
+              lastObject] UTF8String];
+      r["name"] = nameValue;
+      r["path"] = pathValue;
+      results.push_back(r);
     }
   }
   return results;

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -17,41 +17,39 @@ namespace osquery {
 namespace tables {
 
 void genODEntries(ODRecordType type, std::set<std::string> &names) {
-  @autoreleasepool {
-    ODSession *s = [ODSession defaultSession];
-    NSError *err = nullptr;
-    ODNode *root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
-    if (err != nullptr) {
-      TLOG << "Error with OpenDirectory node: "
-           << std::string([[err localizedDescription] UTF8String]);
-      return;
-    }
+  ODSession* s = [ODSession defaultSession];
+  NSError* err = nullptr;
+  ODNode* root = [ODNode nodeWithSession:s name:@"/Local/Default" error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory node: "
+         << std::string([[err localizedDescription] UTF8String]);
+    return;
+  }
 
-    ODQuery *q = [ODQuery queryWithNode:root
-                         forRecordTypes:type
-                              attribute:kODAttributeTypeUniqueID
-                              matchType:kODMatchEqualTo
-                            queryValues:nil
-                       returnAttributes:kODAttributeTypeStandardOnly
-                         maximumResults:0
-                                  error:&err];
-    if (err != nullptr) {
-      TLOG << "Error with OpenDirectory query: "
-           << std::string([[err localizedDescription] UTF8String]);
-      return;
-    }
+  ODQuery* q = [ODQuery queryWithNode:root
+                       forRecordTypes:type
+                            attribute:kODAttributeTypeUniqueID
+                            matchType:kODMatchEqualTo
+                          queryValues:nil
+                     returnAttributes:kODAttributeTypeStandardOnly
+                       maximumResults:0
+                                error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory query: "
+         << std::string([[err localizedDescription] UTF8String]);
+    return;
+  }
 
-    // Obtain the results synchronously, not good for very large sets.
-    NSArray *od_results = [q resultsAllowingPartial:NO error:&err];
-    if (err != nullptr) {
-      TLOG << "Error with OpenDirectory results: "
-           << std::string([[err localizedDescription] UTF8String]);
-      return;
-    }
+  // Obtain the results synchronously, not good for very large sets.
+  NSArray* od_results = [q resultsAllowingPartial:NO error:&err];
+  if (err != nullptr) {
+    TLOG << "Error with OpenDirectory results: "
+         << std::string([[err localizedDescription] UTF8String]);
+    return;
+  }
 
-    for (ODRecord *re in od_results) {
-      names.insert([[re recordName] UTF8String]);
-    }
+  for (ODRecord* re in od_results) {
+    names.insert([[re recordName] UTF8String]);
   }
 }
 


### PR DESCRIPTION
I've been investigating a crash in osqueryd and it seems to involve the use autoreleasepools in places they aren't needed. As a test I removed them from all the tables expecting to have a bunch of leaks but I didn't.

Thus I'm wondering if we can remove, reducing complexity and also hopefully fixing this crash in one fell swoop.