### PR TITLE
Use safeStrtoll instead of strtol

### DIFF
--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -428,9 +428,15 @@ void genProcess(const std::string& pid, QueryData& results) {
     VLOG(1) << proc_io.status.getMessage();
   } else {
     r["disk_bytes_read"] = proc_io.read_bytes;
+    long long write_bytes = 0;
+    long long cancelled_write_bytes = 0;
+
+    osquery::safeStrtoll(proc_io.write_bytes, 10, write_bytes);
+    osquery::safeStrtoll(
+        proc_io.cancelled_write_bytes, 10, cancelled_write_bytes);
+
     r["disk_bytes_written"] =
-        std::to_string(std::stol(proc_io.write_bytes, nullptr) -
-                       std::stol(proc_io.cancelled_write_bytes, nullptr));
+        std::to_string(write_bytes - cancelled_write_bytes);
   }
 
   results.push_back(r);


### PR DESCRIPTION
Addressing a late comment on #4204, fixing the data type while I'm at it.