### PR TITLE
tables: text address arg for SMBIOSParser::tables predicate

### DIFF
--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -101,6 +101,7 @@ QueryData genSMBIOSTables(QueryContext& context) {
     parser.tables(([&results](size_t index,
                               const SMBStructHeader* hdr,
                               uint8_t* address,
+                              uint8_t* textAddrs,
                               size_t size) {
       genSMBIOSTable(index, hdr, address, size, results);
     }));
@@ -119,8 +120,9 @@ QueryData genMemoryDevices(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
-    genSMBIOSMemoryDevices(index, hdr, address, size, results);
+    genSMBIOSMemoryDevices(index, hdr, address, textAddrs, size, results);
   });
 
   return results;
@@ -137,6 +139,7 @@ QueryData genMemoryArrays(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryArrays(index, hdr, address, size, results);
   });
@@ -155,6 +158,7 @@ QueryData genMemoryArrayMappedAddresses(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryArrayMappedAddresses(index, hdr, address, size, results);
   });
@@ -173,6 +177,7 @@ QueryData genMemoryErrorInfo(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryErrorInfo(index, hdr, address, size, results);
   });
@@ -191,6 +196,7 @@ QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryDeviceMappedAddresses(index, hdr, address, size, results);
   });

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -121,6 +121,7 @@ QueryData genSMBIOSTables(QueryContext& context) {
   parser.tables(([&results](size_t index,
                             const SMBStructHeader* hdr,
                             uint8_t* address,
+                            uint8_t* textAddrs,
                             size_t size) {
     genSMBIOSTable(index, hdr, address, size, results);
   }));
@@ -139,8 +140,9 @@ QueryData genMemoryDevices(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
-    genSMBIOSMemoryDevices(index, hdr, address, size, results);
+    genSMBIOSMemoryDevices(index, hdr, address, textAddrs, size, results);
   });
 
   return results;
@@ -157,6 +159,7 @@ QueryData genMemoryArrays(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryArrays(index, hdr, address, size, results);
   });
@@ -175,6 +178,7 @@ QueryData genMemoryArrayMappedAddresses(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryArrayMappedAddresses(index, hdr, address, size, results);
   });
@@ -193,6 +197,7 @@ QueryData genMemoryErrorInfo(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryErrorInfo(index, hdr, address, size, results);
   });
@@ -211,6 +216,7 @@ QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
   parser.tables([&results](size_t index,
                            const SMBStructHeader* hdr,
                            uint8_t* address,
+                           uint8_t* textAddrs,
                            size_t size) {
     genSMBIOSMemoryDeviceMappedAddresses(index, hdr, address, size, results);
   });
@@ -229,18 +235,17 @@ QueryData genPlatformInfo(QueryContext& context) {
   parser.tables(([&results](size_t index,
                             const SMBStructHeader* hdr,
                             uint8_t* address,
+                            uint8_t* textAddrs,
                             size_t size) {
     if (hdr->type != kSMBIOSTypeBIOS || size < 0x12) {
       return;
     }
 
     Row r;
-    // The DMI string data uses offsets (indexes) into a data section that
-    // trails the header and structure offsets.
-    uint8_t* data = address + hdr->length;
-    r["vendor"] = dmiString(data, address, 0x04);
-    r["version"] = dmiString(data, address, 0x05);
-    r["date"] = dmiString(data, address, 0x08);
+
+    r["vendor"] = dmiString(textAddrs, address, 0x04);
+    r["version"] = dmiString(textAddrs, address, 0x05);
+    r["date"] = dmiString(textAddrs, address, 0x08);
 
     // Firmware load address as a WORD.
     size_t firmware_address = (address[0x07] << 8) + address[0x06];

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -11,9 +11,9 @@
 #include <boost/algorithm/string.hpp>
 
 #include <osquery/filesystem.h>
-#include <osquery/tables.h>
 #include <osquery/sql.h>
 #include <osquery/system.h>
+#include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/tables/system/linux/smbios_utils.h"
@@ -93,21 +93,21 @@ QueryData genSystemInfo(QueryContext& context) {
       parser.tables(([&r](size_t index,
                           const SMBStructHeader* hdr,
                           uint8_t* address,
+                          uint8_t* textAddrs,
                           size_t size) {
         if (hdr->type != kSMBIOSTypeSystem || size < 0x12) {
           return;
         }
 
-        uint8_t* data = address + hdr->length;
-        r["hardware_vendor"] = dmiString(data, address, 0x04);
-        r["hardware_model"] = dmiString(data, address, 0x05);
-        r["hardware_version"] = dmiString(data, address, 0x06);
-        r["hardware_serial"] = dmiString(data, address, 0x07);
+        r["hardware_vendor"] = dmiString(textAddrs, address, 0x04);
+        r["hardware_model"] = dmiString(textAddrs, address, 0x05);
+        r["hardware_version"] = dmiString(textAddrs, address, 0x06);
+        r["hardware_serial"] = dmiString(textAddrs, address, 0x07);
       }));
     }
   }
 
   return {r};
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -70,6 +70,7 @@ class SMBIOSParser : private boost::noncopyable {
   virtual void tables(std::function<void(size_t index,
                                          const SMBStructHeader* hdr,
                                          uint8_t* address,
+                                         uint8_t* textAddrs,
                                          size_t size)> predicate);
 
  public:
@@ -94,6 +95,7 @@ void genSMBIOSTable(size_t index,
 void genSMBIOSMemoryDevices(size_t index,
                             const SMBStructHeader* hdr,
                             uint8_t* address,
+                            uint8_t* textAddrs,
                             size_t size,
                             QueryData& results);
 


### PR DESCRIPTION
Update `SMBIOSParser::tables` function parameter to include `textAddrs` so that the caller does not need to do pointer arithmetic to get to `DMI` text string location.