### PR TITLE
pci_devices: model and vendor information from system PCI db && add subsystem info

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -8,6 +8,7 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <fstream>
 #include <locale>
 
 #include <boost/algorithm/string/split.hpp>

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -232,7 +232,7 @@ QueryData genPCIDevices(QueryContext& context) {
 
       if (subsystemIDs.size() == 2) {
         r["subsystem_vendor_id"] = subsystemIDs[0];
-        r["subsystem_device_id"] = subsystemIDs[1];
+        r["subsystem_model_id"] = subsystemIDs[1];
 
         if (pcidb.getVendorName(subsystemIDs[0], content).ok()) {
           r["subsystem_vendor"] = content;
@@ -242,7 +242,7 @@ QueryData genPCIDevices(QueryContext& context) {
                 .getSubsystemInfo(
                     ids[0], ids[1], subsystemIDs[0], subsystemIDs[1], content)
                 .ok()) {
-          r["subsystem_device"] = content;
+          r["subsystem_model"] = content;
         }
       }
     }

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -87,7 +87,8 @@ PciDB::PciDB(std::istream& db_filestream) {
     case 2:
       // Subsystem info;
       if (db_.find(cur_vendor) != db_.end() &&
-          db_[cur_vendor].models.find(cur_model) != db_[cur_vendor].models.end() &&
+          db_[cur_vendor].models.find(cur_model) !=
+              db_[cur_vendor].models.end() &&
           line.size() > 11) {
         // Store current subsystem information under current vendor and model.
         db_[cur_vendor].models[cur_model].subsystemInfo[line.substr(2, 9)] =

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -89,7 +89,7 @@ class PciDB {
    * @brief retrieves PciVendor structure of database for custom work.
    *
    * @param vendor_id ID of the vendor
-   * @param predicate work function with vendor pass as param.
+   * @param predicate work function with vendor structure of vendor_id as param.
    *
    * @return an instance of Status, indicating success or failure.
    */

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -47,16 +47,30 @@ class PciDB {
    * @param modelID ID of the model
    * @param model a reference to a string which will be populated with the
    * model description.
-   * @param subsystemID ID of the subsystem in the format of
-   * "<subsystem vendor> <subsystem device>".  If provided model will be
-   * enriched with the additional information.
    *
    * @return an instance of Status, indicating success or failure.
    */
   Status getModel(const std::string& vendorID,
                   const std::string& modelID,
-                  std::string& model,
-                  const std::string& subsystemID = "");
+                  std::string& model);
+
+  /**
+   * @brief retrieves PCI device subsystem description from pci.ids database.
+   *
+   * @param vendorID ID of the vendor
+   * @param modelID ID of the model
+   * @param subsystemVendorID ID of the subsystem vendor
+   * @param subsystemDeviceID ID of the subsystem model
+   * @param subsystem a reference to a string which will be populated with the
+   * subsystem description.
+   *
+   * @return an instance of Status, indicating success or failure.
+   */
+  Status getSubsystemInfo(const std::string& vendorID,
+                          const std::string& modelID,
+                          const std::string& subsystemVendorID,
+                          const std::string& subsystemDeviceID,
+                          std::string& subsystem);
 
  public:
   PciDB(const std::string& path = "/usr/share/misc/pci.ids");

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -1,0 +1,68 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/tables.h>
+
+namespace osquery {
+namespace tables {
+
+/// Represents a model related data for PCI devices of a given vendor and model.
+struct PciModel {
+  std::string id;
+  std::string desc;
+  std::unordered_map<std::string, std::string> subsystemInfo;
+};
+
+/// Represents vendor related data for a PCI devices of a given vendor.
+struct PciVendor {
+  std::string id;
+  std::string name;
+  std::unordered_map<std::string, PciModel> models;
+};
+
+class PciDB {
+ public:
+  /**
+   * @brief retrieves PCI device vendor name from system pci.ids database.
+   *
+   * @param vendorID ID of the vendor
+   * @param vendor a reference to a string which will be populated with the
+   * vendor name
+   *
+   * @return an instance of Status, indicating success or failure.
+   */
+  Status getVendorName(const std::string& vendorID, std::string& vendor);
+
+  /**
+   * @brief retrieves PCI device model description from pci.ids database.
+   *
+   * @param vendorID ID of the vendor
+   * @param modelID ID of the model
+   * @param model a reference to a string which will be populated with the
+   * model description.
+   * @param subsystemID ID of the subsystem in the format of
+   * "<subsystem vendor> <subsystem device>".  If provided model will be
+   * enriched with the additional information.
+   *
+   * @return an instance of Status, indicating success or failure.
+   */
+  Status getModel(const std::string& vendorID,
+                  const std::string& modelID,
+                  std::string& model,
+                  const std::string& subsystemID = "");
+
+ public:
+  PciDB(const std::string& path = "/usr/share/misc/pci.ids");
+
+ private:
+  std::unordered_map<std::string, PciVendor> db_;
+};
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -44,48 +44,48 @@ class PciDB {
   /**
    * @brief retrieves PCI device vendor name from system pci.ids database.
    *
-   * @param vendorID ID of the vendor
+   * @param vendor_id ID of the vendor
    * @param vendor a reference to a string which will be populated with the
    * vendor name
    *
    * @return an instance of Status, indicating success or failure.
    */
-  Status getVendorName(const std::string& vendorID, std::string& vendor);
+  Status getVendorName(const std::string& vendor_id, std::string& vendor);
 
   /**
    * @brief retrieves PCI device model description from pci.ids database.
    *
-   * @param vendorID ID of the vendor
-   * @param modelID ID of the model
+   * @param vendor_id ID of the vendor
+   * @param model_id ID of the model
    * @param model a reference to a string which will be populated with the
    * model description.
    *
    * @return an instance of Status, indicating success or failure.
    */
-  Status getModel(const std::string& vendorID,
-                  const std::string& modelID,
+  Status getModel(const std::string& vendor_id,
+                  const std::string& model_id,
                   std::string& model);
 
   /**
    * @brief retrieves PCI device subsystem description from pci.ids database.
    *
-   * @param vendorID ID of the vendor
-   * @param modelID ID of the model
-   * @param subsystemVendorID ID of the subsystem vendor
-   * @param subsystemDeviceID ID of the subsystem model
+   * @param vendor_id ID of the vendor
+   * @param model_id ID of the model
+   * @param subsystem_vendor_id ID of the subsystem vendor
+   * @param subsystem_device_id ID of the subsystem model
    * @param subsystem a reference to a string which will be populated with the
    * subsystem description.
    *
    * @return an instance of Status, indicating success or failure.
    */
-  Status getSubsystemInfo(const std::string& vendorID,
-                          const std::string& modelID,
-                          const std::string& subsystemVendorID,
-                          const std::string& subsystemDeviceID,
+  Status getSubsystemInfo(const std::string& vendor_id,
+                          const std::string& model_id,
+                          const std::string& subsystem_vendor_id,
+                          const std::string& subsystem_device_id,
                           std::string& subsystem);
 
  public:
-  PciDB(std::istream& dbfileStream);
+  PciDB(std::istream& db_filestream);
 
  private:
   std::unordered_map<std::string, PciVendor> db_;

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -84,18 +84,6 @@ class PciDB {
                           const std::string& subsystem_device_id,
                           std::string& subsystem);
 
- private:
-  /**
-   * @brief retrieves PciVendor structure of database for custom work.
-   *
-   * @param vendor_id ID of the vendor
-   * @param predicate work function with vendor structure of vendor_id as param.
-   *
-   * @return an instance of Status, indicating success or failure.
-   */
-  Status vendor(const std::string& vendor_id,
-                std::function<Status(const PciVendor&)> predicate);
-
  public:
   PciDB(std::istream& db_filestream);
 

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -44,9 +44,9 @@ class PciDB {
   /**
    * @brief retrieves PCI device vendor name from system pci.ids database.
    *
-   * @param vendor_id ID of the vendor
+   * @param vendor_id ID of the vendor.
    * @param vendor a reference to a string which will be populated with the
-   * vendor name
+   * vendor name.
    *
    * @return an instance of Status, indicating success or failure.
    */
@@ -55,8 +55,8 @@ class PciDB {
   /**
    * @brief retrieves PCI device model description from pci.ids database.
    *
-   * @param vendor_id ID of the vendor
-   * @param model_id ID of the model
+   * @param vendor_id ID of the vendor.
+   * @param model_id ID of the model.
    * @param model a reference to a string which will be populated with the
    * model description.
    *
@@ -69,10 +69,10 @@ class PciDB {
   /**
    * @brief retrieves PCI device subsystem description from pci.ids database.
    *
-   * @param vendor_id ID of the vendor
-   * @param model_id ID of the model
-   * @param subsystem_vendor_id ID of the subsystem vendor
-   * @param subsystem_device_id ID of the subsystem model
+   * @param vendor_id ID of the vendor.
+   * @param model_id ID of the model.
+   * @param subsystem_vendor_id ID of the subsystem vendor.
+   * @param subsystem_device_id ID of the subsystem model.
    * @param subsystem a reference to a string which will be populated with the
    * subsystem description.
    *
@@ -86,6 +86,31 @@ class PciDB {
 
  public:
   PciDB(std::istream& db_filestream);
+
+ private:
+  /**
+   * @brief parses line of pci.ids.
+   *
+   * @param line line to parse.
+   * @param cur_vendor PciVendor* reference that represents the current vendor.
+   * @param cur_model PciModel* reference that represents the current model.
+   *
+   * @return bool true to keep parsing, false to stop.
+   */
+  bool parseLine(std::string& line,
+                 PciVendor*& cur_vendor,
+                 PciModel*& cur_model);
+
+  /// Parses a vendor line.  Updates cur_vendor if no errors.
+  Status parseVendor(std::string& line, PciVendor*& cur_vendor);
+
+  /// Parses a model line.  Updates cur_model if no errors.
+  Status parseModel(std::string& line,
+                    PciVendor* cur_vendor,
+                    PciModel*& cur_model);
+
+  /// Parses a subsystem line.
+  Status parseSubsystem(std::string& line, PciModel* cur_model);
 
  private:
   std::unordered_map<std::string, PciVendor> db_;

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -15,15 +15,27 @@ namespace tables {
 
 /// Represents a model related data for PCI devices of a given vendor and model.
 struct PciModel {
+  /// ID of PCI device.
   std::string id;
+
+  /// Description of PCI device.
   std::string desc;
+
+  /// Stores subsystem information keyed by
+  /// "<subsystem vendor id> <subsystem model id>". Key is preserved same as
+  /// they are in pci.ids since lookup always requires both attribute ids.
   std::unordered_map<std::string, std::string> subsystemInfo;
 };
 
 /// Represents vendor related data for a PCI devices of a given vendor.
 struct PciVendor {
+  /// ID of vendor.
   std::string id;
+
+  /// Name of vendor.
   std::string name;
+
+  /// Stores device models information keyed by PCI device (model) ID.
   std::unordered_map<std::string, PciModel> models;
 };
 
@@ -73,7 +85,7 @@ class PciDB {
                           std::string& subsystem);
 
  public:
-  PciDB(const std::string& path = "/usr/share/misc/pci.ids");
+  PciDB(std::istream& dbfileStream);
 
  private:
   std::unordered_map<std::string, PciVendor> db_;

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -84,6 +84,18 @@ class PciDB {
                           const std::string& subsystem_device_id,
                           std::string& subsystem);
 
+ private:
+  /**
+   * @brief retrieves PciVendor structure of database for custom work.
+   *
+   * @param vendor_id ID of the vendor
+   * @param predicate work function with vendor pass as param.
+   *
+   * @return an instance of Status, indicating success or failure.
+   */
+  Status vendor(const std::string& vendor_id,
+                std::function<Status(const PciVendor&)> predicate);
+
  public:
   PciDB(std::istream& db_filestream);
 

--- a/osquery/tables/system/linux/tests/pci_devices_test.cpp
+++ b/osquery/tables/system/linux/tests/pci_devices_test.cpp
@@ -1,0 +1,119 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "osquery/tables/system/linux/pci_devices.h"
+
+using namespace testing;
+
+namespace osquery {
+namespace tables {
+
+class PciDBTest : public ::testing::Test {};
+
+TEST_F(PciDBTest, basic_db_format) {
+  std::istringstream rawDB(
+      "# Some Test Comment\n"
+      "8002  Fake Vendor, Inc.\n"
+      "\t1312  Foobar\n"
+      "\t1313  Foobar [Some R7 Rapidfire]\n"
+      "\t1314  Wrestler HDMI Audio\n"
+      "\t\t174b 1001  90K Diffusion Mini\n"
+      "\t1315  Foobar [Some R5 Rapidfire]\n"
+      "\t1316  Foobar [Some R5 Rapidfire]\n"
+      "\t1317  Foobar\n"
+      "\t1318  Foobar [Some R5 Rapidfire]\n"
+      "\t131b  Foobar [Some R4 Rapidfire]\n"
+      "\t131c  Foobar [Some R7 Rapidfire]\n"
+      "\t131d  Foobar [Some R6 Rapidfire]\n"
+      "\t1714  BeaverCreek HDMI Audio [Some HD 6500D and 6400G-6600G series]\n"
+      "\t\t103c 168b  ProBook 4535s\n"
+      "\t3150  RV380/M24 [Loops Some X600]\n"
+      "\t\t103c 0934  nx8220\n"
+      "\t3151  RV380 GL [IcyhotMV 2400]\n"
+      "\t3152  RV370/M22 [Loops Some X300]\n"
+      "\t3154  RV380/M24 GL [Loops IcyhotGL V3200]\n"
+      "\t3155  RV380 GL [IcyhotMV 2400]\n"
+      "\t3171  RV380 GL [IcyhotMV 2400] (Secondary)\n"
+      "\t3e50  RV380 [Some X600]\n"
+      "\t3e54  RV380 GL [IcyhotGL V3200]\n"
+      "\t3e70  RV380 [Some X600] (Secondary)\n"
+      "\t4136  RS100 [Loops ABC 320M]\n"
+      "ffff  Illegal Vendor ID\n" // Device class information below.
+      "\n\n"
+      "# List of known device classes, subclasses and programming interfaces\n"
+      "\n"
+      "# Syntax:\n"
+      "# C class	class_name\n"
+      "#	subclass	subclass_name  		<-- single tab\n"
+      "#		prog-if  prog-if_name  	<-- two tabs\n"
+      "\n"
+      "C 00  Unclassified device\n"
+      "\t00  Non-VGA unclassified device\n"
+      "\t01  VGA compatible unclassified device\n"
+      "C 01  Mass storage controller\n"
+      "\t00  SCSI storage controller\n"
+      "\t01  IDE interface\n");
+
+  PciDB parsedDB(rawDB);
+
+  std::string got;
+
+  // Happy Path Tests
+  parsedDB.getVendorName("8002", got);
+  EXPECT_EQ("Fake Vendor, Inc.", got);
+
+  parsedDB.getModel("8002", "1313", got);
+  EXPECT_EQ("Foobar [Some R7 Rapidfire]", got);
+
+  parsedDB.getModel("8002", "1314", got);
+  EXPECT_EQ("Wrestler HDMI Audio", got);
+
+  parsedDB.getModel("8002", "4136", got);
+  EXPECT_EQ("RS100 [Loops ABC 320M]", got);
+
+  parsedDB.getSubsystemInfo("8002", "1314", "174b", "1001", got);
+  EXPECT_EQ("90K Diffusion Mini", got);
+
+  parsedDB.getSubsystemInfo("8002", "3150", "103c", "0934", got);
+  EXPECT_EQ("nx8220", got);
+
+  parsedDB.getSubsystemInfo("8002", "1714", "103c", "168b", got);
+  EXPECT_EQ("ProBook 4535s", got);
+
+  // Negative Tests
+  got = "";
+
+  parsedDB.getVendorName("8086", got);
+  EXPECT_EQ("", got);
+
+  parsedDB.getModel("8002", "1388", got);
+  EXPECT_EQ("", got);
+
+  parsedDB.getSubsystemInfo("8002", "1714", "103c", "168c", got);
+  EXPECT_EQ("", got);
+
+  // Things below 'ffff' should not be retrievable.
+  parsedDB.getVendorName("ffff", got);
+  EXPECT_EQ("", got);
+
+  parsedDB.getVendorName("C 00", got);
+  EXPECT_EQ("", got);
+
+  parsedDB.getVendorName("C 01", got);
+  EXPECT_EQ("", got);
+
+  parsedDB.getModel("C 00", "00", got);
+  EXPECT_EQ("", got);
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/tests/pci_devices_test.cpp
+++ b/osquery/tables/system/linux/tests/pci_devices_test.cpp
@@ -21,7 +21,7 @@ namespace tables {
 class PciDBTest : public ::testing::Test {};
 
 TEST_F(PciDBTest, basic_db_format) {
-  std::istringstream rawDB(
+  std::istringstream raw_db(
       "# Some Test Comment\n"
       "8002  Fake Vendor, Inc.\n"
       "\t1312  Foobar\n"
@@ -64,55 +64,55 @@ TEST_F(PciDBTest, basic_db_format) {
       "\t00  SCSI storage controller\n"
       "\t01  IDE interface\n");
 
-  PciDB parsedDB(rawDB);
+  PciDB parsed_db(raw_db);
 
   std::string got;
 
   // Happy Path Tests
-  parsedDB.getVendorName("8002", got);
+  parsed_db.getVendorName("8002", got);
   EXPECT_EQ("Fake Vendor, Inc.", got);
 
-  parsedDB.getModel("8002", "1313", got);
+  parsed_db.getModel("8002", "1313", got);
   EXPECT_EQ("Foobar [Some R7 Rapidfire]", got);
 
-  parsedDB.getModel("8002", "1314", got);
+  parsed_db.getModel("8002", "1314", got);
   EXPECT_EQ("Wrestler HDMI Audio", got);
 
-  parsedDB.getModel("8002", "4136", got);
+  parsed_db.getModel("8002", "4136", got);
   EXPECT_EQ("RS100 [Loops ABC 320M]", got);
 
-  parsedDB.getSubsystemInfo("8002", "1314", "174b", "1001", got);
+  parsed_db.getSubsystemInfo("8002", "1314", "174b", "1001", got);
   EXPECT_EQ("90K Diffusion Mini", got);
 
-  parsedDB.getSubsystemInfo("8002", "3150", "103c", "0934", got);
+  parsed_db.getSubsystemInfo("8002", "3150", "103c", "0934", got);
   EXPECT_EQ("nx8220", got);
 
-  parsedDB.getSubsystemInfo("8002", "1714", "103c", "168b", got);
+  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168b", got);
   EXPECT_EQ("ProBook 4535s", got);
 
   // Negative Tests
   got = "";
 
-  parsedDB.getVendorName("8086", got);
+  parsed_db.getVendorName("8086", got);
   EXPECT_EQ("", got);
 
-  parsedDB.getModel("8002", "1388", got);
+  parsed_db.getModel("8002", "1388", got);
   EXPECT_EQ("", got);
 
-  parsedDB.getSubsystemInfo("8002", "1714", "103c", "168c", got);
+  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168c", got);
   EXPECT_EQ("", got);
 
   // Things below 'ffff' should not be retrievable.
-  parsedDB.getVendorName("ffff", got);
+  parsed_db.getVendorName("ffff", got);
   EXPECT_EQ("", got);
 
-  parsedDB.getVendorName("C 00", got);
+  parsed_db.getVendorName("C 00", got);
   EXPECT_EQ("", got);
 
-  parsedDB.getVendorName("C 01", got);
+  parsed_db.getVendorName("C 01", got);
   EXPECT_EQ("", got);
 
-  parsedDB.getModel("C 00", "00", got);
+  parsed_db.getModel("C 00", "00", got);
   EXPECT_EQ("", got);
 }
 } // namespace tables

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -15,4 +15,11 @@ schema([
     #Column("thunderbolt", INTEGER, "1 If PCI device is thunderbolt else 0"),
     #Column("removable", INTEGER, "1 If PCI device is removable else 0"),
 ])
+
+extended_schema(LINUX, [
+    Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
+    Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),
+    Column("subsystem_device_id", TEXT, "Device ID of PCI device subsystem"),
+    Column("subsystem_device", TEXT, "Device description of PCI device subsystem"),
+])
 implementation("pci_devices@genPCIDevices")

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -19,7 +19,7 @@ schema([
 extended_schema(LINUX, [
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),
-    Column("subsystem_device_id", TEXT, "Device ID of PCI device subsystem"),
-    Column("subsystem_device", TEXT, "Device description of PCI device subsystem"),
+    Column("subsystem_model_id", TEXT, "Model ID of PCI device subsystem"),
+    Column("subsystem_model", TEXT, "Device description of PCI device subsystem"),
 ])
 implementation("pci_devices@genPCIDevices")


### PR DESCRIPTION
The current implementation linux's `pci_devices` table retrieves vendor and model information from sysFs attributes, which in turn utilizes systemd's hwdb to retrieve the information.  However hwdb utilizes a repo local copy of `pci.ids` to generate the `hwdb` rather than the system copy of `pci.ids` which usually far more updated.   This PR introduces retrieval of vendor and model information from the system copy of `pci.ids`.   New columns `subystem_vendor_id`, `subsystem_vendor`, `subsystem_model`, `subsystem_model_id` have also been added to enrich PCI device hardware information.