### PR TITLE
Fix a unicode parsing error

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -231,10 +231,15 @@ Status JSON::toString(std::string& str) const {
 }
 
 Status JSON::fromString(const std::string& str) {
-  if (doc_.Parse(str.c_str()).HasParseError()) {
-    return Status(1, "Cannot parse JSON");
+  rj::ParseResult pr = doc_.Parse(str.c_str());
+  if (!pr) {
+    std::string message{"Cannot parse JSON: "};
+    message += GetParseError_En(pr.Code());
+    message += "Offset: ";
+    message += pr.Offset();
+    return Status(1, message);
   }
-  return Status();
+  return Status{0};
 }
 
 void JSON::mergeObject(rj::Value& target_obj, rj::Value& source_obj) {

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -235,11 +235,11 @@ Status JSON::fromString(const std::string& str) {
   if (!pr) {
     std::string message{"Cannot parse JSON: "};
     message += GetParseError_En(pr.Code());
-    message += "Offset: ";
-    message += pr.Offset();
+    message += " Offset: ";
+    message += std::to_string(pr.Offset());
     return Status(1, message);
   }
-  return Status{0};
+  return Status();
 }
 
 void JSON::mergeObject(rj::Value& target_obj, rj::Value& source_obj) {

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -67,6 +67,10 @@ TEST_F(ConversionsTests, test_unicode_unescape) {
       std::make_pair("\\uFFFFhi", "\\uFFFFhi"),
       std::make_pair("0000\\u", "0000\\u"),
       std::make_pair("hi", "hi"),
+      std::make_pair("c:\\\\users\\\\obelisk\\\\file.txt",
+                     "c:\\\\users\\\\obelisk\\\\file.txt"),
+      std::make_pair("Edge case test\\", "Edge case test\\"),
+      std::make_pair("Edge case test two\\\\", "Edge case test two\\\\"),
   };
 
   for (const auto& test : conversions) {

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -156,6 +156,14 @@ TEST_F(ConversionsTests, test_json_from_string) {
   EXPECT_FALSE(doc.fromString(json).ok());
 }
 
+TEST_F(ConversionsTests, test_json_from_string_error) {
+  std::string json = "{\"key\":\"value\",\"key2\":{\"key3\":'error'}}";
+  auto doc = JSON::newObject();
+  auto s = doc.fromString(json);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.getMessage(), "Cannot parse JSON: Invalid value. Offset: 30");
+}
+
 TEST_F(ConversionsTests, test_json_add_object) {
   std::string json = "{\"key\":\"value\", \"key2\":{\"key3\":[3,2,1]}}";
   auto doc = JSON::newObject();


### PR DESCRIPTION
There was an error where having a query with a path like C:\users, osquery thought that was a unicode character `sers` after `\u`.

This adds a check for double backslashes and skips them if found.

What would happen before with the new testcase:
```
➜  osquery git:(master) ✗ ./build/darwin/osquery/osquery_tests --gtest_filter="ConversionsTests.test_unicode_unescape"
Note: Google Test filter = ConversionsTests.test_unicode_unescape
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from ConversionsTests
[ RUN      ] ConversionsTests.test_unicode_unescape
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0421 11:44:52.044927 2431210368 conversions.h:212] Unescaping a string with length: 28 failed at: 3
/Users/obelisk/Documents/git_repos/osquery/osquery/core/tests/conversions_tests.cpp:74: Failure
      Expected: unescapeUnicode(test.first)
      Which is: ""
To be equal to: test.second
      Which is: "c:\\\\users\\\\obelisk\\\\file.txt"
[  FAILED  ] ConversionsTests.test_unicode_unescape (1 ms)
[----------] 1 test from ConversionsTests (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ConversionsTests.test_unicode_unescape

 1 FAILED TEST
```