### PR TITLE
deps: Update aws-sdk-cpp to version 1.4.55

### DIFF
--- a/osquery/utils/tests/aws_util_tests.cpp
+++ b/osquery/utils/tests/aws_util_tests.cpp
@@ -46,43 +46,50 @@ TEST_F(AwsUtilTests, test_get_credentials) {
   unsetEnvVar(kAwsAccessKeyEnvVar);
   unsetEnvVar(kAwsSecretKeyEnvVar);
 
-  OsqueryAWSCredentialsProviderChain provider;
   Aws::Auth::AWSCredentials credentials("", "");
 
   FLAGS_aws_access_key_id = "FLAG_ACCESS_KEY_ID";
   FLAGS_aws_secret_access_key = "flag_secret_key";
-  // With the flags set, those credentials should be used
-  provider = OsqueryAWSCredentialsProviderChain();
-  credentials = provider.GetAWSCredentials();
-  ASSERT_EQ("FLAG_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-  ASSERT_EQ("flag_secret_key", credentials.GetAWSSecretKey());
+  {
+    // With the flags set, those credentials should be used
+    OsqueryAWSCredentialsProviderChain provider;
+    credentials = provider.GetAWSCredentials();
+    ASSERT_EQ("FLAG_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+    ASSERT_EQ("flag_secret_key", credentials.GetAWSSecretKey());
+  }
 
   FLAGS_aws_access_key_id = "FLAG_ACCESS_KEY_ID";
   FLAGS_aws_secret_access_key = "flag_secret_key";
-  // With the flags set and sts disabled, those credentials should be used
-  provider = OsqueryAWSCredentialsProviderChain(false);
-  credentials = provider.GetAWSCredentials();
-  ASSERT_EQ("FLAG_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-  ASSERT_EQ("flag_secret_key", credentials.GetAWSSecretKey());
+  {
+    // With the flags set and sts disabled, those credentials should be used
+    OsqueryAWSCredentialsProviderChain provider(false);
+    credentials = provider.GetAWSCredentials();
+    ASSERT_EQ("FLAG_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+    ASSERT_EQ("flag_secret_key", credentials.GetAWSSecretKey());
+  }
 
   // Profiles are not working on Windows; see the constructor of
   // OsqueryAWSCredentialsProviderChain for more information
   if (!isPlatform(PlatformType::TYPE_WINDOWS)) {
     FLAGS_aws_access_key_id = "";
     FLAGS_aws_secret_access_key = "flag_secret_key";
-    // With the flags set improperly, the profile should be used
-    provider = OsqueryAWSCredentialsProviderChain();
-    credentials = provider.GetAWSCredentials();
-    ASSERT_EQ("DEFAULT_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-    ASSERT_EQ("default_secret_key", credentials.GetAWSSecretKey());
+    {
+      // With the flags set improperly, the profile should be used
+      OsqueryAWSCredentialsProviderChain provider;
+      credentials = provider.GetAWSCredentials();
+      ASSERT_EQ("DEFAULT_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+      ASSERT_EQ("default_secret_key", credentials.GetAWSSecretKey());
+    }
 
     FLAGS_aws_access_key_id = "FLAG_ACCESS_KEY_ID";
     FLAGS_aws_secret_access_key = "";
-    // With the flags set improperly, the profile should be used
-    provider = OsqueryAWSCredentialsProviderChain();
-    credentials = provider.GetAWSCredentials();
-    ASSERT_EQ("DEFAULT_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-    ASSERT_EQ("default_secret_key", credentials.GetAWSSecretKey());
+    {
+      // With the flags set improperly, the profile should be used
+      OsqueryAWSCredentialsProviderChain provider;
+      credentials = provider.GetAWSCredentials();
+      ASSERT_EQ("DEFAULT_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+      ASSERT_EQ("default_secret_key", credentials.GetAWSSecretKey());
+    }
 
     // Clear flags
     FLAGS_aws_access_key_id = "";
@@ -90,18 +97,22 @@ TEST_F(AwsUtilTests, test_get_credentials) {
 
     setEnvVar(kAwsAccessKeyEnvVar, "ENV_ACCESS_KEY_ID");
     setEnvVar(kAwsSecretKeyEnvVar, "env_secret_key");
-    // Now env variables should be the primary source
-    provider = OsqueryAWSCredentialsProviderChain();
-    credentials = provider.GetAWSCredentials();
-    ASSERT_EQ("ENV_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-    ASSERT_EQ("env_secret_key", credentials.GetAWSSecretKey());
+    {
+      // Now env variables should be the primary source
+      OsqueryAWSCredentialsProviderChain provider;
+      credentials = provider.GetAWSCredentials();
+      ASSERT_EQ("ENV_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+      ASSERT_EQ("env_secret_key", credentials.GetAWSSecretKey());
+    }
 
     FLAGS_aws_profile_name = "test";
-    provider = OsqueryAWSCredentialsProviderChain();
-    credentials = provider.GetAWSCredentials();
-    // Now the "test" profile should take precedence
-    ASSERT_EQ("TEST_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
-    ASSERT_EQ("test_secret_key", credentials.GetAWSSecretKey());
+    {
+      OsqueryAWSCredentialsProviderChain provider;
+      credentials = provider.GetAWSCredentials();
+      // Now the "test" profile should take precedence
+      ASSERT_EQ("TEST_ACCESS_KEY_ID", credentials.GetAWSAccessKeyId());
+      ASSERT_EQ("test_secret_key", credentials.GetAWSSecretKey());
+    }
   }
 }
 

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -4,15 +4,15 @@ class AwsSdkCpp < AbstractOsqueryFormula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
   license "Apache-2.0"
-  url "https://github.com/aws/aws-sdk-cpp/archive/1.2.7.tar.gz"
-  sha256 "1f65e63dbbceb1e8ffb19851a8e0ee153e05bf63bfa12b0e259d50021ac3ab6e"
-  revision 200
+  url "https://github.com/aws/aws-sdk-cpp/archive/1.4.55.tar.gz"
+  sha256 "0a70c2998d29cc4d8a4db08aac58eb196d404073f6586a136d074730317fe408"
+  revision 1
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "b35c6889799abe5553b428cd300622fc443a6aae8db9114cdc6172bafd2f902a" => :sierra
-    sha256 "afa67a91ae0356516861e677ac6b64f91d848fdc3ae10374934188ac9c70863c" => :x86_64_linux
+    sha256 "6d047fe0f7b0710aea9366af1a4f3c637c1fcd3a2f652abaa8ffc70ef5190451" => :sierra
+    sha256 "d161bd821efffe73ac6cb7e7f0cefe248981c6d3ab59be17ca2de5d7f8c4eff4" => :x86_64_linux
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Fixes #4158.

The `aws-sdk-cpp` version (1.2.x) does not build with `clang-6.0`.