### PR TITLE
Added ntfs acl permissions virtual table

### DIFF
--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -28,7 +28,7 @@ namespace osquery {
 namespace tables {
 
 // map to get access mode string
-static const std::unordered_map<ACCESS_MODE, std::string> accessModeToStr = {
+static const std::unordered_map<ACCESS_MODE, std::string> kAccessModeToStr = {
     {NOT_USED_ACCESS, "Not Used"},
     {GRANT_ACCESS, "Grant"},
     {SET_ACCESS, "Set"},
@@ -38,7 +38,7 @@ static const std::unordered_map<ACCESS_MODE, std::string> accessModeToStr = {
     {SET_AUDIT_FAILURE, "Set Audit Failure"}};
 
 // map to build access string
-static const std::map<unsigned long, std::string> permVals = {
+static const std::map<unsigned long, std::string> kPermVals = {
     {DELETE, "Delete"},
     {READ_CONTROL, "Read Control"},
     {WRITE_DAC, "Write DAC"},
@@ -55,19 +55,19 @@ static const std::map<unsigned long, std::string> permVals = {
     {GENERIC_ALL, "Generic All"}};
 
 // map to get inheritance string
-static const std::unordered_map<unsigned long, std::string> inheritanceToStr = {
-    {CONTAINER_INHERIT_ACE, "Container Inherit Ace"},
-    {INHERIT_NO_PROPAGATE, "Inherit No Propagate"},
-    {INHERIT_ONLY, "Inherit Only"},
-    {OBJECT_INHERIT_ACE, "Object Inherit Ace"},
-    {SUB_CONTAINERS_AND_OBJECTS_INHERIT, "Sub containers and Objects Inherit"},
-    {NO_INHERITANCE, "No Inheritence"}};
+static const std::unordered_map<unsigned long, std::string> kInheritanceToStr =
+    {{CONTAINER_INHERIT_ACE, "Container Inherit Ace"},
+     {INHERIT_NO_PROPAGATE, "Inherit No Propagate"},
+     {INHERIT_ONLY, "Inherit Only"},
+     {OBJECT_INHERIT_ACE, "Object Inherit Ace"},
+     {SUB_CONTAINERS_AND_OBJECTS_INHERIT, "Sub containers and Objects Inherit"},
+     {NO_INHERITANCE, "No Inheritence"}};
 
 // helper function to build access string from permission bit mask
 std::string accessPermsToStr(const unsigned long pmask) {
   std::vector<std::string> permList;
 
-  for (auto const& perm : permVals) {
+  for (auto const& perm : kPermVals) {
     if ((pmask & perm.first) != 0) {
       permList.push_back(perm.second);
     }
@@ -88,9 +88,9 @@ std::string trusteeToStr(const TRUSTEE& trustee) {
   case TRUSTEE_IS_SID: {
     // get the name from the SID
     PSID psid = trustee.ptstrName;
-    auto size = kMaxBuffSize;
+    auto sizea = kMaxBuffSize;
     auto r = LookupAccountSid(
-        nullptr, psid, name, &size, domain, &size, &accountType);
+        nullptr, psid, name, &sizea, domain, &size, &accountType);
     if (r == FALSE) {
       VLOG(1) << "LookupAccountSid error: " << GetLastError();
       return "";
@@ -108,9 +108,9 @@ std::string trusteeToStr(const TRUSTEE& trustee) {
   case TRUSTEE_IS_OBJECTS_AND_SID: {
     // ptstrName member is a pointer to an OBJECTS_AND_SID struct
     auto psid = reinterpret_cast<POBJECTS_AND_SID>(trustee.ptstrName)->pSid;
-    auto size = kMaxBuffSize;
+    auto sizeb = kMaxBuffSize;
     auto r = LookupAccountSid(
-        nullptr, psid, name, &size, domain, &size, &accountType);
+        nullptr, psid, name, &sizeb, domain, &size, &accountType);
     if (r == FALSE) {
       VLOG(1) << "LookupAccountSid error: " << GetLastError();
       return "";
@@ -165,9 +165,9 @@ QueryData genNtfsAclPerms(QueryContext& context) {
       Row r;
 
       auto perms = accessPermsToStr(aceItem->grfAccessPermissions);
-      auto accessMode = accessModeToStr.find(aceItem->grfAccessMode)->second;
+      auto accessMode = kAccessModeToStr.find(aceItem->grfAccessMode)->second;
       auto inheritedFrom =
-          inheritanceToStr.find(aceItem->grfInheritance)->second;
+          kInheritanceToStr.find(aceItem->grfInheritance)->second;
       auto trusteeName = trusteeToStr(aceItem->Trustee);
 
       r["path"] = TEXT(pathString);

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -79,16 +79,16 @@ std::string accessPermsToStr(const unsigned long pmask) {
 // helper function to get account/group name from trustee
 std::string trusteeToStr(const TRUSTEE& trustee) {
   // Max username length for Windows
-  const unsigned long kMaxBuffSize = 256;
-  char name[kMaxBuffSize];
-  char domain[kMaxBuffSize];
+  const unsigned long maxBuffSize = 256;
+  char name[maxBuffSize];
+  char domain[maxBuffSize];
   SID_NAME_USE accountType;
 
   switch (trustee.TrusteeForm) {
   case TRUSTEE_IS_SID: {
     // get the name from the SID
     PSID psid = trustee.ptstrName;
-    auto sizea = kMaxBuffSize;
+    auto sizea = maxBuffSize;
     auto r = LookupAccountSid(
         nullptr, psid, name, &sizea, domain, &size, &accountType);
     if (r == FALSE) {
@@ -108,7 +108,7 @@ std::string trusteeToStr(const TRUSTEE& trustee) {
   case TRUSTEE_IS_OBJECTS_AND_SID: {
     // ptstrName member is a pointer to an OBJECTS_AND_SID struct
     auto psid = reinterpret_cast<POBJECTS_AND_SID>(trustee.ptstrName)->pSid;
-    auto sizeb = kMaxBuffSize;
+    auto sizeb = maxBuffSize;
     auto r = LookupAccountSid(
         nullptr, psid, name, &sizeb, domain, &size, &accountType);
     if (r == FALSE) {

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -8,17 +8,17 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <windows.h>
 #include <AccCtrl.h>
 #include <Aclapi.h>
-#include <string>
 #include <map>
+#include <string>
 #include <vector>
+#include <windows.h>
 
-#include <osquery/logger.h>
-#include <osquery/tables.h>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/filesystem.hpp>
+#include <osquery/logger.h>
+#include <osquery/tables.h>
 
 namespace alg = boost::algorithm;
 namespace fs = boost::filesystem;
@@ -28,200 +28,179 @@ namespace tables {
 
 // helper function to get access mode string
 std::string accessModeToStr(const _ACCESS_MODE& accessMode) {
-	switch (accessMode) {
-	case NOT_USED_ACCESS:
-		return "Not Used";
-	case GRANT_ACCESS:
-		return "Grant";
-	case SET_ACCESS:
-		return "Set";
-	case DENY_ACCESS:
-		return "Deny";
-	case REVOKE_ACCESS:
-		return "Revoke";
-	case SET_AUDIT_SUCCESS:
-		return "Set Audit Success";
-	case SET_AUDIT_FAILURE:
-		return "Set Audit Failure";
-	default:
-		return "Unknown";
-	}
+  switch (accessMode) {
+  case NOT_USED_ACCESS:
+    return "Not Used";
+  case GRANT_ACCESS:
+    return "Grant";
+  case SET_ACCESS:
+    return "Set";
+  case DENY_ACCESS:
+    return "Deny";
+  case REVOKE_ACCESS:
+    return "Revoke";
+  case SET_AUDIT_SUCCESS:
+    return "Set Audit Success";
+  case SET_AUDIT_FAILURE:
+    return "Set Audit Failure";
+  }
+  return "";
 }
 
 // helper function to build access string from permission bit mask
 std::string accessPermsToStr(const unsigned long pmask) {
-	std::vector<std::string> permList;
-	std::string permStr = "";
-	const std::map<unsigned long, std::string> permVals = {
-		{ DELETE                         ,"Delete" },
-		{ READ_CONTROL                   ,"Read Control" },
-		{ WRITE_DAC                      ,"Write DAC" },
-		{ WRITE_OWNER                    ,"Write Owner" },
-		{ SYNCHRONIZE                    ,"Synchronize" },
-		{ STANDARD_RIGHTS_REQUIRED       ,"Std Rights Required" },
-		{ STANDARD_RIGHTS_ALL            ,"Std Rights All" },
-		{ SPECIFIC_RIGHTS_ALL            ,"Specific Rights All" },
-		{ ACCESS_SYSTEM_SECURITY         ,"Access System Security" },
-		{ MAXIMUM_ALLOWED                ,"Maximum Allowed" },
-		{ GENERIC_READ                   ,"Generic Read" },
-		{ GENERIC_WRITE                  ,"Generic Write" },
-		{ GENERIC_EXECUTE                ,"Generic Execute" },
-		{ GENERIC_ALL                    ,"Generic All" }
-	};
+  std::vector<std::string> permList;
+  const std::map<unsigned long, std::string> permVals = {
+      {DELETE, "Delete"},
+      {READ_CONTROL, "Read Control"},
+      {WRITE_DAC, "Write DAC"},
+      {WRITE_OWNER, "Write Owner"},
+      {SYNCHRONIZE, "Synchronize"},
+      {STANDARD_RIGHTS_REQUIRED, "Std Rights Required"},
+      {STANDARD_RIGHTS_ALL, "Std Rights All"},
+      {SPECIFIC_RIGHTS_ALL, "Specific Rights All"},
+      {ACCESS_SYSTEM_SECURITY, "Access System Security"},
+      {MAXIMUM_ALLOWED, "Maximum Allowed"},
+      {GENERIC_READ, "Generic Read"},
+      {GENERIC_WRITE, "Generic Write"},
+      {GENERIC_EXECUTE, "Generic Execute"},
+      {GENERIC_ALL, "Generic All"}};
 
-	for (auto const& perm : permVals) {
-		if ((pmask & perm.first) != 0)
-			permList.push_back(perm.second);
-	}
+  for (auto const& perm : permVals) {
+    if ((pmask & perm.first) != 0) {
+      permList.push_back(perm.second);
+    }
+  }
 
-	permStr = alg::join(permList, ",");
-	return permStr;
+  return alg::join(permList, ",");
 }
 
 // helper function to convert inheritance type to string
 std::string inheritanceToStr(const unsigned long i) {
-	switch (i) {
-	case CONTAINER_INHERIT_ACE: // equivalent to SUB_CONTAINERS_ONLY_INHERIT
-		return "Container Inherit Ace";
-	case INHERIT_NO_PROPAGATE: // equivalent to NO_PROPAGATE_INHERIT_ACE
-		return "Inherit No Propagate";
-	case INHERIT_ONLY: // equivalent to INHERIT_ONLY_ACE
-		return "Inherit Only";
-	case OBJECT_INHERIT_ACE: // equivalent to SUB_OBJECTS_ONLY_INHERIT
-		return "Object Inherit Ace";
-	case SUB_CONTAINERS_AND_OBJECTS_INHERIT:
-		return "Sub containers and Objects Inherit";
-	case NO_INHERITANCE:
-		return "No Inheritence";
-	default:
-		return "Other";
-	}
+  switch (i) {
+  case CONTAINER_INHERIT_ACE: // equivalent to SUB_CONTAINERS_ONLY_INHERIT
+    return "Container Inherit Ace";
+  case INHERIT_NO_PROPAGATE: // equivalent to NO_PROPAGATE_INHERIT_ACE
+    return "Inherit No Propagate";
+  case INHERIT_ONLY: // equivalent to INHERIT_ONLY_ACE
+    return "Inherit Only";
+  case OBJECT_INHERIT_ACE: // equivalent to SUB_OBJECTS_ONLY_INHERIT
+    return "Object Inherit Ace";
+  case SUB_CONTAINERS_AND_OBJECTS_INHERIT:
+    return "Sub containers and Objects Inherit";
+  case NO_INHERITANCE:
+    return "No Inheritence";
+  default:
+    return "Other";
+  }
 }
 
 // helper function to get account/group name from trustee
 std::string trusteeToStr(const TRUSTEE& t) {
-	char name[256];
-	char domain[256];
-	unsigned long size = 256;
-	//bool r;
-	SID_NAME_USE accountType;
+  char name[256];
+  char domain[256];
+  unsigned long size = 256; // Max username length for Windows
+  SID_NAME_USE accountType;
 
-	switch (t.TrusteeForm) {
-	case TRUSTEE_IS_SID:
-		// get the name from the SID
-		if (!LookupAccountSid(NULL, 
-				(PSID) t.ptstrName, name,
-				&size,
-                domain,
-                &size,
-                &accountType)) {
-			//sprintf("LookupAccountSid error: %u\n", GetLastError());
-            TLOG << "LookupAccountSid error: " << GetLastError();
-		}
-		else {
-			return name;
-		}
-	case TRUSTEE_IS_NAME:
-		// get the name from ptstrName
-		return t.ptstrName;
-	case TRUSTEE_BAD_FORM:
-		// invalid
-		return "Invalid";
-	case TRUSTEE_IS_OBJECTS_AND_SID:
-		// ptstrName member is a pointer to an OBJECTS_AND_SID struct
-        if (!LookupAccountSid(
-				NULL,
-                (PSID)((OBJECTS_AND_SID*)t.ptstrName)->pSid,
-                name,
-                &size,
-                domain,
-                &size,
-                &accountType)) {
-			//printf("LookupAccountSid error: %u\n", GetLastError());
-            TLOG << "LookupAccountSid error: " << GetLastError();
-		}
-		else {
-			return name;
-		}
-	case TRUSTEE_IS_OBJECTS_AND_NAME:
-		// ptstrName member is a pointer to an OBJECTS_AND_NAME struct
-		return ((OBJECTS_AND_NAME_*) t.ptstrName)->ptstrName;
-	default:
-		return "";
-	}
+  switch (t.TrusteeForm) {
+  case TRUSTEE_IS_SID:
+    // get the name from the SID
+    if (!LookupAccountSid(nullptr,
+                          reinterpret_cast<PSID>(t.ptstrName),
+                          name,
+                          &size,
+                          domain,
+                          &size,
+                          &accountType)) {
+      TLOG << "LookupAccountSid error: " << GetLastError();
+    } else {
+      return name;
+    }
+  case TRUSTEE_IS_NAME:
+    // get the name from ptstrName
+    return t.ptstrName;
+  case TRUSTEE_BAD_FORM:
+    // invalid
+    return "Invalid";
+  case TRUSTEE_IS_OBJECTS_AND_SID:
+    // ptstrName member is a pointer to an OBJECTS_AND_SID struct
+    if (!LookupAccountSid(nullptr,
+                          reinterpret_cast<PSID>(reinterpret_cast<OBJECTS_AND_SID*>(t.ptstrName)->pSid),
+                          name,
+                          &size,
+                          domain,
+                          &size,
+                          &accountType)) {
+      // printf("LookupAccountSid error: %u\n", GetLastError());
+      TLOG << "LookupAccountSid error: " << GetLastError();
+    } else {
+      return name;
+    }
+  case TRUSTEE_IS_OBJECTS_AND_NAME:
+    // ptstrName member is a pointer to an OBJECTS_AND_NAME struct
+    return reinterpret_cast<OBJECTS_AND_NAME_*>(t.ptstrName)->ptstrName;
+  default:
+    return "";
+  }
 }
 
 QueryData genNTFSACLPerms(QueryContext& context) {
   QueryData results;
+  unsigned long result = 0;
+  PACL DACL = nullptr;
+  PEXPLICIT_ACCESS aceList = nullptr, aceItem = nullptr;
+  unsigned long aceCount = 0, aceIndex = 0;
 
-	std::string ObjName;
-	unsigned long result = 0;
-	PACL DACL = NULL;
-	PEXPLICIT_ACCESS aceList = NULL, aceItem;
-	unsigned long aceCount, aceIndex;
+  auto paths = context.constraints["path"].getAll(EQUALS);
+  for (const auto& path_string : paths) {
+    if (fs::exists(path_string)) {
 
-	auto paths = context.constraints["path"].getAll(EQUALS);
-    for (const auto& path_string : paths) {
-          if (fs::exists(path_string)) {
-				fs::path ObjName = path_string;
+      // Get a pointer to the existing DACL.
 
-				// Get a pointer to the existing DACL.
+      result = GetNamedSecurityInfo(path_string.c_str(),
+                                    SE_FILE_OBJECT,
+                                    DACL_SECURITY_INFORMATION,
+                                    NULL,
+                                    NULL,
+                                    &DACL,
+                                    NULL,
+                                    NULL);
+      if (ERROR_SUCCESS != result) {
+        TLOG << "GetExplicitEnteriesFromAcl Error " << result;
+      }
 
-                result = GetNamedSecurityInfo(path_string.c_str(),
-                                                SE_FILE_OBJECT,
-                                                DACL_SECURITY_INFORMATION,
-                                                NULL,
-                                                NULL,
-                                                &DACL,
-                                                NULL,
-                                                NULL);
-                if (ERROR_SUCCESS != result) {
-                    //printf("GetNamedSecurityInfo Error %u\n", result);
-					TLOG << "GetExplicitEnteriesFromAcl Error " << result;
-                }
+      // get list of ACEs from DACL pointer
+      result = GetExplicitEntriesFromAcl(DACL, &aceCount, &aceList);
+      if (ERROR_SUCCESS != result) {
+        TLOG << "GetExplicitEnteriesFromAcl Error " << result;
+      }
 
-				// get list of ACEs from DACL pointer
-                result = GetExplicitEntriesFromAcl(
-                    DACL, &aceCount, &aceList);
-                if (ERROR_SUCCESS != result) {
-                    //printf("GetExplicitEnteriesFromAcl Error %u\n",
-                    //        result);
-					TLOG << "GetExplicitEnteriesFromAcl Error " << result;
-                }
+      // Loop through list of entries
 
-                // Loop through list of entries
+      aceItem = aceList;
 
-                aceItem = aceList;
-                // printf("AccessMode | TrusteeName | AccessPermissions
-                // | Inheritence\n");
-                for (aceIndex = 0; aceIndex < aceCount; aceItem++) {
-                    Row r;
-                    std::string accessMode;
-                    std::string inheritedFrom;
-                    std::string perms;
-                    std::string trusteeName;
+      for (aceIndex = 0; aceIndex < aceCount; aceItem++) {
+        Row r;
 
-                    perms =
-                        accessPermsToStr(aceItem->grfAccessPermissions);
-                    accessMode = accessModeToStr(aceItem->grfAccessMode);
-                    inheritedFrom =
-                        inheritanceToStr(aceItem->grfInheritance);
-                    trusteeName = trusteeToStr(aceItem->Trustee);
+        auto perms = accessPermsToStr(aceItem->grfAccessPermissions);
+        auto accessMode = accessModeToStr(aceItem->grfAccessMode);
+        auto inheritedFrom = inheritanceToStr(aceItem->grfInheritance);
+        auto trusteeName = trusteeToStr(aceItem->Trustee);
 
-                    r["path"] = TEXT(path_string);
-                    r["type"] = TEXT(accessMode);
-                    r["principal"] = TEXT(trusteeName);
-                    r["access"] = TEXT(perms);
-                    r["inherited_from"] = TEXT(inheritedFrom);
-                    results.push_back(r);
+        r["path"] = TEXT(path_string);
+        r["type"] = TEXT(accessMode);
+        r["principal"] = TEXT(trusteeName);
+        r["access"] = TEXT(perms);
+        r["inherited_from"] = TEXT(inheritedFrom);
+        results.push_back(r);
 
-                    aceIndex++;
-                }
-		  }	
-	}
+        aceIndex++;
+      }
+    }
+  }
 
   return results;
 }
 
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -80,6 +80,7 @@ std::string accessPermsToStr(const unsigned long pmask) {
 std::string trusteeToStr(const TRUSTEE& trustee) {
   // Max username length for Windows
   const unsigned long maxBuffSize = 256;
+  unsigned long sizeOut = maxBuffSize;
   char name[maxBuffSize];
   char domain[maxBuffSize];
   SID_NAME_USE accountType;
@@ -88,9 +89,8 @@ std::string trusteeToStr(const TRUSTEE& trustee) {
   case TRUSTEE_IS_SID: {
     // get the name from the SID
     PSID psid = trustee.ptstrName;
-    auto sizea = maxBuffSize;
     auto r = LookupAccountSid(
-        nullptr, psid, name, &sizea, domain, &size, &accountType);
+        nullptr, psid, name, &sizeOut, domain, &sizeOut, &accountType);
     if (r == FALSE) {
       VLOG(1) << "LookupAccountSid error: " << GetLastError();
       return "";
@@ -108,9 +108,8 @@ std::string trusteeToStr(const TRUSTEE& trustee) {
   case TRUSTEE_IS_OBJECTS_AND_SID: {
     // ptstrName member is a pointer to an OBJECTS_AND_SID struct
     auto psid = reinterpret_cast<POBJECTS_AND_SID>(trustee.ptstrName)->pSid;
-    auto sizeb = maxBuffSize;
     auto r = LookupAccountSid(
-        nullptr, psid, name, &sizeb, domain, &size, &accountType);
+        nullptr, psid, name, &sizeOut, domain, &sizeOut, &accountType);
     if (r == FALSE) {
       VLOG(1) << "LookupAccountSid error: " << GetLastError();
       return "";

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -124,13 +124,15 @@ std::string trusteeToStr(const TRUSTEE& t) {
     return "Invalid";
   case TRUSTEE_IS_OBJECTS_AND_SID:
     // ptstrName member is a pointer to an OBJECTS_AND_SID struct
-    if (!LookupAccountSid(nullptr,
-                          reinterpret_cast<PSID>(reinterpret_cast<OBJECTS_AND_SID*>(t.ptstrName)->pSid),
-                          name,
-                          &size,
-                          domain,
-                          &size,
-                          &accountType)) {
+    if (!LookupAccountSid(
+            nullptr,
+            reinterpret_cast<PSID>(
+                reinterpret_cast<OBJECTS_AND_SID*>(t.ptstrName)->pSid),
+            name,
+            &size,
+            domain,
+            &size,
+            &accountType)) {
       // printf("LookupAccountSid error: %u\n", GetLastError());
       TLOG << "LookupAccountSid error: " << GetLastError();
     } else {
@@ -154,7 +156,6 @@ QueryData genNTFSACLPerms(QueryContext& context) {
   auto paths = context.constraints["path"].getAll(EQUALS);
   for (const auto& path_string : paths) {
     if (fs::exists(path_string)) {
-
       // Get a pointer to the existing DACL.
 
       result = GetNamedSecurityInfo(path_string.c_str(),

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -1,0 +1,227 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <windows.h>
+#include <AccCtrl.h>
+#include <Aclapi.h>
+#include <string>
+#include <map>
+#include <vector>
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem.hpp>
+
+namespace alg = boost::algorithm;
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+// helper function to get access mode string
+std::string accessModeToStr(const _ACCESS_MODE& accessMode) {
+	switch (accessMode) {
+	case NOT_USED_ACCESS:
+		return "Not Used";
+	case GRANT_ACCESS:
+		return "Grant";
+	case SET_ACCESS:
+		return "Set";
+	case DENY_ACCESS:
+		return "Deny";
+	case REVOKE_ACCESS:
+		return "Revoke";
+	case SET_AUDIT_SUCCESS:
+		return "Set Audit Success";
+	case SET_AUDIT_FAILURE:
+		return "Set Audit Failure";
+	default:
+		return "Unknown";
+	}
+}
+
+// helper function to build access string from permission bit mask
+std::string accessPermsToStr(const unsigned long pmask) {
+	std::vector<std::string> permList;
+	std::string permStr = "";
+	const std::map<unsigned long, std::string> permVals = {
+		{ DELETE                         ,"Delete" },
+		{ READ_CONTROL                   ,"Read Control" },
+		{ WRITE_DAC                      ,"Write DAC" },
+		{ WRITE_OWNER                    ,"Write Owner" },
+		{ SYNCHRONIZE                    ,"Synchronize" },
+		{ STANDARD_RIGHTS_REQUIRED       ,"Std Rights Required" },
+		{ STANDARD_RIGHTS_ALL            ,"Std Rights All" },
+		{ SPECIFIC_RIGHTS_ALL            ,"Specific Rights All" },
+		{ ACCESS_SYSTEM_SECURITY         ,"Access System Security" },
+		{ MAXIMUM_ALLOWED                ,"Maximum Allowed" },
+		{ GENERIC_READ                   ,"Generic Read" },
+		{ GENERIC_WRITE                  ,"Generic Write" },
+		{ GENERIC_EXECUTE                ,"Generic Execute" },
+		{ GENERIC_ALL                    ,"Generic All" }
+	};
+
+	for (auto const& perm : permVals) {
+		if ((pmask & perm.first) != 0)
+			permList.push_back(perm.second);
+	}
+
+	permStr = alg::join(permList, ",");
+	return permStr;
+}
+
+// helper function to convert inheritance type to string
+std::string inheritanceToStr(const unsigned long i) {
+	switch (i) {
+	case CONTAINER_INHERIT_ACE: // equivalent to SUB_CONTAINERS_ONLY_INHERIT
+		return "Container Inherit Ace";
+	case INHERIT_NO_PROPAGATE: // equivalent to NO_PROPAGATE_INHERIT_ACE
+		return "Inherit No Propagate";
+	case INHERIT_ONLY: // equivalent to INHERIT_ONLY_ACE
+		return "Inherit Only";
+	case OBJECT_INHERIT_ACE: // equivalent to SUB_OBJECTS_ONLY_INHERIT
+		return "Object Inherit Ace";
+	case SUB_CONTAINERS_AND_OBJECTS_INHERIT:
+		return "Sub containers and Objects Inherit";
+	case NO_INHERITANCE:
+		return "No Inheritence";
+	default:
+		return "Other";
+	}
+}
+
+// helper function to get account/group name from trustee
+std::string trusteeToStr(const TRUSTEE& t) {
+	char name[256];
+	char domain[256];
+	unsigned long size = 256;
+	//bool r;
+	SID_NAME_USE accountType;
+
+	switch (t.TrusteeForm) {
+	case TRUSTEE_IS_SID:
+		// get the name from the SID
+		if (!LookupAccountSid(NULL, 
+				(PSID) t.ptstrName, name,
+				&size,
+                domain,
+                &size,
+                &accountType)) {
+			//sprintf("LookupAccountSid error: %u\n", GetLastError());
+            TLOG << "LookupAccountSid error: " << GetLastError();
+		}
+		else {
+			return name;
+		}
+	case TRUSTEE_IS_NAME:
+		// get the name from ptstrName
+		return t.ptstrName;
+	case TRUSTEE_BAD_FORM:
+		// invalid
+		return "Invalid";
+	case TRUSTEE_IS_OBJECTS_AND_SID:
+		// ptstrName member is a pointer to an OBJECTS_AND_SID struct
+        if (!LookupAccountSid(
+				NULL,
+                (PSID)((OBJECTS_AND_SID*)t.ptstrName)->pSid,
+                name,
+                &size,
+                domain,
+                &size,
+                &accountType)) {
+			//printf("LookupAccountSid error: %u\n", GetLastError());
+            TLOG << "LookupAccountSid error: " << GetLastError();
+		}
+		else {
+			return name;
+		}
+	case TRUSTEE_IS_OBJECTS_AND_NAME:
+		// ptstrName member is a pointer to an OBJECTS_AND_NAME struct
+		return ((OBJECTS_AND_NAME_*) t.ptstrName)->ptstrName;
+	default:
+		return "";
+	}
+}
+
+QueryData genNTFSACLPerms(QueryContext& context) {
+  QueryData results;
+
+	std::string ObjName;
+	unsigned long result = 0;
+	PACL DACL = NULL;
+	PEXPLICIT_ACCESS aceList = NULL, aceItem;
+	unsigned long aceCount, aceIndex;
+
+	auto paths = context.constraints["path"].getAll(EQUALS);
+    for (const auto& path_string : paths) {
+          if (fs::exists(path_string)) {
+				fs::path ObjName = path_string;
+
+				// Get a pointer to the existing DACL.
+
+                result = GetNamedSecurityInfo(path_string.c_str(),
+                                                SE_FILE_OBJECT,
+                                                DACL_SECURITY_INFORMATION,
+                                                NULL,
+                                                NULL,
+                                                &DACL,
+                                                NULL,
+                                                NULL);
+                if (ERROR_SUCCESS != result) {
+                    //printf("GetNamedSecurityInfo Error %u\n", result);
+					TLOG << "GetExplicitEnteriesFromAcl Error " << result;
+                }
+
+				// get list of ACEs from DACL pointer
+                result = GetExplicitEntriesFromAcl(
+                    DACL, &aceCount, &aceList);
+                if (ERROR_SUCCESS != result) {
+                    //printf("GetExplicitEnteriesFromAcl Error %u\n",
+                    //        result);
+					TLOG << "GetExplicitEnteriesFromAcl Error " << result;
+                }
+
+                // Loop through list of entries
+
+                aceItem = aceList;
+                // printf("AccessMode | TrusteeName | AccessPermissions
+                // | Inheritence\n");
+                for (aceIndex = 0; aceIndex < aceCount; aceItem++) {
+                    Row r;
+                    std::string accessMode;
+                    std::string inheritedFrom;
+                    std::string perms;
+                    std::string trusteeName;
+
+                    perms =
+                        accessPermsToStr(aceItem->grfAccessPermissions);
+                    accessMode = accessModeToStr(aceItem->grfAccessMode);
+                    inheritedFrom =
+                        inheritanceToStr(aceItem->grfInheritance);
+                    trusteeName = trusteeToStr(aceItem->Trustee);
+
+                    r["path"] = TEXT(path_string);
+                    r["type"] = TEXT(accessMode);
+                    r["principal"] = TEXT(trusteeName);
+                    r["access"] = TEXT(perms);
+                    r["inherited_from"] = TEXT(inheritedFrom);
+                    results.push_back(r);
+
+                    aceIndex++;
+                }
+		  }	
+	}
+
+  return results;
+}
+
+}
+}

--- a/specs/windows/ntfs_acl_permissions.table
+++ b/specs/windows/ntfs_acl_permissions.table
@@ -2,9 +2,9 @@ table_name("ntfs_acl_permissions")
 description("Retrieve NTFS ACL permission information for files and directories.")
 schema([
   Column("path", TEXT, "Path to the file or directory."),
-  Column("type", TEXT, "Drive letter of the encrypted drive."),
-  Column("principal", TEXT, "Persistent ID of the drive."),
-  Column("access", TEXT, "Persistent ID of the drive."),
-  Column("inherited_from", TEXT, "The bitlocker conversion status of the drive."),
+  Column("type", TEXT, "Type of access mode for the access control entry."),
+  Column("principal", TEXT, "User or group to which the ACE applies."),
+  Column("access", TEXT, "Specific permissions that indicate the rights described by the ACE."),
+  Column("inherited_from", TEXT, "The inheritance policy of the ACE."),
 ])
-implementation("system/windows/ntfs_acl_permissions@genNTFSACLPerms")
+implementation("system/windows/ntfs_acl_permissions@genNtfsAclPerms")

--- a/specs/windows/ntfs_acl_permissions.table
+++ b/specs/windows/ntfs_acl_permissions.table
@@ -1,0 +1,10 @@
+table_name("ntfs_acl_permissions")
+description("Retrieve NTFS ACL permission information for files and directories.")
+schema([
+  Column("path", TEXT, "Path to the file or directory."),
+  Column("type", TEXT, "Drive letter of the encrypted drive."),
+  Column("principal", TEXT, "Persistent ID of the drive."),
+  Column("access", TEXT, "Persistent ID of the drive."),
+  Column("inherited_from", TEXT, "The bitlocker conversion status of the drive."),
+])
+implementation("system/windows/ntfs_acl_permissions@genNTFSACLPerms")


### PR DESCRIPTION
First attempt at a table for fetching permission access control lists for files and directories on Windows. This table requires a path predicate.

Usage: `select * from ntfs_acl_permissions where path = "C:\Program Files\";`

Access permissions string is kinda gross at the moment 🙃 

Looking forward to feedback!