### PR TITLE
build: remove PRODUCT_MOBILE_CORE reference and pin v140 compiler

### DIFF
--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -67,7 +67,6 @@ const std::map<DWORD, std::string> kOsVersion = {
      "Windows Essential Business Server Messaging Server"},
     {PRODUCT_MEDIUMBUSINESS_SERVER_SECURITY,
      "Windows Essential Business Server Security Server"},
-    {PRODUCT_MOBILE_CORE, "Windows 10 Mobile"},
     {PRODUCT_MULTIPOINT_PREMIUM_SERVER,
      "Windows MultiPoint Server Premium (full installation)"},
     {PRODUCT_MULTIPOINT_STANDARD_SERVER,

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -70,6 +70,7 @@ function Invoke-OsqueryCmake {
   $cmake = (Get-Command 'cmake').Source
   $cmakeArgs = @(
     '-G "Visual Studio 14 2015 Win64"',
+    '-T v140',
     '../../'
   )
   $null = Start-OsqueryProcess $cmake $cmakeArgs $false


### PR DESCRIPTION
With newer SDKs, `PRODUCT_MOBILE_CORE` is being removed. As such having the symbol in our virtual table is causing builds to fail, and this value is likely not being used by anyone :) This PR additionally pins our toolkit version to the v140 compiler, which is visual studio 2015. Once @momopranto lands the VS 2017 conversion we'll be able to turn on `/permissive-`.