### PR TITLE
docs: shadow only works for root / sudo

### DIFF
--- a/specs/linux/shadow.table
+++ b/specs/linux/shadow.table
@@ -1,5 +1,5 @@
 table_name("shadow")
-description("Local system users encrypted passwords and related information.")
+description("Local system users encrypted passwords and related information. Please note, that you usually need superuser rights to access `/etc/shadow`.")
 schema([
     Column("password_status", TEXT, "Password status"),
     Column("hash_alg", TEXT, "Password hashing algorithm"),


### PR DESCRIPTION
I was wondering for a 30 min if this is a bug or not, until I remembered, I was running `osqueryi` as my user not as root.