### PR TITLE
bug: do not wait for main service thread before reporting stop to SCM

### DIFF
--- a/osquery/core/posix/process_ops.cpp
+++ b/osquery/core/posix/process_ops.cpp
@@ -91,4 +91,8 @@ int platformGetPid() {
 int platformGetTid() {
   return std::hash<std::thread::id>()(std::this_thread::get_id());
 }
+
+void platformMainThreadExit(int excode) {
+  exit(excode);
+}
 }

--- a/osquery/core/process.h
+++ b/osquery/core/process.h
@@ -41,8 +41,8 @@ namespace osquery {
 /// Constant for an invalid process
 const auto kInvalidPid = (PlatformPidType)-1;
 
-/// The saved thread ID for shutdown to short-circuit raising a signal.
-extern std::thread::id kMainThreadId;
+/// Used by Windows to wait on the main execution thread
+extern unsigned long kLegacyThreadId;
 
 /**
  * @brief Categories of process states adapted to be platform agnostic
@@ -292,4 +292,14 @@ int platformGetPid();
  * and on posix platforms returns gettid()
  */
 int platformGetTid();
+
+/**
+ * @brief Allows for platform specific exit logic
+ *
+ * On Windows this makes use of a thread specific exit APIs
+ * to ensure that our main threads shutdown and notify the SCM
+ * thread so we can close the service cleanly. On posix this is
+ * just a stub to exit()
+ */
+void platformMainThreadExit(int excode);
 } // namespace osquery

--- a/osquery/core/windows/process_ops.cpp
+++ b/osquery/core/windows/process_ops.cpp
@@ -242,4 +242,8 @@ int platformGetPid() {
 int platformGetTid() {
   return static_cast<int>(GetCurrentThreadId());
 }
+
+void platformMainThreadExit(int excode) {
+  ExitThread(excode);
+}
 }

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -30,10 +30,10 @@ static const std::string kDefaultFlagsFile{OSQUERY_HOME "\\osquery.flags"};
 static const std::string kServiceName{"osqueryd"};
 static const std::string kServiceDisplayName{"osquery daemon service"};
 
-const int kServiceShutdownTimeout{1000};
-
 static SERVICE_STATUS_HANDLE kStatusHandle = nullptr;
 static SERVICE_STATUS kServiceStatus = {0};
+
+const unsigned long kServiceShutdownWait{100};
 
 /*
  * This event is set when a SERVICE_CONTROL_STOP or SERVICE_CONTROL_SHUTDOWN
@@ -312,7 +312,7 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
     }
 
     // Give the main thread a chance to shutdown gracefully before exiting
-    UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 3, kServiceShutdownTimeout);
+    UpdateServiceStatus(0, SERVICE_STOP_PENDING, 0, 3, kServiceShutdownWait);
     {
       auto stopEvent = osquery::getStopEvent();
       if (stopEvent != nullptr) {
@@ -323,16 +323,14 @@ void WINAPI ServiceControlHandler(DWORD control_code) {
         }
         CloseHandle(stopEvent);
       }
-      // Give the watcher an opportunity to shutdown gracefully
-      unsigned long tid = static_cast<unsigned long>(
-          std::hash<std::thread::id>{}(kMainThreadId));
-      auto mainThread = OpenThread(SYNCHRONIZE, FALSE, tid);
-      if (mainThread == NULL) {
-        SLOG("Failed to open handle to thread " + std::to_string(tid) +
-             " for service stop with " + std::to_string(GetLastError()));
+      auto thread = OpenThread(SYNCHRONIZE, false, kLegacyThreadId);
+      if (thread != nullptr) {
+        WaitForSingleObjectEx(thread, INFINITE, FALSE);
+        CloseHandle(thread);
+      } else {
+        SLOG("Failed to open handle to main thread of execution with " +
+             std::to_string(GetLastError()));
       }
-      WaitForSingleObjectEx(mainThread, INFINITE, false);
-      CloseHandle(mainThread);
     }
     UpdateServiceStatus(0, SERVICE_STOPPED, 0, 4);
 
@@ -386,7 +384,7 @@ int main(int argc, char* argv[]) {
        static_cast<LPSERVICE_MAIN_FUNCTION>(osquery::ServiceMain)},
       {nullptr, nullptr}};
 
-  if (!::StartServiceCtrlDispatcherA(serviceTable)) {
+  if (!StartServiceCtrlDispatcherA(serviceTable)) {
     DWORD last_error = ::GetLastError();
     if (last_error == ERROR_FAILED_SERVICE_CONTROLLER_CONNECT) {
       // Failing to start the service control dispatcher with this error

--- a/tools/tests/test_windows_service.py
+++ b/tools/tests/test_windows_service.py
@@ -270,9 +270,7 @@ class OsquerydTest(unittest.TestCase):
 
         if code == 0:
             code, _ = stopService(name)
-            # TODO: stopping the service with sc.exe returns error code 109
-            # however the service itself stops correctly with no zombies
-            #self.assertEqual(code, 0)
+            self.assertEqual(code, 0)
 
         test_base.expectTrue(serviceDead)
         self.assertTrue(serviceDead())


### PR DESCRIPTION
The logic that I had implemented around waiting for thread execution to complete before notifying the SCM of our service stopped state was incorrect. This updates the service thread wait logic to obtain a handle to the main execution thread which is used to wait before sending a `SERVICE_STOPPED` status to the SCM. This should prevent SCM returning error codes of 109, as well as prevent system crashes when the service shuts down. This also turns on tests to ensure that we don't see any exit error code aside from 0 when the service shuts down. Below is some contextual history that we found a way around.

Big shoutout to @ExceptionalHandler for helping me work through what this wait logic should look like, and reporting the issue to us in the first place!

~I messed around with the logic a bit, but found that this was causing errors with the SCM stopping, and as in #4379 this is causing failures when the SCM sends a stop signal. This removes the logic to assure that if nothing else the osquery service fully stops and returns a success exit code to the SCM, as well as adds the integration tests to assure this behavior.~

~That being said, with the lack of waits on the main thread of execution, I have seen occasional crashes of the service as there is the possibility that the main thread of execution is caught on joining the dispatcher threads when we report to SCM that we've stopped, which is causing a SIGABORT. I haven't seen this happen all the time, just when the daemon is under heavy load, and given we're currently "failing" to shut down the service now I think this is the lesser of two evils. I still intend to sort out what the proper shutdown logic needs to look like to ensure the dispatcher finishes joining before we interact with SCM, but so far traditional methodologies like `WaitForSingleObjectEx` on the thread handle, and using a "finished" `SetEvent` call in the main thread have not successfully worked, and just made our SCM service stop failures worse.~