### PR TITLE
Set parent to -1 on process_events

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -158,6 +158,10 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     GetStringFieldFromMap(
         row["owner_gid"], first_path_event_record->fields, "ogid", "0");
 
+    // We currently do not support parent, however parent is a BIGINT so it
+    // needs to be set. Set it to -1.
+    row["parent"] = "-1";
+
     emitted_row_list.push_back(row);
   }
 

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -158,8 +158,7 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     GetStringFieldFromMap(
         row["owner_gid"], first_path_event_record->fields, "ogid", "0");
 
-    // We currently do not support parent, however parent is a BIGINT so it
-    // needs to be set. Set it to -1.
+    // Parent is currently not supported on Linux.
     row["parent"] = "-1";
 
     emitted_row_list.push_back(row);

--- a/specs/posix/process_events.table
+++ b/specs/posix/process_events.table
@@ -30,7 +30,7 @@ schema([
     Column("btime", BIGINT, "File creation in UNIX time",
         aliases=["create_time"]),
     Column("overflows", TEXT, "List of structures that overflowed", hidden=True),
-    Column("parent", BIGINT, "Process parent's PID"),
+    Column("parent", BIGINT, "Process parent's PID, or -1 if cannot be determined."),
     Column("time", BIGINT, "Time of execution in UNIX time"),
     Column("uptime", BIGINT, "Time of execution in system uptime"),
     Column("status", BIGINT, "OpenBSM Attribute: Status of the process"),


### PR DESCRIPTION
parent is not provided on linux, but because it is a BIGINT it needs to exist or the casts are going to fail polluting the logs. Set it to -1.