### PR TITLE
Fix acceleration code to use RapidJSON properly

### DIFF
--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -217,22 +217,17 @@ Status Distributed::acceptWork(const std::string& work) {
       }
     }
   }
-
   if (doc.doc().HasMember("accelerate")) {
     const auto& accelerate = doc.doc()["accelerate"];
-    if (accelerate.IsString()) {
-      auto new_time = std::string(accelerate.GetString());
-      unsigned long duration = 0;
-      Status conversion = safeStrtoul(new_time, 10, duration);
-      if (conversion.ok()) {
-        LOG(INFO) << "Accelerating distributed query checkins for " << duration
-                  << " seconds";
-        setDatabaseValue(kPersistentSettings,
-                         "distributed_accelerate_checkins_expire",
-                         std::to_string(getUnixTime() + duration));
-      } else {
-        LOG(WARNING) << "Failed to Accelerate: Timeframe is not an integer";
-      }
+    if (accelerate.IsInt()) {
+      auto duration = accelerate.GetInt();
+      LOG(INFO) << "Accelerating distributed query checkins for " << duration
+                << " seconds";
+      setDatabaseValue(kPersistentSettings,
+                       "distributed_accelerate_checkins_expire",
+                       std::to_string(getUnixTime() + duration));
+    } else {
+      VLOG(1) << "Falied to Accelerate: Timeframe is not an integer";
     }
   }
   return Status();


### PR DESCRIPTION
The acceleration code was not updated to reflect the proper typing of RapidJSON deserialization, thus we were always failing the IsString() check and never running accelerated mode.

This is just a simple fix to use the API correctly. I'm marking it as `API Change` because in theory would have worked before if you made accelerate a string (even though it was supposed to be an int) and now it must be an int.