### PR TITLE
bug: correctly check windows event log channels for firing

### DIFF
--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -12,6 +12,8 @@
 
 #include <Windows.h>
 
+#include <algorithm>
+
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/tokenizer.hpp>
@@ -157,10 +159,12 @@ Status WindowsEventLogEventPublisher::parseEvent(EVT_HANDLE evt,
 bool WindowsEventLogEventPublisher::shouldFire(
     const WindowsEventLogSubscriptionContextRef& sc,
     const WindowsEventLogEventContextRef& ec) const {
-  return sc->sources.find(ec->channel) != sc->sources.end();
+  std::wstring chan = ec->channel;
+  std::transform(chan.begin(), chan.end(), chan.begin(), ::tolower);
+  return sc->sources.find(chan) != sc->sources.end();
 }
 
 bool WindowsEventLogEventPublisher::isSubscriptionActive() const {
   return win_event_handles_.size() > 0;
 }
-}
+} // namespace osquery

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -49,6 +49,10 @@ class WindowsEventSubscriber
       // We remove quotes if they exist
       boost::erase_all(chan, "\"");
       boost::erase_all(chan, "\'");
+
+      // To enforce unification we lower case all channel names for shouldFire
+      std::transform(chan.begin(), chan.end(), chan.begin(), ::tolower);
+
       wc->sources.insert(stringToWstring(chan));
     }
     subscribe(&WindowsEventSubscriber::Callback, wc);


### PR DESCRIPTION
This addresses #4538 by forcing all of our event channel subscriptions to lower case, to ensure our checks are case insensitive.