### PR TITLE
Added certificate serial number column

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -50,6 +50,8 @@ void genCertificate(X509* cert, const std::string& path, QueryData& results) {
   r["subject_key_id"] =
       (cert->skid) ? genKIDProperty(cert->skid->data, cert->skid->length) : "";
 
+  r["serial"] = genSerialForCertificate(cert);
+
   results.push_back(r);
 }
 

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -70,6 +70,7 @@ void genCommonName(X509* cert,
 time_t genEpoch(ASN1_TIME* time);
 
 std::string genSHA1ForCertificate(X509* cert);
+std::string genSerialForCertificate(X509* cert);
 bool CertificateIsCA(X509* cert);
 bool CertificateIsSelfSigned(X509* cert);
 

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -141,10 +141,10 @@ std::string genSerialForCertificate(X509* cert) {
     return hex;
   }
   char* hexBytes = BN_bn2hex(bignumSerial);
+  OPENSSL_free(bignumSerial);
   if (hexBytes == nullptr) {
     return hex;
   }
-  OPENSSL_free(bignumSerial);
   hex = std::string(hexBytes);
   OPENSSL_free(hexBytes);
   return hex;

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -133,6 +133,12 @@ std::string genSHA1ForCertificate(X509* cert) {
   return "";
 }
 
+std::string genSerialForCertificate(X509* cert) {
+  ASN1_INTEGER* serial = X509_get_serialNumber(cert);
+  BIGNUM* bignumSerial = ASN1_INTEGER_to_BN(serial, NULL);
+  return BN_bn2hex(bignumSerial);
+}
+
 bool CertificateIsCA(X509* cert) {
   int ca = X509_check_ca(cert);
   return (ca > 0);

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -134,9 +134,20 @@ std::string genSHA1ForCertificate(X509* cert) {
 }
 
 std::string genSerialForCertificate(X509* cert) {
+  std::string hex;
   ASN1_INTEGER* serial = X509_get_serialNumber(cert);
-  BIGNUM* bignumSerial = ASN1_INTEGER_to_BN(serial, NULL);
-  return BN_bn2hex(bignumSerial);
+  BIGNUM* bignumSerial = ASN1_INTEGER_to_BN(serial, nullptr);
+  if (bignumSerial == nullptr) {
+    return hex;
+  }
+  char* hexBytes = BN_bn2hex(bignumSerial);
+  if (hexBytes == nullptr) {
+    return hex;
+  }
+  OPENSSL_free(bignumSerial);
+  hex = std::string(hexBytes);
+  OPENSSL_free(hexBytes);
+  return hex;
 }
 
 bool CertificateIsCA(X509* cert) {

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -197,6 +197,14 @@ void enumerateCertStore(const HCERTSTORE& certStore,
 
     r["path"] = storeLocation + "\\" + certStoreName;
 
+    std::string serial;
+    boost::algorithm::hex(
+        std::string(certContext->pCertInfo->SerialNumber.pbData,
+                    certContext->pCertInfo->SerialNumber.pbData +
+                        certContext->pCertInfo->SerialNumber.cbData),
+        back_inserter(serial));
+    r["serial"] = serial;
+
     std::string authKeyId;
     if (certContext->pCertInfo->cExtension != 0) {
       auto extension = CertFindExtension(szOID_AUTHORITY_KEY_IDENTIFIER2,

--- a/specs/macwin/certificates.table
+++ b/specs/macwin/certificates.table
@@ -16,6 +16,7 @@ schema([
     Column("authority_key_id", TEXT, "AKID an optionally included SHA1"),
     Column("sha1", TEXT, "SHA1 hash of the raw certificate contents"),
     Column("path", TEXT, "Path to Keychain or PEM bundle"),
+    Column("serial", TEXT, "Certificate serial number"),
 
 ])
 attributes(cacheable=True)


### PR DESCRIPTION
Adding a new column called "serial" to the certificates table, on Darwin and Windows. This is a hex-encoded string, e.g. `2E9EF8E848F2AAFC37C4A1E5A1B67C6`. 

    osquery> select serial from certificates limit 1;
    +----------+
    | serial   |
    +----------+
    | 2ACEAE9A |
    +----------+

I've tested the change on both Windows 10 and OSX 10.13.3.