### PR TITLE
Remove BOOST_FOREACH

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -631,7 +631,7 @@ QueryData genContainerProcesses(QueryContext& context) {
     try {
       for (const auto& processes : container.get_child("Processes")) {
         std::vector<std::string> vector;
-        BOOST_FOREACH (const auto& v, processes.second) {
+        for (const auto& v : processes.second) {
           vector.push_back(v.second.data());
         }
 


### PR DESCRIPTION
We shouldn't need the BOOST_FOREACH macro when we have C++11 range based loops. This removes that last instance of it.