### PR TITLE
Handle placeholder hardware UUIDs

### DIFF
--- a/include/osquery/system.h
+++ b/include/osquery/system.h
@@ -255,6 +255,19 @@ Status getEphemeralUUID(std::string& ident);
 Status getHostUUID(std::string& ident);
 
 /**
+ * @brief Determine whether the UUID is a placeholder.
+ *
+ * Some motherboards report placeholder UUIDs which, from point of view of being
+ * unique, are useless. This method checks the provided UUID against a list of
+ * known placeholders so that it can be treated as invalid. This method ignores
+ * case.
+ *
+ * @param uuid UUID to test.
+ * @return true if UUID is a placeholder and false otherwise.
+ */
+bool isPlaceholderHardwareUUID(const std::string& uuid);
+
+/**
  * @brief generate a uuid to uniquely identify this machine
  *
  * @return uuid string to identify this machine

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -32,6 +32,7 @@
 #include <ctime>
 #include <sstream>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
@@ -85,6 +86,13 @@ FLAG(string,
      "Field used to specify the host_identifier when set to \"specified\"");
 
 FLAG(bool, utc, true, "Convert all UNIX times to UTC");
+
+const std::vector<std::string> kPlaceholderHardwareUUIDList{
+    "00000000-0000-0000-0000-000000000000",
+    "03000200-0400-0500-0006-000700080009",
+    "03020100-0504-0706-0809-0a0b0c0d0e0f",
+    "10000000-0000-8000-0040-000000000000",
+};
 
 #ifdef WIN32
 struct tm* gmtime_r(time_t* t, struct tm* result) {
@@ -155,6 +163,14 @@ std::string generateNewUUID() {
   return boost::uuids::to_string(uuid);
 }
 
+bool isPlaceholderHardwareUUID(const std::string& uuid) {
+  std::string lower_uuid = boost::to_lower_copy(uuid);
+
+  return std::find(kPlaceholderHardwareUUIDList.begin(),
+                   kPlaceholderHardwareUUIDList.end(),
+                   lower_uuid) != kPlaceholderHardwareUUIDList.end();
+}
+
 std::string generateHostUUID() {
   std::string hardware_uuid;
 #ifdef __APPLE__
@@ -184,12 +200,20 @@ std::string generateHostUUID() {
   boost::algorithm::trim(hardware_uuid);
   if (!hardware_uuid.empty()) {
     // Construct a new string to remove trailing nulls.
-    return std::string(hardware_uuid.c_str());
+    hardware_uuid = std::string(hardware_uuid.c_str());
   }
 
-  // Unable to get the hardware UUID, just return a new UUID
-  VLOG(1) << "Failed to read system uuid, returning ephemeral uuid";
-  return generateNewUUID();
+  // Check whether the UUID is valid. If not generate an ephemeral UUID.
+  if (hardware_uuid.empty()) {
+    VLOG(1) << "Failed to read system uuid, returning ephemeral uuid";
+    return generateNewUUID();
+  } else if (isPlaceholderHardwareUUID(hardware_uuid)) {
+    VLOG(1) << "Hardware uuid '" << hardware_uuid
+            << "' is a placeholder, returning ephemeral uuid";
+    return generateNewUUID();
+  } else {
+    return hardware_uuid;
+  }
 }
 
 Status getInstanceUUID(std::string& ident) {

--- a/osquery/core/tests/system_test.cpp
+++ b/osquery/core/tests/system_test.cpp
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include "osquery/system.h"
+
+namespace osquery {
+
+class UUIDTests : public testing::Test {};
+
+TEST_F(UUIDTests, test_invalid_uuid) {
+  std::string uuid = "10000000-0000-8000-0040-000000000000";
+
+  EXPECT_TRUE(isPlaceholderHardwareUUID(uuid));
+}
+
+TEST_F(UUIDTests, test_valid_uuid) {
+  std::string uuid = "226e380e-67d1-4214-9868-5383a79af0b8";
+
+  EXPECT_FALSE(isPlaceholderHardwareUUID(uuid));
+}
+
+} // namespace osquery


### PR DESCRIPTION
Some machines don't report proper UUIDs and placeholders are used
instead, namely the following:

00000000-0000-0000-0000-000000000000
03000200-0400-0500-0006-000700080009
03020100-0504-0706-0809-0A0B0C0D0E0F
10000000-0000-8000-0040-000000000000

Make sure we don't use these UUIDs as they're useless as an unique
identifier and use ephemeral UUIDs instead.