### PR TITLE
Real time query scheduler

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -166,14 +166,15 @@ class Config : private boost::noncopyable {
    * @code{.cpp}
    *   std::map<std::string, ScheduledQuery> queries;
    *   Config::get().scheduledQueries(
-   *      ([&queries](const std::string& name, ScheduledQuery& query) {
-   *        queries[name] = query;
+   *      ([&queries](const std::string& name, std::shared_ptr<ScheduledQuery>
+   * query) { queries[name] = query;
    *      }));
    * @endcode
    */
-  void scheduledQueries(std::function<void(const std::string& name,
-                                           ScheduledQuery& query)> predicate,
-                        bool blacklisted = false);
+  void scheduledQueries(
+      std::function<void(const std::string& name,
+                         std::shared_ptr<ScheduledQuery> query)> predicate,
+      bool blacklisted = false);
 
   /**
    * @brief Map a function across the set of configured files

--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -166,15 +166,14 @@ class Config : private boost::noncopyable {
    * @code{.cpp}
    *   std::map<std::string, ScheduledQuery> queries;
    *   Config::get().scheduledQueries(
-   *      ([&queries](const std::string& name, const ScheduledQuery& query) {
+   *      ([&queries](const std::string& name, ScheduledQuery& query) {
    *        queries[name] = query;
    *      }));
    * @endcode
    */
-  void scheduledQueries(
-      std::function<void(const std::string& name, const ScheduledQuery& query)>
-          predicate,
-      bool blacklisted = false);
+  void scheduledQueries(std::function<void(const std::string& name,
+                                           ScheduledQuery& query)> predicate,
+                        bool blacklisted = false);
 
   /**
    * @brief Map a function across the set of configured files

--- a/include/osquery/packs.h
+++ b/include/osquery/packs.h
@@ -28,6 +28,9 @@ struct PackStats {
   size_t misses{0};
 };
 
+using ScheduledQueryMap =
+    std::map<std::string, std::shared_ptr<ScheduledQuery>>;
+
 /**
  * @brief The programmatic representation of a query pack
  */
@@ -79,10 +82,10 @@ class Pack : private boost::noncopyable {
   }
 
   /// Returns the schedule dictated by the pack
-  const std::map<std::string, ScheduledQuery>& getSchedule() const;
+  const ScheduledQueryMap& getSchedule() const;
 
   /// Returns the schedule dictated by the pack
-  std::map<std::string, ScheduledQuery>& getSchedule();
+  ScheduledQueryMap& getSchedule();
 
   /// Verify that the platform is compatible
   bool checkPlatform() const;
@@ -114,7 +117,7 @@ class Pack : private boost::noncopyable {
   std::vector<std::string> discovery_queries_;
 
   /// Map of query names to the scheduled query details.
-  std::map<std::string, ScheduledQuery> schedule_;
+  ScheduledQueryMap schedule_;
 
   /// Platform requirement for pack.
   std::string platform_;

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -284,8 +284,8 @@ struct ScheduledQuery : private only_movable {
   /// A temporary splayed internal.
   size_t splayed_interval{0};
 
-  /// Last time query ran
-  std::time_t last_runtime{0};
+  /// Last time query scheduled
+  std::time_t last_scheduledtime{0};
 
   /**
    * @brief Queries are blacklisted based on logic in the configuration.

--- a/include/osquery/query.h
+++ b/include/osquery/query.h
@@ -284,6 +284,9 @@ struct ScheduledQuery : private only_movable {
   /// A temporary splayed internal.
   size_t splayed_interval{0};
 
+  /// Last time query ran
+  std::time_t last_runtime{0};
+
   /**
    * @brief Queries are blacklisted based on logic in the configuration.
    *
@@ -292,6 +295,10 @@ struct ScheduledQuery : private only_movable {
    * to return all queries, thus it is important to capture this optional data.
    */
   bool blacklisted{false};
+
+  /// Is query already been scheduled
+  std::shared_ptr<std::atomic_bool> is_scheduled{
+      std::make_shared<std::atomic_bool>(false)};
 
   /// Set of query options.
   std::map<std::string, bool> options;

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -389,7 +389,7 @@ static inline bool blacklistExpired(size_t blt, const ScheduledQuery& query) {
 }
 
 void Config::scheduledQueries(
-    std::function<void(const std::string& name, const ScheduledQuery& query)>
+    std::function<void(const std::string& name, ScheduledQuery& query)>
         predicate,
     bool blacklisted) {
   RecursiveLock lock(config_schedule_mutex_);

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -192,48 +192,48 @@ void Pack::initialize(const std::string& name,
       continue;
     }
 
-    ScheduledQuery query;
-    query.query = q.value["query"].GetString();
+    std::shared_ptr<ScheduledQuery> query = std::make_shared<ScheduledQuery>();
+    query->query = q.value["query"].GetString();
     if (!q.value.HasMember("interval")) {
-      query.interval = FLAGS_schedule_default_interval;
+      query->interval = FLAGS_schedule_default_interval;
     } else {
-      query.interval = JSON::valueToSize(q.value["interval"]);
+      query->interval = JSON::valueToSize(q.value["interval"]);
     }
-    if (query.interval <= 0 || query.query.empty() ||
-        query.interval > kMaxQueryInterval) {
+    if (query->interval <= 0 || query->query.empty() ||
+        query->interval > kMaxQueryInterval) {
       // Invalid pack query.
       LOG(WARNING) << "Query has invalid interval: " << q.name.GetString()
-                   << ": " << query.interval;
+                   << ": " << query->interval;
       continue;
     }
 
-    query.splayed_interval =
-        restoreSplayedValue(q.name.GetString(), query.interval);
+    query->splayed_interval =
+        restoreSplayedValue(q.name.GetString(), query->interval);
 
     if (!q.value.HasMember("snapshot")) {
-      query.options["snapshot"] = false;
+      query->options["snapshot"] = false;
     } else {
-      query.options["snapshot"] = JSON::valueToBool(q.value["snapshot"]);
+      query->options["snapshot"] = JSON::valueToBool(q.value["snapshot"]);
     }
 
     if (!q.value.HasMember("removed")) {
-      query.options["removed"] = true;
+      query->options["removed"] = true;
     } else {
-      query.options["removed"] = JSON::valueToBool(q.value["removed"]);
+      query->options["removed"] = JSON::valueToBool(q.value["removed"]);
     }
-    query.options["blacklist"] = (q.value.HasMember("blacklist"))
-                                     ? q.value["blacklist"].GetBool()
-                                     : true;
+    query->options["blacklist"] = (q.value.HasMember("blacklist"))
+                                      ? q.value["blacklist"].GetBool()
+                                      : true;
 
-    schedule_.emplace(std::make_pair(q.name.GetString(), std::move(query)));
+    schedule_.emplace(std::make_pair(q.name.GetString(), query));
   }
 }
 
-const std::map<std::string, ScheduledQuery>& Pack::getSchedule() const {
+const ScheduledQueryMap& Pack::getSchedule() const {
   return schedule_;
 }
 
-std::map<std::string, ScheduledQuery>& Pack::getSchedule() {
+ScheduledQueryMap& Pack::getSchedule() {
   return schedule_;
 }
 

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -270,7 +270,8 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
   std::vector<std::string> query_names;
   get().addPack("unrestricted_pack", "", getUnrestrictedPack().doc());
   get().scheduledQueries(
-      ([&query_names](const std::string& name, const ScheduledQuery& query) {
+      ([&query_names](const std::string& name,
+                      std::shared_ptr<ScheduledQuery> query) {
         query_names.push_back(name);
       }));
 
@@ -293,8 +294,8 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
 
   // Clear the query names in the scheduled queries and request again.
   query_names.clear();
-  get().scheduledQueries(
-      ([&query_names](const std::string& name, const ScheduledQuery&) {
+  get().scheduledQueries((
+      [&query_names](const std::string& name, std::shared_ptr<ScheduledQuery>) {
         query_names.push_back(name);
       }));
   // The query should not exist.
@@ -305,12 +306,12 @@ TEST_F(ConfigTests, test_get_scheduled_queries) {
   query_names.clear();
   bool blacklisted = false;
   get().scheduledQueries(
-      ([&blacklisted, &query_names, &query_name](const std::string& name,
-                                                 const ScheduledQuery& query) {
+      ([&blacklisted, &query_names, &query_name](
+           const std::string& name, std::shared_ptr<ScheduledQuery> query) {
         if (name == query_name) {
           // Only populate the query we've blacklisted.
           query_names.push_back(name);
-          blacklisted = query.blacklisted;
+          blacklisted = query->blacklisted;
         }
       }),
       true);
@@ -329,8 +330,9 @@ TEST_F(ConfigTests, test_nonblacklist_query) {
 
   std::map<std::string, bool> blacklisted;
   get().scheduledQueries(
-      ([&blacklisted](const std::string& name, const ScheduledQuery& query) {
-        blacklisted[name] = query.blacklisted;
+      ([&blacklisted](const std::string& name,
+                      std::shared_ptr<ScheduledQuery> query) {
+        blacklisted[name] = query->blacklisted;
       }));
 
   // This query cannot be blacklisted.

--- a/osquery/config/tests/packs_tests.cpp
+++ b/osquery/config/tests/packs_tests.cpp
@@ -142,10 +142,10 @@ TEST_F(PacksTests, test_discovery_cache) {
   size_t query_count = 0U;
   size_t query_attemts = 5U;
   for (size_t i = 0; i < query_attemts; i++) {
-    c.scheduledQueries(
-        ([&query_count](const std::string& name, const ScheduledQuery& query) {
-          query_count++;
-        }));
+    c.scheduledQueries(([&query_count](const std::string& name,
+                                       std::shared_ptr<ScheduledQuery> query) {
+      query_count++;
+    }));
   }
   EXPECT_EQ(query_count, query_attemts);
 

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1645,12 +1645,12 @@ int runPack(struct callback_data* data) {
     }
 
     for (const auto& query : pack->getSchedule()) {
-      rc = runQuery(data, query.second.query.c_str());
+      rc = runQuery(data, query.second->query.c_str());
       if (rc != 0) {
         fprintf(stderr,
                 "Could not execute query %s: %s\n",
                 query.first.c_str(),
-                query.second.query.c_str());
+                query.second->query.c_str());
         return;
       }
     }

--- a/osquery/dispatcher/io_service.h
+++ b/osquery/dispatcher/io_service.h
@@ -35,6 +35,10 @@ class IOServiceRunner : public InternalRunnable {
 
   /// The Dispatcher interrupt point.
   void stop() override;
+
+ private:
+  void subordinates();
+  void runLoop();
 };
 
 /// Start IOService

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <boost/asio.hpp>
 #include <map>
 
 #include <osquery/dispatcher.h>
@@ -31,11 +32,17 @@ class SchedulerRunner : public InternalRunnable {
   void start() override;
 
   /// The Dispatcher interrupt point.
-  void stop() override {}
+  void stop() override;
+
+  void scheduleQueries(size_t present_time);
 
  protected:
   /// The UNIX domain socket path for the ExtensionManager.
   std::map<std::string, size_t> splay_;
+
+  boost::asio::io_service ios_;
+
+  std::atomic_bool is_stopped_{false};
 
   /// Interval in seconds between schedule steps.
   size_t interval_;

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -665,31 +665,32 @@ void EventFactory::configUpdate() {
   // Scan the schedule for queries that touch "_events" tables.
   // We will count the queries
   std::map<std::string, SubscriberExpirationDetails> subscriber_details;
-  Config::get().scheduledQueries([&subscriber_details](
-      const std::string& name, const ScheduledQuery& query) {
-    std::vector<std::string> tables;
-    // Convert query string into a list of virtual tables effected.
-    if (!getQueryTables(query.query, tables)) {
-      VLOG(1) << "Cannot get tables from query: " << name;
-      return;
-    }
+  Config::get().scheduledQueries(
+      [&subscriber_details](const std::string& name,
+                            std::shared_ptr<ScheduledQuery> query) {
+        std::vector<std::string> tables;
+        // Convert query string into a list of virtual tables effected.
+        if (!getQueryTables(query->query, tables)) {
+          VLOG(1) << "Cannot get tables from query: " << name;
+          return;
+        }
 
-    // Remove duplicates and select only the subscriber tables.
-    std::set<std::string> subscribers;
-    for (const auto& table : tables) {
-      if (Registry::get().exists("event_subscriber", table)) {
-        subscribers.insert(table);
-      }
-    }
+        // Remove duplicates and select only the subscriber tables.
+        std::set<std::string> subscribers;
+        for (const auto& table : tables) {
+          if (Registry::get().exists("event_subscriber", table)) {
+            subscribers.insert(table);
+          }
+        }
 
-    for (const auto& subscriber : subscribers) {
-      auto& details = subscriber_details[subscriber];
-      details.max_interval = (query.interval > details.max_interval)
-                                 ? query.interval
-                                 : details.max_interval;
-      details.query_count++;
-    }
-  });
+        for (const auto& subscriber : subscribers) {
+          auto& details = subscriber_details[subscriber];
+          details.max_interval = (query->interval > details.max_interval)
+                                     ? query->interval
+                                     : details.max_interval;
+          details.query_count++;
+        }
+      });
 
   auto& ef = EventFactory::getInstance();
   for (const auto& details : subscriber_details) {

--- a/osquery/logger/plugins/buffered.h
+++ b/osquery/logger/plugins/buffered.h
@@ -208,9 +208,6 @@ class BufferedLogForwarder : public InternalRunnable {
   std::atomic<size_t> log_index_{0};
 
   /// Stores the count of buffered logs
-  size_t buffer_count_{0};
-
-  /// Protects the count of buffered logs
-  RecursiveMutex count_mutex_;
+  std::atomic<size_t> buffer_count_{0};
 };
 }

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -231,12 +231,13 @@ QueryData genOsquerySchedule(QueryContext& context) {
   QueryData results;
 
   Config::get().scheduledQueries(
-      [&results](const std::string& name, const ScheduledQuery& query) {
+      [&results](const std::string& name,
+                 std::shared_ptr<ScheduledQuery> query) {
         Row r;
         r["name"] = name;
-        r["query"] = query.query;
-        r["interval"] = INTEGER(query.interval);
-        r["blacklisted"] = (query.blacklisted) ? "1" : "0";
+        r["query"] = query->query;
+        r["interval"] = INTEGER(query->interval);
+        r["blacklisted"] = (query->blacklisted) ? "1" : "0";
         // Set default (0) values for each query if it has not yet executed.
         r["executions"] = "0";
         r["output_size"] = "0";


### PR DESCRIPTION
Implemanting real time query scheduler.
1. Made the query scheduler thread lighter
2. queries are scheduled asynchronously 
3. query are run by io service threads (introduced ioservice_subordinates which drives controls the number of io service threads default is 1, so by default two io service thread are active
4. introduced --query_short_interval flag (Query intervals under this value will be classified as short intervals)
This flag categorizes queries to be short interval or long interval.
So basically this thread introduces the terms long interval vs short interval query
default value of this flag is 600 (seconds) which means all the queries over 600 seconds will first time run immediately and later at there respective intervals while queries below are governed by the logic (present_time % splayed_interval == 0).This is based on the assumption that short interval queries are higher chance of running. 
