### PR TITLE
Don't bail out when querying one namespace fails

### DIFF
--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -75,7 +75,7 @@ Status procGetProcessNamespaces(const std::string& process_id,
     auto status = procGetNamespaceInode(
         namespace_inode, namespace_name, process_namespace_root);
     if (!status.ok()) {
-      return status;
+      continue;
     }
 
     namespace_list[namespace_name] = namespace_inode;


### PR DESCRIPTION
On linux we're not guaranteed to have all namespaces available,
therefore listing namespaces shouldn't quit when one is not available or
fails to read.

This causes problems for instance on systems without cgroups.