### PR TITLE
InterruptableRunnable RunnerInterruptPoint redesign

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -54,13 +54,9 @@ class InterruptableRunnable {
 
  private:
   /**
-   * @brief Protect interruption checking and resource tear down.
-   *
-   * A tearDown mutex protects the runnable service's resources.
-   * Interruption means resources have been stopped.
-   * Non-interruption means no attempt to affect resources has been started.
+   * @brief Used to wait for the interruption notification while sleeping
    */
-  std::mutex stopping_;
+  std::mutex condition_lock;
 
   /// If a service includes a run loop it should check for interrupted.
   std::atomic<bool> interrupted_{false};

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -45,12 +45,12 @@ class InterruptableRunnable {
   virtual void stop() = 0;
 
   /// Put the runnable into an interruptible sleep.
-  virtual void pauseMilli(size_t milli) {
-    pauseMilli(std::chrono::milliseconds(milli));
+  inline bool pauseMilli(size_t milli) {
+    return pauseMilli(std::chrono::milliseconds(milli));
   }
 
   /// Put the runnable into an interruptible sleep.
-  virtual void pauseMilli(std::chrono::milliseconds milli);
+  bool pauseMilli(std::chrono::milliseconds milli);
 
  private:
   /**

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -45,12 +45,12 @@ class InterruptableRunnable {
   virtual void stop() = 0;
 
   /// Put the runnable into an interruptible sleep.
-  inline bool pauseMilli(size_t milli) {
-    return pauseMilli(std::chrono::milliseconds(milli));
+  inline void pauseMilli(size_t milli) {
+    pauseMilli(std::chrono::milliseconds(milli));
   }
 
   /// Put the runnable into an interruptible sleep.
-  bool pauseMilli(std::chrono::milliseconds milli);
+  void pauseMilli(std::chrono::milliseconds milli);
 
  private:
   /**

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -39,7 +39,7 @@ bool InterruptableRunnable::interrupted() {
 
 void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
   if (!interrupted_) {
-    std::unique_lock<std::mutex> lock(stopping_);
+    std::unique_lock<std::mutex> lock(condition_lock);
     condition_.wait_for(lock, milli);
   }
 }

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -27,7 +27,7 @@ void InterruptableRunnable::interrupt() {
     // Tear down the service's resources such that exiting the expected run
     // loop within ::start does not need to.
     stop();
-
+    std::lock_guard<std::mutex> lock(condition_lock);
     // Cancel the run loop's pause request.
     condition_.notify_one();
   }
@@ -38,8 +38,8 @@ bool InterruptableRunnable::interrupted() {
 }
 
 void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
+  std::unique_lock<std::mutex> lock(condition_lock);
   if (!interrupted_) {
-    std::unique_lock<std::mutex> lock(condition_lock);
     condition_.wait_for(lock, milli);
   }
 }

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -20,48 +20,27 @@ namespace osquery {
 /// The worker_threads define the default thread pool size.
 FLAG(int32, worker_threads, 4, "Number of work dispatch threads");
 
-/// Cancel the pause request.
-void RunnerInterruptPoint::cancel() {
-  std::unique_lock<std::mutex> lock(mutex_);
-  stop_ = true;
-  condition_.notify_all();
-}
-
-/// Pause until the requested millisecond delay has elapsed or a cancel.
-void RunnerInterruptPoint::pause(std::chrono::milliseconds milli) {
-  std::unique_lock<std::mutex> lock(mutex_);
-  if (stop_ || condition_.wait_for(lock, milli) == std::cv_status::no_timeout) {
-    stop_ = false;
-    throw RunnerInterruptError();
-  }
-}
 
 void InterruptableRunnable::interrupt() {
-  WriteLock lock(stopping_);
   // Set the service as interrupted.
-  interrupted_ = true;
-  // Tear down the service's resources such that exiting the expected run
-  // loop within ::start does not need to.
-  stop();
-  // Cancel the run loop's pause request.
-  point_.cancel();
+  if (!interrupted_.exchange(true)) {
+    // Tear down the service's resources such that exiting the expected run
+    // loop within ::start does not need to.
+    stop();
+
+    // Cancel the run loop's pause request.
+    condition_.notify_one();
+  }
 }
 
 bool InterruptableRunnable::interrupted() {
-  WriteLock lock(stopping_);
-  // A small conditional to force-skip an interruption check, used in testing.
-  if (bypass_check_ && !checked_) {
-    checked_ = true;
-    return false;
-  }
   return interrupted_;
 }
 
 void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
-  try {
-    point_.pause(milli);
-  } catch (const RunnerInterruptError&) {
-    // The pause request was canceled.
+  if (!interrupted_) {
+    std::unique_lock<std::mutex> lock(stopping_);
+    condition_.wait_for(lock, milli);
   }
 }
 

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -43,7 +43,7 @@ class TestRunnable : public InternalRunnable {
     return i;
   }
 
-  bool interrupted() {
+  bool interrupted() override{
     // A small conditional to force-skip an interruption check, used in testing.
     if (!checked_) {
       checked_ = true;
@@ -116,7 +116,7 @@ class BlockingTestRunnable : public InternalRunnable {
     pauseMilli(100 * 1000);
   }
 
-  bool interrupted() {
+  bool interrupted() override{
     // A small conditional to force-skip an interruption check, used in testing.
     if (!checked_) {
       checked_ = true;

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -43,7 +43,7 @@ class TestRunnable : public InternalRunnable {
     return i;
   }
 
-  bool interrupted() override{
+  bool interrupted() override {
     // A small conditional to force-skip an interruption check, used in testing.
     if (!checked_) {
       checked_ = true;
@@ -116,7 +116,7 @@ class BlockingTestRunnable : public InternalRunnable {
     pauseMilli(100 * 1000);
   }
 
-  bool interrupted() override{
+  bool interrupted() override {
     // A small conditional to force-skip an interruption check, used in testing.
     if (!checked_) {
       checked_ = true;

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -163,4 +163,4 @@ bool WindowsEventLogEventPublisher::shouldFire(
 bool WindowsEventLogEventPublisher::isSubscriptionActive() const {
   return win_event_handles_.size() > 0;
 }
-}
+} // namespace osquery

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -61,7 +61,7 @@ void WindowsEventLogEventPublisher::configure() {
 }
 
 Status WindowsEventLogEventPublisher::run() {
-  pause();
+  pauseMilli(100);
   return Status(0, "OK");
 }
 

--- a/osquery/logger/plugins/tests/buffered_tests.cpp
+++ b/osquery/logger/plugins/tests/buffered_tests.cpp
@@ -232,8 +232,7 @@ TEST_F(BufferedLogForwarderTests, test_multiple) {
   runner1.check();
   runner2.check();
 }
-#include <chrono>
-#include <thread>
+
 TEST_F(BufferedLogForwarderTests, test_async) {
   auto runner = std::make_shared<StrictMock<MockBufferedLogForwarder>>(
       "mock", kLogPeriod);
@@ -243,7 +242,6 @@ TEST_F(BufferedLogForwarderTests, test_async) {
   runner->logString("foo");
 
   Dispatcher::addService(runner);
-  // std::this_thread::sleep_for(std::chrono::seconds(2));
   runner->interrupt();
   Dispatcher::joinServices();
 }

--- a/osquery/logger/plugins/windows_event_log.cpp
+++ b/osquery/logger/plugins/windows_event_log.cpp
@@ -144,4 +144,4 @@ Status WindowsEventLoggerPlugin::emitLogRecord(
 
   return Status();
 }
-}
+} // namespace osquery


### PR DESCRIPTION
There were several inefficiencies in the old version of RunnerInterruptPoint and InterruptableRunnable.

1) RunnerInterruptPoint was throwing the exception when interrupted, however, the exception was always ignored.

2) InterruptableRunnable used the read-write lock, however only write lock was used.

3) InterruptableRunnable InterruptableRunnable, stored almost similar variable stop_, interrupted_.

4) std::atomic<bool> interrupted_ was used with locks, even though it was accessed by default safest access mode memory_order_seq_cst. So no additional cache invalidation was needed.

5) InterruptableRunnable contained code(in method interrupted() and variables bypass_check_, checked) just for testing. Which was slowing down method interrupted().

6) Some more confusing things. notify_all was not needed, as only one thread could be waiting for the conditional variable. RunnerInterruptPoint:: pause(void) looks ambiguous and that's why was not used almost anywhere(Only at one place).

I resolved all these problems by merging InterruptableRunnable and RunnerInterruptPoint into the InterruptableRunnable.

1) No use of the exception.
2) 4) Simple mutex, which is only used for pauseMilli and interrupt. InterruptableRunnable::interrupted is lock-free.
3) Single variable interrupted_.
5) Made InterruptableRunnable::interrupt virtual. Tests override interrupt to make things testable.
6) change to notify_one and removed pause without the specific time.