### PR TITLE
Correct process uid for user name mapping and added is_elevated_token column

### DIFF
--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -242,21 +242,16 @@ void genProcess(const WmiResultItem& result, QueryData& results_data) {
           tok, TokenUser, tokOwner.data(), tokOwnerBuffLen, &tokOwnerBuffLen);
     }
 
-	// Check if the process is using an elevated token
-	BOOL elevated = FALSE;
-	TOKEN_ELEVATION Elevation;
-	DWORD cbSize = sizeof(TOKEN_ELEVATION);
-	if (GetTokenInformation(tok, TokenElevation, &Elevation, sizeof(Elevation), &cbSize)) {
-		elevated = Elevation.TokenIsElevated;
-	}
+    // Check if the process is using an elevated token
+    auto elevated = FALSE;
+    TOKEN_ELEVATION Elevation;
+    DWORD cbSize = sizeof(TOKEN_ELEVATION);
+    if (GetTokenInformation(
+            tok, TokenElevation, &Elevation, sizeof(Elevation), &cbSize)) {
+      elevated = Elevation.TokenIsElevated;
+    }
 
-	if (elevated) {
-		r["is_elevated_token"] = INTEGER(1);
-	} else {
-		r["is_elevated_token"] = INTEGER(0);
-	}
-	
-
+    r["is_elevated_token"] = elevated ? INTEGER(1) : INTEGER(0);
   }
   if (uid != 0 && ret != 0 && !tokOwner.empty()) {
     auto sid = PTOKEN_OWNER(tokOwner.data())->Owner;

--- a/specs/processes.table
+++ b/specs/processes.table
@@ -31,6 +31,9 @@ schema([
     Column("threads", INTEGER, "Number of threads used by process"),
     Column("nice", INTEGER, "Process nice level (-20 to 20, default 0)"),
 ])
+extended_schema(WINDOWS, [
+    Column("is_elevated_token", INTEGER, "Process uses elevated token yes=1, no=0"),
+])
 extended_schema(LINUX, [
     Column("cgroup_namespace", TEXT, "cgroup namespace inode"),
     Column("ipc_namespace", TEXT, "ipc namespace inode"),


### PR DESCRIPTION
Processes uid is now retrieved from TokenUser instead of TokenOwner. This allows for proper mapping of user names to processes. Ref #4360 

Added is_elevated_token to column to processes table which indicates if the process is using an elevated token. 