### PR TITLE
update specs at the root directory to include windows

### DIFF
--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -33,7 +33,7 @@ from gentable import *
 # This data structure represents the directories in specs/ and how they map to
 # the operating systems which support tables found in those directories
 PLATFORM_DIRS = {
-    "specs": ["darwin", "linux"],
+    "specs": ["darwin", "linux", "windows", "freebsd"],
     "utility": ["darwin", "linux", "freebsd", "windows"],
     "yara": ["darwin", "linux"],
     "darwin": ["darwin"],


### PR DESCRIPTION
Fixes https://github.com/osquery/osquery-site/issues/29
The root directory was only accounting for darwin and linux.