### PR TITLE
Osquery Remote Auto-Upgrade Functionality

### DIFF
--- a/CMake/CMakeLibs.cmake
+++ b/CMake/CMakeLibs.cmake
@@ -268,6 +268,7 @@ endmacro(ADD_OSQUERY_LIBRARY TARGET)
 macro(ADD_OSQUERY_EXTENSION TARGET)
   add_executable(${TARGET} ${ARGN})
   TARGET_OSQUERY_LINK_WHOLE(${TARGET} libosquery)
+  TARGET_OSQUERY_LINK_WHOLE(${TARGET} libosquery_transport)
   set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME "${TARGET}.ext")
 endmacro(ADD_OSQUERY_EXTENSION)
 

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -276,6 +276,11 @@ add_custom_target(osquery_library ALL
   DEPENDS libosquery
 )
 
+# Create the static libosquery_transport.
+add_library(libosquery_transport STATIC remote/http/http_client.cpp remote/transports/tls.cpp tables/system/hash.cpp remote/remote.cpp remote/uri.cpp)
+target_link_libraries(libosquery_transport ${OSQUERY_ADDITIONAL_LINKS})
+set_target_properties(libosquery_transport PROPERTIES OUTPUT_NAME osquery_transport)
+
 # make devel (implies install)
 add_custom_target(devel
   COMMAND ${CMAKE_COMMAND} -D COMPONENT=devel -P cmake_install.cmake
@@ -398,7 +403,7 @@ if(NOT SKIP_TESTS)
   # osquery core set of unit tests build with SDK.
   add_executable(osquery_tests main/tests.cpp ${OSQUERY_TESTS})
   ADD_DEFAULT_LINKS(osquery_tests FALSE)
-  target_link_libraries(osquery_tests gtest gmock libosquery_testing)
+  target_link_libraries(osquery_tests gtest gmock libosquery_testing libosquery_transport)
   SET_OSQUERY_COMPILE(osquery_tests "${GTEST_FLAGS}")
   add_test(osquery_tests osquery_tests ${TEST_ARGS})
 

--- a/osquery/config/parsers/software_upgrade.cpp
+++ b/osquery/config/parsers/software_upgrade.cpp
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <boost/filesystem.hpp>
+#include <boost/process.hpp>
+
+#include <osquery/config.h>
+#include <osquery/logger.h>
+
+#include "include/osquery/filesystem.h"
+#include "osquery/remote/http_client.h"
+#include "osquery/remote/transports/tls.h"
+#include "osquery/tables/system/hash.h"
+
+namespace pt = boost::property_tree;
+
+namespace osquery {
+
+const std::string kSoftwareUpgradeRootKey("software_upgrade");
+const std::string kScriptUrl("script_url");
+const std::string kPkgUrl("pkg_url");
+const std::string kPkgSize("pkg_size");
+const std::string kPkgSHA256("pkg_sha256");
+const std::string kScriptSHA256("script_sha256");
+
+const std::string kOsqueryUserAgent{"osquery/"};
+extern const std::string kVersion;
+DECLARE_string(tls_hostname);
+
+/**
+ * @brief A simple ConfigParserPlugin for "software_upgrade" dictionary key.
+ */
+class SWUpgradeConfigParserPlugin : public ConfigParserPlugin {
+ public:
+  virtual ~SWUpgradeConfigParserPlugin() {}
+
+  std::vector<std::string> keys() const override {
+    return {kSoftwareUpgradeRootKey};
+  }
+
+  Status setUp() override {
+    return Status(0);
+  };
+
+  Status update(const std::string& source, const ParserConfig& config) override;
+};
+
+Status SWUpgradeConfigParserPlugin::update(const std::string& source,
+                                           const ParserConfig& config) {
+  if (source != "tls_plugin") {
+    return Status(0, "OK");
+  }
+
+  auto software_upgrade = config.find(kSoftwareUpgradeRootKey);
+  if (software_upgrade == config.end()) {
+    return Status();
+  }
+
+  auto obj = data_.getObject();
+  data_.copyFrom(software_upgrade->second.doc(), obj);
+  data_.add(kSoftwareUpgradeRootKey, obj);
+
+  const auto& doc = data_.doc()[kSoftwareUpgradeRootKey];
+  if (!doc.HasMember(kScriptUrl) || !doc[kScriptUrl].IsString() ||
+      !doc.HasMember(kPkgUrl) || !doc[kPkgUrl].IsString() ||
+      !doc.HasMember(kPkgSize) || !doc[kPkgSize].IsString() ||
+      !doc.HasMember(kPkgSHA256) || !doc[kPkgSHA256].IsString() ||
+      !doc.HasMember(kScriptSHA256) || !doc[kScriptSHA256].IsString()) {
+    LOG(ERROR) << "Invalid software upgrade parameters";
+    return Status(1, "Invalid software upgrade parameters");
+  }
+
+  const std::string script_url = doc[kScriptUrl].GetString();
+  const std::string pkg_url = doc[kPkgUrl].GetString();
+  const long pkg_size = std::stol(doc[kPkgSize].GetString());
+  const std::string pkg_checksum = doc[kPkgSHA256].GetString();
+  const std::string script_checksum = doc[kScriptSHA256].GetString();
+
+  if (pkg_url.empty() || script_url.empty() || pkg_url[0] != '/' ||
+      script_url[0] != '/' || pkg_size < 1 || pkg_checksum.empty() ||
+      script_checksum.empty()) {
+    LOG(ERROR) << "Invalid software upgrade parameters";
+    return Status(1, "Invalid software upgrade parameters");
+  }
+
+#ifdef WIN32
+  std::string installer("_install.bat");
+#else
+  std::string installer("_install.sh");
+#endif
+  std::string package;
+  std::string url;
+
+  try {
+    http::Client::Options options = TLSTransport().getOptions();
+
+    // Set 15 mins timeout and expected body size of http message
+    options.timeout(15 * 60).payload_size(pkg_size);
+    http::Client client(options);
+
+    url = "https://" + FLAGS_tls_hostname + script_url;
+    http::Request req(url);
+    req << http::Request::Header("User-Agent", kOsqueryUserAgent + kVersion);
+    http::Response resp = client.get(req);
+
+    {
+      Hash hash_script(HASH_TYPE_SHA256);
+      hash_script.update(resp.body().data(), resp.body().size());
+      if (script_checksum != hash_script.digest()) {
+        LOG(ERROR) << "Script SHA256 checksum comparision failed";
+        return Status(1, "Script SHA256 checksum comparision failed");
+      }
+    }
+
+    boost::filesystem::path installer_path =
+        boost::filesystem::temp_directory_path() /
+        boost::filesystem::unique_path();
+    installer_path += installer;
+    Status rc = writeTextFile(installer_path, resp.body(), 0700);
+
+    if (!rc.ok()) {
+      boost::system::error_code ec;
+      boost::filesystem::remove(installer_path, ec);
+      LOG(ERROR) << rc.getMessage();
+      return rc;
+    }
+
+    url = "https://" + FLAGS_tls_hostname + pkg_url;
+    req.uri(url);
+    resp = client.get(req);
+
+    {
+      Hash hash_pkg(HASH_TYPE_SHA256);
+      hash_pkg.update(resp.body().data(), resp.body().size());
+      if (pkg_checksum != hash_pkg.digest()) {
+        LOG(ERROR) << "Package SHA256 checksum comparision failed";
+        return Status(1, "Package SHA256 checksum comparision failed");
+      }
+    }
+
+    boost::filesystem::path pkg_path =
+        boost::filesystem::temp_directory_path() /
+        boost::filesystem::unique_path();
+    rc = writeTextFile(pkg_path, resp.body(), 0400);
+    if (!rc.ok()) {
+      boost::system::error_code ec;
+      boost::filesystem::remove(installer_path, ec);
+      boost::filesystem::remove(pkg_path, ec);
+      LOG(ERROR) << rc.getMessage();
+      return rc;
+    }
+
+    installer = installer_path.string();
+    package = pkg_path.string();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Exception making HTTP request to URL (" << url
+               << "): " << e.what();
+    return Status(1, e.what());
+  }
+
+  std::error_code ec;
+  std::string cmd = installer + " " + package;
+  boost::process::child install(cmd, ec);
+  if (ec) {
+    LOG(ERROR) << ec.message();
+    return Status(1, ec.message());
+  }
+
+  install.detach();
+
+  LOG(INFO) << "Softare upgrade started";
+
+  return Status(0, "OK");
+}
+
+REGISTER_INTERNAL(SWUpgradeConfigParserPlugin,
+                  "config_parser",
+                  "software_upgrade");
+} // namespace osquery

--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -237,6 +237,11 @@ void Client::sendRequest(STREAM_TYPE& stream,
     throw std::system_error(ec_.value(), adapted_category(&ec_.category()));
   }
 
+  if (client_options_.payload_size_ !=
+      std::numeric_limits<unsigned long>::max()) {
+    resp.body_limit(client_options_.payload_size_);
+  }
+
   if (client_options_.timeout_) {
     timer_.async_wait(
         [=](boost_system::error_code const& ec) { timeoutHandler(ec); });

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -79,7 +79,8 @@ class Client {
   class Options {
    public:
     Options()
-        : ssl_options_(0),
+        : payload_size_(std::numeric_limits<unsigned long>::max()),
+          ssl_options_(0),
           timeout_(0),
           always_verify_peer_(false),
           follow_redirects_(false),
@@ -161,6 +162,11 @@ class Client {
       return *this;
     }
 
+    Options& payload_size(unsigned long pls) {
+      payload_size_ = pls;
+      return *this;
+    }
+
     bool operator==(Options const& ropts) {
       return (server_certificate_ == ropts.server_certificate_) &&
              (verify_path_ == ropts.verify_path_) &&
@@ -184,6 +190,7 @@ class Client {
     boost::optional<std::string> proxy_hostname_;
     boost::optional<std::string> remote_hostname_;
     boost::optional<std::string> remote_port_;
+    unsigned long payload_size_;
     long ssl_options_;
     int timeout_;
     bool always_verify_peer_;


### PR DESCRIPTION
# Osquery Remote Auto-Upgrade Functionality

This Document describes code changes made to osquery to support remote auto-upgrade functionality. 
### New JSON Node - software_upgrade

```json
    "software_upgrade": {
        "pkg_url": "/agent/download/package",
        # package size in bytes
        "pkg_size": "1234567",
        "script_url": "/agent/download/installer",
        # package checksum, sha256
        "pkg_sha256": "...53bbbd19d5...",
        "script_sha256" : "...0889f7ba1..."
    },
```


Auto upgrade functionality of the osquery will be triggered once osquery process detects the presence of ‘software_upgrade’ node in the arrived configuration.
Config parser has been enhanced via ***SWUpgradeConfigParserPlugin*** to parse the new node **software_upgrade**.
New code resides in **.../osquery/config/parsers/software_upgrade.cpp**.

### S/W Auto-Upgrade parameters 
`pkg_url:` Partial osquery package URL
`pkg_size:` Package size in bytes
`script_url`: Partial custom installer script URL
`pkg_sha256:` Package sha256 checksum
`script_sha256`: Installer script sha256 checksum

##### Once functionality is triggered it will -
1. Download custom installer script
2. Verify checksum of script
3. Download osquery package.
4. Verify checksum of package
5. Trigger downloaded custom installer script and passing package path as an argument.

##### Installer script will in turn -
1. Bring down the already running instance of osquery.
2. Install the package 
3. Bring up the new instance 
4. Delete itself.

Success of this upgrade can be detected by following query-
```
{
   "schedule": {
       "tls_proc": {"query": " “select * from osquery_info;”, "interval": 10},
   },
}
```
**Note:** Please check at the bottom for example installer script.

### Functionality in detail
##### Once config is handed over to SWUpgradeConfigParserPlugin, it verifies and processes the config according to the following steps -
1. If config belong to "tls_plugin", since only tls_plugin is allowed to upgrade.
2. If ‘pkg_url’, ‘pkg_size’, ‘script_url’, ‘pkg_sha256’ and ‘script_sha256’ are present and they have valid values(non-empty and/or non-zero values).
3. Download the installer script from tls_hostname using url "https://" + FLAGS_tls_hostname + script_url. 
4. Compute the sha256 hash from the downloaded contents of script and compare the computed sha256 with script_sha256. If mismatch, abort upgrade process.
5. Dump the downloaded contents at the tmp location in the file with the suffix _install.(sh|bat) and change the permission of the file to 0700.
6. Download the package from tls_hostname using url "https://" + FLAGS_tls_hostname + pkg_url;
7. Compute the sha256 hash from the downloaded contents of the package and compare the computed sha256 with pkg_sha256. If mismatch, abort upgrade process.
8. Dump the downloaded package contents at the tmp location and change the permission of the created file to 0400.
9. Spawn a child process using boost::process::child functionality with command line ‘<UUID>_install.sh package’
10. Detach the child from the parent osquery process.


**Note:** 
1. Custom installer script depends upon platform and how fleet management has been implemented. 
2. Timeout has been hard coded to 15 minutes to download the package.
3. At present entire package is being downloaded in the memory and after verification flushed to a file on disk. For downloading package and script osquery::http_client is being used. osquery::http_client can be enhanced to download large payload in chunks. 


### Example installer script

    #!/bin/bash
    unlink $0 #remove script once its execution ends
    pkg_file=$1
    echo "Stopping osqueryd..."
    echo
    service osqueryd stop
    echo
    echo "installing new package $pkg_file ..."
    echo
    dpkg -i $pkg_file
    echo
    rm -f $pkg_file #remove package.
    echo "Starting osqueryd ..."
    service osqueryd start
    echo
