### PR TITLE
Add const qualifier to some Config methods

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -99,7 +99,7 @@ class Config : private boost::noncopyable {
    *
    * @return The SHA1 hash of the osquery config
    */
-  Status genHash(std::string& hash);
+  Status genHash(std::string& hash) const;
 
   /// Retrieve the hash of a named source.
   std::string getHash(const std::string& source) const;
@@ -175,7 +175,7 @@ class Config : private boost::noncopyable {
   void scheduledQueries(
       std::function<void(std::string name, const ScheduledQuery& query)>
           predicate,
-      bool blacklisted = false);
+      bool blacklisted = false) const;
 
   /**
    * @brief Map a function across the set of configured files
@@ -193,9 +193,9 @@ class Config : private boost::noncopyable {
    *      }));
    * @endcode
    */
-  void files(
-      std::function<void(const std::string& category,
-                         const std::vector<std::string>& files)> predicate);
+  void files(std::function<void(const std::string& category,
+                                const std::vector<std::string>& files)>
+                 predicate) const;
 
   /**
    * @brief Get the performance stats for a specific query, by name
@@ -215,7 +215,7 @@ class Config : private boost::noncopyable {
    */
   void getPerformanceStats(
       const std::string& name,
-      std::function<void(const QueryPerformance& query)> predicate);
+      std::function<void(const QueryPerformance& query)> predicate) const;
 
   /**
    * @brief Helper to access config parsers via the registry

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -391,7 +391,7 @@ static inline bool blacklistExpired(size_t blt, const ScheduledQuery& query) {
 void Config::scheduledQueries(
     std::function<void(std::string name, const ScheduledQuery& query)>
         predicate,
-    bool blacklisted) {
+    bool blacklisted) const {
   RecursiveLock lock(config_schedule_mutex_);
   for (PackRef& pack : *schedule_) {
     for (auto& it : pack->getSchedule()) {
@@ -891,7 +891,7 @@ void Config::recordQueryStart(const std::string& name) {
 
 void Config::getPerformanceStats(
     const std::string& name,
-    std::function<void(const QueryPerformance& query)> predicate) {
+    std::function<void(const QueryPerformance& query)> predicate) const {
   if (performance_.count(name) > 0) {
     RecursiveLock lock(config_performance_mutex_);
     predicate(performance_.at(name));
@@ -909,7 +909,7 @@ bool Config::hashSource(const std::string& source, const std::string& content) {
   return true;
 }
 
-Status Config::genHash(std::string& hash) {
+Status Config::genHash(std::string& hash) const {
   WriteLock lock(config_hash_mutex_);
   if (!valid_) {
     return Status(1, "Current config is not valid");
@@ -949,9 +949,9 @@ const std::shared_ptr<ConfigParserPlugin> Config::getParser(
   return std::dynamic_pointer_cast<ConfigParserPlugin>(plugin);
 }
 
-void Config::files(
-    std::function<void(const std::string& category,
-                       const std::vector<std::string>& files)> predicate) {
+void Config::files(std::function<void(const std::string& category,
+                                      const std::vector<std::string>& files)>
+                       predicate) const {
   RecursiveLock lock(config_files_mutex_);
   for (const auto& it : files_) {
     for (const auto& category : it.second) {


### PR DESCRIPTION
Add const qualifier to some Config methods

  - `void scheduledQueries( std::function<void(std::string name, const ScheduledQuery& query)> predicate, bool blacklisted = false) const;`
  - `void files(std::function<void(const std::string& category, const std::vector<std::string>& files)> predicate) const;`
  - `void getPerformanceStats(const std::string& name, std::function<void(const QueryPerformance& query)> predicate) const;`
  - `Status genHash(std::string& hash) const;`

Because they actually modify nothing during the call. So there is no excuse for them to be non-const.