### PR TITLE
Remove --logger_min_stderr from service files

### DIFF
--- a/tools/deployment/com.facebook.osqueryd.plist
+++ b/tools/deployment/com.facebook.osqueryd.plist
@@ -12,7 +12,6 @@
   <array>
     <string>/usr/local/bin/osqueryd</string>
     <string>--flagfile=/private/var/osquery/osquery.flags</string>
-    <string>--logger_min_stderr=1</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -87,7 +87,6 @@ start() {
 
   $PROG $ARGS \
         --pidfile=$PIDFILE \
-        --logger_min_stderr=1 \
         --daemonize=true
   RETVAL=$?
 }

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -9,7 +9,6 @@ ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"
 ExecStart=/usr/bin/osqueryd \
   --flagfile $FLAG_FILE \
-  --logger_min_stderr 1 \
   --config_path $CONFIG_FILE
 Restart=on-failure
 KillMode=process


### PR DESCRIPTION
This should go into the flags file or configuration to avoid spreading
configs across multiple places.

The documentation also says by default osqueryd will log INFO messages
but a user installing our packages won't see that and reason might not
be obvious.