### PR TITLE
Adding behavioral reverse shell detection to osx-attacks

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -537,6 +537,19 @@
       "version" : "2.8.0",
       "description" : "MaMi OSX Malware 2017-01-12 (https://objective-see.com/blog/blog_0x26.html)",
       "value" : "bogus certificate added to key store by this malware"
+    },
+    "Behavioral_Reverse_Shell": {
+      "query" : "SELECT processes.pid, processes.parent, processes.name, processes.path, \
+        processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
+        processes.start_time \
+        FROM processes LEFT OUTER JOIN process_open_files \
+        ON processes.pid = process_open_files.pid \
+        WHERE (name='Python' OR name='sh' OR name='bash') \
+        AND process_open_files.pid IS NULL;",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description" : "Find shell processes that have open sockets and no open files or TTY (https://clo.ng/blog/osquery_reverse_shell/)",
+      "value" : "Behavioral detection for potential reverse shells"
     }
   }
 }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -539,7 +539,7 @@
       "value" : "bogus certificate added to key store by this malware"
     },
     "Behavioral_Reverse_Shell": {
-      "query" : "SELECT processes.pid, processes.parent, processes.name, processes.path, \
+      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, \
         processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
         processes.start_time \
         FROM processes LEFT OUTER JOIN process_open_files \


### PR DESCRIPTION
This is based off of the blog post here: https://clo.ng/blog/osquery_reverse_shell/

TL;DR - Reverse shells typically have:
- A process of Python, /bin/sh, or /bin/bash
- No associated open files (including TTYs)
- An open socket

It would be awesome if anyone with a fairly decent sized fleet of macs could test this out in their environment, but in my testing it was extremely high signal. 

Also, feel free to suggest improvements to the SQL if there are optimizations that can be made. I got the query to a working state, but I'm positive it's not in an optimal state.