### PR TITLE
virtual_tables: add link_speed column to interface_details for linux

### DIFF
--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -17,7 +17,10 @@
 #include <sys/socket.h>
 
 #ifdef __linux__
+#include <limits>
+#include <linux/ethtool.h>
 #include <linux/if_link.h>
+#include <linux/sockios.h>
 #include <sys/ioctl.h>
 #endif
 
@@ -135,6 +138,18 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
 
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) >= 0) {
         r["type"] = INTEGER_FROM_UCHAR(ifr.ifr_hwaddr.sa_family);
+      }
+
+      struct ethtool_cmd cmd;
+      ifr.ifr_data = reinterpret_cast<char*>(&cmd);
+      cmd.cmd = ETHTOOL_GSET;
+
+      if (ioctl(fd, SIOCETHTOOL, &ifr) >= 0) {
+        auto speed = ethtool_cmd_speed(&cmd);
+
+        if (speed != std::numeric_limits<uint32_t>::max()) {
+          r["link_speed"] = BIGINT_FROM_UINT32(speed);
+        }
       }
 
       close(fd);

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -152,6 +152,14 @@ void genDetailsFromAddr(const struct ifaddrs* addr, QueryData& results) {
         }
       }
 
+      struct ethtool_drvinfo drvInfo;
+      ifr.ifr_data = reinterpret_cast<char*>(&drvInfo);
+      drvInfo.cmd = ETHTOOL_GDRVINFO;
+
+      if (ioctl(fd, SIOCETHTOOL, &ifr) >= 0) {
+        r["pci_slot"] = drvInfo.bus_info;
+      }
+
       close(fd);
     }
 

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -18,6 +18,11 @@ schema([
     Column("collisions", BIGINT, "Packet Collisions detected"),
     Column("last_change", BIGINT, "Time of last device modification (optional)"),
 ])
+
+extended_schema(LINUX, [
+  Column("link_speed", BIGINT, "Interface speed in Mb/s"),
+])
+
 extended_schema(WINDOWS, [
     Column("friendly_name", TEXT, "The friendly display name of the interface."),
     Column("description", TEXT, "Short description of the object—a one-line string."),

--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -21,6 +21,7 @@ schema([
 
 extended_schema(LINUX, [
   Column("link_speed", BIGINT, "Interface speed in Mb/s"),
+  Column("pci_slot", TEXT, "PCI slot number"),
 ])
 
 extended_schema(WINDOWS, [


### PR DESCRIPTION
- Add column for speed in Megabits per sec for interface details on Linux.