### PR TITLE
Adding ubuntu 18.04 to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,9 @@ targets = {
   "ubuntu17.04" => {
     "box" => "bento/ubuntu17.04"
   },
+  "ubuntu18.04" => {
+    "box" => "ubuntu/bionic64"
+  },
   "ubuntu12" => {
     "box" => "ubuntu/precise64"
   },

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -24,7 +24,6 @@ function distro_main() {
   package ruby
   package ruby-dev
   package bsdtar
-  package realpath
   package doxygen
   package valgrind
 


### PR DESCRIPTION
Adding `ubuntu18.04` as new vagrant box. Also removing the package `realpath` since it is no longer a valid Ubuntu 18.04 package and the requirement is not necessary since https://github.com/facebook/osquery/commit/2e5beca2e2e1a9088a6d43a7f4e09aee05f66714

I used the box from ubuntu instead of bento, due to a problem with a linux-headers package.

Verified the building process and it does build correctly:
```
Test project /vagrant/build/shared
    Start 1: osquery_tests
1/8 Test #1: osquery_tests ....................   Passed    0.48 sec
    Start 2: osquery_additional_tests
2/8 Test #2: osquery_additional_tests .........   Passed   19.14 sec
    Start 3: osquery_tables_tests
3/8 Test #3: osquery_tables_tests .............   Passed    1.35 sec
    Start 4: python_test_osqueryi
4/8 Test #4: python_test_osqueryi .............   Passed    7.29 sec
    Start 5: python_test_osqueryd
5/8 Test #5: python_test_osqueryd .............   Passed   14.89 sec
    Start 6: python_test_additional
6/8 Test #6: python_test_additional ...........   Passed    0.35 sec
    Start 7: python_test_extensions
7/8 Test #7: python_test_extensions ...........   Passed    5.37 sec
    Start 8: python_test_example_queries


8/8 Test #8: python_test_example_queries ......   Passed  264.16 sec

100% tests passed, 0 tests failed out of 8
```
And also the current package installs and runs fine:
```
vagrant@ubuntu-bionic:/vagrant$ osqueryi --line "select * from os_version"
         name = Ubuntu
      version = 18.04 LTS (Bionic Beaver)
        major = 18
        minor = 4
        patch = 0
        build =
     platform = ubuntu
platform_like = debian
     codename = bionic
```