### PR TITLE
database: updating migration logic from ptree to rapidjson

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -248,6 +248,8 @@ void resetDatabase();
 /// Allow callers to scan each column family and print each value.
 void dumpDatabase();
 
+Status ptreeToRapidJSON(const std::string& in, std::string& out);
+
 /**
  * @brief Upgrades the legacy database json format from ptree to RapidJSON
  *

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -366,6 +366,11 @@ Status ptreeToRapidJSON(const std::string& in, std::string& out) {
     return Status(1, "Failed to parse JSON");
   }
 
+  if (tree.empty()) {
+    JSON().toString(out);
+    return Status();
+  }
+
   auto json = JSON::newArray();
   for (const auto& t : tree) {
     std::stringstream ss;

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -393,7 +393,8 @@ static Status migrateV0V1(void) {
   for (const auto& key : keys) {
     // Skip over epoch and counter entries, as 0 is parsed by ptree
     if (boost::algorithm::ends_with(key, kDbEpochSuffix) ||
-        boost::algorithm::ends_with(key, kDbCounterSuffix)) {
+        boost::algorithm::ends_with(key, kDbCounterSuffix) ||
+        boost::algorithm::starts_with(key, "query.")) {
       continue;
     }
 


### PR DESCRIPTION
This skips over domain prefixes of `.query`, as these values int he database do not require migration. Further this abstracts the database upgrade logic (#thanks @fmanco!) so that subsequent upgrades should be easier to pull off. Lastly this brings in a base case check for empty json objects being returned as empty RJ objects, as opposed to empty arrays.