### PR TITLE
Enable query planner to understand CAST statements

### DIFF
--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -414,6 +414,31 @@ Status QueryPlanner::applyTypes(TableColumns& columns) {
           column_types.erase(from + i);
         }
       }
+    } else if (row.at("opcode") == "Cast") {
+      auto value = boost::lexical_cast<size_t>(row.at("p1"));
+      auto to = boost::lexical_cast<size_t>(row.at("p2"));
+      switch (to) {
+      case 'A': // BLOB
+        column_types[value] = BLOB_TYPE;
+        break;
+      case 'B': // TEXT
+        column_types[value] = TEXT_TYPE;
+        break;
+      case 'C': // NUMERIC
+        // We don't exactly have an equivalent to NUMERIC (which includes such
+        // things as DATETIME and DECIMAL
+        column_types[value] = UNKNOWN_TYPE;
+        break;
+      case 'D': // INTEGER
+        column_types[value] = BIGINT_TYPE;
+        break;
+      case 'E': // REAL
+        column_types[value] = DOUBLE_TYPE;
+        break;
+      default:
+        column_types[value] = UNKNOWN_TYPE;
+        break;
+      }
     }
 
     if (kSQLOpcodes.count(row.at("opcode"))) {

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -256,5 +256,29 @@ TEST_F(SQLiteUtilTests, test_query_planner) {
       "f1, file as f2, time";
   getQueryColumnsInternal(query, columns, dbc);
   EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE, INTEGER_TYPE, TEXT_TYPE}));
+
+  query = "select CAST(seconds AS INTEGER) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({BIGINT_TYPE}));
+
+  query = "select CAST(seconds AS TEXT) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({TEXT_TYPE}));
+
+  query = "select CAST(seconds AS REAL) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({DOUBLE_TYPE}));
+
+  query = "select CAST(seconds AS BOOLEAN) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({UNKNOWN_TYPE}));
+
+  query = "select CAST(seconds AS DATETIME) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({UNKNOWN_TYPE}));
+
+  query = "select CAST(seconds AS BLOB) FROM time";
+  getQueryColumnsInternal(query, columns, dbc);
+  EXPECT_EQ(getTypes(columns), TypeList({BLOB_TYPE}));
 }
 }


### PR DESCRIPTION
Sometimes `getQueryColumns` gets the types wrong (e.g. when floating-point division is happening). This at least allows people to manually correct it.