### PR TITLE
mac/linux: add disk I/O columns to processes table

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -331,6 +331,10 @@ QueryData genProcesses(QueryContext& context) {
       r["user_time"] = TEXT(rusage_info_data.ri_user_time / CPU_TIME_RATIO);
       r["system_time"] = TEXT(rusage_info_data.ri_system_time / CPU_TIME_RATIO);
 
+      // disk i/o information
+      r["disk_bytes_read"] = TEXT(rusage_info_data.ri_diskio_bytesread);
+      r["disk_bytes_written"] = TEXT(rusage_info_data.ri_diskio_byteswritten);
+
       // Below is the logic to caculate the start_time since boot time
       // with higher precision
       auto uptime = getUptimeInUSec();

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -22,6 +22,8 @@ schema([
         aliases=["phys_footprint"]),
     Column("user_time", BIGINT, "CPU time spent in user space"),
     Column("system_time", BIGINT, "CPU time spent in kernel space"),
+    Column("disk_bytes_read", BIGINT, "Bytes read from disk"),
+    Column("disk_bytes_written", BIGINT, "Bytes written to disk"),
     Column("start_time", BIGINT,
         "Process start in seconds since boot (non-sleeping)"),
     Column("parent", BIGINT, "Process parent's PID"),


### PR DESCRIPTION
Windows and FreeBSD fail to build for me, so I haven't been able to implement support for those platforms. My research indicates that it's possible, though.

Tested with new unit test on both platforms and profiling script on macOS:

```
% tools/analysis/profile.py --query 'select * from processes;' --leaks
Analyzing leaks in query: select * from processes;
  definitely: 0 leaks for 0 total leaked bytes.
```