### PR TITLE
kafka: Support for kafka compression.codec

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -101,6 +101,7 @@ The configuration parameters are exposed via command line options and can be set
   "options": {
     "logger_kafka_brokers": "some.example1.com:9092,some.example2.com:9092",
     "logger_kafka_topic": "base_topic",
+    "logger_kafka_compression": "gzip",
     "logger_kafka_acks": "1"
   },
   "packs": {

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -414,6 +414,10 @@ The Kafka topic to publish logs to.  When using multiple topics this configurati
 
 The number of acknowledgments the Kafka leader has to receive before a publish is considered successful.  Valid options are (0, 1, "all").
 
+`--logger_kafka_compression`
+
+Compression codec to use for compressing message sets.  Valid options are ("none", "gzip").  Default is "none".
+
 ### Distributed query service flags
 
 `--distributed_plugin=tls`


### PR DESCRIPTION
librdkafka in osquery is already built with gzip support.
This change introduces logger kafka flag to specify compression codec.
Because librdkafka is not compiled with snappy and lz4 support
logger_kafka_compression flag only supports two values: "none" (default)
and "gzip".