### PR TITLE
bug: fix fail to read yum sources (#4284)

### DIFF
--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -23,6 +23,7 @@ namespace tables {
 
 const std::string kYumConf{"/etc/yum.conf"};
 const std::string kYumReposDir{"/etc/yum.repos.d"};
+const std::string kYumConfigFileExtension{".repo"};
 
 void parseYumConf(std::istream& source,
                   QueryData& results,
@@ -81,8 +82,10 @@ QueryData genYumSrcs(QueryContext& context) {
   parseYumConf(kYumConf, results, repos_dir);
 
   std::vector<std::string> sources;
-  if (!resolveFilePattern(repos_dir + "/%.list", sources, GLOB_FILES)) {
-    VLOG(1) << "Cannot resolve yum conf files under " << repos_dir << "/*.list";
+  if (!resolveFilePattern(
+          repos_dir + "/%" + kYumConfigFileExtension, sources, GLOB_FILES)) {
+    VLOG(1) << "Cannot resolve yum conf files under " << repos_dir << "/*"
+            << kYumConfigFileExtension;
     return results;
   }
 


### PR DESCRIPTION
Correct the file extension used to look for files under `/etc/yum.repos.d`.