### PR TITLE
Plumb used columns into QueryContext; use that to make processes table more efficient on macOS

### DIFF
--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -127,6 +127,12 @@ class SQL : private only_movable {
                                  ConstraintOperator op,
                                  const std::string& expr);
 
+  static QueryData selectFrom(const std::initializer_list<std::string> columns,
+                              const std::string& table,
+                              const std::string& column,
+                              ConstraintOperator op,
+                              const std::string& expr);
+
  protected:
   /**
    * @brief Private default constructor.

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -127,6 +127,17 @@ class SQL : private only_movable {
                                  ConstraintOperator op,
                                  const std::string& expr);
 
+  /**
+   * @brief Get columns with constraint, 'SELECT [columns] ... where', results
+   * given a virtual table name, column names, and single constraint.
+   *
+   * @param columns the columns to return
+   * @param table The name of the virtual table.
+   * @param column Table column name to apply constraint.
+   * @param op The SQL comparative operator.
+   * @param expr The constraint expression.
+   * @return A QueryData object of the 'SELECT [columns] ...' query results.
+   */
   static QueryData selectFrom(const std::initializer_list<std::string> columns,
                               const std::string& table,
                               const std::string& column,

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -618,6 +618,41 @@ struct QueryContext : private only_movable {
   /// Check if any of the given columns is used by the query
   bool isAnyColumnUsed(std::initializer_list<std::string> colNames) const;
 
+  template <typename Type>
+  inline void setTextColumnIfUsed(Row& r,
+                                  const std::string& colName,
+                                  const Type& value) const {
+    if (isColumnUsed(colName)) {
+      r[colName] = TEXT(value);
+    }
+  }
+
+  template <typename Type>
+  inline void setIntegerColumnIfUsed(Row& r,
+                                     const std::string& colName,
+                                     const Type& value) const {
+    if (isColumnUsed(colName)) {
+      r[colName] = INTEGER(value);
+    }
+  }
+
+  template <typename Type>
+  inline void setBigIntColumnIfUsed(Row& r,
+                                    const std::string& colName,
+                                    const Type& value) const {
+    if (isColumnUsed(colName)) {
+      r[colName] = BIGINT(value);
+    }
+  }
+
+  inline void setColumnIfUsed(Row& r,
+                              const std::string& colName,
+                              const std::string& value) const {
+    if (isColumnUsed(colName)) {
+      r[colName] = value;
+    }
+  }
+
   /// Check if a table-defined index exists within the query cache.
   bool isCached(const std::string& index) const;
 

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -439,6 +440,9 @@ using ConstraintMap = std::map<std::string, struct ConstraintList>;
 /// Populate a constraint list from a query's parsed predicate.
 using ConstraintSet = std::vector<std::pair<std::string, struct Constraint>>;
 
+/// Keep track of which columns are used
+using UsedColumns = std::unordered_set<std::string>;
+
 /**
  * @brief osquery table content descriptor.
  *
@@ -475,6 +479,9 @@ struct VirtualTableContent {
 
   /// Transient set of virtual table access constraints.
   std::unordered_map<size_t, ConstraintSet> constraints;
+
+  /// Transient set of virtual table used columns
+  std::unordered_map<size_t, UsedColumns> colsUsed;
 
   /*
    * @brief A table implementation specific query result cache.
@@ -605,6 +612,12 @@ struct QueryContext : private only_movable {
       std::function<Status(const std::string& constraint,
                            std::set<std::string>& output)> predicate);
 
+  /// Check if the given column is used by the query
+  bool isColumnUsed(const std::string& colName) const;
+
+  /// Check if any of the given columns is used by the query
+  bool isAnyColumnUsed(std::initializer_list<std::string> colNames) const;
+
   /// Check if a table-defined index exists within the query cache.
   bool isCached(const std::string& index) const;
 
@@ -630,6 +643,8 @@ struct QueryContext : private only_movable {
 
   /// The map of column name to constraint list.
   ConstraintMap constraints;
+
+  boost::optional<UsedColumns> colsUsed;
 
  private:
   /// If false then the context is maintaining an ephemeral cache.

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -47,13 +47,21 @@ DECLARE_bool(events_optimize);
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query) {
   // Snapshot the performance and times for the worker before running.
   auto pid = std::to_string(PlatformProcess::getCurrentPid());
-  auto r0 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
+  auto r0 = SQL::selectFrom({"resident_size", "user_time", "system_time"},
+                            "processes",
+                            "pid",
+                            EQUALS,
+                            pid);
   auto t0 = getUnixTime();
   Config::get().recordQueryStart(name);
   SQLInternal sql(query.query, true);
   // Snapshot the performance after, and compare.
   auto t1 = getUnixTime();
-  auto r1 = SQL::selectAllFrom("processes", "pid", EQUALS, pid);
+  auto r1 = SQL::selectFrom({"resident_size", "user_time", "system_time"},
+                            "processes",
+                            "pid",
+                            EQUALS,
+                            pid);
   if (r0.size() > 0 && r1.size() > 0) {
     // Calculate a size as the expected byte output of results.
     // This does not dedup result differentials and is not aware of snapshots.

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -121,6 +121,25 @@ QueryData SQL::selectAllFrom(const std::string& table,
   return response;
 }
 
+QueryData SQL::selectFrom(const std::initializer_list<std::string> columns,
+                          const std::string& table,
+                          const std::string& column,
+                          ConstraintOperator op,
+                          const std::string& expr) {
+  PluginRequest request = {{"action", "generate"}};
+  {
+    // Create a fake content, there will be no caching.
+    QueryContext ctx;
+    ctx.constraints[column].add(Constraint(op, expr));
+    ctx.colsUsed = UsedColumns(columns);
+    TablePlugin::setRequestFromContext(ctx, request);
+  }
+
+  PluginResponse response;
+  Registry::call("table", table, request, response);
+  return response;
+}
+
 Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
   response.clear();
   if (request.count("action") == 0) {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -294,6 +294,7 @@ void SQLiteDBInstance::clearAffectedTables() {
   for (const auto& table : affected_tables_) {
     table.second->constraints.clear();
     table.second->cache.clear();
+    table.second->colsUsed.clear();
   }
   // Since the affected tables are cleared, there are no more affected tables.
   // There is no concept of compounding tables between queries.

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -418,6 +418,25 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
     cost += 200;
   }
 
+  UsedColumns colsUsed;
+  if (pIdxInfo->colUsed > 0) {
+    for (size_t i = 0; i < columns.size(); i++) {
+      // Check whether the column is used. colUsed has one bit for each of the
+      // first 63 columns, and the 64th bit indicates that at least one other
+      // column is used.
+      uint64_t flag;
+      if (i < 63) {
+        flag = 1L << i;
+      } else {
+        flag = 1L << 63;
+      }
+      if ((pIdxInfo->colUsed & flag) != 0) {
+        std::string colName = std::get<0>(columns[i]);
+        colsUsed.insert(colName);
+      }
+    }
+  }
+
   pIdxInfo->idxNum = static_cast<int>(kConstraintIndexID++);
 #if defined(DEBUG)
   plan("Recording constraint set for table: " + pVtab->content->name +
@@ -427,6 +446,7 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
 #endif
   // Add the constraint set to the table's tracked constraints.
   pVtab->content->constraints[pIdxInfo->idxNum] = std::move(constraints);
+  pVtab->content->colsUsed[pIdxInfo->idxNum] = std::move(colsUsed);
   pIdxInfo->estimatedCost = cost;
   return SQLITE_OK;
 }
@@ -528,6 +548,10 @@ static int xFilter(sqlite3_vtab_cursor* pVtabCursor,
         user_based_satisfied = true;
       }
     }
+  }
+
+  if (content->colsUsed.size() > 0) {
+    context.colsUsed = content->colsUsed[idxNum];
   }
 
   if (!user_based_satisfied) {

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -426,9 +426,9 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
       // column is used.
       uint64_t flag;
       if (i < 63) {
-        flag = 1L << i;
+        flag = 1LL << i;
       } else {
-        flag = 1L << 63;
+        flag = 1LL << 63;
       }
       if ((pIdxInfo->colUsed & flag) != 0) {
         std::string colName = std::get<0>(columns[i]);

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -431,8 +431,7 @@ static int xBestIndex(sqlite3_vtab* tab, sqlite3_index_info* pIdxInfo) {
         flag = 1LL << 63;
       }
       if ((pIdxInfo->colUsed & flag) != 0) {
-        std::string colName = std::get<0>(columns[i]);
-        colsUsed.insert(colName);
+        colsUsed.insert(std::get<0>(columns[i]));
       }
     }
   }

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -345,12 +345,8 @@ static inline long getUptimeInUSec() {
               tv.tv_usec);
 }
 
-void genProcRUsage(const QueryContext& context, int pid, Row& r) {
-  if (!context.isAnyColumnUsed({"name",
-                                "path",
-                                "cmdline",
-                                "on_disk",
-                                "wired_size",
+void genProcResourceUsage(const QueryContext& context, int pid, Row& r) {
+  if (!context.isAnyColumnUsed({"wired_size",
                                 "resident_size",
                                 "total_size",
                                 "user_time",
@@ -368,25 +364,23 @@ void genProcRUsage(const QueryContext& context, int pid, Row& r) {
   if (status == 0) {
     // size/memory information
     context.setTextColumnIfUsed(
-        r, "wired_size", TEXT(rusage_info_data.ri_wired_size));
+        r, "wired_size", rusage_info_data.ri_wired_size);
     context.setTextColumnIfUsed(
-        r, "resident_size", TEXT(rusage_info_data.ri_resident_size));
+        r, "resident_size", rusage_info_data.ri_resident_size);
     context.setTextColumnIfUsed(
-        r, "total_size", TEXT(rusage_info_data.ri_phys_footprint));
+        r, "total_size", rusage_info_data.ri_phys_footprint);
 
     // time information
     context.setTextColumnIfUsed(
-        r, "user_time", TEXT(rusage_info_data.ri_user_time / CPU_TIME_RATIO));
+        r, "user_time", rusage_info_data.ri_user_time / CPU_TIME_RATIO);
     context.setTextColumnIfUsed(
-        r,
-        "system_time",
-        TEXT(rusage_info_data.ri_system_time / CPU_TIME_RATIO));
+        r, "system_time", rusage_info_data.ri_system_time / CPU_TIME_RATIO);
 
     // disk i/o information
     context.setTextColumnIfUsed(
-        r, "disk_bytes_read", TEXT(rusage_info_data.ri_diskio_bytesread));
+        r, "disk_bytes_read", rusage_info_data.ri_diskio_bytesread);
     context.setTextColumnIfUsed(
-        r, "disk_bytes_written", TEXT(rusage_info_data.ri_diskio_byteswritten));
+        r, "disk_bytes_written", rusage_info_data.ri_diskio_byteswritten);
 
     if (context.isColumnUsed("start_time")) {
       // Initialize time conversions.
@@ -426,7 +420,7 @@ QueryData genProcesses(QueryContext& context) {
   QueryData results;
 
   auto pidlist = getProcList(context);
-  for (auto& pid : pidlist) {
+  for (const auto& pid : pidlist) {
     Row r;
     context.setIntegerColumnIfUsed(r, "pid", pid);
 
@@ -443,7 +437,7 @@ QueryData genProcesses(QueryContext& context) {
     genProcNamePathAndOnDisk(context, pid, cred, r);
 
     // systems usage and time information
-    genProcRUsage(context, pid, r);
+    genProcResourceUsage(context, pid, r);
 
     genProcNumThreads(context, pid, r);
 


### PR DESCRIPTION
The `processes` table on macOS makes a bunch of system calls and fills in a bunch of columns, both of which are relatively expensive operations. This PR enables the table to be smart about which system calls it makes and which columns it populates, based on what columns are actually used by the current query.

Note that the first few commits are from #4254 and #4262, which have not yet been merged. The new stuff for this PR starts with 4905d312c7628b9193e94c89037a92448accb8b2 Add used columns info and utilities to QueryContext