### PR TITLE
deps: Update yara to version 3.7.1

### DIFF
--- a/tools/provision/formula/yara.rb
+++ b/tools/provision/formula/yara.rb
@@ -4,25 +4,15 @@ class Yara < AbstractOsqueryFormula
   desc "Malware identification and classification tool"
   homepage "https://github.com/VirusTotal/yara/"
   license "BSD-3-Clause"
-  head "https://github.com/VirusTotal/yara.git"
+  url "https://github.com/VirusTotal/yara/archive/v3.7.1.tar.gz"
+  sha256 "df077a29b0fffbf4e7c575f838a440f42d09b215fcb3971e6fb6360318a64892"
   revision 200
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "7071490d9d49934e36de07ecc250c5741256285c65d9d4b0c05c7bf20face8ac" => :sierra
-    sha256 "fafe8b8f40383f99f85c169394c2b654b66157526565ba7ddd57ab835c7f309c" => :x86_64_linux
-  end
-
-  stable do
-    url "https://github.com/VirusTotal/yara/archive/v3.5.0.tar.gz"
-    sha256 "4bc72ee755db85747f7e856afb0e817b788a280ab5e73dee42f159171a9b5299"
-
-    patch do
-      # Fixes variable redefinitions.
-      url "https://github.com/VirusTotal/yara/commit/a0bb3836f16e3c5d0c2a1da097a1ebacbebc3a94.patch"
-      sha256 "dd21219d8137bc8167c7051ea0346119843f4e37c84b1a3b96418fa7e8e62179"
-    end
+    sha256 "6bbcc74e694c2d49d9d9f5d2dfd8383a4210ac0905a1778913a168462aa7ee43" => :sierra
+    sha256 "d76fee94374de3b227e16c969a6814f0639437db86ef16f3a6fc02eea889617e" => :x86_64_linux
   end
 
   depends_on "pcre"
@@ -35,14 +25,10 @@ class Yara < AbstractOsqueryFormula
     ENV.append "CFLAGS", "-std=gnu89"
 
     # find Homebrew's libpcre
-    ENV.append "LDFLAGS", "-L#{Formula["pcre"].opt_lib} -lpcre"
+    ENV.append "LDFLAGS", "-L#{Formula["osquery/osquery-local/pcre"].opt_lib} -lpcre"
 
     system "./bootstrap.sh"
-    system "./configure", "--disable-silent-rules",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-shared",
-                          "--enable-static"
+    system "./configure", *osquery_autoconf_flags
     system "make", "install"
   end
 end

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -33,6 +33,9 @@ function distro_main() {
   # Needed for libcryptsetup
   package autotools-dev
 
+  # Needed for python
+  package unzip
+
   GEM=`which gem`
   do_sudo $GEM install --no-ri --no-rdoc fpm
 }


### PR DESCRIPTION
This updates yara on MacOS and Linux. It’s been a while since we updated.