### PR TITLE
Fix autoloaded extension processes outliving the main process

### DIFF
--- a/osquery/core/posix/process.cpp
+++ b/osquery/core/posix/process.cpp
@@ -59,7 +59,7 @@ bool PlatformProcess::killGracefully() const {
     return false;
   }
 
-  int status = ::kill(nativeHandle(), SIGINT);
+  int status = ::kill(nativeHandle(), SIGTERM);
   return (status == 0);
 }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -246,6 +246,21 @@ void WatcherRunner::start() {
   } while (!interrupted() && ok());
 }
 
+void WatcherRunner::stop() {
+  auto& watcher = Watcher::get();
+
+  for (const auto& extension : watcher.extensions()) {
+    try {
+      stopChild(*extension.second);
+    } catch (std::exception& e) {
+      LOG(ERROR) << "[WatcherRunner] couldn't kill the extension "
+                 << extension.first << "nicely. Reason: " << e.what()
+                 << std::endl;
+      extension.second->kill();
+    }
+  }
+}
+
 void WatcherRunner::watchExtensions() {
   auto& watcher = Watcher::get();
 

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -294,6 +294,8 @@ class WatcherRunner : public InternalRunnable {
   /// Dispatcher (this service thread's) entry point.
   void start() override;
 
+  void stop() override;
+
   /// Boilerplate function to sleep for some configured latency
   bool ok() const;
 

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -141,7 +141,6 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
     retcode = osquery::launchIntoShell(argc, argv);
     // Finally shutdown.
     runner.requestShutdown();
-    runner.waitForShutdown();
   } else {
     retcode = profile(argc, argv);
   }

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -141,6 +141,7 @@ int startShell(osquery::Initializer& runner, int argc, char* argv[]) {
     retcode = osquery::launchIntoShell(argc, argv);
     // Finally shutdown.
     runner.requestShutdown();
+    runner.waitForShutdown();
   } else {
     retcode = profile(argc, argv);
   }


### PR DESCRIPTION
Fix #4358
Added a custom stop function to WatcherRunner to stop all autoloaded extensions, before shutting down. Also, modified PlatformProcess for posix  to send SIGTERM, and not SIGINT (keyboard interrupt) when trying to nicely kill a process.
Run osqueryi locally and checked that after it completes no more Unix socket error messages appear.
Also,  runned an instance of osqueryd and running a simple query with osqueryi. Made sure that osqueryi doesn't kill any process that osqueryd has started.