### PR TITLE
first pass at ssh_config table

### DIFF
--- a/osquery/tables/system/posix/ssh_configs.cpp
+++ b/osquery/tables/system/posix/ssh_configs.cpp
@@ -37,7 +37,7 @@ void genSshConfig(const std::string& uid,
                   QueryData& results) {
   std::string ssh_config_content;
   if (!forensicReadFile(filepath, ssh_config_content).ok()) {
-    VLOG(1) << "Cannot read ssh_config file " << filepath; 
+    VLOG(1) << "Cannot read ssh_config file " << filepath;
     return;
   }
   // the ssh_config file consists of a number of host or match
@@ -49,7 +49,7 @@ void genSshConfig(const std::string& uid,
   for (auto& line : split(ssh_config_content, "\n")) {
     boost::trim(line);
     boost::to_lower(line);
-    if (line.empty() || line[0] += '#') {
+    if (line.empty() || line[0] == '#') {
       return;
     }
     if (boost::starts_with(line, "host ") ||

--- a/osquery/tables/system/posix/ssh_configs.cpp
+++ b/osquery/tables/system/posix/ssh_configs.cpp
@@ -1,0 +1,96 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <string>
+#include <vector>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include <osquery/core.h>
+#include <osquery/filesystem.h>
+#include <osquery/logger.h>
+#include <osquery/posix/system.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/conversions.h"
+#include "osquery/tables/system/system_utils.h"
+
+namespace osquery {
+namespace tables {
+
+const std::string kUserSSHConfig = ".ssh/config";
+const std::string kSystemwideSSHConfig = "/etc/ssh/ssh_config";
+
+void genSSHConfig(const std::string& uid,
+                  const std::string& gid,
+                  const boost::filesystem::path& filepath,
+                  QueryData& results) {
+  std::string ssh_config_content;
+  if (!forensicReadFile(filepath, ssh_config_content).ok()) {
+    // Cannot read a specific ssh_config file.
+    return;
+  }
+  // the ssh_config file consists of a number of host or match
+  // blocks containing newline-separated options for each
+  // block; a block is defined as everything following a
+  // host or match keyword, until the next host or match
+  // keyword, else EOF
+  std::string block;
+  for (auto& line : split(ssh_config_content, "\n")) {
+    boost::trim(line);
+    boost::to_lower(line);
+    if (!line.empty() && line[0] != '#') {
+      if (boost::starts_with(line, "host ") ||
+          boost::starts_with(line, "match ")) {
+        block = line;
+      } else {
+        Row r = {{"uid", uid},
+                 {"block", block},
+                 {"option", line},
+                 {"ssh_config_file", filepath.string()}};
+        results.push_back(r);
+      }
+    }
+  }
+}
+void genSSHConfigForUser(const std::string& uid,
+                         const std::string& gid,
+                         const std::string& directory,
+                         QueryData& results) {
+  auto dropper = DropPrivileges::get();
+  if (!dropper->dropTo(uid, gid)) {
+    VLOG(1) << "Cannot drop privileges to UID " << uid;
+    return;
+  }
+
+  boost::filesystem::path ssh_config_file = directory;
+  ssh_config_file /= kUserSSHConfig;
+
+  genSSHConfig(uid, gid, ssh_config_file, results);
+}
+QueryData getSSHConfigs(QueryContext& context) {
+  QueryData results;
+
+  // Iterate over each user
+  QueryData users = usersFromContext(context);
+  for (const auto& row : users) {
+    auto uid = row.find("uid");
+    auto gid = row.find("gid");
+    auto directory = row.find("directory");
+    if (uid != row.end() && gid != row.end() && directory != row.end()) {
+      genSSHConfigForUser(uid->second, gid->second, directory->second, results);
+    }
+  }
+  genSSHConfig("0", "0", kSystemwideSSHConfig, results);
+  return results;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/ssh_configs.cpp
+++ b/osquery/tables/system/posix/ssh_configs.cpp
@@ -23,10 +23,10 @@
 #include "osquery/core/conversions.h"
 #include "osquery/tables/system/system_utils.h"
 
+namespace fs = boost::filesystem;
+
 namespace osquery {
 namespace tables {
-
-namespace fs = boost::filesystem;
 
 const std::string kUserSshConfig = ".ssh/config";
 const std::string kSystemwideSshConfig = "/etc/ssh/ssh_config";
@@ -50,7 +50,7 @@ void genSshConfig(const std::string& uid,
     boost::trim(line);
     boost::to_lower(line);
     if (line.empty() || line[0] == '#') {
-      return;
+      continue;
     }
     if (boost::starts_with(line, "host ") ||
         boost::starts_with(line, "match ")) {

--- a/specs/posix/ssh_configs.table
+++ b/specs/posix/ssh_configs.table
@@ -3,7 +3,7 @@ description("A table of parsed ssh_configs.")
 schema([
     Column("uid", BIGINT, "The local owner of the ssh_config file",
       additional=True),
-    Column("block",TEXT,"the host or match block"),
+    Column("block",TEXT,"The host or match block"),
     Column("option", TEXT, "The option and value", index=True),
     Column("ssh_config_file", TEXT, "Path to the ssh_config file", index=True),
     ForeignKey(column="uid", table="users"),

--- a/specs/posix/ssh_configs.table
+++ b/specs/posix/ssh_configs.table
@@ -4,7 +4,7 @@ schema([
     Column("uid", BIGINT, "The local owner of the ssh_config file",
       additional=True),
     Column("block",TEXT,"the host or match block"),
-    Column("option", TEXT, "the option and value", index=True),
+    Column("option", TEXT, "The option and value", index=True),
     Column("ssh_config_file", TEXT, "Path to the ssh_config file", index=True),
     ForeignKey(column="uid", table="users"),
 ])

--- a/specs/posix/ssh_configs.table
+++ b/specs/posix/ssh_configs.table
@@ -1,0 +1,19 @@
+table_name("ssh_configs")
+description("A table of parsed ssh_configs.")
+schema([
+    Column("uid", BIGINT, "The local owner of the ssh_config file",
+      additional=True),
+    Column("block",TEXT,"the host or match block"),
+    Column("option", TEXT, "the option and value", index=True),
+    Column("ssh_config_file", TEXT, "Path to the ssh_config file", index=True),
+    ForeignKey(column="uid", table="users"),
+])
+attributes(user_data=True, no_pkey=True)
+implementation("ssh_configs@getSSHConfigs")
+examples([
+  "select * from users join ssh_configs using (uid)",
+])
+fuzz_paths([
+  "/home",
+  "/Users",
+])

--- a/specs/posix/ssh_configs.table
+++ b/specs/posix/ssh_configs.table
@@ -9,7 +9,7 @@ schema([
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True, no_pkey=True)
-implementation("ssh_configs@getSSHConfigs")
+implementation("ssh_configs@getSshConfigs")
 examples([
   "select * from users join ssh_configs using (uid)",
 ])


### PR DESCRIPTION
This PR adds a new table, ssh_configs, which will parse out the systemwide default and per-user ssh_config files, and dump each configuration block therein.

I could be happier with the way that the systemwide config is pulled, so any feedback would be appreciated.

One possible area of contention is the default behavior when querying for the ssh_configs of a particular user.
```
select * from ssh_configs where uid=500;
```
 does not return the blocks from the systemwide config.

 From the ssh_config man page: 
```
ssh(1) obtains configuration data from the following sources in the following order:

           1.   command-line options
           2.   user's configuration file (~/.ssh/config)
           3.   system-wide configuration file (/etc/ssh/ssh_config)

     For each parameter, the first obtained value will be used.  The configuration files contain sections
     separated by Host specifications, and that section is only applied for hosts that match one of the
     patterns given in the specification.  The matched host name is usually the one given on the command
     line (see the CanonicalizeHostname option for exceptions).

     Since the first obtained value for each parameter is used, more host-specific declarations should be
     given near the beginning of the file, and general defaults at the end.
```

This means that users of this table will have to be aware that querying for the ssh_config of a given user will not display all of the blocks that would apply for a given invocation of ssh for that user