### PR TITLE
Rid off the shared_ptr using from config schedule

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -45,6 +45,8 @@ class Config : private boost::noncopyable {
   Config();
 
  public:
+  ~Config();
+
   /// Singleton accessor.
   static Config& get();
 
@@ -310,9 +312,9 @@ class Config : private boost::noncopyable {
    */
   void reset();
 
- protected:
+ private:
   /// Schedule of packs and their queries.
-  std::shared_ptr<Schedule> schedule_;
+  std::unique_ptr<Schedule> schedule_;
 
   /// A set of performance stats for each query in the schedule.
   std::map<std::string, QueryPerformance> performance_;


### PR DESCRIPTION
to avoid UB in non-const access from different threads. It is not a big deal for the interface and other code, because there is no use cases to shared this objects somewhere.