### PR TITLE
Fix debuginfo build-id subdirectory

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -256,13 +256,13 @@ function main() {
 
     # Create Build-ID links for executables and Dwarfs.
     BUILD_ID=`readelf -n "$BUILD_DIR/osquery/osqueryd" | grep "Build ID" | awk '{print $3}'`
-    BUILDLINK_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/.build-id/64
     if [[ ! "$BUILD_ID" = "" ]]; then
+      BUILDLINK_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/.build-id/${BUILD_ID:0:2}
       mkdir -p $BUILDLINK_DEBUG_DIR
-      ln -sf ../../../../bin/osqueryi $BUILDLINK_DEBUG_DIR/$BUILD_ID
-      ln -sf ../../bin/osqueryi.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID.debug
-      ln -sf ../../../../bin/osqueryd $BUILDLINK_DEBUG_DIR/$BUILD_ID
-      ln -sf ../../bin/osqueryd.debug $BUILDLINK_DEBUG_DIR/$BUILD_ID.debug
+      ln -sf ../../../../bin/osqueryi $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}
+      ln -sf ../../bin/osqueryi.debug $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}.debug
+      ln -sf ../../../../bin/osqueryd $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}
+      ln -sf ../../bin/osqueryd.debug $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}.debug
     fi
 
     # Install the non-stripped binaries.


### PR DESCRIPTION
According to https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html

> For the “build ID” method, GDB looks in the .build-id subdirectory of each one of the global debug directories for a file named nn/nnnnnnnn.debug, where nn are the first 2 hex characters of the build
ID bit string, and nnnnnnnn are the rest of the bit string. (Real build ID strings are 32 or more hex characters, not 10.)

Test plan:

```
$ eu-readelf -n /usr/bin/osqueryd
...
Note section [ 5] '.note.gnu.build-id' of 24 bytes at offset 0x30f14c:
  Owner          Data size  Type
  GNU                    8  GNU_BUILD_ID
    Build ID: cd23155a411c711a

$ strace -eaccess,readlink gdb /usr/bin/osqueryd
...
access("/usr/lib/debug/.build-id/cd/23155a411c711a.debug", F_OK) = 0
readlink("/usr/lib/debug/.build-id/cd/23155a411c711a.debug", "../../bin/osqueryd.debug", 4095) = 24
...
```