### PR TITLE
Ephemeral native support for int

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -94,6 +94,10 @@ class DatabasePlugin : public Plugin {
                      const std::string& key,
                      std::string& value) const = 0;
 
+  virtual Status get(const std::string& domain,
+                     const std::string& key,
+                     int& value) const = 0;
+
   /**
    * @brief Store a string-represented value using a domain and key index.
    *
@@ -108,6 +112,12 @@ class DatabasePlugin : public Plugin {
   virtual Status put(const std::string& domain,
                      const std::string& key,
                      const std::string& value) = 0;
+
+  virtual Status put(const std::string& domain,
+                     const std::string& key,
+                     const int& value) = 0;
+
+  virtual void dumpDatabase() const = 0;
 
   /// Data removal method.
   virtual Status remove(const std::string& domain, const std::string& k) = 0;
@@ -232,7 +242,7 @@ Status setDatabaseValue(const std::string& domain,
 
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        int value);
+                        const int& value);
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);

--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -115,7 +115,7 @@ class DatabasePlugin : public Plugin {
 
   virtual Status put(const std::string& domain,
                      const std::string& key,
-                     const int& value) = 0;
+                     int value) = 0;
 
   virtual void dumpDatabase() const = 0;
 
@@ -242,7 +242,7 @@ Status setDatabaseValue(const std::string& domain,
 
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        const int& value);
+                        int value);
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -186,10 +186,10 @@ inline Status safeStrtoi(const std::string& rep, int base, int& out) {
   try {
     out = std::stoi(rep, 0, base);
   } catch (const std::invalid_argument& ia) {
-    return Status(1, "If no conversion could be performed.");
+    return Status(1, "If no conversion could be performed. " + ia.what());
   } catch (const std::out_of_range& oor) {
     return Status(
-        1, "Value read is out of the range of representable values by an int.");
+        1, "Value read is out of the range of representable values by an int. " + oor.what());
   }
   return Status(0);
 }

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -186,10 +186,13 @@ inline Status safeStrtoi(const std::string& rep, int base, int& out) {
   try {
     out = std::stoi(rep, 0, base);
   } catch (const std::invalid_argument& ia) {
-    return Status(1, "If no conversion could be performed. " + ia.what());
-  } catch (const std::out_of_range& oor) {
     return Status(
-        1, "Value read is out of the range of representable values by an int. " + oor.what());
+        1, std::string("If no conversion could be performed. ") + ia.what());
+  } catch (const std::out_of_range& oor) {
+    return Status(1,
+                  std::string("Value read is out of the range of representable "
+                              "values by an int. ") +
+                      oor.what());
   }
   return Status(0);
 }

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -182,6 +182,19 @@ inline Status safeStrtoll(const std::string& rep, size_t base, long long& out) {
 }
 
 /// Safely convert a string representation of an integer base.
+inline Status safeStrtoi(const std::string& rep, size_t base, int& out) {
+  try {
+    out = std::stoi(rep, 0, base);
+  } catch (const std::invalid_argument& ia) {
+    return Status(1, "If no conversion could be performed.");
+  } catch (const std::out_of_range& oor) {
+    return Status(
+        1, "Value read is out of the range of representable values by an int.");
+  }
+  return Status(0);
+}
+
+/// Safely convert a string representation of an integer base.
 inline Status safeStrtoull(const std::string& rep,
                            size_t base,
                            unsigned long long& out) {

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -182,7 +182,7 @@ inline Status safeStrtoll(const std::string& rep, size_t base, long long& out) {
 }
 
 /// Safely convert a string representation of an integer base.
-inline Status safeStrtoi(const std::string& rep, size_t base, int& out) {
+inline Status safeStrtoi(const std::string& rep, int base, int& out) {
   try {
     out = std::stoi(rep, 0, base);
   } catch (const std::invalid_argument& ia) {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -257,7 +257,7 @@ Status setDatabaseValue(const std::string& domain,
 
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        const int& value) {
+                        int value) {
   return setDatabaseValue(domain, key, std::to_string(value));
 }
 

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -257,7 +257,7 @@ Status setDatabaseValue(const std::string& domain,
 
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
-                        int value) {
+                        const int& value) {
   return setDatabaseValue(domain, key, std::to_string(value));
 }
 
@@ -358,20 +358,8 @@ void resetDatabase() {
 }
 
 void dumpDatabase() {
-  for (const auto& domain : kDomains) {
-    std::vector<std::string> keys;
-    if (!scanDatabaseKeys(domain, keys)) {
-      continue;
-    }
-    for (const auto& key : keys) {
-      std::string value;
-      if (!getDatabaseValue(domain, key, value)) {
-        continue;
-      }
-      fprintf(
-          stdout, "%s[%s]: %s\n", domain.c_str(), key.c_str(), value.c_str());
-    }
-  }
+  auto plugin = getDatabasePlugin();
+  plugin->dumpDatabase();
 }
 
 Status ptreeToRapidJSON(const std::string& in, std::string& out) {

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -18,10 +18,16 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
                                     const std::string& key,
                                     std::string& value) const {
   if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
-    value = boost::get<std::string>(db_.at(domain).at(key));
+    try {
+      value = boost::get<string>(db_.at(domain).at(key));
+    } catch (const std::exception& e) {
+      LOG(WARNING) << "Type error getting string value for (domain,key) : (" << key
+                   << "," << domain << ") " << e.what();
+      return Status(1, "EphemeralDatabasePlugin::get was requested incorrect type(string)");
+    }
     return Status(0);
   } else {
-    return Status(1);
+    return Status(1, "Key or domain does not exist");
   }
 }
 
@@ -34,11 +40,11 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
     } catch (const std::exception& e) {
       LOG(WARNING) << "Type error getting int value for (domain,key) : (" << key
                    << "," << domain << ") " << e.what();
-      return Status(1);
+      return Status(1, "EphemeralDatabasePlugin::get was requested incorrect type(int)");
     }
     return Status(0);
   } else {
-    return Status(1);
+    return Status(1, "Key or domain does not exist");
   }
 }
 

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -20,7 +20,7 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
   if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
     try {
       value = boost::get<std::string>(db_.at(domain).at(key));
-    } catch (const std::exception& e) {
+    } catch (const boost::bad_get& e) {
       LOG(WARNING) << "Type error getting string value for (domain,key) : ("
                    << key << "," << domain << ") " << e.what();
       return Status(
@@ -39,7 +39,7 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
   if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
     try {
       value = boost::get<int>(db_.at(domain).at(key));
-    } catch (const std::exception& e) {
+    } catch (const boost::bad_get& e) {
       LOG(WARNING) << "Type error getting int value for (domain,key) : (" << key
                    << "," << domain << ") " << e.what();
       return Status(

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -14,43 +14,41 @@
 
 namespace osquery {
 
+template <typename T>
+Status EphemeralDatabasePlugin::getAny(const std::string& domain,
+                                       const std::string& key,
+                                       T& value) const {
+  auto domainIterator = db_.find(domain);
+  if (domainIterator == db_.end()) {
+    return Status(1, "Domain " + domain + " does not exist");
+  }
+
+  auto keyIterator = domainIterator->second.find(key);
+  if (keyIterator == domainIterator->second.end()) {
+    return Status(1, "Key " + key + " in domain " + domain + " does not exist");
+  }
+
+  try {
+    value = boost::get<T>(keyIterator->second);
+  } catch (const boost::bad_get& e) {
+    LOG(WARNING) << "Type error getting string value for (domain,key) : ("
+                 << key << "," << domain << ") " << e.what();
+    return Status(
+        1, "EphemeralDatabasePlugin::get was requested incorrect type(string)");
+  }
+  return Status(0);
+}
+
 Status EphemeralDatabasePlugin::get(const std::string& domain,
                                     const std::string& key,
                                     std::string& value) const {
-  if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
-    try {
-      value = boost::get<std::string>(db_.at(domain).at(key));
-    } catch (const boost::bad_get& e) {
-      LOG(WARNING) << "Type error getting string value for (domain,key) : ("
-                   << key << "," << domain << ") " << e.what();
-      return Status(
-          1,
-          "EphemeralDatabasePlugin::get was requested incorrect type(string)");
-    }
-    return Status(0);
-  } else {
-    return Status(1, "Key or domain does not exist");
-  }
+  return this->getAny(domain, key, value);
 }
-
 Status EphemeralDatabasePlugin::get(const std::string& domain,
                                     const std::string& key,
                                     int& value) const {
-  if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
-    try {
-      value = boost::get<int>(db_.at(domain).at(key));
-    } catch (const boost::bad_get& e) {
-      LOG(WARNING) << "Type error getting int value for (domain,key) : (" << key
-                   << "," << domain << ") " << e.what();
-      return Status(
-          1, "EphemeralDatabasePlugin::get was requested incorrect type(int)");
-    }
-    return Status(0);
-  } else {
-    return Status(1, "Key or domain does not exist");
-  }
+  return this->getAny(domain, key, value);
 }
-
 Status EphemeralDatabasePlugin::put(const std::string& domain,
                                     const std::string& key,
                                     const std::string& value) {

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -60,7 +60,7 @@ Status EphemeralDatabasePlugin::put(const std::string& domain,
 
 Status EphemeralDatabasePlugin::put(const std::string& domain,
                                     const std::string& key,
-                                    const int& value) {
+                                    int value) {
   db_[domain][key] = value;
   return Status(0);
 }

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -19,11 +19,13 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
                                     std::string& value) const {
   if (db_.count(domain) > 0 && db_.at(domain).count(key) > 0) {
     try {
-      value = boost::get<string>(db_.at(domain).at(key));
+      value = boost::get<std::string>(db_.at(domain).at(key));
     } catch (const std::exception& e) {
-      LOG(WARNING) << "Type error getting string value for (domain,key) : (" << key
-                   << "," << domain << ") " << e.what();
-      return Status(1, "EphemeralDatabasePlugin::get was requested incorrect type(string)");
+      LOG(WARNING) << "Type error getting string value for (domain,key) : ("
+                   << key << "," << domain << ") " << e.what();
+      return Status(
+          1,
+          "EphemeralDatabasePlugin::get was requested incorrect type(string)");
     }
     return Status(0);
   } else {
@@ -40,7 +42,8 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
     } catch (const std::exception& e) {
       LOG(WARNING) << "Type error getting int value for (domain,key) : (" << key
                    << "," << domain << ") " << e.what();
-      return Status(1, "EphemeralDatabasePlugin::get was requested incorrect type(int)");
+      return Status(
+          1, "EphemeralDatabasePlugin::get was requested incorrect type(int)");
     }
     return Status(0);
   } else {

--- a/osquery/database/plugins/ephemeral.h
+++ b/osquery/database/plugins/ephemeral.h
@@ -12,23 +12,35 @@
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 
+#include "boost/variant.hpp"
+
 namespace osquery {
 
 DECLARE_string(database_path);
 
 class EphemeralDatabasePlugin : public DatabasePlugin {
-  using DBType = std::map<std::string, std::map<std::string, std::string>>;
+  using DBType =
+      std::map<std::string,
+               std::map<std::string, boost::variant<int, std::string>>>;
 
  public:
   /// Data retrieval method.
   Status get(const std::string& domain,
              const std::string& key,
              std::string& value) const override;
+  Status get(const std::string& domain,
+             const std::string& key,
+             int& value) const override;
 
   /// Data storage method.
   Status put(const std::string& domain,
              const std::string& key,
              const std::string& value) override;
+  Status put(const std::string& domain,
+             const std::string& key,
+             const int& value) override;
+
+  void dumpDatabase() const override;
 
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;

--- a/osquery/database/plugins/ephemeral.h
+++ b/osquery/database/plugins/ephemeral.h
@@ -38,7 +38,7 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
              const std::string& value) override;
   Status put(const std::string& domain,
              const std::string& key,
-             const int& value) override;
+             int value) override;
 
   void dumpDatabase() const override;
 

--- a/osquery/database/plugins/ephemeral.h
+++ b/osquery/database/plugins/ephemeral.h
@@ -22,16 +22,20 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
   using DBType =
       std::map<std::string,
                std::map<std::string, boost::variant<int, std::string>>>;
+  template <typename T>
+  Status getAny(const std::string& domain,
+                const std::string& key,
+                T& value) const;
 
  public:
   /// Data retrieval method.
+
   Status get(const std::string& domain,
              const std::string& key,
              std::string& value) const override;
   Status get(const std::string& domain,
              const std::string& key,
              int& value) const override;
-
   /// Data storage method.
   Status put(const std::string& domain,
              const std::string& key,

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -254,6 +254,16 @@ Status RocksDBDatabasePlugin::get(const std::string& domain,
   return Status(s.code(), s.ToString());
 }
 
+Status RocksDBDatabasePlugin::get(const std::string& domain,
+                                  const std::string& key,
+                                  int& value) const {
+  std::string result;
+  auto s = this->get(domain, key, result);
+  if (s.ok()) {
+    value = std::stoi(result);
+  }
+  return s;
+}
 Status RocksDBDatabasePlugin::put(const std::string& domain,
                                   const std::string& key,
                                   const std::string& value) {
@@ -283,6 +293,14 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
   }
   return Status(s.code(), s.ToString());
 }
+
+Status RocksDBDatabasePlugin::put(const std::string& domain,
+                                  const std::string& key,
+                                  const int& value) {
+  return this->put(domain, key, std::to_string(value));
+}
+
+void RocksDBDatabasePlugin::dumpDatabase() const {}
 
 Status RocksDBDatabasePlugin::remove(const std::string& domain,
                                      const std::string& key) {

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -20,6 +20,7 @@
 
 #include "osquery/database/plugins/rocksdb.h"
 #include "osquery/filesystem/fileops.h"
+#include "osquery/core/conversions.h"
 
 namespace fs = boost::filesystem;
 
@@ -260,7 +261,9 @@ Status RocksDBDatabasePlugin::get(const std::string& domain,
   std::string result;
   auto s = this->get(domain, key, result);
   if (s.ok()) {
-    value = std::stoi(result);
+    if (safeStrtoi(result, 10, value)) {
+      return Status(1, "Could not deserialize str to int");
+    }
   }
   return s;
 }

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -296,7 +296,7 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
 
 Status RocksDBDatabasePlugin::put(const std::string& domain,
                                   const std::string& key,
-                                  const int& value) {
+                                  int value) {
   return this->put(domain, key, std::to_string(value));
 }
 

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -18,9 +18,9 @@
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 
+#include "osquery/core/conversions.h"
 #include "osquery/database/plugins/rocksdb.h"
 #include "osquery/filesystem/fileops.h"
-#include "osquery/core/conversions.h"
 
 namespace fs = boost::filesystem;
 

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -39,10 +39,20 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
              const std::string& key,
              std::string& value) const override;
 
+  Status get(const std::string& domain,
+             const std::string& key,
+             int& value) const override;
+
   /// Data storage method.
   Status put(const std::string& domain,
              const std::string& key,
              const std::string& value) override;
+
+  Status put(const std::string& domain,
+             const std::string& key,
+             const int& value) override;
+
+  void dumpDatabase() const override;
 
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -50,7 +50,7 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
 
   Status put(const std::string& domain,
              const std::string& key,
-             const int& value) override;
+             int value) override;
 
   void dumpDatabase() const override;
 

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -192,7 +192,7 @@ Status SQLiteDatabasePlugin::put(const std::string& domain,
 
 Status SQLiteDatabasePlugin::put(const std::string& domain,
                                  const std::string& key,
-                                 const int& value) {
+                                 int value) {
   return this->put(domain, key, std::to_string(value));
 }
 

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -14,9 +14,9 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
+#include "osquery/core/conversions.h"
 #include "osquery/database/plugins/sqlite.h"
 #include "osquery/filesystem/fileops.h"
-#include "osquery/core/conversions.h"
 
 namespace osquery {
 

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -16,6 +16,7 @@
 
 #include "osquery/database/plugins/sqlite.h"
 #include "osquery/filesystem/fileops.h"
+#include "osquery/core/conversions.h"
 
 namespace osquery {
 
@@ -145,7 +146,9 @@ Status SQLiteDatabasePlugin::get(const std::string& domain,
   std::string result;
   auto s = this->get(domain, key, result);
   if (s.ok()) {
-    value = std::stoi(result);
+    if (safeStrtoi(result, 10, value)) {
+      return Status(1, "Could not deserialize str to int");
+    }
   }
   return s;
 }

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -139,6 +139,17 @@ Status SQLiteDatabasePlugin::get(const std::string& domain,
   return Status(1);
 }
 
+Status SQLiteDatabasePlugin::get(const std::string& domain,
+                                 const std::string& key,
+                                 int& value) const {
+  std::string result;
+  auto s = this->get(domain, key, result);
+  if (s.ok()) {
+    value = std::stoi(result);
+  }
+  return s;
+}
+
 static void tryVacuum(sqlite3* db) {
   std::string q =
       "SELECT (sum(s1.pageno + 1 == s2.pageno) * 1.0 / count(*)) < 0.01 as v "
@@ -179,6 +190,12 @@ Status SQLiteDatabasePlugin::put(const std::string& domain,
   return Status(0);
 }
 
+Status SQLiteDatabasePlugin::put(const std::string& domain,
+                                 const std::string& key,
+                                 const int& value) {
+  return this->put(domain, key, std::to_string(value));
+}
+
 Status SQLiteDatabasePlugin::remove(const std::string& domain,
                                     const std::string& key) {
   if (read_only_) {
@@ -201,6 +218,8 @@ Status SQLiteDatabasePlugin::remove(const std::string& domain,
   }
   return Status(0);
 }
+
+void SQLiteDatabasePlugin::dumpDatabase() const {}
 
 Status SQLiteDatabasePlugin::removeRange(const std::string& domain,
                                          const std::string& low,

--- a/osquery/database/plugins/sqlite.h
+++ b/osquery/database/plugins/sqlite.h
@@ -27,11 +27,19 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
   Status get(const std::string& domain,
              const std::string& key,
              std::string& value) const override;
+  Status get(const std::string& domain,
+             const std::string& key,
+             int& value) const override;
 
   /// Data storage method.
   Status put(const std::string& domain,
              const std::string& key,
              const std::string& value) override;
+  Status put(const std::string& domain,
+             const std::string& key,
+             const int& value) override;
+
+  void dumpDatabase() const override;
 
   /// Data removal method.
   Status remove(const std::string& domain, const std::string& k) override;

--- a/osquery/database/plugins/sqlite.h
+++ b/osquery/database/plugins/sqlite.h
@@ -37,7 +37,7 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
              const std::string& value) override;
   Status put(const std::string& domain,
              const std::string& key,
-             const int& value) override;
+             int value) override;
 
   void dumpDatabase() const override;
 


### PR DESCRIPTION
Ephemeral supports int without serialization.
Dump get and put pushed from database.cpp to the database plugin.
Basic support for rocksDB and sqlite