### PR TITLE
adding fields to docker_containers table

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -409,6 +409,14 @@ QueryData genContainers(QueryContext& context) {
       r["privileged"] = container_details.get<bool>("Privileged", false)
                             ? INTEGER(1)
                             : INTEGER(0);
+      r["path"] = container_details.get<std::string>("Path", "");
+
+      std::vector<std::string> entry_pts;
+      BOOST_FOREACH (const pt::ptree::value_type& ent_pt,
+                     container_details.get_child("Config.Entrypoint")) {
+        entry_pts.push_back(ent_pt.second.data());
+      }
+      r["config_entrypoint"] = boost::algorithm::join(entry_pts, ", ");
 
       std::vector<std::string> sec_opts;
       BOOST_FOREACH (const pt::ptree::value_type& sec_opt,

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -401,8 +401,8 @@ QueryData genContainers(QueryContext& context) {
     s = dockerApi("/containers/" + r["id"] + "/json?stream=false",
                   container_details);
     if (s.ok()) {
-      r["pid"] = std::to_string(
-          container_details.get_child("State").get<pid_t>("Pid", -1));
+      r["pid"] =
+          BIGINT(container_details.get_child("State").get<pid_t>("Pid", -1));
       r["started_at"] = container_details.get_child("State").get<std::string>(
           "StartedAt", "");
       r["finished_at"] = container_details.get_child("State").get<std::string>(

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -10,6 +10,11 @@ schema([
     Column("state", TEXT, "Container state (created, restarting, running, removing, paused, exited, dead)"),
     Column("status", TEXT, "Container status information"),
     Column("pid", TEXT, "Identifier of the initial process"),
+    Column("started_at", TEXT, "Container start time as string"),
+    Column("finished_at", TEXT, "Container finish time as string"),
+    Column("privileged", INTEGER, "Is the container privileged"),
+    Column("security_options", TEXT, "List of container security options"),
+    Column("env_variables", TEXT, "Container environmental variables"),
 ])
 extended_schema(LINUX, [
     Column("cgroup_namespace", TEXT, "cgroup namespace"),

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -9,7 +9,7 @@ schema([
     Column("created", BIGINT, "Time of creation as UNIX time"),
     Column("state", TEXT, "Container state (created, restarting, running, removing, paused, exited, dead)"),
     Column("status", TEXT, "Container status information"),
-    Column("pid", TEXT, "Identifier of the initial process"),
+    Column("pid", BIGINT, "Identifier of the initial process"),
     Column("path", TEXT, "Container path"),
     Column("config_entrypoint", TEXT, "Container entrypoint(s)"),
     Column("started_at", TEXT, "Container start time as string"),

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -10,6 +10,8 @@ schema([
     Column("state", TEXT, "Container state (created, restarting, running, removing, paused, exited, dead)"),
     Column("status", TEXT, "Container status information"),
     Column("pid", TEXT, "Identifier of the initial process"),
+    Column("path", TEXT, "Container path"),
+    Column("config_entrypoint", TEXT, "Container entrypoint(s)"),
     Column("started_at", TEXT, "Container start time as string"),
     Column("finished_at", TEXT, "Container finish time as string"),
     Column("privileged", INTEGER, "Is the container privileged"),


### PR DESCRIPTION
Adding the following fields to the docker_container table to capture more context about a container:
    Column("path", TEXT, "Container path"),
    Column("config_entrypoint", TEXT, "Container entrypoint(s)"),
    Column("started_at", TEXT, "Container start time as string"),
    Column("finished_at", TEXT, "Container finish time as string"),
    Column("privileged", INTEGER, "Is the container privileged"),
    Column("security_options", TEXT, "List of container security options"),
    Column("env_variables", TEXT, "Container environmental variables"),

Also ensured the "pid" field is populated for OS X.