### PR TITLE
Fix typos in packs/windows-hardening.conf

### DIFF
--- a/packs/windows-hardening.conf
+++ b/packs/windows-hardening.conf
@@ -24,25 +24,25 @@
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecureBoot\\State\\UEFISecureBootEnabled'",
       "interval": "86400",
       "snapshot": true,
-      "description" : "Wether Secureboot is enabled"
+      "description" : "Whether Secureboot is enabled"
     },
     "FontBlocking": {
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\MitigationOptions\\MitigationOptions_FontBlocking'",
       "interval": "86400",
       "snapshot": true,
-      "description" : "Wether FontBlocking is enabled"
+      "description" : "Whether FontBlocking is enabled"
     },
     "DepPolicy": {
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SystemStartOptions'",
       "interval": "86400",
       "snapshot": true,
-      "description" : "Wether DEP is enabled"
+      "description" : "Whether DEP is enabled"
     },
     "MitigationOptions": {
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\MitigationOptions'",
       "interval": "86400",
       "snapshot": true,
-      "description" : "Wether DEP is enabled with application mitigation options"
+      "description" : "Whether DEP is enabled with application mitigation options"
     },
     "MoveImages": {
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management\\moveImages'",
@@ -54,7 +54,7 @@
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Kernel\\KernelSEHOPEnabled'",
       "interval": "86400",
       "snapshot": true,
-      "description" : "Wether SEHOP is enabled"
+      "description" : "Whether SEHOP is enabled"
     },
     "EnableCertPaddingCheck": {
       "query" : "select * from registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\WinTrust\\Config\\EnableCertPaddingCheck'",


### PR DESCRIPTION
Replaced all occurrences of "Wether" with "Whether"