### PR TITLE
Add some more features to the cpuid table.

### DIFF
--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -69,10 +69,16 @@ std::map<size_t, std::vector<FeatureDef>> kCPUFeatures{
      }},
     {0x80000001,
      {
+         FEATURE("lahfsahf", "ecx", 0"),
          FEATURE("svm", "ecx", 2),
+         FEATURE("prefetchw", "ecx", 8),
          FEATURE("ibs", "ecx", 10),
          FEATURE("skinit", "ecx", 12),
          FEATURE("lwp", "ecx", 15),
+         
+         FEATURE("nx", "edx", 20),
+         FEATURE("page1gb", "edx", 26),
+         FEATURE("lm", "edx", 29),
      }}};
 
 static inline void cpuid(size_t eax, size_t ecx, int regs[4]) {

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -69,7 +69,7 @@ std::map<size_t, std::vector<FeatureDef>> kCPUFeatures{
      }},
     {0x80000001,
      {
-         FEATURE("lahfsahf", "ecx", 0"),
+         FEATURE("lahfsahf", "ecx", 0),
          FEATURE("svm", "ecx", 2),
          FEATURE("prefetchw", "ecx", 8),
          FEATURE("ibs", "ecx", 10),

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -75,7 +75,7 @@ std::map<size_t, std::vector<FeatureDef>> kCPUFeatures{
          FEATURE("ibs", "ecx", 10),
          FEATURE("skinit", "ecx", 12),
          FEATURE("lwp", "ecx", 15),
-         
+
          FEATURE("nx", "edx", 20),
          FEATURE("page1gb", "edx", 26),
          FEATURE("lm", "edx", 29),

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -71,7 +71,7 @@ std::map<size_t, std::vector<FeatureDef>> kCPUFeatures{
      {
          FEATURE("lahfsahf", "ecx", 0),
          FEATURE("svm", "ecx", 2),
-         FEATURE("prefetchw", "ecx", 8),
+         FEATURE("3dnowprefetch", "ecx", 8),
          FEATURE("ibs", "ecx", 10),
          FEATURE("skinit", "ecx", 12),
          FEATURE("lwp", "ecx", 15),


### PR DESCRIPTION
Information taken from https://www.lowlevel.eu/wiki/CPUID
Only added flags I actually have some interest in: long mode (64 bit support), NX , huge page support, ...
Some of these could probably be inferred from other flags (or their combination) but it seems cleaner to just pull them from the cpuid functions directly.