### PR TITLE
Fix Mojave BSSIDs

### DIFF
--- a/osquery/tables/networking/darwin/wifi_survey.mm
+++ b/osquery/tables/networking/darwin/wifi_survey.mm
@@ -33,13 +33,16 @@ QueryData genWifiScan(QueryContext& context) {
 
       for (CWNetwork* network in networks) {
         Row r;
-        r["interface"] = std::string([[interface interfaceName] UTF8String]);
+        r["interface"] = [[interface interfaceName] UTF8String];
         r["ssid"] = extractSsid((__bridge CFDataRef)[network ssidData]);
-        r["bssid"] = std::string([[network bssid] UTF8String]);
-        r["network_name"] = std::string([[network ssid] UTF8String]);
+        auto bssid = [network bssid];
+        if (bssid != nullptr) {
+          r["bssid"] = [bssid UTF8String];
+        }
+        r["network_name"] = [[network ssid] UTF8String];
         NSString* country_code = [network countryCode];
         if (country_code != nil) {
-          r["country_code"] = std::string([country_code UTF8String]);
+          r["country_code"] = [country_code UTF8String];
         }
         r["rssi"] = INTEGER([network rssiValue]);
         r["noise"] = INTEGER([network noiseMeasurement]);


### PR DESCRIPTION
In Mojave, BSSIDs are not returned if location services are disabled.

This checks that there are returned before pulling a string out. It all removes
some extra string casts.