### PR TITLE
Provide the full Boost library to extension developers

### DIFF
--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -346,7 +346,7 @@ function Install-ThirdParty {
   # List of our third party packages, hosted in our AWS S3 bucket
   $packages = @(
     "aws-sdk-cpp.1.4.55",
-    "boost-msvc14.1.66.0-r1",
+    "boost-msvc14.1.66.0-r2",
     "bzip2.1.0.6",
     "doxygen.1.8.11",
     "gflags-dev.2.2.1",

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -56,6 +56,9 @@ function platform_linux_main() {
 
   brew_tool osquery/osquery-local/gcc
   brew_tool osquery/osquery-local/llvm
+  brew_tool flex
+  brew_tool bison
+  brew_tool m4
   brew_dependency osquery/osquery-local/libcpp
 
   if [ ! -d "$DEPS_DIR/Cellar/xz" ]; then

--- a/tools/provision/chocolatey/boost-msvc14.ps1
+++ b/tools/provision/chocolatey/boost-msvc14.ps1
@@ -100,12 +100,6 @@ $b2x64args = @(
   'threading=multi',
   'runtime-link=static',
   'optimization=space',
-  '--with-filesystem',
-  '--with-regex',
-  '--with-system',
-  '--with-thread',
-  '--with-coroutine',
-  '--with-context',
   '--layout=tagged',
   '--ignore-site-config',
   '--disable-icu'

--- a/tools/provision/chocolatey/boost-msvc14.ps1
+++ b/tools/provision/chocolatey/boost-msvc14.ps1
@@ -14,7 +14,7 @@
 # $chocoVersion - The chocolatey package version, used for incremental bumps
 #                 without changing the version of the software package
 $version = '1.66.0'
-$chocoVersion = '1.66.0-r1'
+$chocoVersion = '1.66.0-r2'
 $versionUnderscores = $version -replace '\.', '_'
 $packageName = 'boost-msvc14'
 $projectSource = `

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -111,13 +111,20 @@ function Invoke-BatchFile {
     [string]$path,
     [string]$parameters
   )
+
   $tempFile = [IO.Path]::GetTempFileName()
+
   cmd.exe /c " `"$path`" $parameters && set > `"$tempFile`" "
+  if (-Not $?) {
+    throw "The invoked .bat script has failed. Please see the following output log for more information: `"$tempFile`""
+  }
+
   Get-Content $tempFile | Foreach-Object {
     if ($_ -match '^(.*?)=(.*)$') {
       Set-Content "env:\$($matches[1])" $matches[2]
     }
   }
+
   Remove-Item $tempFile
 }
 

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -13,7 +13,7 @@ class Boost < AbstractOsqueryFormula
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
     sha256 "260f6810e5d1276f1866aff5bf0e997c12ed8ab46617ce16f5e985230ca8f062" => :sierra
-    sha256 "2807ae0b29f9aae8a6eccd36e297f7ff902742bef8d7b9fb0dadbeb99341c6ca" => :x86_64_linux
+    sha256 "0930fdd0693f199c312cb7024442ffb86daedef4064297fedacfeee2a54a11fc" => :x86_64_linux
   end
 
   depends_on "bzip2" unless OS.mac?

--- a/tools/provision/formula/boost.rb
+++ b/tools/provision/formula/boost.rb
@@ -7,7 +7,7 @@ class Boost < AbstractOsqueryFormula
   url "https://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.bz2"
   sha256 "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9"
   head "https://github.com/boostorg/boost.git"
-  revision 200
+  revision 300
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
@@ -38,12 +38,6 @@ class Boost < AbstractOsqueryFormula
       "--layout=tagged",
       "--ignore-site-config",
       "--disable-icu",
-      "--with-filesystem",
-      "--with-regex",
-      "--with-system",
-      "--with-thread",
-      "--with-coroutine",
-      "--with-context",
       "threading=multi",
       "link=static",
       "optimization=space",


### PR DESCRIPTION
This PR adds a small change to the Chocolatey and Homebrew scripts in order to build and ship all the Boost modules (on development environments) so that extension developers can use them without attempting to link a secondary Boost copy alongside the provided one