### PR TITLE
Add a hash_resources parameter (column) to the macOS signature table

### DIFF
--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -30,40 +30,46 @@ namespace tables {
 // Empty string runs default verification on a file
 std::set<std::string> kCheckedArches{"", "i386", "ppc", "arm", "x86_64"};
 
-// Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on
-// the OS version.
-Status getVerifyFlags(SecCSFlags& flags) {
+int getOSMinorVersion() {
   using boost::lexical_cast;
   using boost::bad_lexical_cast;
 
-  static SecCSFlags sFlags;
-
-  if (sFlags == 0) {
-    auto qd = SQL::selectAllFrom("os_version");
-    if (qd.size() != 1) {
-      return Status(-1, "Couldn't determine OS X version");
-    }
-
-    int minorVersion;
-    try {
-      minorVersion = lexical_cast<int>(qd.front().at("minor"));
-    } catch (const bad_lexical_cast& e) {
-      return Status(-1, "Couldn't determine OS X version");
-    }
-
-    sFlags = kSecCSStrictValidate | kSecCSCheckAllArchitectures |
-             kSecCSCheckNestedCode;
-    if (minorVersion > 8) {
-      sFlags |= kSecCSCheckNestedCode;
-    }
+  auto qd = SQL::selectAllFrom("os_version");
+  if (qd.size() != 1) {
+    return -1;
   }
 
-  flags = sFlags;
+  try {
+    return lexical_cast<int>(qd.front().at("minor"));
+  } catch (const bad_lexical_cast& e) {
+    return -1;
+  }
+}
+
+// Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on
+// the OS version.
+Status getVerifyFlags(SecCSFlags& flags, bool hashResources) {
+  static const auto minorVersion = getOSMinorVersion();
+  if (minorVersion == -1) {
+    return Status(-1, "Couldn't determine OS X version");
+  }
+
+  flags = kSecCSStrictValidate | kSecCSCheckAllArchitectures |
+          kSecCSCheckNestedCode;
+  if (minorVersion > 8) {
+    flags |= kSecCSCheckNestedCode;
+  }
+
+  if (!hashResources) {
+    flags |= kSecCSDoNotValidateResources;
+  }
+
   return Status(0, "ok");
 }
 
 Status genSignatureForFileAndArch(const std::string& path,
                                   const std::string& arch,
+                                  bool hashResources,
                                   QueryData& results) {
   OSStatus result;
   SecStaticCodeRef static_code = nullptr;
@@ -106,11 +112,12 @@ Status genSignatureForFileAndArch(const std::string& path,
 
   Row r;
   r["path"] = path;
+  r["hash_resources"] = INTEGER(hashResources);
   r["arch"] = arch;
   r["identifier"] = "";
 
   SecCSFlags flags = 0;
-  getVerifyFlags(flags);
+  getVerifyFlags(flags, hashResources);
   result = SecStaticCodeCheckValidityWithErrors(
       static_code, flags, nullptr, nullptr);
   if (result == errSecSuccess) {
@@ -216,11 +223,13 @@ Status genSignatureForFileAndArch(const std::string& path,
 }
 
 // Generate a signature for a single file.
-void genSignatureForFile(const std::string& path, QueryData& results) {
+void genSignatureForFile(const std::string& path,
+                         bool hashResources,
+                         QueryData& results) {
   for (const auto& arch : kCheckedArches) {
     // This returns a status but there is nothing we need to handle
     // here so we can safely ignore it
-    genSignatureForFileAndArch(path, arch, results);
+    genSignatureForFileAndArch(path, arch, hashResources, results);
   }
 }
 
@@ -232,7 +241,9 @@ QueryData genSignature(QueryContext& context) {
   // operator.
   auto paths = context.constraints["path"].getAll(EQUALS);
   context.expandConstraints(
-      "path", LIKE, paths,
+      "path",
+      LIKE,
+      paths,
       ([&](const std::string& pattern, std::set<std::string>& out) {
         std::vector<std::string> patterns;
         auto status =
@@ -244,6 +255,19 @@ QueryData genSignature(QueryContext& context) {
         }
         return status;
       }));
+
+  auto hashResContraints = context.constraints["hash_resources"].getAll(EQUALS);
+  if (hashResContraints.size() > 1) {
+    VLOG(1) << "Received multiple constraint values for column hash_resources. "
+               "Only the first one will be evaluated.";
+  }
+
+  bool hashResources = true;
+  if (!hashResContraints.empty()) {
+    const auto& value = *hashResContraints.begin();
+    hashResources = (value != "0");
+  }
+
   @autoreleasepool {
     for (const auto& path_string : paths) {
       // Note: we are explicitly *not* using is_regular_file here, since you can
@@ -252,7 +276,7 @@ QueryData genSignature(QueryContext& context) {
       if (!pathExists(path_string).ok()) {
         continue;
       }
-      genSignatureForFile(path_string, results);
+      genSignatureForFile(path_string, hashResources, results);
     }
   }
 

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -2,6 +2,7 @@ table_name("signature")
 description("File (executable, bundle, installer, disk) code signing status.")
 schema([
     Column("path", TEXT, "Must provide a path or directory", required=True),
+    Column("hash_resources", INTEGER, "Set to 1 to also hash resources, or 0 otherwise. Default is 1"),
     Column("arch", TEXT, "If applicable, the arch of the signed code"),
     Column("signed", INTEGER, "1 If the file is signed else 0"),
     Column("identifier", TEXT, "The signing identifier sealed into the signature"),
@@ -12,5 +13,6 @@ schema([
 implementation("signature@genSignature")
 examples([
   "SELECT * FROM signature WHERE path = '/bin/ls'",
+  "SELECT * FROM signature WHERE path = '/Applications/Xcode.app' AND hash_resources=0",
   "SELECT * FROM (SELECT path, MIN(signed) AS all_signed, MIN(CASE WHEN authority = 'Software Signing' AND signed = 1 THEN 1 ELSE 0 END) AS all_signed_by_apple FROM signature WHERE path LIKE '/bin/%' GROUP BY path);"
 ])


### PR DESCRIPTION
This is an attempt at solving issue #2987 

The new column allows the user to disable resource hashing when querying the table.

```
Using a virtual database. Need help, type '.help'
osquery> SELECT *, hash_resources FROM signature WHERE path = '/Applications/Xcode.app' AND hash_resources = 0;
+-------------------------+--------+--------------------+------------------------------------------+-----------------+----------------------------------+----------------+
| path                    | signed | identifier         | cdhash                                   | team_identifier | authority                        | hash_resources |
+-------------------------+--------+--------------------+------------------------------------------+-----------------+----------------------------------+----------------+
| /Applications/Xcode.app | 1      | com.apple.dt.Xcode | 73a18b1658fad362c2e13359feafc517b1325870 | 59GAB85EFG      | Apple Mac OS Application Signing | 0              |
+-------------------------+--------+--------------------+------------------------------------------+-----------------+----------------------------------+----------------+
```

EDIT: Got rid of a static variable I didn't initially notice in the code! Everything works fine now!