### PR TITLE
Add Vendor Guidelines for the Osquery Slack

### DIFF
--- a/VENDOR_GUIDELINES.md
+++ b/VENDOR_GUIDELINES.md
@@ -1,0 +1,38 @@
+# Vendor Guidelines
+
+Vendors can make up an important part of our community, and our [Slack team](https://slack.osquery.io) provides a unique method to engage with a user base directly, but vendors should adhere to the following guidelines to help ensure they do not engage in behaviour that violates our Code of Conduct or Vendor Guidelines.
+
+## Direct Messages & Emails
+
+It is not permitted to direct message a member of our community for the purposes of promoting your product without their clear permission beforehand. Further, it is not permitted to use email addresses acquired from the Slack to reach out to users about a vendor product.
+
+### What is okay
+
+> Vendor: Hey @personX, is it ok if I message you about #productY?
+
+> personX: Sure, that's fine.
+
+### What is not okay
+
+* Direct messaging the user before they have responded to a posting in a public channel like the above.
+* Direct messaging the user when they have responded in any manner that could be taken as a negative response to a posting in a public channel like the above.
+* Emailing a user about a vendor product after pulling their email from their Slack account.
+
+## Promoting your product in public channels
+
+If you wish to promote your product in a public channel, it is important that:
+
+* Your message is relevant to the current discussion topic. For example, if you make a proprietary osquery server, it may be useful to post a link to your own channel if the current discussion is on a topic that is especially relevant.
+* Your message cannot be considered 'spam' - in addition to being on topic, it shouldn't be posted repeatedly, either in the same channel or in multiple channels.
+
+### What is okay
+
+> personX: I'm looking for a tool that performs X - does anyone have any ideas?
+
+> Vendor: Hey @personX, I work for companyY and we make something that may help. Maybe you would like to come over to #companyY?
+
+### What is not okay
+
+> [Unrelated conversation]
+
+> Hey! We're reaching out to organizations to see if you would be interested in streamlining security operations and incident response using an Osquery-based security platform. Would you be interested in seeing a demo or webinar?


### PR DESCRIPTION
In the osquery slack, we've had problems with multiple vendors reaching out to users in the osquery slack. We've talked about establishing a vendor code of conduct and, after fielding some complaints from users that had vendors reaching out to them as soon as they joined slack, I think it's time for us to be a little more serious about articulating the rules and enforcing them so that the Slack continues to be a safe, friendly place for people to communicate with each other without getting endlessly spammed by vendors. I adapted this document from the [MacAdmins Slack Vendor Guidelines](https://github.com/macadminsdotorg/codeofconduct/blob/master/Vendor_Guidelines.md). I'm happy to expand the limitations if anyone has feedback, but I think the doc as it stands now represents a minimal set of rules that all vendors should be following in Slack.