### PR TITLE
Move singleton accessors into implementations

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -45,10 +45,8 @@ class Config : private boost::noncopyable {
   Config();
 
  public:
-  static Config& get() {
-    static Config instance;
-    return instance;
-  };
+  /// Singleton accessor.
+  static Config& get();
 
   /**
    * @brief Update the internal config data.

--- a/include/osquery/posix/system.h
+++ b/include/osquery/posix/system.h
@@ -29,10 +29,7 @@ using DropPrivilegesRef = std::shared_ptr<DropPrivileges>;
 class DropPrivileges : private boost::noncopyable {
  public:
   /// Make call sites use 'dropTo' booleans to improve the UI.
-  static DropPrivilegesRef get() {
-    DropPrivilegesRef handle = DropPrivilegesRef(new DropPrivileges());
-    return handle;
-  }
+  static DropPrivilegesRef get();
 
   /**
    * @brief Attempt to drop privileges to that of the parent of a given path.

--- a/include/osquery/registry.h
+++ b/include/osquery/registry.h
@@ -420,10 +420,8 @@ using RegistryInterfaceRef = std::shared_ptr<RegistryInterface>;
 
 class RegistryFactory : private boost::noncopyable {
  public:
-  static RegistryFactory& get() {
-    static RegistryFactory instance;
-    return instance;
-  };
+  /// Singleton accessor.
+  static RegistryFactory& get();
 
   /**
    * @brief Call a registry item.
@@ -630,8 +628,7 @@ class AutoRegisterInterface {
   /// Either autoload a registry, or create an internal plugin.
   bool optional_;
 
-  AutoRegisterInterface(const char* _type, const char* _name, bool optional)
-      : type_(_type), name_(_name), optional_(optional) {}
+  AutoRegisterInterface(const char* _type, const char* _name, bool optional);
   virtual ~AutoRegisterInterface() = default;
 
   /// A call-in for the iterator.
@@ -639,26 +636,16 @@ class AutoRegisterInterface {
 
  public:
   /// Access all registries.
-  static AutoRegisterSet& registries() {
-    static AutoRegisterSet registries_;
-    return registries_;
-  }
+  static AutoRegisterSet& registries();
 
   /// Insert a new registry.
-  static void autoloadRegistry(std::unique_ptr<AutoRegisterInterface> ar_) {
-    registries().push_back(std::move(ar_));
-  }
+  static void autoloadRegistry(std::unique_ptr<AutoRegisterInterface> ar_);
 
   /// Access all plugins.
-  static AutoRegisterSet& plugins() {
-    static AutoRegisterSet plugins_;
-    return plugins_;
-  }
+  static AutoRegisterSet& plugins();
 
   /// Insert a new plugin.
-  static void autoloadPlugin(std::unique_ptr<AutoRegisterInterface> ar_) {
-    plugins().push_back(std::move(ar_));
-  }
+  static void autoloadPlugin(std::unique_ptr<AutoRegisterInterface> ar_);
 };
 
 namespace registries {

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -302,6 +302,11 @@ Config::Config()
       valid_(false),
       refresh_runner_(std::make_shared<ConfigRefreshRunner>()) {}
 
+Config& Config::get() {
+  static Config instance;
+  return instance;
+}
+
 void Config::addPack(const std::string& name,
                      const std::string& source,
                      const rj::Value& obj) {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -409,6 +409,11 @@ static inline bool ownerFromResult(const Row& row, long& uid, long& gid) {
   return true;
 }
 
+DropPrivilegesRef DropPrivileges::get() {
+  DropPrivilegesRef handle = DropPrivilegesRef(new DropPrivileges());
+  return handle;
+}
+
 bool DropPrivileges::dropToParent(const fs::path& path) {
   auto parent = path.parent_path().string();
   auto result = SQL::selectAllFrom("file", "path", EQUALS, parent);

--- a/osquery/registry/registry.cpp
+++ b/osquery/registry/registry.cpp
@@ -375,6 +375,11 @@ bool RegistryInterface::exists_(const std::string& item_name,
   return (local) ? has_local : has_local || has_external || has_route;
 }
 
+RegistryFactory& RegistryFactory::get() {
+  static RegistryFactory instance;
+  return instance;
+}
+
 void RegistryFactory::add(const std::string& name, RegistryInterfaceRef reg) {
   if (exists(name)) {
     throw std::runtime_error("Cannot add duplicate registry: " + name);
@@ -650,5 +655,30 @@ void Plugin::setResponse(const std::string& key,
     // The plugin response could not be serialized.
   }
   response.push_back({{key, output.str()}});
+}
+
+AutoRegisterInterface::AutoRegisterInterface(const char* _type,
+                                             const char* _name,
+                                             bool optional)
+    : type_(_type), name_(_name), optional_(optional) {}
+
+AutoRegisterSet& AutoRegisterInterface::registries() {
+  static AutoRegisterSet registries_;
+  return registries_;
+}
+
+AutoRegisterSet& AutoRegisterInterface::plugins() {
+  static AutoRegisterSet plugins_;
+  return plugins_;
+}
+
+void AutoRegisterInterface::autoloadRegistry(
+    std::unique_ptr<AutoRegisterInterface> ar_) {
+  registries().push_back(std::move(ar_));
+}
+
+void AutoRegisterInterface::autoloadPlugin(
+    std::unique_ptr<AutoRegisterInterface> ar_) {
+  plugins().push_back(std::move(ar_));
 }
 }


### PR DESCRIPTION
To be honest, I am not sure why this results in ODR violations but in practice, some methods of compiling will include multiple instances of the accessor methods (bad!). This does not occur with osquery's default compiler/linker configuration so this is hard to catch.