### PR TITLE
Use correct family on rocksdb

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -228,9 +228,9 @@ rocksdb::DB* RocksDBDatabasePlugin::getDB() const {
 rocksdb::ColumnFamilyHandle* RocksDBDatabasePlugin::getHandleForColumnFamily(
     const std::string& cf) const {
   try {
-    for (size_t i = 0; i < kDomains.size(); i++) {
-      if (kDomains[i] == cf) {
-        return handles_[i];
+    for (auto handle : handles_) {
+      if (cf == handle->GetName()) {
+        return handle;
       }
     }
   } catch (const std::exception& /* e */) {


### PR DESCRIPTION
Fix RocksDBDatabasePlugin::getHandleForColumnFamily to return the
correct handle for a family. This method was returning handle n-1 for
familiy n due to using kDomains to search for the family index which
misses the default family.

Because this method is always used to get the handle, everything works
but data is written to the DB using the wrong family, e.g.
configurations entries are written to default and queries to
configurations.