### PR TITLE
rocksDB simplify

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -74,55 +74,50 @@ void GlogRocksDBLogger::Logv(const char* format, va_list ap) {
 }
 
 Status RocksDBDatabasePlugin::setUp() {
-  /// Column family descriptors which are used to connect to RocksDB
-  std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
-  /// The RocksDB connection options that are used to connect to RocksDB
-  rocksdb::Options options;
-
   if (!DatabasePlugin::kDBAllowOpen) {
     LOG(WARNING) << RLOG(1629) << "Not allowed to set up database plugin";
   }
 
   if (!initialized_) {
     initialized_ = true;
-    options.OptimizeForSmallDb();
+    options_.OptimizeForSmallDb();
 
     // Set meta-data (mostly) handling options.
-    options.create_if_missing = true;
-    options.create_missing_column_families = true;
-    options.info_log_level = rocksdb::ERROR_LEVEL;
-    options.log_file_time_to_roll = 0;
-    options.keep_log_file_num = 10;
-    options.max_log_file_size = 1024 * 1024 * 1;
-    options.max_open_files = 128;
-    options.stats_dump_period_sec = 0;
-    options.max_manifest_file_size = 1024 * 500;
+    options_.create_if_missing = true;
+    options_.create_missing_column_families = true;
+    options_.info_log_level = rocksdb::ERROR_LEVEL;
+    options_.log_file_time_to_roll = 0;
+    options_.keep_log_file_num = 10;
+    options_.max_log_file_size = 1024 * 1024 * 1;
+    options_.max_open_files = 128;
+    options_.stats_dump_period_sec = 0;
+    options_.max_manifest_file_size = 1024 * 500;
 
     // Performance and optimization settings.
     // Use rocksdb::kZSTD to use ZSTD database compression
-    options.compression = rocksdb::kNoCompression;
-    options.compaction_style = rocksdb::kCompactionStyleLevel;
-    options.arena_block_size = (4 * 1024);
-    options.write_buffer_size = (4 * 1024) * FLAGS_rocksdb_buffer_blocks;
-    options.max_write_buffer_number =
+    options_.compression = rocksdb::kNoCompression;
+    options_.compaction_style = rocksdb::kCompactionStyleLevel;
+    options_.arena_block_size = (4 * 1024);
+    options_.write_buffer_size = (4 * 1024) * FLAGS_rocksdb_buffer_blocks;
+    options_.max_write_buffer_number =
         static_cast<int>(FLAGS_rocksdb_write_buffer);
-    options.min_write_buffer_number_to_merge =
+    options_.min_write_buffer_number_to_merge =
         static_cast<int>(FLAGS_rocksdb_merge_number);
-    options.max_background_flushes =
+    options_.max_background_flushes =
         static_cast<int>(FLAGS_rocksdb_background_flushes);
 
     // Create an environment to replace the default logger.
     if (logger_ == nullptr) {
       logger_ = std::make_shared<GlogRocksDBLogger>();
     }
-    options.info_log = logger_;
+    options_.info_log = logger_;
 
-    column_families.push_back(rocksdb::ColumnFamilyDescriptor(
-        rocksdb::kDefaultColumnFamilyName, options));
+    column_families_.push_back(rocksdb::ColumnFamilyDescriptor(
+        rocksdb::kDefaultColumnFamilyName, options_));
 
     for (const auto& cf_name : kDomains) {
-      column_families.push_back(
-          rocksdb::ColumnFamilyDescriptor(cf_name, options));
+      column_families_.push_back(
+          rocksdb::ColumnFamilyDescriptor(cf_name, options_));
     }
   }
 
@@ -142,12 +137,13 @@ Status RocksDBDatabasePlugin::setUp() {
   close();
 
   // Attempt to create a RocksDB instance and handles.
-  auto s = rocksdb::DB::Open(options, path_, column_families, &handles_, &db_);
+  auto s =
+      rocksdb::DB::Open(options_, path_, column_families_, &handles_, &db_);
 
   if (s.IsCorruption()) {
     // The database is corrupt - try to repair it
     repairDB();
-    s = rocksdb::DB::Open(options, path_, column_families, &handles_, &db_);
+    s = rocksdb::DB::Open(options_, path_, column_families_, &handles_, &db_);
   }
 
   if (!s.ok() || db_ == nullptr) {

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -120,14 +120,8 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
   /// RocksDB logger instance.
   std::shared_ptr<GlogRocksDBLogger> logger_{nullptr};
 
-  /// Column family descriptors which are used to connect to RocksDB
-  std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
-
   /// A vector of pointers to column family handles
   std::vector<rocksdb::ColumnFamilyHandle*> handles_;
-
-  /// The RocksDB connection options that are used to connect to RocksDB
-  rocksdb::Options options_;
 
   /// Deconstruction mutex.
   Mutex close_mutex_;

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -123,11 +123,11 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
   /// Column family descriptors which are used to connect to RocksDB
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
 
-  /// The RocksDB connection options that are used to connect to RocksDB
-  rocksdb::Options options_;
-
   /// A vector of pointers to column family handles
   std::vector<rocksdb::ColumnFamilyHandle*> handles_;
+
+  /// The RocksDB connection options that are used to connect to RocksDB
+  rocksdb::Options options_;
 
   /// Deconstruction mutex.
   Mutex close_mutex_;

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -120,6 +120,12 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
   /// RocksDB logger instance.
   std::shared_ptr<GlogRocksDBLogger> logger_{nullptr};
 
+  /// Column family descriptors which are used to connect to RocksDB
+  std::vector<rocksdb::ColumnFamilyDescriptor> column_families_;
+
+  /// The RocksDB connection options that are used to connect to RocksDB
+  rocksdb::Options options_;
+
   /// A vector of pointers to column family handles
   std::vector<rocksdb::ColumnFamilyHandle*> handles_;
 


### PR DESCRIPTION
unnecessary private variables moved to functions.
Find method replaced by std::find