### PR TITLE
Fix up flaky fileops_tests

### DIFF
--- a/osquery/filesystem/tests/fileops_tests.cpp
+++ b/osquery/filesystem/tests/fileops_tests.cpp
@@ -63,12 +63,11 @@ class FileOpsTests : public testing::Test {
 
 class TempFile {
  public:
-  TempFile()
-      : path_((fs::temp_directory_path() /
-               (std::string("osquery-") +
-                std::to_string((rand() % 10000) + 20000)))
-                  .make_preferred()
-                  .string()) {}
+  TempFile() {
+    do {
+      path_ = generateTempPath();
+    } while (fs::exists(path_));
+  }
 
   ~TempFile() {
     if (fs::exists(path_)) {
@@ -78,6 +77,13 @@ class TempFile {
 
   const std::string& path() const {
     return path_;
+  }
+
+ private:
+  static std::string generateTempPath() {
+    return (fs::temp_directory_path() / fs::unique_path("osquery-%%%%-%%%%"))
+        .make_preferred()
+        .string();
   }
 
  private:


### PR DESCRIPTION
There was used unsafe way to generate unique name for temporary file. It led for collisions sometimes, which make tests randomly failing. I have change mechanism of filename generating (used the one from the boost). And added check to make sure generated name is not exist.

```
$ ./build/darwin/osquery/osquery_tests --gtest_filter='FileOpsTests.*' 
...
[==========] 14 tests from 1 test case ran. (164 ms total)
[  PASSED  ] 13 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] FileOpsTests.test_append

 1 FAILED TEST
```