### PR TITLE
[bug] aws_log_forwarder: incrementing index for batches of records that could not be sent

### DIFF
--- a/osquery/logger/plugins/aws_log_forwarder.h
+++ b/osquery/logger/plugins/aws_log_forwarder.h
@@ -104,6 +104,8 @@ class AwsLogForwarder : public BufferedLogForwarder {
       const auto& record = *it;
       const auto& raw_buffer = record.GetData();
 
+      index++;
+
       std::string buffer(
           reinterpret_cast<const char*>(raw_buffer.GetUnderlyingData()),
           raw_buffer.GetLength());


### PR DESCRIPTION
### Changes

* Fixing an issue that cause the logged errors to not have the proper record index by incrementing said index.

### Example of bug:
```
aws_kinesis logger: Failed to write the following records:
Record #0: {"name":"pack_foo","hostIdentifier":"foobar"...}
Record #0: {"name":"pack_bar","hostIdentifier":"foobar"...}
```
