### PR TITLE
Simple solution to reduce drift time in loop of scheduled queries

### DIFF
--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -22,11 +22,15 @@ namespace osquery {
 /// A Dispatcher service thread that watches an ExtensionManagerHandler.
 class SchedulerRunner : public InternalRunnable {
  public:
-  SchedulerRunner(unsigned long int timeout, size_t interval)
+  SchedulerRunner(
+      unsigned long int timeout,
+      size_t interval,
+      std::chrono::milliseconds max_time_drift = std::chrono::seconds::zero())
       : InternalRunnable("SchedulerRunner"),
         interval_{std::chrono::seconds{interval}},
         timeout_(timeout),
-        time_drift_{std::chrono::milliseconds::zero()} {}
+        time_drift_{std::chrono::milliseconds::zero()},
+        max_time_drift_{max_time_drift} {}
 
  public:
   /// The Dispatcher thread entry point.
@@ -35,16 +39,22 @@ class SchedulerRunner : public InternalRunnable {
   /// The Dispatcher interrupt point.
   void stop() override {}
 
-  std::chrono::milliseconds getTimeDrift() const noexcept;
+  /// Accumulated for some time time drift to compensate.
+  std::chrono::milliseconds getCurrentTimeDrift() const noexcept;
 
  private:
   /// Interval in seconds between schedule steps.
-  std::chrono::milliseconds interval_;
+  const std::chrono::milliseconds interval_;
 
   /// Maximum number of steps.
-  unsigned long int timeout_;
+  const unsigned long int timeout_;
 
+  /// Accumulated for some time time drift to compensate.
+  /// It will be either reduced during compensation process or
+  /// after exceding the limit @see max_time_drift_
   std::chrono::milliseconds time_drift_;
+
+  const std::chrono::milliseconds max_time_drift_;
 };
 
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query);

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <map>
 
 #include <osquery/dispatcher.h>
@@ -39,6 +40,8 @@ class SchedulerRunner : public InternalRunnable {
 
   /// Maximum number of steps.
   unsigned long int timeout_;
+
+  std::chrono::milliseconds sum_overtime_ = std::chrono::milliseconds::zero();
 };
 
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query);

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -24,8 +24,9 @@ class SchedulerRunner : public InternalRunnable {
  public:
   SchedulerRunner(unsigned long int timeout, size_t interval)
       : InternalRunnable("SchedulerRunner"),
-        interval_(interval),
-        timeout_(timeout) {}
+        interval_{std::chrono::seconds{interval}},
+        timeout_(timeout),
+        time_drift_{std::chrono::milliseconds::zero()} {}
 
  public:
   /// The Dispatcher thread entry point.
@@ -34,14 +35,16 @@ class SchedulerRunner : public InternalRunnable {
   /// The Dispatcher interrupt point.
   void stop() override {}
 
+  std::chrono::milliseconds getTimeDrift() const noexcept;
+
  private:
   /// Interval in seconds between schedule steps.
-  size_t interval_;
+  std::chrono::milliseconds interval_;
 
   /// Maximum number of steps.
   unsigned long int timeout_;
 
-  std::chrono::milliseconds sum_overtime_ = std::chrono::milliseconds::zero();
+  std::chrono::milliseconds time_drift_;
 };
 
 SQLInternal monitor(const std::string& name, const ScheduledQuery& query);

--- a/osquery/dispatcher/tests/scheduler_tests.cpp
+++ b/osquery/dispatcher/tests/scheduler_tests.cpp
@@ -207,7 +207,7 @@ TEST_F(SchedulerTests, test_scheduler_sum_overtime) {
 
   EXPECT_GE(start_duration, std::chrono::seconds{1});
   EXPECT_LE(start_duration, std::chrono::milliseconds{1010});
-  EXPECT_LE(runner.sumOvertime(), std::chrono::milliseconds::zero());
+  EXPECT_LE(runner.getTimeDrift(), std::chrono::milliseconds::zero());
 
   // Restore plugin settings.
   TablePlugin::kCacheStep = backup_step;


### PR DESCRIPTION
based on measuring time of loop step and reduce sleep time on it.
Issue: #4301