### PR TITLE
Build posix with -fno-limit-debug-info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ else()
     # To be safe, only include them when building 'release' outputs.
     add_compile_options(
       -g
+      -fno-limit-debug-info
       -fPIE
       -fpie
       -fPIC


### PR DESCRIPTION
When building with lto clang will not generate debug information for libstdc++ with the assumption we will have those symbols separately. Since we're statically linking the lib we need to tell clang to generate these to make debugging easier. One major advantage is to be able to look into std::string while debugging osquery.

This adds 23MB to the debug symbols on Linux, but obviously doesn't affect the binary.