### PR TITLE
Return SQL statuses in distributed response fix

### DIFF
--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -104,7 +104,7 @@ Status Distributed::serializeResults(std::string& json) {
   }
 
   doc.add("queries", queries_obj);
-  doc.add("statuses", queries_obj);
+  doc.add("statuses", statuses_obj);
   return doc.toString(json);
 }
 


### PR DESCRIPTION
This was a bug introduced in the port to RapidJSON. I noticed last night while debugging that we are doubling up on the data sent back and losing all the SQL status. This simply fixes that.