### PR TITLE
recover interface flags

### DIFF
--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -32,6 +32,10 @@
 namespace osquery {
 namespace tables {
 
+const size_t sysfsFlags =
+    IFF_UP|IFF_DEBUG|IFF_NOTRAILERS|IFF_NOARP|IFF_PROMISC|\
+    IFF_ALLMULTI|IFF_MULTICAST|IFF_PORTSEL|IFF_AUTOMEDIA|IFF_DYNAMIC;
+
 // Functions for safe sign-extension
 std::basic_string<char> INTEGER_FROM_UCHAR(unsigned char x) {
   return INTEGER(static_cast<uint16_t>(x));
@@ -81,10 +85,7 @@ static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
   if (content[0] == '0' && content[1] == 'x') {
     unsigned long int lflags = 0;
     if (safeStrtoul(content.substr(2, content.size() - 3), 16, lflags)) {
-      const size_t sysfsFlags =
-	      IFF_UP|IFF_DEBUG|IFF_NOTRAILERS|IFF_NOARP|IFF_PROMISC|\
-	      IFF_ALLMULTI|IFF_MULTICAST|IFF_PORTSEL|IFF_AUTOMEDIA|IFF_DYNAMIC;
-          flags |= lflags & sysfsFlags;
+      flags |= lflags & sysfsFlags;
     }
   }
 }

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -70,19 +70,21 @@ void genAddressesFromAddr(const struct ifaddrs* addr, QueryData& results) {
 
 static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
   auto flags_path = "/sys/class/net/" + name + "/flags";
-  if (pathExists(flags_path)) {
-    std::string content;
-    // This will take the form, 0xVALUE\n.
-    if (readFile(flags_path, content) && content.size() > 3) {
-      if (content[0] == '0' && content[1] == 'x') {
-        unsigned long int lflags = 0;
-        if (safeStrtoul(content.substr(2, content.size() - 3), 16, lflags)) {
-	   const size_t sysfsFlags =
+  std::string content;
+  if (!pathExists(flags_path)
+	|| !readFile(flags_path, content)
+	|| content.size() <= 3) {
+    return;
+  }
+
+  // This will take the form, 0xVALUE\n.
+  if (content[0] == '0' && content[1] == 'x') {
+    unsigned long int lflags = 0;
+    if (safeStrtoul(content.substr(2, content.size() - 3), 16, lflags)) {
+      const size_t sysfsFlags =
 	      IFF_UP|IFF_DEBUG|IFF_NOTRAILERS|IFF_NOARP|IFF_PROMISC|\
 	      IFF_ALLMULTI|IFF_MULTICAST|IFF_PORTSEL|IFF_AUTOMEDIA|IFF_DYNAMIC;
           flags |= lflags & sysfsFlags;
-        }
-      }
     }
   }
 }

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -32,9 +32,11 @@
 namespace osquery {
 namespace tables {
 
+#ifdef __linux__
 const size_t sysfsFlags = IFF_UP | IFF_DEBUG | IFF_NOTRAILERS | IFF_NOARP |
                           IFF_PROMISC | IFF_ALLMULTI | IFF_MULTICAST |
                           IFF_PORTSEL | IFF_AUTOMEDIA | IFF_DYNAMIC;
+#endif
 
 // Functions for safe sign-extension
 std::basic_string<char> INTEGER_FROM_UCHAR(unsigned char x) {
@@ -72,6 +74,7 @@ void genAddressesFromAddr(const struct ifaddrs* addr, QueryData& results) {
   results.push_back(r);
 }
 
+#ifdef __linux__
 static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
   auto flags_path = "/sys/class/net/" + name + "/flags";
   std::string content;
@@ -88,6 +91,7 @@ static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
     }
   }
 }
+#endif
 
 void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
   Row r;

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -77,7 +77,10 @@ static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
       if (content[0] == '0' && content[1] == 'x') {
         unsigned long int lflags = 0;
         if (safeStrtoul(content.substr(2, content.size() - 3), 16, lflags)) {
-          flags |= lflags;
+	   const size_t sysfsFlags =
+	      IFF_UP|IFF_DEBUG|IFF_NOTRAILERS|IFF_NOARP|IFF_PROMISC|\
+	      IFF_ALLMULTI|IFF_MULTICAST|IFF_PORTSEL|IFF_AUTOMEDIA|IFF_DYNAMIC;
+          flags |= lflags & sysfsFlags;
         }
       }
     }
@@ -134,7 +137,7 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
       close(fd);
     }
 
-    // Flags populated by sysfs are more reliable.
+    // Sysfs flags populated by sysfs are more reliable.
     flagsFromSysfs(r["interface"], flags);
 
     // Last change is not implemented in Linux.

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -134,13 +134,13 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
         r["type"] = INTEGER_FROM_UCHAR(ifr.ifr_hwaddr.sa_family);
       }
 
-      if (ioctl(fd, SIOCGIFFLAGS, &ifr) >= 0) {
-        flags |= static_cast<size_t>(ifr.ifr_flags);
-      }
       close(fd);
     }
 
-    // Sysfs flags populated by sysfs are more reliable.
+    // Filter out sysfs flags.
+    flags &= ~sysfsFlags;
+
+    // Populate sysfs flags from sysfs.
     flagsFromSysfs(r["interface"], flags);
 
     // Last change is not implemented in Linux.

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -68,7 +68,7 @@ void genAddressesFromAddr(const struct ifaddrs* addr, QueryData& results) {
   results.push_back(r);
 }
 
-static inline void flagsFromSysfs(const std::string& name, std::string& flags) {
+static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
   auto flags_path = "/sys/class/net/" + name + "/flags";
   if (pathExists(flags_path)) {
     std::string content;
@@ -77,7 +77,7 @@ static inline void flagsFromSysfs(const std::string& name, std::string& flags) {
       if (content[0] == '0' && content[1] == 'x') {
         unsigned long int lflags = 0;
         if (safeStrtoul(content.substr(2, content.size() - 3), 16, lflags)) {
-          flags = std::to_string(lflags);
+          flags |= lflags;
         }
       }
     }
@@ -92,6 +92,8 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["interface"] = "";
   }
   r["mac"] = macAsString(addr);
+
+  size_t flags = addr->ifa_flags;
 
   if (addr->ifa_data != nullptr && addr->ifa_name != nullptr) {
 #ifdef __linux__
@@ -127,13 +129,13 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
       }
 
       if (ioctl(fd, SIOCGIFFLAGS, &ifr) >= 0) {
-        r["flags"] = INTEGER(static_cast<size_t>(ifr.ifr_flags));
+        flags |= static_cast<size_t>(ifr.ifr_flags);
       }
       close(fd);
     }
 
     // Flags populated by sysfs are more reliable.
-    flagsFromSysfs(r["interface"], r["flags"]);
+    flagsFromSysfs(r["interface"], flags);
 
     // Last change is not implemented in Linux.
     r["last_change"] = "-1";
@@ -153,9 +155,8 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
     r["odrops"] = INTEGER(0);
     r["collisions"] = BIGINT_FROM_UINT32(ifd->ifi_collisions);
     r["last_change"] = BIGINT_FROM_UINT32(ifd->ifi_lastchange.tv_sec);
-
-    r["flags"] = INTEGER(addr->ifa_flags);
 #endif
+    r["flags"] = INTEGER(flags);
   }
 
   results.push_back(r);

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -32,9 +32,9 @@
 namespace osquery {
 namespace tables {
 
-const size_t sysfsFlags =
-    IFF_UP|IFF_DEBUG|IFF_NOTRAILERS|IFF_NOARP|IFF_PROMISC|\
-    IFF_ALLMULTI|IFF_MULTICAST|IFF_PORTSEL|IFF_AUTOMEDIA|IFF_DYNAMIC;
+const size_t sysfsFlags = IFF_UP | IFF_DEBUG | IFF_NOTRAILERS | IFF_NOARP |
+                          IFF_PROMISC | IFF_ALLMULTI | IFF_MULTICAST |
+                          IFF_PORTSEL | IFF_AUTOMEDIA | IFF_DYNAMIC;
 
 // Functions for safe sign-extension
 std::basic_string<char> INTEGER_FROM_UCHAR(unsigned char x) {
@@ -75,9 +75,8 @@ void genAddressesFromAddr(const struct ifaddrs* addr, QueryData& results) {
 static inline void flagsFromSysfs(const std::string& name, size_t& flags) {
   auto flags_path = "/sys/class/net/" + name + "/flags";
   std::string content;
-  if (!pathExists(flags_path)
-	|| !readFile(flags_path, content)
-	|| content.size() <= 3) {
+  if (!pathExists(flags_path) || !readFile(flags_path, content) ||
+      content.size() <= 3) {
     return;
   }
 
@@ -213,5 +212,5 @@ QueryData genInterfaceDetails(QueryContext& context) {
   freeifaddrs(if_addrs);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery


### PR DESCRIPTION
orred the value from sysfs and ifaddrs to both fix issue 4048 (flags not updated for promiscuous mode with `tcdump` for example) and maintain volatile flags mentioned issue 4272.