### PR TITLE
Add an mdfind table to macOS

### DIFF
--- a/osquery/tables/system/darwin/mdfind.mm
+++ b/osquery/tables/system/darwin/mdfind.mm
@@ -1,0 +1,119 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <CoreServices/CoreServices.h>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+
+namespace osquery {
+namespace tables {
+
+typedef std::pair<MDQueryRef, std::string> NamedQuery;
+
+const size_t kMaxQueryWait = 5;
+
+void genResults(const std::vector<NamedQuery>& queries, QueryData& results) {
+  // The results can update live from macOS so we stop subscribing to updates
+  // so we have a moment in time
+  for (const auto& query : queries) {
+    MDQueryDisableUpdates(query.first);
+  }
+
+  // Get data from all the queries
+  for (const auto& query : queries) {
+    for (auto i{0}; i < MDQueryGetResultCount(query.first); ++i) {
+      MDItemRef mdi = (MDItemRef)(MDQueryGetResultAtIndex(query.first, i));
+      CFTypeRef tr = MDItemCopyAttribute(mdi, CFSTR("kMDItemPath"));
+      if (tr == nullptr) {
+        continue;
+      }
+      Row r;
+      r["path"] = stringFromCFString((CFStringRef)tr);
+      r["query"] = query.second;
+      results.push_back(r);
+      CFRelease(tr);
+    }
+  }
+}
+
+std::vector<NamedQuery> genSpotlightSearches(
+    const std::set<std::string>& queries) {
+  std::vector<NamedQuery> mdrefs;
+  mdrefs.reserve(queries.size());
+
+  // Kick off all the queries
+  for (const auto& str_query : queries) {
+    CFStringRef cfquery = CFStringCreateWithCString(
+        kCFAllocatorDefault, str_query.c_str(), kCFStringEncodingUTF8);
+    auto query = MDQueryCreate(nullptr, cfquery, nullptr, nullptr);
+    if (query == nullptr) {
+      LOG(WARNING) << str_query << " is invalid";
+      continue;
+    }
+    auto started = MDQueryExecute(query, static_cast<MDQueryOptionFlags>(0x0));
+
+    // Query could not be started, warn the user and move on
+    if (!started) {
+      LOG(WARNING) << "Could not execute mdfind query";
+      continue;
+    }
+    mdrefs.push_back(std::make_pair(query, str_query));
+  }
+
+  return mdrefs;
+}
+
+Status waitForSpotlight(const std::vector<NamedQuery>& queries) {
+  // Wait for all the queries
+  bool all_done{true};
+  for (size_t time_started{getUnixTime()};
+       (getUnixTime() - time_started) < kMaxQueryWait;) {
+    // The queries run asynchronously in the threads CFRunLoop
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, YES);
+
+    // Check if all the queries are complete
+    all_done = true;
+    for (const auto& query : queries) {
+      all_done &= MDQueryIsGatheringComplete(query.first);
+    }
+    // If all the queries are complete, don't spin any longer
+    if (all_done) {
+      return Status{0};
+    }
+  }
+  if (!all_done) {
+    LOG(WARNING) << "Timed out waiting for queries";
+    for (const auto& query : queries) {
+      MDQueryStop(query.first);
+    }
+    return Status{1};
+  }
+  return Status{0};
+}
+
+QueryData genMdfindResults(QueryContext& context) {
+  QueryData results;
+  auto query_strings = context.constraints["query"].getAll(EQUALS);
+  auto queries = genSpotlightSearches(query_strings);
+
+  if (!waitForSpotlight(queries).ok()) {
+    return results;
+  }
+
+  genResults(queries, results);
+  return results;
+}
+}
+}

--- a/osquery/tables/system/darwin/mdfind.mm
+++ b/osquery/tables/system/darwin/mdfind.mm
@@ -33,8 +33,9 @@ void genResults(const std::vector<NamedQuery>& queries, QueryData& results) {
 
   // Get data from all the queries
   for (const auto& query : queries) {
-    for (auto i{0}; i < MDQueryGetResultCount(query.first); ++i) {
-      MDItemRef mdi = (MDItemRef)(MDQueryGetResultAtIndex(query.first, i));
+    for (int i = 0; i < MDQueryGetResultCount(query.first); ++i) {
+      auto mdi = reinterpret_cast<MDItemRef>(
+          const_cast<void*>(MDQueryGetResultAtIndex(query.first, i)));
       CFTypeRef tr = MDItemCopyAttribute(mdi, CFSTR("kMDItemPath"));
       if (tr == nullptr) {
         continue;

--- a/osquery/tables/system/darwin/tests/mdfind_tests.cpp
+++ b/osquery/tables/system/darwin/tests/mdfind_tests.cpp
@@ -1,0 +1,47 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <CoreServices/CoreServices.h>
+
+#include <gtest/gtest.h>
+
+#include <osquery/logger.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/tests/test_util.h"
+
+namespace osquery {
+namespace tables {
+
+typedef std::pair<MDQueryRef, std::string> NamedQuery;
+
+std::vector<NamedQuery> genSpotlightSearches(
+    const std::set<std::string>& queries);
+Status waitForSpotlight(const std::vector<NamedQuery>& queries);
+void genResults(const std::vector<NamedQuery>& queries, QueryData& results);
+
+class MdFindTests : public testing::Test {};
+
+TEST_F(MdFindTests, test_mdfind_finds_osquery) {
+  auto queries = genSpotlightSearches({"kMDItemTextContent == \"osquery\""});
+  auto s = waitForSpotlight(queries);
+  EXPECT_TRUE(s.ok());
+  QueryData results;
+  genResults(queries, results);
+
+  EXPECT_GE(results.size(), 0UL);
+
+  long count;
+  s = safeStrtol(results[0]["count(*)"], 10, count);
+
+  EXPECT_GE(count, 0);
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/darwin/mdfind.table
+++ b/specs/darwin/mdfind.table
@@ -9,5 +9,5 @@ fuzz_paths([])
 examples([
 	"select count(*) from mdfind where query = 'kMDItemTextContent == \"osquery\"';"
 	"select * from mdfind where query = 'kMDItemDisplayName == \"rook.stl\"';",
-    "select * from mdfind where query in ('kMDItemDisplayName == \"rook.stl\"', 'kMDItemDisplayName == \"video.mp4\"')"
+	"select * from mdfind where query in ('kMDItemDisplayName == \"rook.stl\"', 'kMDItemDisplayName == \"video.mp4\"')"
 ])

--- a/specs/darwin/mdfind.table
+++ b/specs/darwin/mdfind.table
@@ -1,0 +1,13 @@
+table_name("mdfind")
+description("Run searches against the spotlight database.")
+schema([
+    Column("path", TEXT, "Path of the file returned from spotlight"),
+    Column("query", TEXT, "The query that was run to find the file"),
+])
+implementation("mdfind@genMdfindResults")
+fuzz_paths([])
+examples([
+	"select count(*) from mdfind where query = 'kMDItemTextContent == \"osquery\"';"
+	"select * from mdfind where query = 'kMDItemDisplayName == \"rook.stl\"';",
+    "select * from mdfind where query in ('kMDItemDisplayName == \"rook.stl\"', 'kMDItemDisplayName == \"video.mp4\"')"
+])


### PR DESCRIPTION
This adds a new mdfind table to darwin capable of searching the filesystem. A properly formatted mdfind query must be passed to the table for it to work ([here is the documentation](https://developer.apple.com/library/content/documentation/Carbon/Conceptual/SpotlightQuery/Concepts/QueryFormat.html))

Leaks tests:

```
➜  osquery git:(mdfind) ✗ ./tools/analysis/profile.py --leaks --query "select * from mdfind where query in ('kMDItemDisplayName == \"rook.stl\"', 'kMDItemDisplayName == \"Siroca.mp4\"');"
Analyzing leaks in query: select * from mdfind where query in ('kMDItemDisplayName == "rook.stl"', 'kMDItemDisplayName == "Siroca.mp4"');
  definitely: 0 leaks for 0 total leaked bytes.
➜  osquery git:(mdfind) ✗ sudo ./tools/analysis/profile.py --leaks --query "select * from mdfind where query in ('kMDItemDisplayName == \"rook.stl\"', 'kMDItemDisplayName == \"Siroca.mp4\"');"
Analyzing leaks in query: select * from mdfind where query in ('kMDItemDisplayName == "rook.stl"', 'kMDItemDisplayName == "Siroca.mp4"');
  definitely: 0 leaks for 0 total leaked bytes.
➜  osquery git:(mdfind) ✗
```