### PR TITLE
freebsd: Update CMake for thrift 11 and boost 1.66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,9 @@ include_directories("${CMAKE_SOURCE_DIR}/third-party/sqlite3")
 include_directories("${CMAKE_SOURCE_DIR}/include")
 include_directories("${CMAKE_SOURCE_DIR}")
 
-include_directories("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
+if(NOT FREEBSD)
+  include_directories("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
+endif()
 
 set(MKDIR_OPTS "")
 if(WINDOWS)
@@ -664,7 +666,10 @@ if(NOT SKIP_TESTS)
 endif()
 
 add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/sqlite3")
-add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
+
+if(NOT FREEBSD)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/third-party/linenoise-ng")
+endif()
 
 add_subdirectory(osquery)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ else()
   # component-specific globbing is needed.
   if(${OSQUERY_BUILD_PLATFORM} STREQUAL "freebsd")
     set(FREEBSD TRUE)
+    set(DEPS FALSE)
     include_directories("/usr/local/include")
     include_directories("/usr/include")
   else()
@@ -564,11 +565,6 @@ if(POSIX AND DEPS)
   if(CLANG)
     include_directories(SYSTEM "${BUILD_DEPS}/lib/clang/4.0.0/include")
   endif()
-endif()
-
-if(FREEBSD)
-  # Including Boost Beast within third-party until it's merged into boot 1.66.
-  include_directories("${CMAKE_SOURCE_DIR}/third-party/beast")
 endif()
 
 include_directories("${CMAKE_SOURCE_DIR}/third-party/sqlite3")

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ ifneq ($(VERBOSE_TEST),)
 	VERBOSE_TEST = "-V"
 endif
 
-ifneq ($(DISTRO),darwin)
-        LINK_FLAGS = -B$(DEPS_DIR)/legacy/lib -rtlib=compiler-rt -fuse-ld=lld
+ifeq ($(PLATFORM),Linux)
+	LINK_FLAGS = -B$(DEPS_DIR)/legacy/lib -rtlib=compiler-rt -fuse-ld=lld
 endif
 
 PATH_SET := PATH="$(DEPS_DIR)/bin:/usr/local/bin:$(PATH)"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -213,7 +213,7 @@ Vagrant.configure("2") do |config|
         build.vm.provision 'shell',
           inline:
             # Switching to latest may cause failures if dependencies are not built.
-            # "sudo sed -i '' -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf;"\
+            "sudo sed -i '' -e 's/quarterly/latest/g' /etc/pkg/FreeBSD.conf;"\
             "su -m root -c 'hostname vagrant';"\
             "su -m root -c 'pkg update -f';"\
             "sudo pkg install -y openjdk8 bash git gmake python ruby;"\

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -147,6 +147,7 @@ if(APPLE OR LINUX)
   ADD_OSQUERY_LINK_ADDITIONAL("rocksdb_lite")
 elseif(FREEBSD)
   ADD_OSQUERY_LINK_CORE("icuuc")
+  ADD_OSQUERY_LINK_CORE("linenoise")
   ADD_OSQUERY_LINK_ADDITIONAL("rocksdb-lite")
 endif()
 

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -61,10 +61,14 @@ endif()
 
 # Construct a set of all object files, starting with third-party and all
 # of the osquery core objects (sources from ADD_CORE_LIBRARY macros).
-set(OSQUERY_OBJECTS
-  $<TARGET_OBJECTS:osquery_sqlite>
-  $<TARGET_OBJECTS:linenoise-ng>
-)
+if(FREEBSD)
+  set(OSQUERY_OBJECTS $<TARGET_OBJECTS:osquery_sqlite>)
+else()
+  set(OSQUERY_OBJECTS
+    $<TARGET_OBJECTS:osquery_sqlite>
+    $<TARGET_OBJECTS:linenoise-ng>
+  )
+endif()
 
 # Add subdirectories
 add_subdirectory(config)

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -32,6 +32,7 @@ function distro_main() {
   package rocksdb-lite
   package rapidjson
   package zstd
+  package linenoise-ng
 
   # Non-optional features.
   package augeas
@@ -43,6 +44,5 @@ function distro_main() {
   package lldpd
 
   # For testing
-  package doxygen
   package valgrind
 }


### PR DESCRIPTION
FreeBSD has thrift 11 and boost 1.66 so we can remove special handling (local include of beast).