### PR TITLE
Error parsing the "windows-attacks" pack JSON: <unspecified file>(47): invalid escape sequence

### DIFF
--- a/packs/windows-attacks.conf
+++ b/packs/windows-attacks.conf
@@ -44,17 +44,7 @@
       "value" : "Artifact used by this malware"
     },
     "StickyKeys_File_Replace_Backdoor": {
-      "query": "SELECT * FROM hash WHERE \
-        (path='c:\\windows\\system32\\osk.exe' \
-         OR path='c:\\windows\\system32\\sethc.exe' \
-         OR path='c:\\windows\\system32\\narrator.exe' \
-         OR path='c:\\windows\\system32\\magnify.exe' \
-         OR path='c:\\windows\\system32\\displayswitch.exe') \
-        AND sha256 IN (SELECT sha256 FROM hash \
-          WHERE path='c:\\windows\\system32\\cmd.exe' \
-          OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' \
-          OR path='c:\\windows\\system32\\explorer.exe') \
-          AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
+      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe') AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
       "interval": 3600,
       "version": "2.2.1",
       "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: (https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1)"


### PR DESCRIPTION
Not sure if escape is supposed to work but it doesn't here

https://ci.appveyor.com/project/juju4/ansible-win-osquery/build/0.1.x.35/job/i8g2axx80emxwd28#L881
```
changed: [localhost] => {
    "changed": true,
    "cmd": "c:\\ProgramData\\osquery\\osqueryi.exe --config_path c:\\ProgramData\\osquery\\osquery.conf --config_check --verbose",
    "delta": "0:00:01.281920",
    "end": "2018-02-25 03:00:15.157841",
    "rc": 0,
    "start": "2018-02-25 03:00:13.875920",
    "stderr": "I0225 15:00:14.079041  1840 init.cpp:380] osquery initialized [version=2.11.2]\r\nI0225 15:00:14.079041  1840 extensions.cpp:300] Could not autoload extensions: Failed reading: \\ProgramData\\osquery\\extensions.load\r\nI0225 15:00:14.079041  1840 init.cpp:609] Cannot start extension manager: Extensions disabled\r\nW0225 15:00:14.079041  1840 config.cpp:620] Error parsing the \"windows-attacks\" pack JSON: <unspecified file>(47): invalid escape sequence\r\n",
    "stderr_lines": [
        "I0225 15:00:14.079041  1840 init.cpp:380] osquery initialized [version=2.11.2]",
        "I0225 15:00:14.079041  1840 extensions.cpp:300] Could not autoload extensions: Failed reading: \\ProgramData\\osquery\\extensions.load",
        "I0225 15:00:14.079041  1840 init.cpp:609] Cannot start extension manager: Extensions disabled",
        "W0225 15:00:14.079041  1840 config.cpp:620] Error parsing the \"windows-attacks\" pack JSON: <unspecified file>(47): invalid escape sequence"
    ],
    "stdout": "",
    "stdout_lines": []
}
```