### PR TITLE
Code audit for flags and dispatcher parts

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -181,10 +181,7 @@ class Dispatcher : private boost::noncopyable {
    *
    * @return The osquery::Dispatcher instance.
    */
-  static Dispatcher& instance() {
-    static Dispatcher instance;
-    return instance;
-  }
+  static Dispatcher& instance();
 
   /// See `add`, but services are not limited to a thread poll size.
   static Status addService(InternalRunnableRef service);

--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -78,10 +78,8 @@ class Flag : private boost::noncopyable {
   /// Create a Gflags alias to name, using the Flag::getValue accessor.
   static int createAlias(const std::string& alias, const FlagDetail& flag);
 
-  static Flag& instance() {
-    static Flag f;
-    return f;
-  }
+  /// Singleton accessor.
+  static Flag& instance();
 
  private:
   /// Keep the ctor private, for accessing through `add` wrapper.

--- a/osquery/carver/carver.h
+++ b/osquery/carver/carver.h
@@ -45,7 +45,7 @@ class Carver : public InternalRunnable {
    * in one fell swoop. Use of this class should largely happen through
    * this function.
    */
-  void start();
+  void start() override;
 
  private:
   /*

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -236,7 +236,7 @@ class ConfigRefreshRunner : public InternalRunnable {
   ConfigRefreshRunner() : InternalRunnable("ConfigRefreshRunner") {}
 
   /// A simple wait/interruptible lock.
-  void start();
+  void start() override;
 
  private:
   /// The current refresh rate in seconds.

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -34,6 +34,11 @@ namespace flags = GFLAGS_NAMESPACE;
 
 namespace osquery {
 
+Flag& Flag::instance() {
+  static Flag f;
+  return f;
+}
+
 int Flag::create(const std::string& name, const FlagDetail& flag) {
   instance().flags_.insert(std::make_pair(name, flag));
   return 0;

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -292,7 +292,7 @@ class WatcherRunner : public InternalRunnable {
 
  private:
   /// Dispatcher (this service thread's) entry point.
-  void start();
+  void start() override;
 
   /// Boilerplate function to sleep for some configured latency
   bool ok() const;
@@ -365,7 +365,7 @@ class WatcherWatcherRunner : public InternalRunnable {
       : InternalRunnable("WatcherWatcherRunner"), watcher_(watcher) {}
 
   /// Runnable thread's entry point.
-  void start();
+  void start() override;
 
  private:
   /// Parent, or watchdog, process ID.

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -73,6 +73,11 @@ void InternalRunnable::run() {
   Dispatcher::removeService(this);
 }
 
+Dispatcher& Dispatcher::instance() {
+  static Dispatcher instance;
+  return instance;
+}
+
 Status Dispatcher::addService(InternalRunnableRef service) {
   if (service->hasRun()) {
     return Status(1, "Cannot schedule a service twice");

--- a/osquery/dispatcher/distributed.h
+++ b/osquery/dispatcher/distributed.h
@@ -22,7 +22,7 @@ class DistributedRunner : public InternalRunnable {
 
  public:
   /// The Dispatcher thread entry point.
-  void start();
+  void start() override;
 };
 
 Status startDistributed();


### PR DESCRIPTION
This is a quick code review of the flags and dispatcher parts. I was casually browsing code changes via a proposed code-sync and saw some things I was unhappy with. Moving the singleton accessors into implementation files prevents odd ODR violations. The runner thread abstractions should `override` their start otherwise they will be spinning needless wheels (good practice).