### PR TITLE
Add decode back to cmdline pieces

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -143,7 +143,7 @@ Status AuditProcessEventSubscriber::ProcessEvents(
         row["cmdline"] += " ";
       }
 
-      row["cmdline"] += arg.second;
+      row["cmdline"] += DecodeAuditPathValues(arg.second);
     }
 
     // There may be a better way to calculate actual size from audit.


### PR DESCRIPTION
This got missed in the rewrite causing extra quotes around cmdline pieces along with hex encodings that are not decoded.