### PR TITLE
Parse structured options as string

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -362,6 +362,7 @@ class Config : private boost::noncopyable {
   FRIEND_TEST(ViewsConfigParserPluginTests, test_swap_view);
   FRIEND_TEST(ViewsConfigParserPluginTests, test_update_view);
   FRIEND_TEST(OptionsConfigParserPluginTests, test_unknown_option);
+  FRIEND_TEST(OptionsConfigParserPluginTests, test_json_option);
   FRIEND_TEST(EventsConfigParserPluginTests, test_get_event);
   FRIEND_TEST(PacksTests, test_discovery_cache);
   FRIEND_TEST(PacksTests, test_multi_pack);

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -80,6 +80,11 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
       value = std::to_string(option.value.GetInt());
     } else if (option.value.IsNumber()) {
       value = std::to_string(option.value.GetUint64());
+    } else if (option.value.IsObject() || option.value.IsArray()){
+      auto doc = JSON::newFromValue(option.value);
+      doc.toString(value);
+    } else {
+      LOG(WARNING) << "Cannot parse unknown value type for option: " << name;
     }
 
     if (value.empty() || name.empty()) {

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -80,7 +80,7 @@ Status OptionsConfigParserPlugin::update(const std::string& source,
       value = std::to_string(option.value.GetInt());
     } else if (option.value.IsNumber()) {
       value = std::to_string(option.value.GetUint64());
-    } else if (option.value.IsObject() || option.value.IsArray()){
+    } else if (option.value.IsObject() || option.value.IsArray()) {
       auto doc = JSON::newFromValue(option.value);
       doc.toString(value);
     } else {

--- a/osquery/config/parsers/tests/options_tests.cpp
+++ b/osquery/config/parsers/tests/options_tests.cpp
@@ -65,15 +65,21 @@ TEST_F(OptionsConfigParserPluginTests, test_json_option) {
   Config c;
   std::map<std::string, std::string> update;
 
-  update["awesome"] =
-          "{\"options\": {\"complex\": {\"foo\": 1, \"bar\": \"baz\"}}}";
+  update["awesome"] = R"raw({
+    "options": {
+      "custom_nested_json": 
+        {"foo":1,"bar":"baz"}
+    }
+  })raw";
   auto s = c.update(update);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.toString(), "OK");
 
   const auto& doc = c.getParser("options")->getData().doc()["options"];
 
-  EXPECT_TRUE(doc.HasMember("complex"));
-  EXPECT_FALSE(Flag::getValue("complex").empty());
-  EXPECT_EQ("{\"foo\": 1, \"bar\": \"baz\"}", std::string(doc["complex"].GetString()));
-  EXPECT_EQ("{\"foo\": 1, \"bar\": \"baz\"}", Flag::getValue("complex"));
+  EXPECT_TRUE(doc.HasMember("custom_nested_json"));
+  EXPECT_FALSE(Flag::getValue("custom_nested_json").empty());
+  EXPECT_EQ(R"raw({"foo":1,"bar":"baz"})raw",
+            Flag::getValue("custom_nested_json"));
 }
 }

--- a/osquery/config/parsers/tests/options_tests.cpp
+++ b/osquery/config/parsers/tests/options_tests.cpp
@@ -60,4 +60,20 @@ TEST_F(OptionsConfigParserPluginTests, test_unknown_option) {
   EXPECT_EQ(1U, doc["custom_fake"].GetUint());
   EXPECT_FALSE(Flag::getValue("custom_fake").empty());
 }
+
+TEST_F(OptionsConfigParserPluginTests, test_json_option) {
+  Config c;
+  std::map<std::string, std::string> update;
+
+  update["awesome"] =
+          "{\"options\": {\"complex\": {\"foo\": 1, \"bar\": \"baz\"}}}";
+  auto s = c.update(update);
+
+  const auto& doc = c.getParser("options")->getData().doc()["options"];
+
+  EXPECT_TRUE(doc.HasMember("complex"));
+  EXPECT_FALSE(Flag::getValue("complex").empty());
+  EXPECT_EQ("{\"foo\": 1, \"bar\": \"baz\"}", std::string(doc["complex"].GetString()));
+  EXPECT_EQ("{\"foo\": 1, \"bar\": \"baz\"}", Flag::getValue("complex"));
+}
 }


### PR DESCRIPTION
If an option is not String/Number/Bool, parse it as string. Fix for #4566

This allows more complex option values that are valid json strings.