### PR TITLE
deps: Update libdpkg to version 1.19.0.5

### DIFF
--- a/tools/provision/formula/libdpkg.rb
+++ b/tools/provision/formula/libdpkg.rb
@@ -4,14 +4,15 @@ class Libdpkg < AbstractOsqueryFormula
   desc "Debian package management system"
   homepage "https://wiki.debian.org/Teams/Dpkg"
   license "GPL-2.0+"
-  url "http://download.openpkg.org/components/cache/dpkg/dpkg_1.18.23.tar.xz"
-  sha256 "cc08802a0cea2ccd0c10716bc71531ff9b9234dd454b83a59f71117a37f36923"
+  url "https://launchpad.net/debian/+archive/primary/+sourcefiles/dpkg/1.19.0.5/dpkg_1.19.0.5.tar.xz"
+  mirror "http://snapshot.debian.org/archive/debian/20180121T094839Z/pool/main/d/dpkg/dpkg_1.19.0.5.tar.xz"
+  sha256 "818046927a7f77c1bcbbad7d8dbc04cdf0f3e6ec4e1a4f9d313378ecc69d85b5"
   revision 200
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "cd38c7f2af0fa21326777204c432ada3dc8275b583041de0bfb57193052fcf53" => :x86_64_linux
+    sha256 "c4762be902915a3eb31d59da73e392f9458a8f21d9e6484171a4f500f341a765" => :x86_64_linux
   end
 
   def install


### PR DESCRIPTION
The older `libdpkg` source tarball (1.18.23) was removed. This updates the dependency and includes a mirror to prevent this from happening again (at least reduce the chances). 