### PR TITLE
Remove unused member from SchedulerRunner class

### DIFF
--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -33,10 +33,7 @@ class SchedulerRunner : public InternalRunnable {
   /// The Dispatcher interrupt point.
   void stop() override {}
 
- protected:
-  /// The UNIX domain socket path for the ExtensionManager.
-  std::map<std::string, size_t> splay_;
-
+ private:
   /// Interval in seconds between schedule steps.
   size_t interval_;
 


### PR DESCRIPTION
- Member [splay_] was removed because there is no use case for it.
- All members was hidden under private specifier.