### PR TITLE
Fixed up resource releasing order UB in `ImplExtensionClient`

### DIFF
--- a/osquery/extensions/impl_fbthrift.cpp
+++ b/osquery/extensions/impl_fbthrift.cpp
@@ -89,9 +89,10 @@ struct ImplExtensionRunner {
 };
 
 struct ImplExtensionClient {
+  folly::EventBase base;
+
   std::shared_ptr<extensions::ExtensionAsyncClient> e;
   std::shared_ptr<extensions::ExtensionManagerAsyncClient> em;
-  folly::EventBase base;
 
   /// Raw socket descriptor.
   int sd;


### PR DESCRIPTION
`base` should be released after `e` and `em` members of `ImplExtensionClient`.