### PR TITLE
llvm 6.0 and libFuzzer implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ elseif(DEFINED ENV{SANITIZE})
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls
     -fsanitize-blacklist=${SANITIZE_BLACKLIST}
+    -O1
   )
   if (DEFINED ENV{SANITIZE_THREAD})
     add_compile_options(-fsanitize=thread)
@@ -265,6 +266,13 @@ elseif(DEFINED ENV{SANITIZE})
       # LSAN is not available on OS X 10.12.
       add_compile_options(-fsanitize=leak)
     endif()
+  endif()
+
+  if(DEFINED ENV{FUZZ})
+    add_compile_options(
+      -fsanitize=fuzzer
+    )
+    set(FUZZ TRUE)
   endif()
 
   if(LINUX)

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,11 @@ fuzz: .setup
 	@echo "[+] zzuf (`$(PATH_SET) which zzuf`) version: `$(PATH_SET) zzuf -V | head -n 1`"
 	@$(PATH_SET) python tools/analysis/fuzz.py
 
+libfuzz: .setup
+	@cd $(BUILD_DIR) && SKIP_TESTS=True SANITIZE=True FUZZ=True $(CMAKE) && \
+		$(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)
+	@echo "[+] Now run the osqueryf target"
+
 sdk: .setup
 	@cd $(BUILD_DIR) && SDK=True $(CMAKE) && \
 		$(DEFINES) $(MAKE) --no-print-directory $(MAKEFLAGS)

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -160,17 +160,21 @@ If you want to make build changes see the Cookbook for `revision` edits. Note th
 **If this is a new dependency** then you need to add a line to `./tools/provision.sh` for Linux and or macOS at the order/time it should be installed.
 
 When a dependency is updated by a maintainer or contributor the flow should follow:
+
 * Update the target formula in `./tools/provision/formula/`.
 * Run `make deps` and the dependency change should cause a rebuild from source.
 * Build and run the osquery tests, and submit the change in a pull request.
 
 After the change is merged, a maintainer can provide a bottle/binary version:
+
 * Run `./tools/provision.sh uninstall TARGET` to remove the from-source build.
 * Run `make build_deps` to build a bottle version from source.
 * Run `./tools/provision.sh bottle TARGET` to generate the bottle.
 * Update the formula again with the SHA256 printed to stdout.
 * Upload the `/usr/local/osquery/TARGET-VERSION.tar.gz` to the S3 `bottles` folder.
 * Create a pull request with the updated SHA256.
+
+This post-merge process can be automated using `./tools/release/deps_release.sh TARGET`. This will update the formula files and place the bottled TAR.GZ in the osquery root. You will need to place these bottles into S3 manually.
 
 ## AWS EC2 Backed Vagrant Targets
 

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -291,21 +291,22 @@ add_custom_target(devel
 )
 add_dependencies(devel libosquery)
 
-if(NOT SKIP_TABLES)
-  # Generate the osquery additional tables (the non-util).
-  GENERATE_TABLES("${CMAKE_SOURCE_DIR}")
-  AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
-  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
+if(NOT OSQUERY_BUILD_SDK_ONLY)
+  if(NOT SKIP_TABLES)
+    # Generate the osquery additional tables (the non-util).
+    GENERATE_TABLES("${CMAKE_SOURCE_DIR}")
+    AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
+    ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
+
+    AMALGAMATE("${CMAKE_SOURCE_DIR}" "foreign" AMALGAMATION_FOREIGN)
+    ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_foreign_amalgamation ${AMALGAMATION_FOREIGN})
+  endif()
+
+  # Create the static libosquery_additional.
+  add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})
+  target_link_libraries(libosquery_additional ${OSQUERY_ADDITIONAL_LINKS})
+  set_target_properties(libosquery_additional PROPERTIES OUTPUT_NAME osquery_additional)
 endif()
-
-AMALGAMATE("${CMAKE_SOURCE_DIR}" "foreign" AMALGAMATION_FOREIGN)
-ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_foreign_amalgamation ${AMALGAMATION_FOREIGN})
-
-# Create the static libosquery_additional.
-add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})
-target_link_libraries(libosquery_additional ${OSQUERY_ADDITIONAL_LINKS})
-set_target_properties(libosquery_additional PROPERTIES OUTPUT_NAME osquery_additional)
-
 
 if(FUZZ)
   add_executable(fuzz

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -58,6 +58,9 @@ if(DEFINED ENV{SANITIZE})
     ADD_OSQUERY_LINK_CORE(-fsanitize=address -fsanitize=leak)
   endif()
   ADD_OSQUERY_LINK_CORE(-fsanitize-blacklist=${SANITIZE_BLACKLIST})
+  if(DEFINED ENV{FUZZ})
+    ADD_OSQUERY_LINK_CORE(-fsanitize=fuzzer)
+  endif()
 endif()
 
 # Construct a set of all object files, starting with third-party and all
@@ -91,7 +94,9 @@ if(NOT SKIP_CARVER)
 endif()
 
 # Add externals directory from parent
-add_subdirectory("${CMAKE_SOURCE_DIR}/external" "${CMAKE_BINARY_DIR}/external")
+if(NOT DEFINED ENV{FUZZ})
+  add_subdirectory("${CMAKE_SOURCE_DIR}/external" "${CMAKE_BINARY_DIR}/external")
+endif()
 
 if(NOT SKIP_TABLES)
   add_subdirectory(tables)
@@ -286,22 +291,33 @@ add_custom_target(devel
 )
 add_dependencies(devel libosquery)
 
-if(NOT OSQUERY_BUILD_SDK_ONLY)
-  if(NOT SKIP_TABLES)
-    # Generate the osquery additional tables (the non-util).
-    GENERATE_TABLES("${CMAKE_SOURCE_DIR}")
-    AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
-    ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
-  endif()
+if(NOT SKIP_TABLES)
+  # Generate the osquery additional tables (the non-util).
+  GENERATE_TABLES("${CMAKE_SOURCE_DIR}")
+  AMALGAMATE("${CMAKE_SOURCE_DIR}" "additional" AMALGAMATION)
+  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_additional_amalgamation ${AMALGAMATION})
+endif()
 
-  AMALGAMATE("${CMAKE_SOURCE_DIR}" "foreign" AMALGAMATION_FOREIGN)
-  ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_foreign_amalgamation ${AMALGAMATION_FOREIGN})
+AMALGAMATE("${CMAKE_SOURCE_DIR}" "foreign" AMALGAMATION_FOREIGN)
+ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_foreign_amalgamation ${AMALGAMATION_FOREIGN})
 
-  # Create the static libosquery_additional.
-  add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})
-  target_link_libraries(libosquery_additional ${OSQUERY_ADDITIONAL_LINKS})
-  set_target_properties(libosquery_additional PROPERTIES OUTPUT_NAME osquery_additional)
+# Create the static libosquery_additional.
+add_library(libosquery_additional STATIC ${OSQUERY_ADDITIONAL_SOURCES})
+target_link_libraries(libosquery_additional ${OSQUERY_ADDITIONAL_LINKS})
+set_target_properties(libosquery_additional PROPERTIES OUTPUT_NAME osquery_additional)
 
+
+if(FUZZ)
+  add_executable(fuzz
+    main/fuzz.cpp
+  )
+
+  ADD_DEFAULT_LINKS(fuzz TRUE)
+  SET_OSQUERY_COMPILE(fuzz)
+  set_target_properties(fuzz PROPERTIES OUTPUT_NAME osqueryf)
+endif()
+
+if(NOT OSQUERY_BUILD_SDK_ONLY AND NOT FUZZ)
   # Create the dynamic libosquery_additional.
   if(DEFINED ENV{OSQUERY_BUILD_SHARED})
     add_library(libosquery_additional_shared SHARED ${OSQUERY_ADDITIONAL_SOURCES})

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -318,7 +318,6 @@ Status procDescriptors(const std::string& process,
                      const std::string& fd,
                      const std::string& link_name,
                      std::map<std::string, std::string>& _descriptors) -> bool {
-
     _descriptors[fd] = link_name;
     return true;
   };

--- a/osquery/main/fuzz.cpp
+++ b/osquery/main/fuzz.cpp
@@ -1,0 +1,70 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/config.h>
+#include <osquery/database.h>
+#include <osquery/registry.h>
+#include <osquery/sql.h>
+
+void init() {
+  osquery::registryAndPluginInit();
+  osquery::DatabasePlugin::setAllowOpen(true);
+  osquery::Registry::get().setActive("database", "ephemeral");
+  osquery::DatabasePlugin::initPlugin().ok();
+
+  osquery::PluginRequest r;
+  r["action"] = "detach";
+  r["table"] = "file";
+
+  osquery::PluginResponse rsp;
+  osquery::Registry::get().call("sql", r, rsp);
+}
+
+#if 0
+/**
+ * Example: This will mostly fuzz SQLites internals.
+ */
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  static bool setup = false;
+  if (!setup) {
+    init();
+    setup = true;
+  }
+
+  std::string q((const char*)data, size);
+  std::transform(q.begin(), q.end(), q.begin(), ::tolower);
+
+  // Short circuit the file table.
+  if (q.find("from file") != std::string::npos) {
+    return 0;
+  }
+
+
+  osquery::QueryData r;
+  osquery::query(q, r);
+  return 0;
+}
+#endif
+
+/**
+ * Example: This will fuzz configuration handling and the config parsers.
+ */
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  static bool setup = false;
+  if (!setup) {
+    init();
+    setup = true;
+  }
+
+  std::string q((const char*)data, size);
+  osquery::Config::get().update({{"fuzz", q}});
+
+  return 0;
+}

--- a/osquery/main/fuzz.cpp
+++ b/osquery/main/fuzz.cpp
@@ -13,6 +13,11 @@
 #include <osquery/registry.h>
 #include <osquery/sql.h>
 
+/* Use these defines to flip the fuzzing harnesses. */
+// #define OSQUERY_FUZZ_SQL
+#define OSQUERY_FUZZ_CONFIG
+
+
 void init() {
   osquery::registryAndPluginInit();
   osquery::DatabasePlugin::setAllowOpen(true);
@@ -27,10 +32,10 @@ void init() {
   osquery::Registry::get().call("sql", r, rsp);
 }
 
-#if 0
 /**
  * Example: This will mostly fuzz SQLites internals.
  */
+#ifdef OSQUERY_FUZZ_SQL
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   static bool setup = false;
   if (!setup) {
@@ -56,6 +61,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 /**
  * Example: This will fuzz configuration handling and the config parsers.
  */
+#ifdef OSQUERY_FUZZ_CONFIG
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   static bool setup = false;
   if (!setup) {
@@ -68,3 +74,4 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   return 0;
 }
+#endif

--- a/osquery/main/fuzz.cpp
+++ b/osquery/main/fuzz.cpp
@@ -17,7 +17,6 @@
 // #define OSQUERY_FUZZ_SQL
 #define OSQUERY_FUZZ_CONFIG
 
-
 void init() {
   osquery::registryAndPluginInit();
   osquery::DatabasePlugin::setAllowOpen(true);
@@ -36,7 +35,7 @@ void init() {
  * Example: This will mostly fuzz SQLites internals.
  */
 #ifdef OSQUERY_FUZZ_SQL
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   static bool setup = false;
   if (!setup) {
     init();
@@ -50,7 +49,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (q.find("from file") != std::string::npos) {
     return 0;
   }
-
 
   osquery::QueryData r;
   osquery::query(q, r);

--- a/osquery/remote/uri.cpp
+++ b/osquery/remote/uri.cpp
@@ -13,6 +13,10 @@
 
 #include "osquery/remote/uri.h"
 
+#ifndef UINT16_MAX
+#define UINT16_MAX (65535U)
+#endif
+
 namespace osquery {
 
 static std::string submatch(const std::smatch& m, int idx) {

--- a/tools/provision/formula/Abstract/abstract-osquery-formula.rb
+++ b/tools/provision/formula/Abstract/abstract-osquery-formula.rb
@@ -12,7 +12,7 @@ def macos_minimum_sdk
 end
 
 def llvm_version
-  return "5.0.1"
+  return "6.0.0"
 end
 
 def legacy_prefix

--- a/tools/provision/formula/libcpp.rb
+++ b/tools/provision/formula/libcpp.rb
@@ -8,40 +8,40 @@ class Libcpp < AbstractOsqueryFormula
 
   stable do
     url "http://releases.llvm.org/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
-    sha256 "5fa7489fc0225b11821cab0362f5813a05f2bcf2533e8a4ea9c9c860168807b0"
+    sha256 "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408"
 
     # Only required to build & run Compiler-RT tests on macOS, optional otherwise.
     # https://clang.llvm.org/get_started.html
     resource "libcxx" do
       url "http://releases.llvm.org/#{llvm_version}/libcxx-#{llvm_version}.src.tar.xz"
-      sha256 "fa8f99dd2bde109daa3276d529851a3bce5718d46ce1c5d0806f46caa3e57c00"
+      sha256 "70931a87bde9d358af6cb7869e7535ec6b015f7e6df64def6d2ecdd954040dd9"
     end
 
     resource "clang" do
       url "http://releases.llvm.org/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
-      sha256 "135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff"
+      sha256 "e07d6dd8d9ef196cfc8e8bb131cbd6a2ed0b1caf1715f9d05b0f0eeaddb6df32"
     end
 
     resource "libcxxabi" do
       url "http://llvm.org/releases/#{llvm_version}/libcxxabi-#{llvm_version}.src.tar.xz"
-      sha256 "5a25152cb7f21e3c223ad36a1022faeb8a5ac27c9e75936a5ae2d3ac48f6e854"
+      sha256 "91c6d9c5426306ce28d0627d6a4448e7d164d6a3f64b01cb1d196003b16d641b"
     end
 
     resource "compiler-rt" do
       url "http://releases.llvm.org/#{llvm_version}/compiler-rt-#{llvm_version}.src.tar.xz"
-      sha256 "4edd1417f457a9b3f0eb88082530490edf3cf6a7335cdce8ecbc5d3e16a895da"
+      sha256 "d0cc1342cf57e9a8d52f5498da47a3b28d24ac0d39cbc92308781b3ee0cea79a"
     end
 
     resource "libunwind" do
       url "http://releases.llvm.org/#{llvm_version}/libunwind-#{llvm_version}.src.tar.xz"
-      sha256 "6bbfbf6679435b858bd74bdf080386d084a76dfbf233fb6e47b2c28e0872d0fe"
+      sha256 "256c4ed971191bde42208386c8d39e5143fa4afd098e03bd2c140c878c63f1d6"
     end
   end
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "068bf3beabbb71f4ba62e5e52abddbc30acb829374a28d3e1440c3135b0d3b24" => :x86_64_linux
+    sha256 "c5e1320c7b565adf4ecedce603d0e3317e271c62eaf0fc94a6b7fa3718d9a681" => :x86_64_linux
   end
 
   depends_on "binutils"
@@ -74,6 +74,7 @@ class Libcpp < AbstractOsqueryFormula
       -DLIBCXXABI_USE_LLVM_UNWINDER=ON
       -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
       -DCLANG_DEFAULT_CXX_STDLIB=libstdc++
+      -DLIBFUZZER_ENABLE=YES
     ]
 
     mktemp do

--- a/tools/provision/formula/llvm.rb
+++ b/tools/provision/formula/llvm.rb
@@ -8,43 +8,43 @@ class Llvm < AbstractOsqueryFormula
 
   stable do
     url "http://releases.llvm.org/#{llvm_version}/llvm-#{llvm_version}.src.tar.xz"
-    sha256 "5fa7489fc0225b11821cab0362f5813a05f2bcf2533e8a4ea9c9c860168807b0"
+    sha256 "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408"
 
     resource "clang" do
       url "http://releases.llvm.org/#{llvm_version}/cfe-#{llvm_version}.src.tar.xz"
-      sha256 "135f6c9b0cd2da1aff2250e065946258eb699777888df39ca5a5b4fe5e23d0ff"
+      sha256 "e07d6dd8d9ef196cfc8e8bb131cbd6a2ed0b1caf1715f9d05b0f0eeaddb6df32"
     end
 
     resource "clang-extra-tools" do
       url "http://releases.llvm.org/#{llvm_version}/clang-tools-extra-#{llvm_version}.src.tar.xz"
-      sha256 "9aada1f9d673226846c3399d13fab6bba4bfd38bcfe8def5ee7b0ec24f8cd225"
+      sha256 "053b424a4cd34c9335d8918734dd802a8da612d13a26bbb88fcdf524b2d989d2"
     end
 
     resource "lld" do
       url "http://releases.llvm.org/#{llvm_version}/lld-#{llvm_version}.src.tar.xz"
-      sha256 "d5b36c0005824f07ab093616bdff247f3da817cae2c51371e1d1473af717d895"
+      sha256 "6b8c4a833cf30230c0213d78dbac01af21387b298225de90ab56032ca79c0e0b"
     end
 
     resource "lldb" do
       url "http://releases.llvm.org/#{llvm_version}/lldb-#{llvm_version}.src.tar.xz"
-      sha256 "b7c1c9e67975ca219089a3a6a9c77c2d102cead2dc38264f2524aa3326da376a"
+      sha256 "46f54c1d7adcd047d87c0179f7b6fa751614f339f4f87e60abceaa45f414d454"
     end
 
     resource "openmp" do
       url "http://releases.llvm.org/#{llvm_version}/openmp-#{llvm_version}.src.tar.xz"
-      sha256 "adb635cdd2f9f828351b1e13d892480c657fb12500e69c70e007bddf0fca2653"
+      sha256 "7c0e050d5f7da3b057579fb3ea79ed7dc657c765011b402eb5bbe5663a7c38fc"
     end
 
     resource "polly" do
       url "http://releases.llvm.org/#{llvm_version}/polly-#{llvm_version}.src.tar.xz"
-      sha256 "9dd52b17c07054aa8998fc6667d41ae921430ef63fa20ae130037136fdacf36e"
+      sha256 "47e493a799dca35bc68ca2ceaeed27c5ca09b12241f87f7220b5f5882194f59c"
     end
   end
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "ada916f175f62e8ed5f5c7630edb5783d927e20989f0d6c843c66bde1d863e2d" => :x86_64_linux
+    sha256 "54ff9c6b305defdc34408abe1c446f2fd7f3645e415833d80e16c4a1bab65564" => :x86_64_linux
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This adds a new target (optional) `osqueryf`. This is built when using `make libfuzz`.

To use `libfuzzer` we need LLVM 6.0 so this also includes an update to the dependencies for `llvm` and `libcpp`. The `libcpp` dependency is what contains libFuzzer in this incarnation. This allows us to build libFuzzer with a clang that does not contain it, since libFuzzer needs a c++ runtime.

This is what found 6+ RapidJSON problems with config and config parsers. I am sure there are other fund parts you can fuzz by swapping out the content of `fuzz.cpp`.