### PR TITLE
Remove useless links on debug package creation

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -259,8 +259,6 @@ function main() {
     if [[ ! "$BUILD_ID" = "" ]]; then
       BUILDLINK_DEBUG_DIR=$DEBUG_PREFIX/usr/lib/debug/.build-id/${BUILD_ID:0:2}
       mkdir -p $BUILDLINK_DEBUG_DIR
-      ln -sf ../../../../bin/osqueryi $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}
-      ln -sf ../../bin/osqueryi.debug $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}.debug
       ln -sf ../../../../bin/osqueryd $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}
       ln -sf ../../bin/osqueryd.debug $BUILDLINK_DEBUG_DIR/${BUILD_ID:2}.debug
     fi


### PR DESCRIPTION
osqueryd and osqueryi build-ids are the same  (because this is the same binary) so the first ln wasn't doing much.