### PR TITLE
deployment: adding default path for Windows packs to example conf

### DIFF
--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -68,6 +68,8 @@
     // "osx-attacks": "/usr/share/osquery/packs/osx-attacks.conf",
     // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
     // "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
-    // "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf"
+    // "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf",
+    // "windows-hardening": "C:\\ProgramData\\osquery\\packs\\windows-hardening.conf",
+    // "windows-attacks": "C:\\ProgramData\\osquery\\packs\\windows-attacks.conf"
   }
 }


### PR DESCRIPTION
This adds the Windows packs default path to the example osquery configuration.