### PR TITLE
http_client: Always close socket on exception

### DIFF
--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -60,9 +60,6 @@ void Client::closeSocket() {
   if (sock_.is_open()) {
     boost_system::error_code rc;
     sock_.shutdown(boost_asio::ip::tcp::socket::shutdown_both, rc);
-    if (rc) {
-      return;
-    }
     sock_.close(rc);
   }
 }

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -102,13 +102,6 @@ http::Client::Options TLSTransport::getOptions() {
     options.proxy_hostname(FLAGS_proxy_hostname);
   }
 
-#if defined(DEBUG)
-  // Configuration may allow unsafe TLS testing if compiled as a debug target.
-  if (FLAGS_tls_allow_unsafe) {
-    options.always_verify_peer(false);
-  }
-#endif
-
   options.openssl_ciphers(kTLSCiphers);
   options.openssl_options(SSL_OP_NO_SSLv3 | SSL_OP_NO_SSLv2 | SSL_OP_ALL);
 
@@ -153,6 +146,13 @@ http::Client::Options TLSTransport::getOptions() {
   if (it != options_.doc().MemberEnd() && it->value.IsString()) {
     options.openssl_sni_hostname(it->value.GetString());
   }
+
+#if defined(DEBUG)
+  // Configuration may allow unsafe TLS testing if compiled as a debug target.
+  if (FLAGS_tls_allow_unsafe) {
+    options.always_verify_peer(false);
+  }
+#endif
 
   return options;
 }


### PR DESCRIPTION
Fixes #4398.

I noticed the TLS debugging should be moved to 'after all other OpenSSL options are set' because there's potential for the peer-verification setting to be flipped back on. I cannot reproduce this error without active termination of the socket.