### PR TITLE
Add video_info table to collect video card information

### DIFF
--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -18,41 +18,39 @@
 #include "osquery/core/windows/wmi.h"
 
 namespace osquery {
-	namespace tables {
+namespace tables {
 
-		QueryData genVideoInfo(QueryContext& context) {
-			Row r;
-			QueryData results;
+QueryData genVideoInfo(QueryContext& context) {
+  Row r;
+  QueryData results;
 
-			WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
-			std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
-			if (!wmiResults.empty()) {;
-			long bitsPerPixel = 0;
-			std::string vramholder;
-			unsigned long long vram = 42;
-				wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
-				r["color_depth"] = INTEGER(bitsPerPixel);
-				wmiResults[0].GetString("InstalledDisplayDrivers", r["driver"]);
-				wmiResults[0].GetString("DriverDate", r["driver_date"]);
-				wmiResults[0].GetString("DriverVersion", r["driver_version"]);
-				wmiResults[0].GetString("AdapterCompatibility", r["manufacturer"]);
-				wmiResults[0].GetString("VideoProcessor", r["model"]);
-				wmiResults[0].GetString("Name", r["series"]);
-				wmiResults[0].GetString("VideoModeDescription", r["video_mode"]);
-			}
-			else {
-				r["color_depth"] = "-1";
-				r["driver"] = "-1";
-				r["driver_date"] = "-1";
-				r["driver_version"] = "-1";
-				r["manufacturer"] = "-1";
-				r["model"] = " - 1";
-				r["series"] = "-1";
-				r["video_mode"] = "-1";
-			}
+  WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
+  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  if (!wmiResults.empty()) {
+    ;
+    long bitsPerPixel = 0;
+    wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
+    r["color_depth"] = INTEGER(bitsPerPixel);
+    wmiResults[0].GetString("InstalledDisplayDrivers", r["driver"]);
+    wmiResults[0].GetString("DriverDate", r["driver_date"]);
+    wmiResults[0].GetString("DriverVersion", r["driver_version"]);
+    wmiResults[0].GetString("AdapterCompatibility", r["manufacturer"]);
+    wmiResults[0].GetString("VideoProcessor", r["model"]);
+    wmiResults[0].GetString("Name", r["series"]);
+    wmiResults[0].GetString("VideoModeDescription", r["video_mode"]);
+  } else {
+    r["color_depth"] = "-1";
+    r["driver"] = "-1";
+    r["driver_date"] = "-1";
+    r["driver_version"] = "-1";
+    r["manufacturer"] = "-1";
+    r["model"] = " - 1";
+    r["series"] = "-1";
+    r["video_mode"] = "-1";
+  }
 
-			results.push_back(r);
-			return results;
-		}
-	}
+  results.push_back(r);
+  return results;
+}
+}
 }

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -27,7 +27,6 @@ QueryData genVideoInfo(QueryContext& context) {
   WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
   std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (!wmiResults.empty()) {
-    ;
     long bitsPerPixel = 0;
     wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
     r["color_depth"] = INTEGER(bitsPerPixel);

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -26,7 +26,10 @@ QueryData genVideoInfo(QueryContext& context) {
 
   WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
   std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
-  if (!wmiResults.empty()) {
+  if (wmiResults.empty()) {
+    LOG(WARNING) << "Failed to retrieve video information";
+    return {};
+  } else {
     long bitsPerPixel = 0;
     wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
     r["color_depth"] = INTEGER(bitsPerPixel);
@@ -37,15 +40,6 @@ QueryData genVideoInfo(QueryContext& context) {
     wmiResults[0].GetString("VideoProcessor", r["model"]);
     wmiResults[0].GetString("Name", r["series"]);
     wmiResults[0].GetString("VideoModeDescription", r["video_mode"]);
-  } else {
-    r["color_depth"] = "-1";
-    r["driver"] = "-1";
-    r["driver_date"] = "-1";
-    r["driver_version"] = "-1";
-    r["manufacturer"] = "-1";
-    r["model"] = " - 1";
-    r["series"] = "-1";
-    r["video_mode"] = "-1";
   }
 
   results.push_back(r);

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -45,5 +45,5 @@ QueryData genVideoInfo(QueryContext& context) {
   results.push_back(r);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <osquery/logger.h>
 #include <osquery/sql.h>
 #include <osquery/system.h>
 #include <osquery/tables.h>

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -1,0 +1,58 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <boost/algorithm/string.hpp>
+
+#include <osquery/sql.h>
+#include <osquery/system.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+	namespace tables {
+
+		QueryData genVideoInfo(QueryContext& context) {
+			Row r;
+			QueryData results;
+
+			WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
+			std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+			if (!wmiResults.empty()) {;
+			long bitsPerPixel = 0;
+			std::string vramholder;
+			unsigned long long vram = 42;
+				wmiResults[0].GetLong("CurrentBitsPerPixel", bitsPerPixel);
+				r["color_depth"] = INTEGER(bitsPerPixel);
+				wmiResults[0].GetString("InstalledDisplayDrivers", r["driver"]);
+				wmiResults[0].GetString("DriverDate", r["driver_date"]);
+				wmiResults[0].GetString("DriverVersion", r["driver_version"]);
+				wmiResults[0].GetString("AdapterCompatibility", r["manufacturer"]);
+				wmiResults[0].GetString("VideoProcessor", r["model"]);
+				wmiResults[0].GetString("Name", r["series"]);
+				wmiResults[0].GetString("VideoModeDescription", r["video_mode"]);
+			}
+			else {
+				r["color_depth"] = "-1";
+				r["driver"] = "-1";
+				r["driver_date"] = "-1";
+				r["driver_version"] = "-1";
+				r["manufacturer"] = "-1";
+				r["model"] = " - 1";
+				r["series"] = "-1";
+				r["video_mode"] = "-1";
+			}
+
+			results.push_back(r);
+			return results;
+		}
+	}
+}

--- a/specs/windows/video_info.table
+++ b/specs/windows/video_info.table
@@ -4,10 +4,10 @@ schema([
     Column("color_depth", INTEGER, "The amount of bits per pixel to represent color."),
     Column("driver", TEXT, "The driver of the device."),
     Column("driver_date", TEXT, "The date listed on the installed driver."),
-	Column("driver_version", TEXT, "The version of the installed driver."),
+    Column("driver_version", TEXT, "The version of the installed driver."),
     Column("manufacturer", TEXT, "The manufaturer of the gpu."),
     Column("model", TEXT, "The model of the gpu."),
     Column("series", TEXT, "The series of the gpu."),
-	Column("video_mode", TEXT, "The current resolution of the display."),
+    Column("video_mode", TEXT, "The current resolution of the display."),
 ])
 implementation("video_info@genVideoInfo")

--- a/specs/windows/video_info.table
+++ b/specs/windows/video_info.table
@@ -1,0 +1,13 @@
+table_name("video_info")
+description("Retrieve video card information of the machine.")
+schema([
+    Column("color_depth", INTEGER, "The amount of bits per pixel to represent color."),
+    Column("driver", TEXT, "The driver of the device."),
+    Column("driver_date", TEXT, "The date listed on the installed driver."),
+	Column("driver_version", TEXT, "The version of the installed driver."),
+    Column("manufacturer", TEXT, "The manufaturer of the gpu."),
+    Column("model", TEXT, "The model of the gpu."),
+    Column("series", TEXT, "The series of the gpu."),
+	Column("video_mode", TEXT, "The current resolution of the display."),
+])
+implementation("video_info@genVideoInfo")


### PR DESCRIPTION
I omitted the wmi property for AdapterRam, which should in theory return the video card memory (in bytes), but I am having some major type conversion and/or overflow issues when I approach it for devices that have over 4GB of memory on their card. Maybe someone else can add it in?