### PR TITLE
aws: Deal with missing uuid file on C5/M5 instances.

### DIFF
--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -381,10 +381,7 @@ bool isEc2Instance() {
     checked = true;
 
     std::ifstream fd(kHypervisorUuid, std::ifstream::in);
-    if (!fd) {
-      return; // No hypervisor UUID file. Not EC2
-    }
-    if (!(fd.get() == 'e' && fd.get() == 'c' && fd.get() == '2')) {
+    if (fd && !(fd.get() == 'e' && fd.get() == 'c' && fd.get() == '2')) {
       return; // Not EC2 instance
     }
 


### PR DESCRIPTION
C5/M5 instances are missing /sys/hypervisor/uuid file. We used to use this
file to do a quick EC2/non-EC2 check. If UUID file is missing or UUID does not
start with string 'ec2', it was treated as non-EC2 instance.

Since C5/M5 instances are missing this file (?) we have to perform other
checks before deciding whether the instance is EC2 or not.

See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html

This fixes: https://github.com/facebook/osquery/issues/4378