### PR TITLE
bug split(string,string,size_t)

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -384,28 +384,6 @@ std::vector<std::string> split(const std::string& s, const std::string& delim) {
   return elems;
 }
 
-std::vector<std::string> split(const std::string& s,
-                               const std::string& delim,
-                               size_t occurences) {
-  // Split the string normally with the required delimiter.
-  auto content = split(s, delim);
-  // While the result split exceeds the number of requested occurrences, join.
-  std::vector<std::string> accumulator;
-  std::vector<std::string> elems;
-  for (size_t i = 0; i < content.size(); i++) {
-    if (i < occurences) {
-      elems.push_back(content.at(i));
-    } else {
-      accumulator.push_back(content.at(i));
-    }
-  }
-  // Join the optional accumulator.
-  if (accumulator.size() > 0) {
-    elems.push_back(join(accumulator, delim));
-  }
-  return elems;
-}
-
 std::string join(const std::vector<std::string>& s, const std::string& tok) {
   return boost::algorithm::join(s, tok);
 }

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -385,10 +385,11 @@ std::vector<std::string> split(const std::string& s, const std::string& delim) {
 }
 
 std::vector<std::string> split(const std::string& s,
-                               const std::string& delim,
+                               char delim,
                                size_t occurences) {
+  auto delims = std::string(1, delim);
   // Split the string normally with the required delimiter.
-  auto content = split(s, delim);
+  auto content = split(s, delims);
   // While the result split exceeds the number of requested occurrences, join.
   std::vector<std::string> accumulator;
   std::vector<std::string> elems;
@@ -401,7 +402,7 @@ std::vector<std::string> split(const std::string& s,
   }
   // Join the optional accumulator.
   if (accumulator.size() > 0) {
-    elems.push_back(join(accumulator, delim));
+    elems.push_back(join(accumulator, delims));
   }
   return elems;
 }

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -384,6 +384,28 @@ std::vector<std::string> split(const std::string& s, const std::string& delim) {
   return elems;
 }
 
+std::vector<std::string> split(const std::string& s,
+                               const std::string& delim,
+                               size_t occurences) {
+  // Split the string normally with the required delimiter.
+  auto content = split(s, delim);
+  // While the result split exceeds the number of requested occurrences, join.
+  std::vector<std::string> accumulator;
+  std::vector<std::string> elems;
+  for (size_t i = 0; i < content.size(); i++) {
+    if (i < occurences) {
+      elems.push_back(content.at(i));
+    } else {
+      accumulator.push_back(content.at(i));
+    }
+  }
+  // Join the optional accumulator.
+  if (accumulator.size() > 0) {
+    elems.push_back(join(accumulator, delim));
+  }
+  return elems;
+}
+
 std::string join(const std::vector<std::string>& s, const std::string& tok) {
   return boost::algorithm::join(s, tok);
 }

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -67,6 +67,19 @@ std::vector<std::string> split(const std::string& s,
                                const std::string& delim = "\t ");
 
 /**
+ * @brief Split a given string based on an delimiter.
+ *
+ * @param s the string that you'd like to split.
+ * @param delim the delimiter which you'd like to split the string by.
+ * @param occurrences the number of times to split by delim.
+ *
+ * @return a vector of strings split by delim for occurrences.
+ */
+std::vector<std::string> split(const std::string& s,
+                               char delim,
+                               size_t occurences);
+
+/**
  * @brief In-line replace all instances of from with to.
  *
  * @param str The input/output mutable string.

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -67,19 +67,6 @@ std::vector<std::string> split(const std::string& s,
                                const std::string& delim = "\t ");
 
 /**
- * @brief Split a given string based on an delimiter.
- *
- * @param s the string that you'd like to split.
- * @param delim the delimiter which you'd like to split the string by.
- * @param occurrences the number of times to split by delim.
- *
- * @return a vector of strings split by delim for occurrences.
- */
-std::vector<std::string> split(const std::string& s,
-                               const std::string& delim,
-                               size_t occurences);
-
-/**
  * @brief In-line replace all instances of from with to.
  *
  * @param str The input/output mutable string.
@@ -126,7 +113,7 @@ std::string join(const std::set<std::string>& s, const std::string& tok);
  * @param encoded The encode base64 string.
  * @return Decoded string.
  */
-std::string base64Decode(const std::string& encoded);
+std::string base64Decode(std::string encoded);
 
 /**
  * @brief Encode a  string.

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -113,7 +113,7 @@ std::string join(const std::set<std::string>& s, const std::string& tok);
  * @param encoded The encode base64 string.
  * @return Decoded string.
  */
-std::string base64Decode(std::string encoded);
+std::string base64Decode(const std::string& encoded);
 
 /**
  * @brief Encode a  string.

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -91,14 +91,6 @@ TEST_F(ConversionsTests, test_join) {
   EXPECT_EQ(join(content, ", "), "one, two, three");
 }
 
-TEST_F(ConversionsTests, test_split_occurences) {
-  std::string content = "T: 'S:S'";
-  std::vector<std::string> expected = {
-      "T", "'S:S'",
-  };
-  EXPECT_EQ(split(content, ":", 1), expected);
-}
-
 TEST_F(ConversionsTests, test_buffer_sha1) {
   std::string test = "test\n";
   EXPECT_EQ("4e1243bd22c66e76c2ba9eddc1f91394e57f9f83",

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -91,6 +91,14 @@ TEST_F(ConversionsTests, test_join) {
   EXPECT_EQ(join(content, ", "), "one, two, three");
 }
 
+TEST_F(ConversionsTests, test_split_occurences) {
+  std::string content = "T: 'S:S'";
+  std::vector<std::string> expected = {
+      "T", "'S:S'",
+  };
+  EXPECT_EQ(split(content, ':', 1), expected);
+}
+
 TEST_F(ConversionsTests, test_buffer_sha1) {
   std::string test = "test\n";
   EXPECT_EQ("4e1243bd22c66e76c2ba9eddc1f91394e57f9f83",

--- a/osquery/tables/system/linux/md_tables.cpp
+++ b/osquery/tables/system/linux/md_tables.cpp
@@ -463,7 +463,7 @@ void MD::parseMDStat(const std::vector<std::string>& lines, MDStat& result) {
     // Work off of first 2 character instead of just the first to be safe.
     std::string firstTwo = lines[n].substr(0, 2);
     if (firstTwo == "md") {
-      auto mdline(split(lines[n], ":", 1));
+      auto mdline(split(lines[n], ':', 1));
       if (mdline.size() < 2) {
         LOG(WARNING) << "Unexpected md device line structure: " << lines[n];
         n += 1;

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -49,7 +49,7 @@ void genOSRelease(Row& r) {
   }
 
   for (const auto& line : osquery::split(content, "\n")) {
-    auto fields = osquery::split(line, "=", 1);
+    auto fields = osquery::split(line, '=', 1);
     if (fields.size() != 2) {
       continue;
     }

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -69,7 +69,7 @@ void genOSRelease(Row& r) {
     }
 
     if (column.get() == "_id") {
-      auto parts = osquery::split(r.at(column), ".", 2);
+      auto parts = osquery::split(r.at(column), '.', 2);
       switch (parts.size()) {
       case 3:
         r["patch"] = parts[2];

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -253,7 +253,7 @@ SimpleProcStat::SimpleProcStat(const std::string& pid) {
 
   for (const auto& line : osquery::split(content, "\n")) {
     // Status lines are formatted: Key: Value....\n.
-    auto detail = osquery::split(line, ":", 1);
+    auto detail = osquery::split(line, ':', 1);
     if (detail.size() != 2) {
       continue;
     }
@@ -313,7 +313,7 @@ SimpleProcIo::SimpleProcIo(const std::string& pid) {
 
   for (const auto& line : osquery::split(content, "\n")) {
     // IO lines are formatted: Key: Value....\n.
-    auto detail = osquery::split(line, ":", 1);
+    auto detail = osquery::split(line, ':', 1);
     if (detail.size() != 2) {
       continue;
     }


### PR DESCRIPTION
split contained bug, it was joining on every delimiter, which would result to unusual outcome. However, test could not detect this problem as delim.size() was 1. 