### PR TITLE
Basic db int type support

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -209,6 +209,9 @@ class DatabasePlugin : public Plugin {
 Status getDatabaseValue(const std::string& domain,
                         const std::string& key,
                         std::string& value);
+Status getDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int& value);
 
 /**
  * @brief Set or put a value into the active osquery DatabasePlugin storage.
@@ -225,6 +228,9 @@ Status getDatabaseValue(const std::string& domain,
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         const std::string& value);
+Status setDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int value);
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -219,6 +219,17 @@ Status getDatabaseValue(const std::string& domain,
   }
 }
 
+Status getDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int& value){
+  std::string result;
+  auto s = getDatabaseValue(domain, key, result);
+  if(s.ok()){
+    value = std::stoi(result);
+  }
+  return s;
+}
+
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         const std::string& value) {
@@ -241,6 +252,12 @@ Status setDatabaseValue(const std::string& domain,
     auto plugin = getDatabasePlugin();
     return plugin->put(domain, key, value);
   }
+}
+
+Status setDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int value){
+  return setDatabaseValue(domain, key, std::to_string(value));
 }
 
 Status deleteDatabaseValue(const std::string& domain, const std::string& key) {

--- a/osquery/sql/sqlite_filesystem.cpp
+++ b/osquery/sql/sqlite_filesystem.cpp
@@ -17,33 +17,31 @@ namespace osquery {
 
 static boost::optional<std::string> findExistingProgramPathFromCommand(
     const char* path, char escape_symbol, bool allow_quoting, bool shortest) {
-  size_t length = strlen(path);
   std::string result;
-  size_t pos = 0;
   // Skip spaces
-  for (; pos < length; ++pos) {
-    if (!isspace(path[pos])) {
+  for (; *path != '\0'; ++path) {
+    if (!isspace(*path)) {
       break;
     }
   }
   std::string temp_string;
   bool is_quoted = false;
   bool is_escaped = false;
-  for (; pos < length; ++pos) {
+  for (; *path != '\0'; ++path) {
     if (is_escaped) {
-      temp_string += path[pos];
+      temp_string += *path;
       is_escaped = false;
       continue;
     }
-    if (allow_quoting && path[pos] == '"') {
+    if (allow_quoting && *path == '"') {
       is_quoted = !is_quoted;
       continue;
     }
-    if (path[pos] == escape_symbol) {
+    if (*path == escape_symbol) {
       is_escaped = true;
       continue;
     }
-    if (!is_quoted && isspace(path[pos])) {
+    if (!is_quoted && isspace(*path)) {
       // validate temp string
       boost::filesystem::path test_path = temp_string;
       auto status = boost::filesystem::status(test_path);
@@ -55,7 +53,7 @@ static boost::optional<std::string> findExistingProgramPathFromCommand(
         }
       }
     }
-    temp_string += path[pos];
+    temp_string += *path;
   }
   if (result.length() == 0 || !shortest) {
     boost::filesystem::path test_path = temp_string;


### PR DESCRIPTION
Added API and tests for int types in the database abstraction.

For now, it's just the  wrapper over the string type. In the following commits, will utilize specific database capabilites for additional performance.