### PR TITLE
tables: memory related SMBIOS tables

### DIFF
--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -126,6 +126,78 @@ QueryData genMemoryDevices(QueryContext& context) {
   return results;
 }
 
+QueryData genMemoryArrays(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryArrays(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryArrayMappedAddresses(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryArrayMappedAddresses(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryErrorInfo(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryErrorInfo(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryDeviceMappedAddresses(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
 QueryData genPlatformInfo(QueryContext& context) {
   auto rom = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/rom");
   if (rom == 0) {
@@ -184,5 +256,5 @@ QueryData genPlatformInfo(QueryContext& context) {
   CFRelease(details);
   return {r};
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -146,6 +146,78 @@ QueryData genMemoryDevices(QueryContext& context) {
   return results;
 }
 
+QueryData genMemoryArrays(QueryContext& context) {
+  QueryData results;
+
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryArrays(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryArrayMappedAddresses(QueryContext& context) {
+  QueryData results;
+
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryArrayMappedAddresses(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryErrorInfo(QueryContext& context) {
+  QueryData results;
+
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryErrorInfo(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
+QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
+  QueryData results;
+
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size) {
+    genSMBIOSMemoryDeviceMappedAddresses(index, hdr, address, size, results);
+  });
+
+  return results;
+}
+
 QueryData genPlatformInfo(QueryContext& context) {
   LinuxSMBIOSParser parser;
   if (!parser.discover()) {
@@ -190,5 +262,5 @@ QueryData genPlatformInfo(QueryContext& context) {
 
   return results;
 }
-}
+} // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -10,8 +10,8 @@
 
 #include <boost/algorithm/string/trim.hpp>
 
-#include "osquery/tables/system/smbios_utils.h"
 #include "osquery/core/hashing.h"
+#include "osquery/tables/system/smbios_utils.h"
 
 namespace osquery {
 namespace tables {
@@ -116,6 +116,76 @@ const std::map<uint8_t, std::string> kSMBIOSMemoryTypeTable = {
     {0x1C, "LPDDR2"},   {0x1D, "LPDDR3"},       {0x1E, "LPDDR4"},
 };
 
+const std::map<uint8_t, std::string> kSMBIOSMemoryArrayLocationTable = {
+    {0x01, "Other"},
+    {0x02, "Unknown"},
+    {0x03, "System board or motherboard"},
+    {0x04, "ISA add-on card"},
+    {0x05, "EISA add-on card"},
+    {0x06, "PCI add-on card"},
+    {0x07, "MCA add-on card"},
+    {0x08, "PCMCIA add-on card"},
+    {0x09, "Proprietary add-on card"},
+    {0x0A, "NuBus"},
+    {0xA0, "PC-98/C20 add-on card"},
+    {0xA1, "PC-98/C24 add-on card"},
+    {0xA2, "PC-98/E add-on card"},
+    {0xA3, "PC-98/Local bus add-on card"},
+};
+
+const std::map<uint8_t, std::string> kSMBIOSMemoryArrayUseTable = {
+    {0x01, "Other"},
+    {0x02, "Unknown"},
+    {0x03, "System memory"},
+    {0x04, "Video memory"},
+    {0x05, "Flash memory"},
+    {0x06, "Non-volatile RAM"},
+    {0x07, "Cache memory"},
+};
+
+const std::map<uint8_t, std::string>
+    kSMBIOSMemoryArrayErrorCorrectionTypesTable = {
+        {0x01, "Other"},
+        {0x02, "Unknown"},
+        {0x03, "none"},
+        {0x04, "Parity"},
+        {0x05, "Single-bit ECC"},
+        {0x06, "Multi-bit ECC"},
+        {0x07, "CRC"},
+};
+
+const std::map<uint8_t, std::string> kSMBIOSMemoryErrorTypeTable = {
+    {0x01, "Other"},
+    {0x02, "Unknown"},
+    {0x03, "OK"},
+    {0x04, "Bad read"},
+    {0x05, "Parity error"},
+    {0x06, "Single-bit error"},
+    {0x07, "Double-bit error"},
+    {0x08, "Multi-bit error"},
+    {0x09, "Nibble error"},
+    {0x0A, "Checksum error"},
+    {0x0B, "CRC error"},
+    {0x0C, "Corrected single-bit error"},
+    {0x0D, "Corrected error"},
+    {0x0E, "Uncorrectable error"},
+};
+
+const std::map<uint8_t, std::string> kSMBIOSMemoryErrorGranularityTable = {
+    {0x01, "Other"},
+    {0x02, "Unknown"},
+    {0x03, "Device level"},
+    {0x04, "Memory partition level"},
+};
+
+const std::map<uint8_t, std::string> kSMBIOSMemoryErrorOperationTable = {
+    {0x01, "Other"},
+    {0x02, "Unknown"},
+    {0x03, "Read"},
+    {0x04, "Write"},
+    {0x05, "Partial write"},
+};
+
 template <class T>
 static inline std::string toHexStr(T num, int width = 4) {
   std::stringstream ss;
@@ -154,6 +224,24 @@ inline uint32_t dmiToDWord(uint8_t* address, uint8_t offset) {
          (static_cast<uint32_t>(address[offset + 2]) << 16) |
          (static_cast<uint32_t>(address[offset + 1]) << 8) |
          static_cast<uint32_t>(address[offset]);
+}
+
+/**
+ * @brief Returns uint64_t representation of a QWORD length field
+ *
+ *
+ * @param address A pointer to the examined structure.
+ * @Param offset The field index into address.
+ */
+inline uint64_t dmiToQWord(uint8_t* address, uint8_t offset) {
+  return (static_cast<uint64_t>(address[offset + 7]) << 56) |
+         (static_cast<uint64_t>(address[offset + 6]) << 48) |
+         (static_cast<uint64_t>(address[offset + 5]) << 40) |
+         (static_cast<uint64_t>(address[offset + 4]) << 32) |
+         (static_cast<uint64_t>(address[offset + 3]) << 24) |
+         (static_cast<uint64_t>(address[offset + 2]) << 16) |
+         (static_cast<uint64_t>(address[offset + 1]) << 8) |
+         static_cast<uint64_t>(address[offset]);
 }
 
 static inline std::string dmiWordToHexStr(uint8_t* address, uint8_t offset) {
@@ -305,6 +393,158 @@ void genSMBIOSMemoryDevices(size_t index,
   if (vt != 0) {
     r["configured_voltage"] = INTEGER(vt);
   }
+
+  results.push_back(std::move(r));
+}
+
+void genSMBIOSMemoryArrays(size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size,
+                           QueryData& results) {
+  if (hdr->type != kSMBIOSTypeMemoryArray || size < 0x12) {
+    return;
+  }
+
+  Row r;
+  r["handle"] = dmiWordToHexStr(address, 0x02);
+
+  auto location = kSMBIOSMemoryArrayLocationTable.find(address[0x04]);
+  if (location != kSMBIOSMemoryArrayLocationTable.end()) {
+    r["location"] = location->second;
+  }
+
+  auto use = kSMBIOSMemoryArrayUseTable.find(address[0x05]);
+  if (use != kSMBIOSMemoryArrayUseTable.end()) {
+    r["use"] = use->second;
+  }
+
+  auto errCorrection =
+      kSMBIOSMemoryArrayErrorCorrectionTypesTable.find(address[0x06]);
+  if (errCorrection != kSMBIOSMemoryArrayErrorCorrectionTypesTable.end()) {
+    r["memory_error_correction"] = errCorrection->second;
+  }
+
+  auto cap = dmiToDWord(address, 0x07);
+  // SMBIOS returns capacity in KB or bytes, but we want a more human
+  // friendly GB.
+  r["max_capacity"] = (cap >= 0x80000000)
+                          ? INTEGER(dmiToQWord(address, 0x0F) / 1073741824)
+                          : INTEGER(cap / 1048576);
+
+  auto errHandle = dmiToWord(address, 0x0B);
+  if (errHandle != 0xFFFE) {
+    r["memory_error_info_handle"] =
+        (errHandle == 0xFFFF) ? "No Errors" : toHexStr(errHandle);
+  }
+
+  r["number_memory_devices"] = INTEGER(dmiToWord(address, 0x0D));
+
+  results.push_back(std::move(r));
+}
+
+void genSMBIOSMemoryArrayMappedAddresses(size_t index,
+                                         const SMBStructHeader* hdr,
+                                         uint8_t* address,
+                                         size_t size,
+                                         QueryData& results) {
+  if (hdr->type != kSMBIOSTypeMemoryArrayMappedAddress || size < 0x12) {
+    return;
+  }
+
+  Row r;
+  r["handle"] = dmiWordToHexStr(address, 0x02);
+
+  auto addr = dmiToDWord(address, 0x04);
+  if (addr != 0xFFFFFFFF) {
+    r["starting_address"] = toHexStr(addr, 8);
+    r["ending_address"] = toHexStr(dmiToDWord(address, 0x08), 8);
+  } else {
+    r["starting_address"] = toHexStr(dmiToQWord(address, 0x0F), 12);
+    r["ending_address"] = toHexStr(dmiToQWord(address, 0x17), 12);
+  }
+
+  r["memory_array_handle"] = dmiWordToHexStr(address, 0x0C);
+  r["partition_width"] = INTEGER(static_cast<int>(address[0x0E]));
+
+  results.push_back(std::move(r));
+}
+
+void genSMBIOSMemoryErrorInfo(size_t index,
+                              const SMBStructHeader* hdr,
+                              uint8_t* address,
+                              size_t size,
+                              QueryData& results) {
+  if (hdr->type != kSMBIOSTypeMemoryErrorInformation || size < 0x12) {
+    return;
+  }
+
+  Row r;
+  r["handle"] = dmiWordToHexStr(address, 0x02);
+
+  auto errType = kSMBIOSMemoryErrorTypeTable.find(address[0x04]);
+  if (errType != kSMBIOSMemoryErrorTypeTable.end()) {
+    r["error_type"] = errType->second;
+  }
+
+  auto errGran = kSMBIOSMemoryErrorGranularityTable.find(address[0x05]);
+  if (errGran != kSMBIOSMemoryErrorGranularityTable.end()) {
+    r["error_granularity"] = errGran->second;
+  }
+
+  auto errOp = kSMBIOSMemoryErrorOperationTable.find(address[0x06]);
+  if (errOp != kSMBIOSMemoryErrorOperationTable.end()) {
+    r["error_operation"] = errOp->second;
+  }
+
+  auto dword = dmiToDWord(address, 0x07);
+  if (dword != 0x00000000) {
+    r["vendor_syndrome"] = toHexStr(dword, 8);
+  }
+
+  dword = dmiToDWord(address, 0x0B);
+  if (dword != 0x80000000) {
+    r["memory_array_error_address"] = toHexStr(dword, 8);
+  }
+
+  dword = dmiToDWord(address, 0x0F);
+  if (dword != 0x80000000) {
+    r["device_error_address"] = toHexStr(dword, 8);
+  }
+
+  dword = dmiToDWord(address, 0x13);
+  if (dword != 0x80000000) {
+    r["error_resolution"] = toHexStr(dword, 8);
+  }
+
+  results.push_back(std::move(r));
+}
+
+void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
+                                          const SMBStructHeader* hdr,
+                                          uint8_t* address,
+                                          size_t size,
+                                          QueryData& results) {
+  if (hdr->type != kSMBIOSTypeMemoryDeviceMappedAddress || size < 0x12) {
+    return;
+  }
+
+  Row r;
+  r["handle"] = dmiWordToHexStr(address, 0x02);
+
+  auto addr = dmiToDWord(address, 0x04);
+  if (addr != 0xFFFFFFFF) {
+    r["starting_address"] = toHexStr(addr, 8);
+    r["ending_address"] = toHexStr(dmiToDWord(address, 0x08), 8);
+  } else {
+    r["starting_address"] = toHexStr(dmiToQWord(address, 0x13), 12);
+    r["ending_address"] = toHexStr(dmiToQWord(address, 0x1B), 12);
+  }
+
+  r["memory_device_handle"] = dmiWordToHexStr(address, 0x0C);
+  r["partition_row_position"] = INTEGER(static_cast<int>(address[0x10]));
+  r["interleave_position"] = INTEGER(static_cast<int>(address[0x11]));
+  r["interleave_data_depth"] = INTEGER(static_cast<int>(address[0x12]));
 
   results.push_back(std::move(r));
 }

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -433,9 +433,8 @@ void genSMBIOSMemoryArrays(size_t index,
                           : INTEGER(cap / 1048576);
 
   auto errHandle = dmiToWord(address, 0x0B);
-  if (errHandle != 0xFFFE) {
-    r["memory_error_info_handle"] =
-        (errHandle == 0xFFFF) ? "No Errors" : toHexStr(errHandle);
+  if (errHandle != 0xFFFE && errHandle != 0xFFFF) {
+    r["memory_error_info_handle"] = toHexStr(errHandle);
   }
 
   r["number_memory_devices"] = INTEGER(dmiToWord(address, 0x0D));

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -39,13 +39,24 @@ typedef struct DMIEntryPoint {
 extern const std::map<uint8_t, std::string> kSMBIOSMemoryFormFactorTable;
 extern const std::map<uint8_t, std::string> kSMBIOSMemoryDetailsTable;
 extern const std::map<uint8_t, std::string> kSMBIOSMemoryTypeTable;
+extern const std::map<uint8_t, std::string> kSMBIOSMemoryArrayLocationTable;
+extern const std::map<uint8_t, std::string> kSMBIOSMemoryArrayUseTable;
+extern const std::map<uint8_t, std::string>
+    kSMBIOSMemoryArrayErrorCorrectionTypesTable;
+extern const std::map<uint8_t, std::string> kSMBIOSMemoryErrorTypeTable;
+extern const std::map<uint8_t, std::string> kSMBIOSMemoryErrorGranularityTable;
+extern const std::map<uint8_t, std::string> kSMBIOSMemoryErrorOperationTable;
 
 /// Get friendly names for each SMBIOS table/section type.
 extern const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions;
 
 constexpr uint8_t kSMBIOSTypeBIOS = 0;
 constexpr uint8_t kSMBIOSTypeSystem = 1;
+constexpr uint8_t kSMBIOSTypeMemoryArray = 16;
 constexpr uint8_t kSMBIOSTypeMemoryDevice = 17;
+constexpr uint8_t kSMBIOSTypeMemoryErrorInformation = 18;
+constexpr uint8_t kSMBIOSTypeMemoryArrayMappedAddress = 19;
+constexpr uint8_t kSMBIOSTypeMemoryDeviceMappedAddress = 20;
 
 /**
  * @brief A generic parser for SMBIOS tables.
@@ -85,6 +96,35 @@ void genSMBIOSMemoryDevices(size_t index,
                             uint8_t* address,
                             size_t size,
                             QueryData& results);
+
+/// Helper, cross platform, table row generator for memory arrays.
+void genSMBIOSMemoryArrays(size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           size_t size,
+                           QueryData& results);
+
+/// Helper, cross platform, table row generator for memory mapped addresses.
+void genSMBIOSMemoryArrayMappedAddresses(size_t index,
+                                         const SMBStructHeader* hdr,
+                                         uint8_t* address,
+                                         size_t size,
+                                         QueryData& results);
+
+/// Helper, cross platform, table row generator for memory error info.
+void genSMBIOSMemoryErrorInfo(size_t index,
+                              const SMBStructHeader* hdr,
+                              uint8_t* address,
+                              size_t size,
+                              QueryData& results);
+
+/// Helper, cross platform, table row generator for memory device mapped
+/// addresses.
+void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
+                                          const SMBStructHeader* hdr,
+                                          uint8_t* address,
+                                          size_t size,
+                                          QueryData& results);
 
 /**
  * @brief Return a 0-terminated strings from an SMBIOS address and handle.

--- a/specs/blacklist
+++ b/specs/blacklist
@@ -17,6 +17,10 @@ freebsd:usb_devices
 freebsd:yara_events
 freebsd:smbios_tables
 freebsd:memory_devices
+freebsd:memory_arrays
+freebsd:memory_error_info
+freebsd:memory_array_mapped_addresses
+freebsd:memory_device_mapped_addresses
 
 # Blacklisting as an example:
 example

--- a/specs/posix/memory_array_mapped_addresses.table
+++ b/specs/posix/memory_array_mapped_addresses.table
@@ -1,0 +1,15 @@
+table_name("memory_array_mapped_addresses")
+description("Data associated for address mapping of physical memory arrays.")
+schema([
+    Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
+    Column("memory_array_handle", TEXT,
+      "Handle of the memory array associated with this structure"),
+    Column("starting_address",  TEXT,
+      "Physical stating address, in kilobytes, of a range of memory mapped to physical memory array"),
+    Column("ending_address", TEXT,
+      "Physical ending address of last kilobyte of a range of memory mapped to physical memory array"),
+    Column("partition_width", INTEGER,
+      "Number of memory devices that form a single row of memory for the address partition of this structure"),
+])
+
+implementation("smbios_tables@genMemoryArrayMappedAddresses")

--- a/specs/posix/memory_arrays.table
+++ b/specs/posix/memory_arrays.table
@@ -1,0 +1,15 @@
+table_name("memory_arrays")
+description("Data associated with collection of memory devices that operate to form a memory address.")
+schema([
+    Column("handle",  TEXT, "Handle, or instance number, associated with the array"),
+    Column("location",  TEXT, "Physical location of the memory array"),
+    Column("use", TEXT, "Function for which the array is used"),
+    Column("memory_error_correction", TEXT,
+      "Primary hardware error correction or detection method supported"),
+    Column("max_capacity", INTEGER, "Maximum capacity of array in gigabytes"),
+    Column("memory_error_info_handle", TEXT,
+      "Handle, or instance number, associated with any error that was detected for the array"),
+    Column("number_memory_devices", INTEGER, "Number of memory devices on array"),
+])
+
+implementation("smbios_tables@genMemoryArrays")

--- a/specs/posix/memory_device_mapped_addresses.table
+++ b/specs/posix/memory_device_mapped_addresses.table
@@ -1,0 +1,21 @@
+table_name("memory_device_mapped_addresses")
+description("Data associated for address mapping of physical memory devices.")
+schema([
+    Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
+    Column("memory_device_handle", TEXT,
+      "Handle of the memory device structure associated with this structure"),
+    Column("memory_array_mapped_address_handle", TEXT,
+      "Handle of the memory array mapped address to which this device range is mapped to"),
+    Column("starting_address",  TEXT,
+      "Physical stating address, in kilobytes, of a range of memory mapped to physical memory array"),
+    Column("ending_address", TEXT,
+      "Physical ending address of last kilobyte of a range of memory mapped to physical memory array"),
+    Column("partition_row_position", INTEGER,
+      "Identifies the position of the referenced memory device in a row of the address partition"),
+    Column("interleave_position", INTEGER,
+      "The position of the device in a interleave, i.e. 0 indicates non-interleave, 1 indicates 1st interleave, 2 indicates 2nd interleave, etc."),
+    Column("interleave_data_depth", INTEGER,
+      "The max number of consecutive rows from memory device that are accessed in a single interleave transfer; 0 indicates device is non-interleave"),
+])
+
+implementation("smbios_tables@genMemoryDeviceMappedAddresses")

--- a/specs/posix/memory_error_info.table
+++ b/specs/posix/memory_error_info.table
@@ -1,0 +1,21 @@
+table_name("memory_error_info")
+description("Data associated with errors of a physical memory array.")
+schema([
+    Column("handle",  TEXT, "Handle, or instance number, associated with the structure"),
+    Column("error_type",  TEXT,
+      "type of error associated with current error status for array or device"),
+    Column("error_granularity", TEXT,
+      "Granularity to which the error can be resolved"),
+    Column("error_operation", TEXT,
+      "Memory access operation that caused the error"),
+    Column("vendor_syndrome", TEXT,
+      "Vendor specific ECC syndrome or CRC data associated with the erroneous access"),
+    Column("memory_array_error_address", TEXT,
+      "32 bit physical address of the error based on the addressing of the bus to which the memory array is connected"),
+    Column("device_error_address", TEXT,
+        "32 bit physical address of the error relative to the start of the failing memory address, in bytes"),
+    Column("error_resolution", TEXT,
+      "Range, in bytes, within which this error can be determined, when an error address is given"),
+])
+
+implementation("smbios_tables@genMemoryErrorInfo")


### PR DESCRIPTION
Currently `memory_devices` exists as a virtual table.  This PR implements the remaining memory related tables of `SMBIOS`.
Tables are:
- `memory_arrays`
- `memory_array_mapped_addresses`
- `memory_error_info`
- `memory_device_mapped_addresses`

Note:  In `memory_device_mapped_addresses`, the `handle` column isn't really useful, meaning that it can't be used to join with any of the other tables.  It was left there for consistency with the other tables.   I will remove it if that's not what we want.