### PR TITLE
Basic db int type support

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -210,6 +210,10 @@ Status getDatabaseValue(const std::string& domain,
                         const std::string& key,
                         std::string& value);
 
+Status getDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int& value);
+
 /**
  * @brief Set or put a value into the active osquery DatabasePlugin storage.
  *
@@ -225,6 +229,10 @@ Status getDatabaseValue(const std::string& domain,
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         const std::string& value);
+
+Status setDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int value);
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -220,6 +220,17 @@ Status getDatabaseValue(const std::string& domain,
   }
 }
 
+Status getDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int& value){
+  std::string result;
+  auto s = getDatabaseValue(domain, key, result);
+  if(s.ok()){
+    value = std::stoi(result);
+  }
+  return s;
+}
+
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         const std::string& value) {
@@ -242,6 +253,12 @@ Status setDatabaseValue(const std::string& domain,
     auto plugin = getDatabasePlugin();
     return plugin->put(domain, key, value);
   }
+}
+
+Status setDatabaseValue(const std::string& domain,
+                        const std::string& key,
+                        int value){
+  return setDatabaseValue(domain, key, std::to_string(value));
 }
 
 Status deleteDatabaseValue(const std::string& domain, const std::string& key) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -222,10 +222,10 @@ Status getDatabaseValue(const std::string& domain,
 
 Status getDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        int& value){
+                        int& value) {
   std::string result;
   auto s = getDatabaseValue(domain, key, result);
-  if(s.ok()){
+  if (s.ok()) {
     value = std::stoi(result);
   }
   return s;
@@ -257,7 +257,7 @@ Status setDatabaseValue(const std::string& domain,
 
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        int value){
+                        int value) {
   return setDatabaseValue(domain, key, std::to_string(value));
 }
 

--- a/osquery/database/tests/database_tests.cpp
+++ b/osquery/database/tests/database_tests.cpp
@@ -17,6 +17,8 @@
 
 #include <osquery/logger.h>
 
+#include <limits>
+
 namespace rj = rapidjson;
 
 namespace osquery {
@@ -58,7 +60,15 @@ TEST_F(DatabaseTests, test_get_value_does_not_exist) {
 }
 
 TEST_F(DatabaseTests, test_get_value_str) {
-  std::string expected = "{}";
+  std::string expected;
+  for (unsigned char i = std::numeric_limits<unsigned char>::min();
+       i < std::numeric_limits<unsigned char>::max();
+       i++) {
+    if (std::isprint(i)) {
+      expected += i;
+    }
+  }
+
   setDatabaseValue(kLogs, "str", expected);
 
   std::string value;
@@ -69,10 +79,10 @@ TEST_F(DatabaseTests, test_get_value_str) {
 }
 
 TEST_F(DatabaseTests, test_get_value_int) {
-  int expected = -1;
+  int expected = std::numeric_limits<int>::min();
   setDatabaseValue(kLogs, "int", expected);
 
-  int value;
+  int value = 0;
   auto s = getDatabaseValue(kLogs, "int", value);
 
   EXPECT_TRUE(s.ok());
@@ -80,7 +90,8 @@ TEST_F(DatabaseTests, test_get_value_int) {
 }
 
 TEST_F(DatabaseTests, test_get_value_mix1) {
-  int expected = -1;
+  int expected = std::numeric_limits<int>::max();
+  setDatabaseValue(kLogs, "strint", "{}");
   setDatabaseValue(kLogs, "strint", expected);
 
   int value;
@@ -92,6 +103,7 @@ TEST_F(DatabaseTests, test_get_value_mix1) {
 
 TEST_F(DatabaseTests, test_get_value_mix2) {
   std::string expected = "{}";
+  setDatabaseValue(kLogs, "intstr", -1);
   setDatabaseValue(kLogs, "intstr", expected);
 
   std::string value;
@@ -136,7 +148,7 @@ TEST_F(DatabaseTests, test_delete_values_str) {
 
 TEST_F(DatabaseTests, test_delete_values_int) {
   int expected = 0;
-  setDatabaseValue(kLogs, "k", 0);
+  setDatabaseValue(kLogs, "k", expected);
 
   int value;
   getDatabaseValue(kLogs, "k", value);


### PR DESCRIPTION
Added API and tests for int types in the database abstraction.

For now, it's just the  wrapper over the string type. In the following commits, will utilize specific database capabilites for additional performance.