### PR TITLE
Fix parsing of EventData block for Windows Events.

### DIFF
--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -61,14 +61,25 @@ REGISTER(WindowsEventSubscriber, "event_subscriber", "windows_events");
 /// Helper function to recursively parse a boost ptree
 void parseTree(const pt::ptree& tree, std::map<std::string, std::string>& res) {
   for (const auto& node : tree) {
-    auto nodeName = node.second.get("<xmlattr>.Name", "");
+    // Skip this since it's not actually part of the EventData. Also prevents
+    // us from adding every Name attribute into its own key invalidly. This is
+    // part of a quirk of boost::ptree and its parsing of XML.
+    if (node.first == "<xmlattr>") {
+      continue;
+    }
 
+    auto nodeName = node.second.get("<xmlattr>.Name", "");
     if (nodeName.empty()) {
       nodeName = node.first.empty() ? "DataElement" : node.first;
     }
-    res[nodeName] = res[nodeName] == ""
-                        ? node.second.data()
-                        : res[nodeName] + "," + node.second.data();
+
+    if (res[nodeName] == "") {
+      res[nodeName] = node.second.data();
+    }
+    else {
+      res[nodeName] = res[nodeName] + "," + node.second.data();
+    }
+
     parseTree(node.second, res);
   }
 }

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -75,8 +75,7 @@ void parseTree(const pt::ptree& tree, std::map<std::string, std::string>& res) {
 
     if (res[nodeName] == "") {
       res[nodeName] = node.second.data();
-    }
-    else {
+    } else {
       res[nodeName] = res[nodeName] + "," + node.second.data();
     }
 


### PR DESCRIPTION
Fix parsing of EventData block for Windows Events. Previously, parsed EventData blocks from the Windows EventLog would contain two additional "non-real" fields:

Old event example (4688 - process start), **note the properties`<xmlattr>` and `Name`**:
```
{
    "EventData": {
        "<xmlattr>": "",
        "CommandLine": "osqueryi  --disable_events=false",
        "MandatoryLabel": "S-1-16-12288",
        "Name": "SubjectUserSid,SubjectUserName,SubjectDomainName,SubjectLogonId,NewProcessId,NewProcessName,TokenElevationType,ProcessId,CommandLine,TargetUserSid,TargetUserName,TargetDomainName,TargetLogonId,ParentProcessName,MandatoryLabel",
        "NewProcessId": "0x1d88",
        "NewProcessName": "C:\\ProgramData\\osquery\\osqueryi.exe",
        "ParentProcessName": "C:\\Windows\\System32\\cmd.exe",
        "ProcessId": "0x1e20",
        "SubjectDomainName": "DESKTOP-L8H2M4",
        "SubjectLogonId": "0x12345",
        "SubjectUserName": "Some Username",
        "SubjectUserSid": "S-1-5-21-1338873204-2012490888-2498879288-1000",
        "TargetDomainName": "-",
        "TargetLogonId": "0x0",
        "TargetUserName": "-",
        "TargetUserSid": "S-1-0-0",
        "TokenElevationType": "%%1937"
    }
}
```

Fixed output is as follows:
```
{
    "EventData": {
        "CommandLine": "C:/dev/oss/osquery/build/windows10/osquery/RelWithDebInfo/osqueryi.exe  --disable-events=false",
        "MandatoryLabel": "S-1-16-12288",
        "NewProcessId": "0x14ec",
        "NewProcessName": "C:\\dev\\oss\\osquery\\build\\windows10\\osquery\\RelWithDebInfo\\osqueryi.exe",
        "ParentProcessName": "C:\\Windows\\System32\\cmd.exe",
        "ProcessId": "0xa30",
        "SubjectDomainName": "DESKTOP-L8H2M4",
        "SubjectLogonId": "0x12345",
        "SubjectUserName": "Some User",
        "SubjectUserSid": "S-1-5-21-1338873204-2012490888-2498879288-1000",
        "TargetDomainName": "-",
        "TargetLogonId": "0x0",
        "TargetUserName": "-",
        "TargetUserSid": "S-1-0-0",
        "TokenElevationType": "%%1937"
    }
}
```