### PR TITLE
Adding readonly_rootfs field to docker_containers table.

### DIFF
--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -416,6 +416,10 @@ QueryData genContainers(QueryContext& context) {
                                 .get<bool>("Privileged", false)
                             ? INTEGER(1)
                             : INTEGER(0);
+      r["readonly_rootfs"] = container_details.get_child("HostConfig")
+                                     .get<bool>("ReadonlyRootfs", false)
+                                 ? INTEGER(1)
+                                 : INTEGER(0);
       r["path"] = container_details.get<std::string>("Path", "");
 
       std::vector<std::string> entry_pts;

--- a/specs/posix/docker_containers.table
+++ b/specs/posix/docker_containers.table
@@ -17,6 +17,7 @@ schema([
     Column("privileged", INTEGER, "Is the container privileged"),
     Column("security_options", TEXT, "List of container security options"),
     Column("env_variables", TEXT, "Container environmental variables"),
+    Column("readonly_rootfs", INTEGER, "Is the root filesystem mounted as read only"),
 ])
 extended_schema(LINUX, [
     Column("cgroup_namespace", TEXT, "cgroup namespace"),


### PR DESCRIPTION
Adding the readonly_rootfs field to the docker_container table. 

`Column("readonly_rootfs", INTEGER, "Is the root filesystem mounted as read only"),`