### PR TITLE
Updating reverse shell query in osx-attacks

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -541,10 +541,11 @@
     "Behavioral_Reverse_Shell": {
       "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, \
         processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
-        processes.start_time \
-        FROM processes LEFT OUTER JOIN process_open_files \
+        processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port \
+        FROM processes JOIN process_open_sockets USING (pid) \
+        LEFT OUTER JOIN process_open_files \
         ON processes.pid = process_open_files.pid \
-        WHERE (name='Python' OR name='sh' OR name='bash') \
+        WHERE (name='sh' OR name='bash') \
         AND process_open_files.pid IS NULL;",
       "interval" : "3600",
       "version" : "2.8.0",

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -541,7 +541,8 @@
     "Behavioral_Reverse_Shell": {
       "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, \
         processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, \
-        processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port \
+        processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, \
+        (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline \
         FROM processes JOIN process_open_sockets USING (pid) \
         LEFT OUTER JOIN process_open_files \
         ON processes.pid = process_open_files.pid \


### PR DESCRIPTION
In previous commit for this query I accidentally copy and pasted a previous iteration of the query that didn't include any socket-based filtering. I have also realized the `name='Python'` clause was redundant and has the potential to cause false positives. This version should be MUCH more high signal. My apologies for adding the wrong one initially! 