### PR TITLE
Add documentation for Darwin ALF "Block all incoming connections" mode

### DIFF
--- a/specs/darwin/alf.table
+++ b/specs/darwin/alf.table
@@ -3,7 +3,7 @@ description("OS X application layer firewall (ALF) service details.")
 schema([
     Column("allow_signed_enabled", INTEGER, "1 If allow signed mode is enabled else 0"),
     Column("firewall_unload", INTEGER, "1 If firewall unloading enabled else 0"),
-    Column("global_state", INTEGER, "1 If the firewall start by default else 0"),
+    Column("global_state", INTEGER, "1 If the firewall is enabled with exceptions, 2 if the firewall is configured to block all incoming connections, else 0"),
     Column("logging_enabled", INTEGER, "1 If logging mode is enabled else 0"),
     Column("logging_option", INTEGER, "Firewall logging option"),
     Column("stealth_enabled", INTEGER, "1 If stealth mode is enabled else 0"),


### PR DESCRIPTION
This PR adds documentation for "Block all incoming" connections mode in macOS.

When macOS application layer firewall is in "Block all incoming connections" mode, the `global_state` column of the `alf` table is `2`:

<img width="540" alt="screenshot 2018-03-31 20 07 31" src="https://user-images.githubusercontent.com/7683112/38169443-2b75d064-351f-11e8-8493-cdb229dd17a2.png">

```
osquery> select global_state from alf;
+--------------+
| global_state |
+--------------+
| 2            |
+--------------+
```

I'm open to suggestions on wording, but want to fix this documentation because I ran into a problem where I thought ALF was not enabled on a bunch of devices when it actually was enabled in the strictest mode.  😄 