### PR TITLE
Fix handling of python in Windows

### DIFF
--- a/tools/analysis/fuzz.py
+++ b/tools/analysis/fuzz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/analysis/stress.py
+++ b/tools/analysis/stress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/analysis/system_stress.py
+++ b/tools/analysis/system_stress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/codegen/amalgamate.py
+++ b/tools/codegen/amalgamate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import argparse
 import json

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Generate a complete table specification for the website
 
 This script will generate JSON output as expected by the osquery website given

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """Generate a new website version metadata file based on a new release version
 
 Usage:

--- a/tools/deployment/getfiles.py
+++ b/tools/deployment/getfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/formatting/git-clang-format.py
+++ b/tools/formatting/git-clang-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #===- git-clang-format - ClangFormat Git Integration ---------*- python -*--===#
 #

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -134,44 +134,61 @@ function Test-ChocoPackageInstalled {
   return $false
 }
 
-# Helper function to check the version of python installed, as well as
-# return the parent path where Python is installed.
+# Helper function to check the correct version of python is installed,
+# as well as return its parent path if found.
 function Test-PythonInstalled {
-  $major = '*2.7*'
-  $pythonInstall = (Get-Command 'python' -ErrorAction SilentlyContinue).Source
-  if ($pythonInstall -eq $null) {
+  $pythonCommands = Get-Command -All 'python' -ErrorAction SilentlyContinue
+  if ($pythonCommands -eq $null) {
     $msg = '[-] Python binary not found in system path'
     Write-Host $msg -ForegroundColor Yellow
     return $false
+  } else {
+    ForEach($pythonCmd in $pythonCommands) {
+	  if ((Test-PythonVersion $pythonCmd.Source) -eq $true) {
+	    return (Get-Item $pythonCmd.Source).Directory.Fullname
+	  }
+	}
+    return $false
   }
-  $out = Start-OsqueryProcess $pythonInstall @('--version')
-  if (($out.exitcode -ne 0) -or (-not ($out.stderr -like $major))) {
-    $msg = '[-] Python major version != 2.7'
-    Write-Host $msg -ForegroundColor Yellow
+}
+
+# Helper function to test if a specific python binary is the version we want
+function Test-PythonVersion {
+  param(
+    [string] $pythonPath
+  )
+  $major = '*2.7*'
+  $out = Start-OsqueryProcess $pythonPath @('--version')
+  if ($out.exitcode -ne 0) {
+    $msg = " => Ignoring Python refusing to report version at $pythonPath"
+	Write-Host $msg -ForegroundColor Cyan
+	return $false
+  }
+  if (-not ($out.stderr -like $major)) {
+    $msg = " => Ignoring Python with major version != 2.7 at $pythonPath"
+    Write-Host $msg -ForegroundColor Cyan
     return $false
   }
   # Get the specific version returned
   $version = $out.stderr.Split(" ")
   if ($version.Length -lt 2) {
-    $msg = '[-] Encountered unknown version of python'
-    Write-Host $msg -ForegroundColor Yellow
+    $msg = " => Ignoring Python with unknown version format at $pythonPath"
+    Write-Host $msg -ForegroundColor Cyan
     return $false
   }
   $minor = $version[1].Trim().Split(".")
   if ($minor.Length -le 2) {
-    $msg = '[-] Encountered unknown version of python'
-    Write-Host $msg -ForegroundColor Yellow
+    $msg = " => Ignoring python with unknown version format at $pythonPath"
+    Write-Host $msg -ForegroundColor Cyan
     return $false
   }
   # The oldest Python variant we support is 2.7.12
   if ([int]$minor[2] -lt 12) {
-    $msg = '[-] Python minor version < 12'
-    Write-Host $msg -ForegroundColor Yellow
+    $msg = " => Ignoring Python 2.7 with minor version < 12 at $pythonPath"
+    Write-Host $msg -ForegroundColor Cyan
     return $false
   }
-  # Lastly derive the parent path of the binary, as we use this to
-  # get the pip path also.
-  return (Get-Item $pythonInstall).Directory.Fullname
+  return $true
 }
 
 # Installs the Powershell Analzyer: https://github.com/PowerShell/PSScriptAnalyzer
@@ -307,15 +324,14 @@ function Install-PipPackage {
   }
   Write-Host " => Attempting to install Python packages" -foregroundcolor DarkYellow
   $pythonPath = [Environment]::GetEnvironmentVariable("OSQUERY_PYTHON_PATH", "Machine")
-  Add-ToPath $pythonPath
-  $pipPath = "$pythonPath\Scripts"
-  Add-ToPath $pipPath
   if (-not (Test-Path "$pythonPath\python.exe")) {
     Write-Host "[-] ERROR: failed to find python at $pythonPath" -foregroundcolor Red
     Exit -1
   }
+  $pipPath = "$pythonPath\Scripts"
+  Add-ToPath $pipPath
   if (-not (Test-Path "$pipPath\pip.exe")) {
-    Write-Host "[-] ERROR: failed to find pip in $pythonPath\Scripts!" -foregroundcolor Red
+    Write-Host "[-] ERROR: failed to find pip at $pipPath" -foregroundcolor Red
     Exit -1
   }
 
@@ -461,21 +477,28 @@ function Main {
   $out = Install-ChocoPackage 'cmake.portable'
   $out = Install-ChocoPackage 'windows-sdk-10.0'
 
-  # Only install python if it's not needed
+  # Only install python if it's not installed yet
+  Write-Host " => Determining whether Python 2 is already available on the system..."
   $pythonInstall = Test-PythonInstalled
   if (-not ($pythonInstall)) {
     Install-ChocoPackage 'python2'
     # Update the system path and re-derive the python install
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+    # Check if python was successfully installed
     $pythonInstall = Test-PythonInstalled
+    if (-not ($pythonInstall)) {
+      Write-Host "[-] ERROR: Python2 failed to install" -foregroundcolor Red
+      Exit -1
+    }
   }
+
+  # Convenience variable for accessing Python
+  [Environment]::SetEnvironmentVariable("OSQUERY_PYTHON_PATH", $pythonInstall, "Machine")
 
   $out = Install-ChocoPackage 'wixtoolset' '' @('--version', '3.10.3.300701')
   # Add the WiX binary path to the system path for use
   Add-ToSystemPath 'C:\Program Files (x86)\WiX Toolset v3.10\bin'
 
-  # Convenience variable for accessing Python
-  [Environment]::SetEnvironmentVariable("OSQUERY_PYTHON_PATH", $pythonInstall, "Machine")
   $out = Install-PipPackage
   $out = Update-GitSubmodule
   if (Test-Path env:OSQUERY_BUILD_HOST) {

--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_example_queries.py
+++ b/tools/tests/test_example_queries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_osqueryd_win.py
+++ b/tools/tests/test_osqueryd_win.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.

--- a/tools/tests/winexpect.py
+++ b/tools/tests/winexpect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.


### PR DESCRIPTION
This forces python2 to be used when both python2 and python3 are
available on the system. Also makes the provisioning script more
resilient to errors if python is not properly installed or can't be
found after the installation.