### PR TITLE
Cache unchanging values in processes table in macOS

### DIFF
--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -288,6 +288,13 @@ void genProcCmdline(int pid, Row& r) {
   r["cmdline"] = cmdline;
 }
 
+void genProcNamePathCmdlineAndOnDisk(int pid,
+                                     const struct proc_cred& cred,
+                                     Row& r) {
+  genProcCmdline(pid, r);
+  genProcNamePathAndOnDisk(pid, cred, r);
+}
+
 static inline long getUptimeInUSec() {
   struct timeval boot_time;
   size_t len = sizeof(boot_time);
@@ -366,8 +373,6 @@ QueryData genProcesses(QueryContext& context) {
     Row r;
     r["pid"] = INTEGER(pid);
 
-    genProcCmdline(pid, r);
-
     // The process relative root and current working directory.
     genProcRootAndCWD(pid, r);
 
@@ -375,8 +380,7 @@ QueryData genProcesses(QueryContext& context) {
     if (!genProcCred(pid, cred, r)) {
       continue;
     }
-
-    genProcNamePathAndOnDisk(pid, cred, r);
+    genProcNamePathCmdlineAndOnDisk(pid, cred, r);
 
     // systems usage and time information
     genProcRUsage(pid, r);

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -109,7 +109,7 @@ struct proc_cred {
   } real, effective, saved;
 };
 
-inline bool getProcCred(int pid, proc_cred& cred) {
+inline bool genProcCred(int pid, proc_cred& cred, Row& r) {
   struct proc_bsdinfo bsdinfo;
   struct proc_bsdshortinfo bsdinfo_short;
 
@@ -125,7 +125,6 @@ inline bool getProcCred(int pid, proc_cred& cred) {
     cred.effective.gid = bsdinfo.pbi_gid;
     cred.saved.uid = bsdinfo.pbi_svuid;
     cred.saved.gid = bsdinfo.pbi_svgid;
-    return true;
   } else if (proc_pidinfo(pid,
                           PROC_PIDT_SHORTBSDINFO,
                           1,
@@ -141,9 +140,25 @@ inline bool getProcCred(int pid, proc_cred& cred) {
     cred.effective.gid = bsdinfo_short.pbsi_gid;
     cred.saved.uid = bsdinfo_short.pbsi_svuid;
     cred.saved.gid = bsdinfo_short.pbsi_svgid;
-    return true;
+  } else {
+    return false;
   }
-  return false;
+
+  r["parent"] = BIGINT(cred.parent);
+  r["pgroup"] = BIGINT(cred.group);
+  // check if process state is one of the expected ones
+  r["state"] = (1 <= cred.status && cred.status <= 5)
+                   ? TEXT(kProcessStateMapping[cred.status])
+                   : TEXT('?');
+  r["nice"] = INTEGER(cred.nice);
+  r["uid"] = BIGINT(cred.real.uid);
+  r["gid"] = BIGINT(cred.real.gid);
+  r["euid"] = BIGINT(cred.effective.uid);
+  r["egid"] = BIGINT(cred.effective.gid);
+  r["suid"] = BIGINT(cred.saved.uid);
+  r["sgid"] = BIGINT(cred.saved.gid);
+
+  return true;
 }
 
 // Get the max args space
@@ -176,6 +191,44 @@ void genProcRootAndCWD(int pid, Row& r) {
     if (pathinfo.pvi_rdir.vip_vi.vi_stat.vst_dev != 0) {
       r["root"] = std::string(pathinfo.pvi_rdir.vip_path);
     }
+  }
+}
+
+void genProcNamePathAndOnDisk(int pid, const struct proc_cred& cred, Row& r) {
+  // If the process is not a Zombie, try to find the path and name.
+  if (cred.status != 5) {
+    r["path"] = getProcPath(pid);
+    // OS X proc_name only returns 16 bytes, use the basename of the path.
+    r["name"] = fs::path(r["path"]).filename().string();
+  } else {
+    r["path"] = "";
+    std::vector<char> name(17);
+    proc_name(pid, name.data(), 16);
+    r["name"] = std::string(name.data());
+  }
+
+  // If the path of the executable that started the process is available and
+  // the path exists on disk, set on_disk to 1. If the path is not
+  // available, set on_disk to -1. If, and only if, the path of the
+  // executable is available and the file does NOT exist on disk, set on_disk
+  // to 0.
+  if (r["path"].empty()) {
+    r["on_disk"] = INTEGER(-1);
+  } else if (pathExists(r["path"])) {
+    r["on_disk"] = INTEGER(1);
+  } else {
+    r["on_disk"] = INTEGER(0);
+  }
+}
+
+void genProcNumThreads(int pid, Row& r) {
+  struct proc_taskinfo task_info;
+  int status =
+      proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &task_info, sizeof(task_info));
+  if (status == sizeof(task_info)) {
+    r["threads"] = INTEGER(task_info.pti_threadnum);
+  } else {
+    r["threads"] = "-1";
   }
 }
 
@@ -227,6 +280,14 @@ proc_args getProcRawArgs(int pid, size_t argmax) {
   return args;
 }
 
+void genProcCmdline(int pid, Row& r) {
+  int argmax = genMaxArgs();
+  // The command line invocation including arguments.
+  auto args = getProcRawArgs(pid, argmax);
+  std::string cmdline = boost::algorithm::join(args.args, " ");
+  r["cmdline"] = cmdline;
+}
+
 static inline long getUptimeInUSec() {
   struct timeval boot_time;
   size_t len = sizeof(boot_time);
@@ -246,128 +307,81 @@ static inline long getUptimeInUSec() {
               tv.tv_usec);
 }
 
-QueryData genProcesses(QueryContext& context) {
-  QueryData results;
-
+void genProcRUsage(int pid, Row& r) {
   // Initialize time conversions.
   static mach_timebase_info_data_t time_base;
   if (time_base.denom == 0) {
     mach_timebase_info(&time_base);
   }
 
-  auto pidlist = getProcList(context);
-  int argmax = genMaxArgs();
+  struct rusage_info_v2 rusage_info_data;
+  int status =
+      proc_pid_rusage(pid, RUSAGE_INFO_V2, (rusage_info_t*)&rusage_info_data);
+  // proc_pid_rusage returns -1 if it was unable to gather information
+  if (status == 0) {
+    // size/memory information
+    r["wired_size"] = TEXT(rusage_info_data.ri_wired_size);
+    r["resident_size"] = TEXT(rusage_info_data.ri_resident_size);
+    r["total_size"] = TEXT(rusage_info_data.ri_phys_footprint);
 
+    // time information
+    r["user_time"] = TEXT(rusage_info_data.ri_user_time / CPU_TIME_RATIO);
+    r["system_time"] = TEXT(rusage_info_data.ri_system_time / CPU_TIME_RATIO);
+
+    // disk i/o information
+    r["disk_bytes_read"] = TEXT(rusage_info_data.ri_diskio_bytesread);
+    r["disk_bytes_written"] = TEXT(rusage_info_data.ri_diskio_byteswritten);
+
+    // Below is the logic to caculate the start_time since boot time
+    // with higher precision
+    auto uptime = getUptimeInUSec();
+    uint64_t absoluteTime = mach_absolute_time();
+
+    auto multiply = static_cast<double>(time_base.numer) /
+                    static_cast<double>(time_base.denom);
+    auto diff = static_cast<long>(
+        (rusage_info_data.ri_proc_start_abstime - absoluteTime));
+
+    // This is a negative value
+    auto seconds_since_launch =
+        static_cast<long>(diff * multiply) / NSECS_IN_USEC;
+
+    // Get the start_time of process since the computer started
+    r["start_time"] = TEXT((uptime + seconds_since_launch) / CPU_TIME_RATIO);
+  } else {
+    r["wired_size"] = "-1";
+    r["resident_size"] = "-1";
+    r["total_size"] = "-1";
+    r["user_time"] = "-1";
+    r["system_time"] = "-1";
+    r["start_time"] = "-1";
+  }
+}
+
+QueryData genProcesses(QueryContext& context) {
+  QueryData results;
+
+  auto pidlist = getProcList(context);
   for (auto& pid : pidlist) {
     Row r;
     r["pid"] = INTEGER(pid);
 
-    {
-      // The command line invocation including arguments.
-      auto args = getProcRawArgs(pid, argmax);
-      std::string cmdline = boost::algorithm::join(args.args, " ");
-      r["cmdline"] = cmdline;
-    }
+    genProcCmdline(pid, r);
 
     // The process relative root and current working directory.
     genProcRootAndCWD(pid, r);
 
     proc_cred cred;
-    if (getProcCred(pid, cred)) {
-      r["parent"] = BIGINT(cred.parent);
-      r["pgroup"] = BIGINT(cred.group);
-      // check if process state is one of the expected ones
-      r["state"] = (1 <= cred.status && cred.status <= 5)
-                       ? TEXT(kProcessStateMapping[cred.status])
-                       : TEXT('?');
-      r["nice"] = INTEGER(cred.nice);
-      r["uid"] = BIGINT(cred.real.uid);
-      r["gid"] = BIGINT(cred.real.gid);
-      r["euid"] = BIGINT(cred.effective.uid);
-      r["egid"] = BIGINT(cred.effective.gid);
-      r["suid"] = BIGINT(cred.saved.uid);
-      r["sgid"] = BIGINT(cred.saved.gid);
-    } else {
+    if (!genProcCred(pid, cred, r)) {
       continue;
     }
 
-    // If the process is not a Zombie, try to find the path and name.
-    if (cred.status != 5) {
-      r["path"] = getProcPath(pid);
-      // OS X proc_name only returns 16 bytes, use the basename of the path.
-      r["name"] = fs::path(r["path"]).filename().string();
-    } else {
-      r["path"] = "";
-      std::vector<char> name(17);
-      proc_name(pid, name.data(), 16);
-      r["name"] = std::string(name.data());
-    }
-
-    // If the path of the executable that started the process is available and
-    // the path exists on disk, set on_disk to 1. If the path is not
-    // available, set on_disk to -1. If, and only if, the path of the
-    // executable is available and the file does NOT exist on disk, set on_disk
-    // to 0.
-    if (r["path"].empty()) {
-      r["on_disk"] = INTEGER(-1);
-    } else if (pathExists(r["path"])) {
-      r["on_disk"] = INTEGER(1);
-    } else {
-      r["on_disk"] = INTEGER(0);
-    }
+    genProcNamePathAndOnDisk(pid, cred, r);
 
     // systems usage and time information
-    struct rusage_info_v2 rusage_info_data;
-    int status =
-        proc_pid_rusage(pid, RUSAGE_INFO_V2, (rusage_info_t*)&rusage_info_data);
-    // proc_pid_rusage returns -1 if it was unable to gather information
-    if (status == 0) {
-      // size/memory information
-      r["wired_size"] = TEXT(rusage_info_data.ri_wired_size);
-      r["resident_size"] = TEXT(rusage_info_data.ri_resident_size);
-      r["total_size"] = TEXT(rusage_info_data.ri_phys_footprint);
+    genProcRUsage(pid, r);
 
-      // time information
-      r["user_time"] = TEXT(rusage_info_data.ri_user_time / CPU_TIME_RATIO);
-      r["system_time"] = TEXT(rusage_info_data.ri_system_time / CPU_TIME_RATIO);
-
-      // disk i/o information
-      r["disk_bytes_read"] = TEXT(rusage_info_data.ri_diskio_bytesread);
-      r["disk_bytes_written"] = TEXT(rusage_info_data.ri_diskio_byteswritten);
-
-      // Below is the logic to caculate the start_time since boot time
-      // with higher precision
-      auto uptime = getUptimeInUSec();
-      uint64_t absoluteTime = mach_absolute_time();
-
-      auto multiply = static_cast<double>(time_base.numer) /
-                      static_cast<double>(time_base.denom);
-      auto diff = static_cast<long>(
-          (rusage_info_data.ri_proc_start_abstime - absoluteTime));
-
-      // This is a negative value
-      auto seconds_since_launch =
-          static_cast<long>(diff * multiply) / NSECS_IN_USEC;
-
-      // Get the start_time of process since the computer started
-      r["start_time"] = TEXT((uptime + seconds_since_launch) / CPU_TIME_RATIO);
-    } else {
-      r["wired_size"] = "-1";
-      r["resident_size"] = "-1";
-      r["total_size"] = "-1";
-      r["user_time"] = "-1";
-      r["system_time"] = "-1";
-      r["start_time"] = "-1";
-    }
-
-    struct proc_taskinfo task_info;
-    status =
-        proc_pidinfo(pid, PROC_PIDTASKINFO, 0, &task_info, sizeof(task_info));
-    if (status == sizeof(task_info)) {
-      r["threads"] = INTEGER(task_info.pti_threadnum);
-    } else {
-      r["threads"] = "-1";
-    }
+    genProcNumThreads(pid, r);
 
     results.push_back(r);
   }

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -186,16 +186,16 @@ struct proc_args {
 
 proc_args getProcRawArgs(int pid, size_t argmax) {
   proc_args args;
-  std::vector<char> procargs(argmax);
+  std::unique_ptr<char[]> pprocargs{new char[argmax]};
+  char* procargs = pprocargs.get();
   int mib[3] = {CTL_KERN, KERN_PROCARGS2, pid};
-  if (sysctl(mib, 3, procargs.data(), &argmax, nullptr, 0) == -1 ||
-      argmax == 0) {
+  if (sysctl(mib, 3, procargs, &argmax, nullptr, 0) == -1 || argmax == 0) {
     return args;
   }
 
   // The number of arguments is an integer in front of the result buffer.
   int nargs = 0;
-  memcpy(&nargs, procargs.data(), sizeof(nargs));
+  memcpy(&nargs, procargs, sizeof(nargs));
   // Walk the \0-tokenized list of arguments until reaching the returned 'max'
   // number of arguments or the number appended to the front.
   const char* current_arg = &procargs[0] + sizeof(nargs);


### PR DESCRIPTION
The name, path, cmdline, and on_disk status of a process don't change over its lifetime, and they can be pretty expensive to compute. This PR caches these values, being sure to evict them when a process disappears or its pid is reused.

Note that this PR builds on #4254, which has not yet merged, so the commit from that one can be ignored in reviewing this one.

Before:
```
~/osquery % sudo tools/analysis/profile.py --config test.json
Profiling query: select total_size from processes;
/Users/jkeljo/osquery/tools/analysis/../tests/utils.py:147: FutureWarning: memory_info_ex() is deprecated and will be removed; use memory_info() instead
  "memory": p.memory_info_ex(),
 D:0  C:0  M:1  F:0  U:0  pack_processes (1/1): duration: 0.588259935379 cpu_time: 0.07418382 memory: 12398592 fds: 4 utilization: 7.1

~/osquery % sudo tools/analysis/profile.py --config test.json --count 50
Profiling query: select total_size from processes;
/Users/jkeljo/osquery/tools/analysis/../tests/utils.py:147: FutureWarning: memory_info_ex() is deprecated and will be removed; use memory_info() instead
  "memory": p.memory_info_ex(),
 D:2  C:2  M:2  F:0  U:3  pack_processes (1/1): duration: 1.5203359127 cpu_time: 1.415935936 memory: 16990208 fds: 4 utilization: 70.475
```

After:

```
~/osquery % sudo tools/analysis/profile.py --config test.json
Profiling query: select total_size from processes;
/Users/jkeljo/osquery/tools/analysis/../tests/utils.py:147: FutureWarning: memory_info_ex() is deprecated and will be removed; use memory_info() instead
  "memory": p.memory_info_ex(),
 D:0  C:0  M:1  F:0  U:0  pack_processes (1/1): duration: 0.559644937515 cpu_time: 0.075561436 memory: 12566528 fds: 4 utilization: 7.2

~/osquery % sudo tools/analysis/profile.py --config test.json --count 50
Profiling query: select total_size from processes;
/Users/jkeljo/osquery/tools/analysis/../tests/utils.py:147: FutureWarning: memory_info_ex() is deprecated and will be removed; use memory_info() instead
  "memory": p.memory_info_ex(),
 D:2  C:1  M:2  F:0  U:2  pack_processes (1/1): duration: 1.01243519783 cpu_time: 0.736211552 memory: 18972672 fds: 4 utilization: 48.9333333333

```