### PR TITLE
tables: Add yum_sources table

### DIFF
--- a/osquery/tables/system/posix/tests/yum_sources_tests.cpp
+++ b/osquery/tables/system/posix/tests/yum_sources_tests.cpp
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include<sstream>
+
+#include <gtest/gtest.h>
+
+#include <osquery/sql.h>
+
+namespace osquery {
+namespace tables {
+
+void parseYumConf(std::istream&, QueryData&ults, std::string&epos_dir);
+
+class YumSourcesTests : public testing::Test {};
+
+TEST_F(YumSourcesTests, parse_yum_conf) {
+  QueryData results;
+  std::string repos_dir;
+
+  std::istringstream stream1("");
+  parseYumConf(stream1, results, repos_dir);
+  ASSERT_EQ(repos_dir, "/etc/yum.repos.d");
+  ASSERT_EQ(results.size(), (unsigned long) 0);
+
+  std::istringstream stream2(R"STRLIT(
+# Some comment
+
+[main]
+cachedir=/var/cache/yum
+reposdir=/etc/local/yum.repos.d
+
+[personal]
+baseurl=http://my.repo.url/1/v2/3
+enabled=1
+name=My personal repo
+reposdir=/ignored/path
+
+[math]
+baseurl=http://some.math.repo.url
+enabled=0
+name=Mathematic library repo
+gpgcheck=0
+)STRLIT");
+
+  parseYumConf(stream2, results, repos_dir);
+  ASSERT_EQ(repos_dir, "/etc/local/yum.repos.d");
+  ASSERT_EQ(results.size(), (unsigned long) 2);
+  ASSERT_EQ(results.at(0).at("baseurl"), "http://my.repo.url/1/v2/3");
+  ASSERT_EQ(results.at(0).at("enabled"), "1");
+  ASSERT_EQ(results.at(0).at("name"), "My personal repo");
+  ASSERT_EQ(results.at(0).find("gpgcheck"), results.at(0).end());
+  ASSERT_EQ(results.at(1).at("baseurl"), "http://some.math.repo.url");
+  ASSERT_EQ(results.at(1).at("enabled"), "0");
+  ASSERT_EQ(results.at(1).at("name"), "Mathematic library repo");
+  ASSERT_EQ(results.at(1).at("gpgcheck"), "0");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/tests/yum_sources_tests.cpp
+++ b/osquery/tables/system/posix/tests/yum_sources_tests.cpp
@@ -17,7 +17,7 @@
 namespace osquery {
 namespace tables {
 
-void parseYumConf(std::istream&, QueryData&ults, std::string&epos_dir);
+void parseYumConf(std::istream&, QueryData& ults, std::string& repos_dir);
 
 class YumSourcesTests : public testing::Test {};
 
@@ -28,7 +28,7 @@ TEST_F(YumSourcesTests, parse_empty_yum_conf) {
   parseYumConf(stream1, results, repos_dir);
   // Default is used when no main.reposdir is set
   ASSERT_EQ(repos_dir, "/etc/yum.repos.d");
-  ASSERT_EQ(results.size(), (unsigned long) 0);
+  ASSERT_EQ(results.size(), (unsigned long)0);
 }
 
 TEST_F(YumSourcesTests, parse_yum_conf) {
@@ -58,7 +58,7 @@ gpgkey=ftp://repokeys/mykey
 
   parseYumConf(stream2, results, repos_dir);
   ASSERT_EQ(repos_dir, "/etc/local/yum.repos.d");
-  ASSERT_EQ(results.size(), (unsigned long) 2);
+  ASSERT_EQ(results.size(), (unsigned long)2);
 
   ASSERT_EQ(results.at(0).at("baseurl"), "http://my.repo.url/1/v2/3");
   ASSERT_EQ(results.at(0).at("enabled"), "1");

--- a/osquery/tables/system/posix/tests/yum_sources_tests.cpp
+++ b/osquery/tables/system/posix/tests/yum_sources_tests.cpp
@@ -8,7 +8,7 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include<sstream>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
@@ -21,20 +21,25 @@ void parseYumConf(std::istream&, QueryData&ults, std::string&epos_dir);
 
 class YumSourcesTests : public testing::Test {};
 
+TEST_F(YumSourcesTests, parse_empty_yum_conf) {
+  QueryData results;
+  std::string repos_dir;
+  std::istringstream stream1("");
+  parseYumConf(stream1, results, repos_dir);
+  // Default is used when no main.reposdir is set
+  ASSERT_EQ(repos_dir, "/etc/yum.repos.d");
+  ASSERT_EQ(results.size(), (unsigned long) 0);
+}
+
 TEST_F(YumSourcesTests, parse_yum_conf) {
   QueryData results;
   std::string repos_dir;
-
-  std::istringstream stream1("");
-  parseYumConf(stream1, results, repos_dir);
-  ASSERT_EQ(repos_dir, "/etc/yum.repos.d");
-  ASSERT_EQ(results.size(), (unsigned long) 0);
-
   std::istringstream stream2(R"STRLIT(
 # Some comment
 
 [main]
 cachedir=/var/cache/yum
+# This should override the default
 reposdir=/etc/local/yum.repos.d
 
 [personal]

--- a/osquery/tables/system/posix/tests/yum_sources_tests.cpp
+++ b/osquery/tables/system/posix/tests/yum_sources_tests.cpp
@@ -48,19 +48,24 @@ baseurl=http://some.math.repo.url
 enabled=0
 name=Mathematic library repo
 gpgcheck=0
+gpgkey=ftp://repokeys/mykey
 )STRLIT");
 
   parseYumConf(stream2, results, repos_dir);
   ASSERT_EQ(repos_dir, "/etc/local/yum.repos.d");
   ASSERT_EQ(results.size(), (unsigned long) 2);
+
   ASSERT_EQ(results.at(0).at("baseurl"), "http://my.repo.url/1/v2/3");
   ASSERT_EQ(results.at(0).at("enabled"), "1");
   ASSERT_EQ(results.at(0).at("name"), "My personal repo");
   ASSERT_EQ(results.at(0).find("gpgcheck"), results.at(0).end());
+  ASSERT_EQ(results.at(0).find("gpgkey"), results.at(0).end());
+
   ASSERT_EQ(results.at(1).at("baseurl"), "http://some.math.repo.url");
   ASSERT_EQ(results.at(1).at("enabled"), "0");
   ASSERT_EQ(results.at(1).at("name"), "Mathematic library repo");
   ASSERT_EQ(results.at(1).at("gpgcheck"), "0");
+  ASSERT_EQ(results.at(1).at("gpgkey"), "ftp://repokeys/mykey");
 }
 
 } // namespace tables

--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -1,0 +1,92 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+void parseYumConf(const std::string& source, QueryData& results, std::string& repos_dir) {
+  // Default value
+  repos_dir = "/etc/yum.repos.d";
+
+  std::string content;
+  if (!readFile(source, content)) {
+    return;
+  }
+
+  std::string section = "";
+  for (const auto& line : osquery::split(content, "\n")) {
+    auto size = line.size();
+
+    // Skip comments.
+    if (size == 0 || line[0] == '#') {
+      continue;
+    }
+
+    if (size > 2) {
+      if  (line[0] == '[' && line[size - 1] == ']') {
+        section = line.substr(1, size - 2);
+      } else {
+        if ("" == "section") {
+          continue;
+        }
+        auto pos = line.find("=");
+        if (pos != std::string::npos) {
+          std::string option = line.substr(0, pos);
+          std::string value = line.substr(pos + 1, size - pos - 1);
+          if ("main" == section) {
+            if ("reposdir" == option) {
+              repos_dir = value;
+            }
+          } else {
+            // Repository section
+            if ("baseurl" == option || "enabled" == option
+                || "gpgcheck" == option || "name" == option) {
+              Row r;
+              r[option] = value;
+              results.push_back(r);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+QueryData genYumSrcs(QueryContext& context) {
+  QueryData results;
+
+  // We are going to read a few files.
+  auto dropper = DropPrivileges::get();
+  dropper->dropTo("nobody");
+
+  // Expect the YUM home to be /etc/yum.conf
+  std::string repos_dir;
+  parseYumConf("/etc/yum.conf", results, repos_dir);
+
+  std::vector<std::string> sources;
+  if (!resolveFilePattern(repos_dir + "/%.list", sources, GLOB_FILES)) {
+    VLOG(1) << "Cannot resolve yum conf files";
+    return results;
+  }
+
+  for (const auto& source : sources) {
+    VLOG(1) << source;
+    parseYumConf(source, results, repos_dir);
+  }
+
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -39,7 +39,8 @@ void parseYumConf(std::istream& source, QueryData& results, std::string& repos_d
     for (auto it2: it1.second) {
       // Option
       if ("baseurl" == it2.first || "enabled" == it2.first
-          || "gpgcheck" == it2.first || "name" == it2.first) {
+          || "gpgcheck" == it2.first || "name" == it2.first
+          || "gpgkey" == it2.first) {
         r[it2.first] = it2.second.data();
       }
     }

--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -9,8 +9,8 @@
  */
 
 #include <boost/property_tree/ini_parser.hpp>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
@@ -21,26 +21,28 @@
 namespace osquery {
 namespace tables {
 
-const std::string kYumConf { "/etc/yum.conf" };
-const std::string kYumReposDir { "/etc/yum.repos.d" };
+const std::string kYumConf{"/etc/yum.conf"};
+const std::string kYumReposDir{"/etc/yum.repos.d"};
 
-void parseYumConf(std::istream& source, QueryData& results, std::string& repos_dir) {
+void parseYumConf(std::istream& source,
+                  QueryData& results,
+                  std::string& repos_dir) {
   boost::property_tree::ptree tree;
   boost::property_tree::ini_parser::read_ini(source, tree);
   repos_dir = tree.get("main.reposdir", kYumReposDir);
 
-  for (auto it1: tree) {
+  for (auto it1 : tree) {
     // Section
     if (it1.first == "main") {
       continue;
     }
 
     Row r;
-    for (auto it2: it1.second) {
+    for (auto it2 : it1.second) {
       // Option
-      if ("baseurl" == it2.first || "enabled" == it2.first
-          || "gpgcheck" == it2.first || "name" == it2.first
-          || "gpgkey" == it2.first) {
+      if ("baseurl" == it2.first || "enabled" == it2.first ||
+          "gpgcheck" == it2.first || "name" == it2.first ||
+          "gpgkey" == it2.first) {
         r[it2.first] = it2.second.data();
       }
     }
@@ -48,7 +50,9 @@ void parseYumConf(std::istream& source, QueryData& results, std::string& repos_d
   }
 }
 
-void parseYumConf(const std::string& source, QueryData& results, std::string& repos_dir) {
+void parseYumConf(const std::string& source,
+                  QueryData& results,
+                  std::string& repos_dir) {
   std::ifstream stream(source.c_str());
   if (!stream) {
     VLOG(1) << "File " << source << " cannot be read";
@@ -60,7 +64,7 @@ void parseYumConf(const std::string& source, QueryData& results, std::string& re
     parseYumConf(stream, results, repos_dir);
   } catch (boost::property_tree::ini_parser::ini_parser_error& e) {
     VLOG(1) << "File " << source
-      << " either cannot be read or cannot be parsed as ini";
+            << " either cannot be read or cannot be parsed as ini";
     repos_dir = kYumReposDir;
   }
 }

--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -51,8 +51,7 @@ void parseYumConf(std::istream& source, QueryData& results, std::string& repos_d
 void parseYumConf(const std::string& source, QueryData& results, std::string& repos_dir) {
   std::ifstream stream(source.c_str());
   if (!stream) {
-    VLOG(1) << "File " << source
-      << " either cannot be read or cannot be parsed as ini";
+    VLOG(1) << "File " << source << " cannot be read";
     repos_dir = kYumReposDir;
     return;
   }
@@ -79,7 +78,7 @@ QueryData genYumSrcs(QueryContext& context) {
 
   std::vector<std::string> sources;
   if (!resolveFilePattern(repos_dir + "/%.list", sources, GLOB_FILES)) {
-    VLOG(1) << "Cannot resolve yum conf files under" << repos_dir << "/*.list";
+    VLOG(1) << "Cannot resolve yum conf files under " << repos_dir << "/*.list";
     return results;
   }
 

--- a/specs/posix/yum_sources.table
+++ b/specs/posix/yum_sources.table
@@ -5,5 +5,6 @@ schema([
     Column("baseurl", TEXT, "Repository base URL"),
     Column("enabled", TEXT, "Whether the repository is used"),
     Column("gpgcheck", TEXT, "Whether packages are GPG checked"),
+    Column("gpgkey", TEXT, "URL to GPG key"),
 ])
 implementation("system/yum_sources@genYumSrcs")

--- a/specs/posix/yum_sources.table
+++ b/specs/posix/yum_sources.table
@@ -1,0 +1,9 @@
+table_name("yum_sources")
+description("Current list of APT repositories or software channels.")
+schema([
+    Column("name", TEXT, "Repository name"),
+    Column("baseurl", TEXT, "Repository base URL"),
+    Column("enabled", TEXT, "Whether the repository is used"),
+    Column("gpgcheck", TEXT, "Whether packages are GPG checked"),
+])
+implementation("system/yum_sources@genYumSrcs")

--- a/specs/posix/yum_sources.table
+++ b/specs/posix/yum_sources.table
@@ -1,5 +1,5 @@
 table_name("yum_sources")
-description("Current list of APT repositories or software channels.")
+description("Current list of Yum repositories or software channels.")
 schema([
     Column("name", TEXT, "Repository name"),
     Column("baseurl", TEXT, "Repository base URL"),


### PR DESCRIPTION
Similar to the apt_sources table.

This assumes the configuration is at `/etc/yum.conf`. It will follow the `reposdir` option if it's set, but only does that once.

@fmanco 