### PR TITLE
fbthrift: Second set of Apache and FbThrift refactors

### DIFF
--- a/include/osquery/extensions.h
+++ b/include/osquery/extensions.h
@@ -32,8 +32,8 @@ extern const size_t kExtensionInitializeLatency;
 struct ExtensionInfo {
   std::string name;
   std::string version;
-  std::string min_sdk_version;
   std::string sdk_version;
+  std::string min_sdk_version;
 };
 
 typedef std::map<RouteUUID, ExtensionInfo> ExtensionList;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -28,8 +28,6 @@
 #include "osquery/extensions/interface.h"
 #include "osquery/filesystem/fileops.h"
 
-using namespace osquery::extensions;
-
 namespace fs = boost::filesystem;
 
 namespace osquery {
@@ -164,10 +162,9 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
   return applyExtensionDelay(([path, &use_timeout](bool& stop) {
     if (socketExists(path)) {
       try {
-        ExtensionStatus status;
         // Create a client with a 10-second receive timeout.
-        EXManagerClient client(path, 10 * 1000);
-        client.get()->API_PING(status);
+        ExtensionManagerClient client(path, 10 * 1000);
+        auto status = client.ping();
         return Status(0, "OK");
       } catch (const std::exception& /* e */) {
         // Path might exist without a connected extension or extension manager.
@@ -214,8 +211,8 @@ void ExtensionManagerWatcher::start() {
   for (const auto& uuid : uuids) {
     try {
       auto path = getExtensionSocket(uuid);
-      EXClient client(path);
-      client.get()->API_SHUTDOWN();
+      ExtensionClient client(path);
+      client.shutdown();
     } catch (const std::exception& /* e */) {
       VLOG(1) << "Extension UUID " << uuid << " shutdown request failed";
       continue;
@@ -233,13 +230,13 @@ void ExtensionWatcher::exitFatal(int return_code) {
 void ExtensionWatcher::watch() {
   // Attempt to ping the extension core.
   // This does NOT use pingExtension to avoid the latency checks applied.
-  ExtensionStatus status;
+  Status status;
   bool core_sane = true;
   if (socketExists(path_)) {
     try {
-      EXManagerClient client(path_);
+      ExtensionManagerClient client(path_);
       // Ping the extension manager until it goes down.
-      client.get()->API_PING(status);
+      status = client.ping();
     } catch (const std::exception& /* e */) {
       core_sane = false;
     }
@@ -253,7 +250,7 @@ void ExtensionWatcher::watch() {
     exitFatal(0);
   }
 
-  if (status.code != (int)ExtensionCode::EXT_SUCCESS && fatal_) {
+  if (status.getCode() != (int)ExtensionCode::EXT_SUCCESS && fatal_) {
     // The core may be healthy but return a failed ping status.
     exitFatal();
   }
@@ -264,7 +261,7 @@ void ExtensionManagerWatcher::watch() {
   // will be deregistered.
   const auto uuids = RegistryFactory::get().routeUUIDs();
 
-  ExtensionStatus status;
+  Status status;
   for (const auto& uuid : uuids) {
     auto path = getExtensionSocket(uuid);
     auto exists = socketExists(path);
@@ -281,9 +278,9 @@ void ExtensionManagerWatcher::watch() {
     failures_[uuid] = 1;
     if (exists.ok()) {
       try {
-        EXClient client(path);
+        ExtensionClient client(path);
         // Ping the extension until it goes down.
-        client.get()->API_PING(status);
+        status = client.ping();
       } catch (const std::exception& /* e */) {
         failures_[uuid] += 1;
         continue;
@@ -294,7 +291,7 @@ void ExtensionManagerWatcher::watch() {
       continue;
     }
 
-    if (status.code != (int)ExtensionCode::EXT_SUCCESS) {
+    if (status.getCode() != (int)ExtensionCode::EXT_SUCCESS) {
       LOG(INFO) << "Extension UUID " << uuid << " ping failed";
       failures_[uuid] += 1;
     } else {
@@ -471,34 +468,34 @@ Status startExtension(const std::string& manager_path,
   // The Registry broadcast is used as the ExtensionRegistry.
   auto broadcast = RegistryFactory::get().getBroadcast();
   // The extension will register and provide name, version, sdk details.
-  InternalExtensionInfo info;
+  ExtensionInfo info;
   info.name = name;
   info.version = version;
   info.sdk_version = sdk_version;
   info.min_sdk_version = min_sdk_version;
 
   // If registration is successful, we will also request the manager's options.
-  InternalOptionList options;
+  OptionList options;
   // Register the extension's registry broadcast with the manager.
-  ExtensionStatus ext_status;
+  RouteUUID uuid = 0;
   try {
-    EXManagerClient client(manager_path);
-    client.get()->API_REGISTER(ext_status, info, broadcast);
+    ExtensionManagerClient client(manager_path);
+    status = client.registerExtension(info, broadcast, uuid);
     // The main reason for a failed registry is a duplicate extension name
     // (the extension process is already running), or the extension broadcasts
     // a duplicate registry item.
-    if (ext_status.code != (int)ExtensionCode::EXT_SUCCESS) {
-      return Status(ext_status.code, ext_status.message);
+    if (status.getCode() == (int)ExtensionCode::EXT_FAILED) {
+      return status;
     }
     // Request the core options, mainly to set the active registry plugins for
     // logger and config.
-    client.get()->API_OPTIONS(options);
+    options = client.options();
   } catch (const std::exception& e) {
     return Status(1, "Extension register failed: " + std::string(e.what()));
   }
 
   // Now that the UUID is known, try to clean up stale socket paths.
-  auto extension_path = getExtensionSocket(ext_status.uuid, manager_path);
+  auto extension_path = getExtensionSocket(uuid, manager_path);
 
   status = socketExists(extension_path, true);
   if (!status) {
@@ -515,11 +512,10 @@ Status startExtension(const std::string& manager_path,
   rf.setUp();
 
   // Start the extension's Thrift server
-  Dispatcher::addService(
-      std::make_shared<ExtensionRunner>(manager_path, ext_status.uuid));
-  VLOG(1) << "Extension (" << name << ", " << ext_status.uuid << ", " << version
-          << ", " << sdk_version << ") registered";
-  return Status(0, std::to_string(ext_status.uuid));
+  Dispatcher::addService(std::make_shared<ExtensionRunner>(manager_path, uuid));
+  VLOG(1) << "Extension (" << name << ", " << uuid << ", " << version << ", "
+          << sdk_version << ") registered";
+  return Status(0, std::to_string(uuid));
 }
 
 Status queryExternal(const std::string& manager_path,
@@ -531,19 +527,14 @@ Status queryExternal(const std::string& manager_path,
     return status;
   }
 
-  ExtensionResponse response;
   try {
-    EXManagerClient client(manager_path);
-    client.get()->API_QUERY(response, query);
+    ExtensionManagerClient client(manager_path);
+    status = client.query(query, results);
   } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
 
-  for (const auto& row : response.response) {
-    results.push_back(row);
-  }
-
-  return Status(response.status.code, response.status.message);
+  return status;
 }
 
 Status queryExternal(const std::string& query, QueryData& results) {
@@ -559,23 +550,23 @@ Status getQueryColumnsExternal(const std::string& manager_path,
     return status;
   }
 
-  ExtensionResponse response;
+  QueryData qd;
   try {
-    EXManagerClient client(manager_path);
-    client.get()->API_COLUMNS(response, query);
+    ExtensionManagerClient client(manager_path);
+    status = client.getQueryColumns(query, qd);
   } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
 
   // Translate response map: {string: string} to a vector: pair(name, type).
-  for (const auto& column : response.response) {
+  for (const auto& column : qd) {
     for (const auto& col : column) {
       columns.push_back(std::make_tuple(
           col.first, columnTypeName(col.second), ColumnOptions::DEFAULT));
     }
   }
 
-  return Status(response.status.code, response.status.message);
+  return status;
 }
 
 Status getQueryColumnsExternal(const std::string& query,
@@ -594,15 +585,14 @@ Status pingExtension(const std::string& path) {
     return status;
   }
 
-  ExtensionStatus ext_status;
   try {
-    EXClient client(path);
-    client.get()->API_PING(ext_status);
+    ExtensionClient client(path);
+    status = client.ping();
   } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
 
-  return Status(ext_status.code, ext_status.message);
+  return Status(0, status.getMessage());
 }
 
 Status getExtensions(ExtensionList& extensions) {
@@ -620,10 +610,10 @@ Status getExtensions(const std::string& manager_path,
     return status;
   }
 
-  InternalExtensionList ext_list;
+  ExtensionList ext_list;
   try {
-    EXManagerClient client(manager_path);
-    client.get()->API_EXTENSIONS(ext_list);
+    ExtensionManagerClient client(manager_path);
+    ext_list = client.extensions();
   } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
@@ -665,21 +655,14 @@ Status callExtension(const std::string& extension_path,
     return status;
   }
 
-  ExtensionResponse ext_response;
   try {
-    EXClient client(extension_path);
-    client.get()->API_CALL(ext_response, registry, item, request);
+    ExtensionClient client(extension_path);
+    status = client.call(registry, item, request, response);
   } catch (const std::exception& e) {
     return Status(1, "Extension call failed: " + std::string(e.what()));
   }
 
-  // Convert from Thrift-internal list type to PluginResponse type.
-  if (ext_response.status.code == (int)ExtensionCode::EXT_SUCCESS) {
-    for (const auto& response_item : ext_response.response) {
-      response.push_back(response_item);
-    }
-  }
-  return Status(ext_response.status.code, ext_response.status.message);
+  return status;
 }
 
 Status startExtensionWatcher(const std::string& manager_path,

--- a/osquery/extensions/impl_fbthrift.cpp
+++ b/osquery/extensions/impl_fbthrift.cpp
@@ -12,132 +12,418 @@
 #include <osquery/filesystem.h>
 #include <osquery/system.h>
 
-#include "osquery/extensions/interface.h"
-
 #include <thrift/lib/cpp/async/TAsyncSocket.h>
 #include <thrift/lib/cpp2/async/HeaderClientChannel.h>
-#include <thrift/lib/cpp2/protocol/BinaryProtocol.h>
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 
-using namespace osquery::extensions;
+// Include intermediate Thrift-generated interface definitions.
+#include "osquery/gen-cpp2/Extension.h"
+#include "osquery/gen-cpp2/ExtensionManager.h"
+
+#include "osquery/extensions/interface.h"
 
 namespace osquery {
 
-using namespace apache::thrift::protocol;
-using namespace apache::thrift::transport;
-using namespace apache::thrift::server;
-using namespace apache::thrift::concurrency;
+using namespace extensions;
 
-typedef std::shared_ptr<AsyncProcessorFactory> TProcessorRef;
-using TThreadedServerRef = std::shared_ptr<ThriftServer>;
+class ExtensionHandler : virtual public extensions::ExtensionSvIf,
+                         public ExtensionInterface {
+ public:
+  ExtensionHandler() : ExtensionInterface(0) {}
+  explicit ExtensionHandler(RouteUUID uuid) : ExtensionInterface(uuid) {}
 
-typedef std::shared_ptr<ExtensionHandler> ExtensionHandlerRef;
-typedef std::shared_ptr<ExtensionManagerHandler> ExtensionManagerHandlerRef;
+ public:
+  using ExtensionInterface::ping;
+  void ping(ExtensionStatus& _return) override;
 
-struct ImpExtensionRunner {
-  TThreadedServerRef server_{nullptr};
-  TProcessorRef processor_{nullptr};
+  using ExtensionInterface::call;
+  void call(ExtensionResponse& _return,
+            const std::string& registry,
+            const std::string& item,
+            const ExtensionPluginRequest& request) override;
+
+  using ExtensionInterface::shutdown;
+  void shutdown() override;
+
+ protected:
+  /// UUID accessor.
+  RouteUUID getUUID() const;
 };
 
-struct ImpExtensionManagerServer {
-  folly::EventBase base_;
+class ExtensionManagerHandler : virtual public extensions::ExtensionManagerSvIf,
+                                public ExtensionManagerInterface,
+                                public ExtensionHandler {
+ public:
+  ExtensionManagerHandler() = default;
+
+ public:
+  using ExtensionManagerInterface::extensions;
+  void extensions(InternalExtensionList& _return) override;
+
+  using ExtensionManagerInterface::options;
+  void options(InternalOptionList& _return) override;
+
+  using ExtensionManagerInterface::registerExtension;
+  void registerExtension(ExtensionStatus& _return,
+                         const InternalExtensionInfo& info,
+                         const ExtensionRegistry& registry) override;
+
+  using ExtensionManagerInterface::deregisterExtension;
+  void deregisterExtension(ExtensionStatus& _return,
+                           const ExtensionRouteUUID uuid) override;
+
+  using ExtensionManagerInterface::query;
+  void query(ExtensionResponse& _return, const std::string& sql) override;
+
+  using ExtensionManagerInterface::getQueryColumns;
+  void getQueryColumns(ExtensionResponse& _return,
+                       const std::string& sql) override;
 };
 
-ExtensionRunnerImpl::~ExtensionRunnerImpl() {
+struct ImplExtensionRunner {
+  std::unique_ptr<apache::thrift::ThriftServer> server;
+  std::shared_ptr<ExtensionHandler> handler;
+
+  /// Raw socket descriptor.
+  int sd;
+};
+
+struct ImplExtensionClient {
+  std::shared_ptr<extensions::ExtensionAsyncClient> e;
+  std::shared_ptr<extensions::ExtensionManagerAsyncClient> em;
+  folly::EventBase base;
+
+  /// Raw socket descriptor.
+  int sd;
+};
+
+void ExtensionHandler::ping(ExtensionStatus& _return) {
+  auto s = ExtensionInterface::ping();
+  _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+  _return.uuid = s.getCode();
+  _return.message = s.getMessage();
+}
+
+void ExtensionHandler::call(ExtensionResponse& _return,
+                            const std::string& registry,
+                            const std::string& item,
+                            const ExtensionPluginRequest& request) {
+  PluginRequest plugin_request;
+  for (const auto& request_item : request) {
+    // Create a PluginRequest from an ExtensionPluginRequest.
+    plugin_request[request_item.first] = request_item.second;
+  }
+
+  PluginResponse response;
+  auto s = ExtensionInterface::call(registry, item, plugin_request, response);
+  _return.status.code = s.getCode();
+  _return.status.message = s.getMessage();
+  _return.status.uuid = getUUID();
+
+  if (s.ok()) {
+    for (const auto& response_item : response) {
+      // Translate a PluginResponse to an ExtensionPluginResponse.
+      _return.response.push_back(response_item);
+    }
+  }
+}
+
+void ExtensionHandler::shutdown() {}
+
+RouteUUID ExtensionHandler::getUUID() const {
+  return uuid_;
+}
+
+void ExtensionManagerHandler::extensions(InternalExtensionList& _return) {
+  //_return = ExtensionManagerInterface::extensions();
+  auto extensions = ExtensionManagerInterface::extensions();
+  for (const auto& extension : extensions) {
+    auto& ext = _return[extension.first];
+    ext.min_sdk_version = extension.second.min_sdk_version;
+    ext.version = extension.second.version;
+    ext.sdk_version = extension.second.sdk_version;
+    ext.name = extension.second.name;
+  }
+}
+
+void ExtensionManagerHandler::options(InternalOptionList& _return) {
+  auto options = ExtensionManagerInterface::options();
+  for (const auto& option : options) {
+    _return[option.first].value = option.second.value;
+    _return[option.first].default_value = option.second.default_value;
+    _return[option.first].type = option.second.type;
+  }
+}
+
+void ExtensionManagerHandler::registerExtension(
+    ExtensionStatus& _return,
+    const InternalExtensionInfo& info,
+    const ExtensionRegistry& registry,
+    RouteUUID& uuid) {
+  ExtensionRegistry er;
+  for (const auto& rt : registry) {
+    er[rt.first] = rt.second;
+  }
+
+  RouteUUID uuid;
+  auto s = ExtensionManagerInterface::registerExtension(
+      {info.name, info.version, info.sdk_version, info.min_sdk_version},
+      er,
+      uuid);
+  _return.message = s.getMessage();
+  if (s.ok()) {
+    _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.uuid = uuid;
+  } else {
+    _return.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::deregisterExtension(
+    ExtensionStatus& _return, const ExtensionRouteUUID uuid) {
+  auto s = ExtensionManagerInterface::deregisterExtension(uuid);
+  _return.message = s.getMessage();
+  if (s.ok()) {
+    _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.uuid = getUUID();
+  } else {
+    _return.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::query(ExtensionResponse& _return,
+                                    const std::string& sql) {
+  QueryData qd;
+  auto s = ExtensionManagerInterface::query(sql, qd);
+  for (auto& row : qd) {
+    _return.response.emplace_back(std::move(row));
+  }
+  _return.status.message = s.getMessage();
+  if (s.ok()) {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.status.uuid = getUUID();
+  } else {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::getQueryColumns(ExtensionResponse& _return,
+                                              const std::string& sql) {
+  QueryData qd;
+  auto s = ExtensionManagerInterface::getQueryColumns(sql, qd);
+  for (auto& row : qd) {
+    _return.response.emplace_back(std::move(row));
+  }
+  _return.status.message = s.getMessage();
+  if (s.ok()) {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.status.uuid = getUUID();
+  } else {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+ExtensionRunnerInterface::~ExtensionRunnerInterface() {
   removePath(path_);
 
-  if (raw_socket_ > 0) {
-    close(raw_socket_);
-    raw_socket_ = 0;
+  if (server_->sd > 0) {
+    close(server_->sd);
+    server_->sd = 0;
   }
 };
 
-ExtensionRunnerImpl::ExtensionRunnerImpl()
-    : server{std::make_unique<ImpExtensionRunner>()} {}
+ExtensionRunnerInterface::ExtensionRunnerInterface()
+    : server_{std::make_unique<ImplExtensionRunner>()} {}
 
-void ExtensionRunnerImpl::serve() {
+void ExtensionRunnerInterface::serve() {
   // Start the Thrift server's run loop.
-  server->server_->serve();
+  server_->server->serve();
 }
 
-void ExtensionRunnerImpl::connect() {
-  server->server_ = TThreadedServerRef(new ThriftServer());
-  server->server_->setProcessorFactory(server->processor_);
+void ExtensionRunnerInterface::connect() {
+  server_->server = std::make_unique<apache::thrift::ThriftServer>();
+  server_->server->setInterface(server_->handler);
 
-  raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  server_->sd = socket(AF_UNIX, SOCK_STREAM, 0);
   struct sockaddr_un addr;
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
   strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
-  if (bind(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+  if (::bind(server_->sd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
     throw std::runtime_error("Cannot bind to socket");
   }
-  server->server_->useExistingSocket(raw_socket_);
+  server_->server->useExistingSocket(server_->sd);
 }
 
-void ExtensionRunnerImpl::init(RouteUUID uuid) {
+void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
+  manager_ = manager;
+
   // Create the thrift instances.
-  auto handler = ExtensionHandlerRef(new ExtensionHandler(uuid));
-  server->processor_ =
-      std::make_shared<ThriftServerAsyncProcessorFactory<ExtensionHandler>>(
-          handler);
-}
-
-void ExtensionRunnerImpl::initManager() {
-  // Create the thrift instances.
-  auto handler = ExtensionManagerHandlerRef(new ExtensionManagerHandler());
-  server->processor_ = std::make_shared<
-      ThriftServerAsyncProcessorFactory<ExtensionManagerHandler>>(handler);
-}
-
-void ExtensionRunnerImpl::stopServer() {
-  // In most cases the service thread has started before the stop request.
-  if (server->server_ != nullptr) {
-    server->server_->stop();
+  if (!manager_) {
+    server_->handler = std::make_shared<ExtensionHandler>(uuid);
+  } else {
+    server_->handler = std::make_shared<ExtensionManagerHandler>();
   }
 }
 
-void ExtensionRunnerImpl::stopServerManager() {
-  if (server->server_ != nullptr) {
+void ExtensionRunnerInterface::stopServer() {
+  // In most cases the service thread has started before the stop request.
+  if (server_->server != nullptr) {
+    server_->server->stop();
+  }
+}
+
+void ExtensionRunnerInterface::stopServerManager() {
+  if (server_->server != nullptr) {
     removeStalePaths(path_);
   }
 }
 
-EXInternal::EXInternal(const std::string& path)
-    : path_(path), server{std::make_unique<ImpExtensionManagerServer>()} {
-  raw_socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+void ExtensionClientCore::init(const std::string& path, bool manager) {
+  path_ = path;
+  manager_ = manager;
+
+  client_ = std::make_unique<ImplExtensionClient>();
+  client_->sd = socket(AF_UNIX, SOCK_STREAM, 0);
+
   struct sockaddr_un addr;
   memset(&addr, 0, sizeof(addr));
   addr.sun_family = AF_UNIX;
   strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
-  if (connect(raw_socket_, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+  if (::connect(client_->sd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
     throw std::runtime_error("Cannot connect to socket");
+  }
+
+  auto tsock(apache::thrift::async::TAsyncSocket::newSocket(&client_->base,
+                                                            client_->sd));
+  auto channel(apache::thrift::HeaderClientChannel::newChannel(tsock));
+  channel->setProtocolId(apache::thrift::protocol::T_BINARY_PROTOCOL);
+  channel->setClientType(THRIFT_UNFRAMED_DEPRECATED);
+
+  if (!manager_) {
+    client_->e = std::make_shared<ExtensionAsyncClient>(std::move(channel));
+  } else {
+    client_->em =
+        std::make_shared<ExtensionManagerAsyncClient>(std::move(channel));
   }
 }
 
-EXInternal::~EXInternal() = default;
+ExtensionClientCore::~ExtensionClientCore() = default;
 
-void EXInternal::setTimeouts(size_t timeouts) {}
+void ExtensionClientCore::setTimeouts(size_t /* timeouts */) {}
 
-EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
+bool ExtensionClientCore::manager() {
+  return manager_;
+}
+
+ExtensionClient::ExtensionClient(const std::string& path, size_t timeout) {
+  init(path, false);
   setTimeouts(timeout);
-  // client_ = std::make_shared<_Client>(HeaderClientChannel::newChannel(
-  //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
 }
 
-EXManagerClient::EXManagerClient(const std::string& manager_path,
-                                 size_t timeout)
-    : EXInternal(manager_path) {
+ExtensionManagerClient::ExtensionManagerClient(const std::string& path,
+                                               size_t timeout) {
+  init(path, true);
   setTimeouts(timeout);
-  // client_ = std::make_shared<_ManagerClient>(HeaderClientChannel::newChannel(
-  //    async::TAsyncSocket::newSocket(&server->base_, raw_socket_)));
 }
 
-const std::shared_ptr<_Client>& EXClient::get() const {
-  return client_;
+Status ExtensionClient::ping() {
+  ExtensionStatus status;
+  auto client = manager() ? client_->em : client_->e;
+  client->sync_ping(status);
+  if (status.code != (int)extensions::ExtensionCode::EXT_FAILED) {
+    return Status(0, status.message);
+  }
+  return Status(1);
 }
 
-const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
-  return client_;
+Status ExtensionClient::call(const std::string& registry,
+                             const std::string& item,
+                             const PluginRequest& request,
+                             PluginResponse& response) {
+  ExtensionResponse er;
+  auto client = manager() ? client_->em : client_->e;
+  client->sync_call(er, registry, item, request);
+  for (const auto& r : er.response) {
+    response.push_back(r);
+  }
+
+  return Status(er.status.code, er.status.message);
 }
+
+void ExtensionClient::shutdown() {
+  auto client = manager() ? client_->em : client_->e;
+  client->sync_shutdown();
+}
+
+ExtensionList ExtensionManagerClient::extensions() {
+  ExtensionList el;
+  InternalExtensionList iel;
+  client_->em->sync_extensions(iel);
+  for (const auto& extension : iel) {
+    auto& ext = el[extension.first];
+    ext.min_sdk_version = extension.second.min_sdk_version;
+    ext.version = extension.second.version;
+    ext.sdk_version = extension.second.sdk_version;
+    ext.name = extension.second.name;
+  }
+  return el;
+}
+
+OptionList ExtensionManagerClient::options() {
+  OptionList ol;
+  InternalOptionList iol;
+  client_->em->sync_options(iol);
+  for (const auto& option : iol) {
+    auto& opt = option.second;
+    ol[option.first] = {opt.value, opt.default_value, opt.type};
+  }
+  return ol;
+}
+
+Status ExtensionManagerClient::registerExtension(
+    const ExtensionInfo& info,
+    const ExtensionRegistry& registry,
+    RouteUUID& uuid) {
+  InternalExtensionInfo iei;
+  iei.name = info.name;
+  iei.version = info.version;
+  iei.sdk_version = info.sdk_version;
+  iei.min_sdk_version = info.min_sdk_version;
+  ExtensionStatus status;
+  client_->em->sync_registerExtension(status, iei, registry);
+  uuid = status.uuid;
+  return Status(status.code, status.message);
+}
+
+Status ExtensionManagerClient::query(const std::string& sql, QueryData& qd) {
+  ExtensionResponse er;
+  client_->em->sync_query(er, sql);
+  for (const auto& row : er.response) {
+    qd.push_back(row);
+  }
+
+  return Status();
+}
+
+Status ExtensionManagerClient::getQueryColumns(const std::string& sql,
+                                               QueryData& qd) {
+  ExtensionResponse er;
+  client_->em->sync_getQueryColumns(er, sql);
+  for (const auto& row : er.response) {
+    qd.push_back(row);
+  }
+
+  return Status(er.status.code, er.status.message);
+}
+
+Status ExtensionManagerClient::deregisterExtension(RouteUUID uuid) {
+  ExtensionStatus status;
+  client_->em->sync_deregisterExtension(status, uuid);
+  return Status(status.code, status.message);
+}
+
+ExtensionClient::~ExtensionClient() {}
+
+ExtensionManagerClient::~ExtensionManagerClient() {}
 } // namespace osquery

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -69,6 +69,11 @@ class ExtensionHandler : virtual public extensions::ExtensionIf,
   RouteUUID getUUID() const;
 };
 
+#ifdef WIN32
+#pragma warning(push, 3)
+#pragma warning(disable : 4250)
+#endif
+
 class ExtensionManagerHandler : virtual public extensions::ExtensionManagerIf,
                                 public ExtensionManagerInterface,
                                 public ExtensionHandler {
@@ -105,6 +110,10 @@ class ExtensionManagerHandler : virtual public extensions::ExtensionManagerIf,
   using ExtensionHandler::call;
   using ExtensionHandler::shutdown;
 };
+
+#ifdef WIN32
+#pragma warning(pop)
+#endif
 
 struct ImplExtensionRunner {
   std::shared_ptr<TServerTransport> transport;

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -12,8 +12,6 @@
 #include <osquery/filesystem.h>
 #include <osquery/system.h>
 
-#include "osquery/extensions/interface.h"
-
 #include <thrift/concurrency/ThreadManager.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/server/TThreadedServer.h>
@@ -27,7 +25,10 @@
 #include <thrift/transport/TSocket.h>
 #endif
 
-using namespace osquery::extensions;
+#include "Extension.h"
+#include "ExtensionManager.h"
+
+#include "osquery/extensions/interface.h"
 
 namespace osquery {
 
@@ -37,130 +38,408 @@ using namespace apache::thrift::server;
 using namespace apache::thrift::concurrency;
 
 #ifdef WIN32
-typedef TPipe TPlatformSocket;
-typedef TPipeServer TPlatformServerSocket;
-typedef std::shared_ptr<TPipe> TPlatformSocketRef;
+using TPlatformServerSocket = TPipeServer;
+using TPlatformSocket = TPipe;
 #else
-typedef TSocket TPlatformSocket;
-typedef TServerSocket TPlatformServerSocket;
-typedef std::shared_ptr<TSocket> TPlatformSocketRef;
+using TPlatformServerSocket = TServerSocket;
+using TPlatformSocket = TSocket;
 #endif
 
-typedef std::shared_ptr<TTransport> TTransportRef;
-typedef std::shared_ptr<TProtocol> TProtocolRef;
-typedef std::shared_ptr<TServerTransport> TServerTransportRef;
-typedef std::shared_ptr<TProcessor> TProcessorRef;
-typedef std::shared_ptr<TTransportFactory> TTransportFactoryRef;
-typedef std::shared_ptr<TProtocolFactory> TProtocolFactoryRef;
-using TThreadedServerRef = std::shared_ptr<TThreadedServer>;
+class ExtensionHandler : virtual public extensions::ExtensionIf,
+                         public ExtensionInterface {
+ public:
+  ExtensionHandler() : ExtensionInterface(0) {}
+  explicit ExtensionHandler(RouteUUID uuid) : ExtensionInterface(uuid) {}
 
-typedef std::shared_ptr<ExtensionHandler> ExtensionHandlerRef;
-typedef std::shared_ptr<ExtensionManagerHandler> ExtensionManagerHandlerRef;
+ public:
+  using ExtensionInterface::ping;
+  void ping(extensions::ExtensionStatus& _return) override;
 
-struct ImpExtensionRunner {
-  TServerTransportRef transport_{nullptr};
-  TThreadedServerRef server_{nullptr};
-  TProcessorRef processor_{nullptr};
+  using ExtensionInterface::call;
+  void call(extensions::ExtensionResponse& _return,
+            const std::string& registry,
+            const std::string& item,
+            const extensions::ExtensionPluginRequest& request) override;
+
+  using ExtensionInterface::shutdown;
+  void shutdown() override;
+
+ protected:
+  /// UUID accessor.
+  RouteUUID getUUID() const;
 };
 
-struct ImpExtensionManagerServer {
-  TPlatformSocketRef socket_;
-  TTransportRef transport_;
-  TProtocolRef protocol_;
+class ExtensionManagerHandler : virtual public extensions::ExtensionManagerIf,
+                                public ExtensionManagerInterface,
+                                public ExtensionHandler {
+ public:
+  ExtensionManagerHandler() = default;
+
+ public:
+  using ExtensionManagerInterface::extensions;
+  void extensions(extensions::InternalExtensionList& _return) override;
+
+  using ExtensionManagerInterface::options;
+  void options(extensions::InternalOptionList& _return) override;
+
+  using ExtensionManagerInterface::registerExtension;
+  void registerExtension(
+      extensions::ExtensionStatus& _return,
+      const extensions::InternalExtensionInfo& info,
+      const extensions::ExtensionRegistry& registry) override;
+
+  using ExtensionManagerInterface::deregisterExtension;
+  void deregisterExtension(extensions::ExtensionStatus& _return,
+                           const extensions::ExtensionRouteUUID uuid) override;
+
+  using ExtensionManagerInterface::query;
+  void query(extensions::ExtensionResponse& _return,
+             const std::string& sql) override;
+
+  using ExtensionManagerInterface::getQueryColumns;
+  void getQueryColumns(extensions::ExtensionResponse& _return,
+                       const std::string& sql) override;
 };
 
-ExtensionRunnerImpl::~ExtensionRunnerImpl() {
-  if (pathExists(path_).ok()) {
-    removePath(path_);
-  }
+struct ImplExtensionRunner {
+  std::shared_ptr<TServerTransport> transport;
+  std::shared_ptr<TThreadedServer> server;
+  std::shared_ptr<TProcessor> processor;
 };
 
-ExtensionRunnerImpl::ExtensionRunnerImpl()
-    : server{std::make_unique<ImpExtensionRunner>()} {}
+struct ImplExtensionClient {
+  std::shared_ptr<extensions::ExtensionClient> e;
+  std::shared_ptr<extensions::ExtensionManagerClient> em;
 
-void ExtensionRunnerImpl::serve() {
-  // Start the Thrift server's run loop.
-  server->server_->serve();
+  std::shared_ptr<TBufferedTransport> transport;
+  std::shared_ptr<TPlatformSocket> socket;
+};
+
+void ExtensionHandler::ping(extensions::ExtensionStatus& _return) {
+  auto s = ExtensionInterface::ping();
+  _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+  _return.uuid = s.getCode();
+  _return.message = s.getMessage();
 }
 
-void ExtensionRunnerImpl::connect() {
-  server->transport_ = TServerTransportRef(new TPlatformServerSocket(path_));
+void ExtensionHandler::call(extensions::ExtensionResponse& _return,
+                            const std::string& registry,
+                            const std::string& item,
+                            const extensions::ExtensionPluginRequest& request) {
+  PluginRequest plugin_request;
+  for (const auto& request_item : request) {
+    // Create a PluginRequest from an ExtensionPluginRequest.
+    plugin_request[request_item.first] = request_item.second;
+  }
+
+  PluginResponse response;
+  auto s = ExtensionInterface::call(registry, item, plugin_request, response);
+  _return.status.code = s.getCode();
+  _return.status.message = s.getMessage();
+  _return.status.uuid = getUUID();
+
+  if (s.ok()) {
+    for (const auto& response_item : response) {
+      // Translate a PluginResponse to an ExtensionPluginResponse.
+      _return.response.push_back(response_item);
+    }
+  }
+}
+
+void ExtensionHandler::shutdown() {}
+
+RouteUUID ExtensionHandler::getUUID() const {
+  return uuid_;
+}
+
+void ExtensionManagerHandler::extensions(
+    extensions::InternalExtensionList& _return) {
+  //_return = ExtensionManagerInterface::extensions();
+  auto extensions = ExtensionManagerInterface::extensions();
+  for (const auto& extension : extensions) {
+    auto& ext = _return[extension.first];
+    ext.min_sdk_version = extension.second.min_sdk_version;
+    ext.version = extension.second.version;
+    ext.sdk_version = extension.second.sdk_version;
+    ext.name = extension.second.name;
+  }
+}
+
+void ExtensionManagerHandler::options(extensions::InternalOptionList& _return) {
+  auto options = ExtensionManagerInterface::options();
+  for (const auto& option : options) {
+    _return[option.first].value = option.second.value;
+    _return[option.first].default_value = option.second.default_value;
+    _return[option.first].type = option.second.type;
+  }
+}
+
+void ExtensionManagerHandler::registerExtension(
+    extensions::ExtensionStatus& _return,
+    const extensions::InternalExtensionInfo& info,
+    const extensions::ExtensionRegistry& registry) {
+  extensions::ExtensionRegistry er;
+  for (const auto& rt : registry) {
+    er[rt.first] = rt.second;
+  }
+
+  RouteUUID uuid;
+  auto s = ExtensionManagerInterface::registerExtension(
+      {info.name, info.version, info.sdk_version, info.min_sdk_version},
+      er,
+      uuid);
+  _return.message = s.getMessage();
+  if (s.ok()) {
+    _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.uuid = uuid;
+  } else {
+    _return.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::deregisterExtension(
+    extensions::ExtensionStatus& _return,
+    const extensions::ExtensionRouteUUID uuid) {
+  auto s = ExtensionManagerInterface::deregisterExtension(uuid);
+  _return.message = s.getMessage();
+  if (s.ok()) {
+    _return.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.uuid = getUUID();
+  } else {
+    _return.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::query(extensions::ExtensionResponse& _return,
+                                    const std::string& sql) {
+  QueryData qd;
+  auto s = ExtensionManagerInterface::query(sql, qd);
+  for (auto& row : qd) {
+    _return.response.emplace_back(std::move(row));
+  }
+  _return.status.message = s.getMessage();
+  if (s.ok()) {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.status.uuid = getUUID();
+  } else {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+void ExtensionManagerHandler::getQueryColumns(
+    extensions::ExtensionResponse& _return, const std::string& sql) {
+  QueryData qd;
+  auto s = ExtensionManagerInterface::getQueryColumns(sql, qd);
+  for (auto& row : qd) {
+    _return.response.emplace_back(std::move(row));
+  }
+  _return.status.message = s.getMessage();
+  if (s.ok()) {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_SUCCESS;
+    _return.status.uuid = getUUID();
+  } else {
+    _return.status.code = (int)extensions::ExtensionCode::EXT_FAILED;
+  }
+}
+
+ExtensionRunnerInterface::~ExtensionRunnerInterface() {
+  removePath(path_);
+};
+
+ExtensionRunnerInterface::ExtensionRunnerInterface()
+    : server_{std::make_unique<ImplExtensionRunner>()} {}
+
+void ExtensionRunnerInterface::serve() {
+  // Start the Thrift server's run loop.
+  server_->server->serve();
+}
+
+void ExtensionRunnerInterface::connect() {
+  server_->transport = std::make_shared<TPlatformServerSocket>(path_);
 
   // Construct the service's transport, protocol, thread pool.
-  auto transport_fac = TTransportFactoryRef(new TBufferedTransportFactory());
-  auto protocol_fac = TProtocolFactoryRef(new TBinaryProtocolFactory());
+  auto transport_fac = std::make_shared<TBufferedTransportFactory>();
+  auto protocol_fac = std::make_shared<TBinaryProtocolFactory>();
 
-  server->server_ = TThreadedServerRef(new TThreadedServer(
-      server->processor_, server->transport_, transport_fac, protocol_fac));
+  server_->server = std::make_shared<TThreadedServer>(
+      server_->processor, server_->transport, transport_fac, protocol_fac);
 }
 
-void ExtensionRunnerImpl::init(RouteUUID uuid) {
+void ExtensionRunnerInterface::init(RouteUUID uuid, bool manager) {
+  manager_ = manager;
+
   // Create the thrift instances.
-  auto handler = ExtensionHandlerRef(new ExtensionHandler(uuid));
-  server->processor_ = TProcessorRef(new ExtensionProcessor(handler));
-}
-
-void ExtensionRunnerImpl::initManager() {
-  // Create the thrift instances.
-  auto handler = ExtensionManagerHandlerRef(new ExtensionManagerHandler());
-  server->processor_ = TProcessorRef(new ExtensionManagerProcessor(handler));
-}
-
-void ExtensionRunnerImpl::stopServer() {
-  // In most cases the service thread has started before the stop request.
-  if (server->server_ != nullptr) {
-    server->server_->stop();
+  if (!manager_) {
+    auto handler = std::make_shared<ExtensionHandler>(uuid);
+    server_->processor =
+        std::make_shared<extensions::ExtensionProcessor>(handler);
+  } else {
+    auto handler = std::make_shared<ExtensionManagerHandler>();
+    server_->processor =
+        std::make_shared<extensions::ExtensionManagerProcessor>(handler);
   }
 }
 
-void ExtensionRunnerImpl::stopServerManager() {
-  if (server->server_ != nullptr) {
+void ExtensionRunnerInterface::stopServer() {
+  // In most cases the service thread has started before the stop request.
+  if (server_->server != nullptr) {
+    server_->server->stop();
+  }
+}
+
+void ExtensionRunnerInterface::stopServerManager() {
+  if (server_->server != nullptr) {
     removeStalePaths(path_);
   }
 }
 
-EXInternal::EXInternal(const std::string& path)
-    : path_(path), server{std::make_unique<ImpExtensionManagerServer>()} {
-  server->socket_ = std::make_shared<TPlatformSocket>(path);
-  server->transport_ = std::make_shared<TBufferedTransport>(server->socket_);
-  server->protocol_ = std::make_shared<TBinaryProtocol>(server->transport_);
+void ExtensionClientCore::init(const std::string& path, bool manager) {
+  path_ = path;
+  manager_ = manager;
+
+  client_ = std::make_unique<ImplExtensionClient>();
+  client_->socket = std::make_shared<TPlatformSocket>(path);
+  client_->transport = std::make_shared<TBufferedTransport>(client_->socket);
+  auto protocol = std::make_shared<TBinaryProtocol>(client_->transport);
+
+  if (!manager_) {
+    client_->e = std::make_shared<extensions::ExtensionClient>(protocol);
+  } else {
+    client_->em =
+        std::make_shared<extensions::ExtensionManagerClient>(protocol);
+  }
+
+  (void)client_->transport->open();
 }
 
-EXInternal::~EXInternal() {
+ExtensionClientCore::~ExtensionClientCore() {
   try {
-    server->transport_->close();
+    client_->transport->close();
   } catch (const std::exception& /* e */) {
     // The transport/socket may have exited.
   }
 }
 
-void EXInternal::setTimeouts(size_t timeouts) {
+void ExtensionClientCore::setTimeouts(size_t timeouts) {
 #if !defined(WIN32)
   // Windows TPipe does not support timeouts.
-  server->socket_->setRecvTimeout(timeouts);
-  server->socket_->setSendTimeout(timeouts);
+  client_->socket->setRecvTimeout(timeouts);
+  client_->socket->setSendTimeout(timeouts);
 #endif
 }
 
-EXClient::EXClient(const std::string& path, size_t timeout) : EXInternal(path) {
+bool ExtensionClientCore::manager() {
+  return manager_;
+}
+
+ExtensionClient::ExtensionClient(const std::string& path, size_t timeout) {
+  init(path, false);
   setTimeouts(timeout);
-  client_ = std::make_shared<_Client>(server->protocol_);
-  (void)server->transport_->open();
 }
 
-EXManagerClient::EXManagerClient(const std::string& manager_path,
-                                 size_t timeout)
-    : EXInternal(manager_path) {
+ExtensionManagerClient::ExtensionManagerClient(const std::string& path,
+                                               size_t timeout) {
+  init(path, true);
   setTimeouts(timeout);
-  client_ = std::make_shared<_ManagerClient>(server->protocol_);
-  (void)server->transport_->open();
 }
 
-const std::shared_ptr<_Client>& EXClient::get() const {
-  return client_;
+Status ExtensionClient::ping() {
+  extensions::ExtensionStatus status;
+  auto client = manager() ? client_->em : client_->e;
+  client->ping(status);
+  if (status.code != (int)extensions::ExtensionCode::EXT_FAILED) {
+    return Status(0, status.message);
+  }
+  return Status(1);
 }
 
-const std::shared_ptr<_ManagerClient>& EXManagerClient::get() const {
-  return client_;
+Status ExtensionClient::call(const std::string& registry,
+                             const std::string& item,
+                             const PluginRequest& request,
+                             PluginResponse& response) {
+  extensions::ExtensionResponse er;
+  auto client = manager() ? client_->em : client_->e;
+  client->call(er, registry, item, request);
+  for (const auto& r : er.response) {
+    response.push_back(r);
+  }
+
+  return Status(er.status.code, er.status.message);
 }
+
+void ExtensionClient::shutdown() {
+  auto client = manager() ? client_->em : client_->e;
+  client->shutdown();
+}
+
+ExtensionList ExtensionManagerClient::extensions() {
+  ExtensionList el;
+  extensions::InternalExtensionList iel;
+  client_->em->extensions(iel);
+  for (const auto& extension : iel) {
+    auto& ext = el[extension.first];
+    ext.min_sdk_version = extension.second.min_sdk_version;
+    ext.version = extension.second.version;
+    ext.sdk_version = extension.second.sdk_version;
+    ext.name = extension.second.name;
+  }
+  return el;
+}
+
+OptionList ExtensionManagerClient::options() {
+  OptionList ol;
+  extensions::InternalOptionList iol;
+  client_->em->options(iol);
+  for (const auto& option : iol) {
+    auto& opt = option.second;
+    ol[option.first] = {opt.value, opt.default_value, opt.type};
+  }
+  return ol;
+}
+
+Status ExtensionManagerClient::registerExtension(
+    const ExtensionInfo& info,
+    const extensions::ExtensionRegistry& registry,
+    RouteUUID& uuid) {
+  extensions::InternalExtensionInfo iei;
+  iei.name = info.name;
+  iei.version = info.version;
+  iei.sdk_version = info.sdk_version;
+  iei.min_sdk_version = info.min_sdk_version;
+  extensions::ExtensionStatus status;
+  client_->em->registerExtension(status, iei, registry);
+  uuid = status.uuid;
+  return Status(status.code, status.message);
+}
+
+Status ExtensionManagerClient::query(const std::string& sql, QueryData& qd) {
+  extensions::ExtensionResponse er;
+  client_->em->query(er, sql);
+  for (const auto& row : er.response) {
+    qd.push_back(row);
+  }
+
+  return Status();
+}
+
+Status ExtensionManagerClient::getQueryColumns(const std::string& sql,
+                                               QueryData& qd) {
+  extensions::ExtensionResponse er;
+  client_->em->getQueryColumns(er, sql);
+  for (const auto& row : er.response) {
+    qd.push_back(row);
+  }
+
+  return Status(er.status.code, er.status.message);
+}
+
+Status ExtensionManagerClient::deregisterExtension(RouteUUID uuid) {
+  extensions::ExtensionStatus status;
+  client_->em->deregisterExtension(status, uuid);
+  return Status(status.code, status.message);
+}
+
+ExtensionClient::~ExtensionClient() {}
+
+ExtensionManagerClient::~ExtensionManagerClient() {}
 } // namespace osquery

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -99,6 +99,11 @@ class ExtensionManagerHandler : virtual public extensions::ExtensionManagerIf,
   using ExtensionManagerInterface::getQueryColumns;
   void getQueryColumns(extensions::ExtensionResponse& _return,
                        const std::string& sql) override;
+
+ public:
+  using ExtensionHandler::ping;
+  using ExtensionHandler::call;
+  using ExtensionHandler::shutdown;
 };
 
 struct ImplExtensionRunner {

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -106,8 +106,8 @@ class ExtensionManagerHandler : virtual public extensions::ExtensionManagerIf,
                        const std::string& sql) override;
 
  public:
-  using ExtensionHandler::ping;
   using ExtensionHandler::call;
+  using ExtensionHandler::ping;
   using ExtensionHandler::shutdown;
 };
 

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -30,7 +30,8 @@ const std::vector<std::string> kSDKVersionChanges = {
 
 Status ExtensionInterface::ping() {
   // Need to translate return code into 0 and extract the UUID.
-  return Status(uuid_, "pong");
+  assert(uuid_ < INT_MAX);
+  return Status(static_cast<int>(uuid_), "pong");
 }
 
 Status ExtensionInterface::call(const std::string& registry,

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -78,7 +78,6 @@ Status ExtensionManagerInterface::registerExtension(
     const ExtensionInfo& info,
     const ExtensionRegistry& registry,
     RouteUUID& uuid) {
-  ;
   if (exists(info.name)) {
     LOG(WARNING) << "Refusing to register duplicate extension " << info.name;
     return Status((int)ExtensionCode::EXT_FAILED,

--- a/osquery/extensions/tests/extensions_tests.cpp
+++ b/osquery/extensions/tests/extensions_tests.cpp
@@ -25,8 +25,6 @@
 #include "osquery/filesystem/fileops.h"
 #include "osquery/tests/test_util.h"
 
-using namespace osquery::extensions;
-
 namespace osquery {
 
 const int kDelay = 20;
@@ -62,12 +60,12 @@ class ExtensionsTest : public testing::Test {
 
   bool ping(int attempts = 3) {
     // Calling open will except if the socket does not exist.
-    ExtensionStatus status;
     for (int i = 0; i < attempts; ++i) {
       try {
-        EXManagerClient client(socket_path);
-        client.get()->API_PING(status);
-        return (status.code == (int)ExtensionCode::EXT_SUCCESS);
+        ExtensionManagerClient client(socket_path);
+
+        auto status = client.ping();
+        return (status.getCode() == (int)ExtensionCode::EXT_SUCCESS);
       } catch (const std::exception& /* e */) {
         sleepFor(kDelay);
       }
@@ -78,19 +76,15 @@ class ExtensionsTest : public testing::Test {
 
   QueryData query(const std::string& sql, int attempts = 3) {
     // Calling open will except if the socket does not exist.
-    ExtensionResponse response;
+    QueryData qd;
     for (int i = 0; i < attempts; ++i) {
       try {
-        EXManagerClient client(socket_path);
-        client.get()->API_QUERY(response, sql);
+        ExtensionManagerClient client(socket_path);
+
+        client.query(sql, qd);
       } catch (const std::exception& /* e */) {
         sleepFor(kDelay);
       }
-    }
-
-    QueryData qd;
-    for (const auto& row : response.response) {
-      qd.push_back(row);
     }
 
     return qd;
@@ -151,9 +145,9 @@ TEST_F(ExtensionsTest, test_extension_start) {
   // Now allow duplicates (for testing, since EM/E are the same).
   rf.allowDuplicates(true);
   status = startExtension(socket_path, "test", "0.1", "0.0.0", "9.9.9");
-  // This will not be false since we are allowing deplicate items.
+  // This will not be false since we are allowing duplicate items.
   // Otherwise, starting an extension and extensionManager would fatal.
-  ASSERT_TRUE(status.ok());
+  ASSERT_NE(status.getCode(), (int)ExtensionCode::EXT_FAILED);
 
   // Checks for version comparisons (also used by packs).
   ASSERT_FALSE(versionAtLeast("1.1.1", "0.0.1"));


### PR DESCRIPTION
The goal of this PR is to separate the server (API) and client implementations of Apache and FbThrift.

The current code should work with both (set the flag `FBTHRIFT=1`) to use the FbThrift implementation. This is not recommended for open source builds. Actually, it is only recommended if you are know you will need FbThrift.

The current code uses some pre-processor tricks that we would like to remove. This completes the isolation of the two implementations. There is a little more code this way, but there are several forcing functions to make sure the implementation code changes if the API does.

Note: this is not an API change, just a refactor.