### PR TITLE
dispatcher race conditions

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -165,7 +165,7 @@ class InternalRunnable : private boost::noncopyable,
 
 /// An internal runnable used throughout osquery as dispatcher services.
 using InternalRunnableRef = std::shared_ptr<InternalRunnable>;
-using InternalThreadRef = std::shared_ptr<std::thread>;
+using InternalThreadRef = std::unique_ptr<std::thread>;
 
 /**
  * @brief Singleton for queuing asynchronous tasks to be executed in parallel
@@ -195,9 +195,7 @@ class Dispatcher : private boost::noncopyable {
   static void stopServices();
 
   /// Return number of services.
-  size_t serviceCount() {
-    return services_.size();
-  }
+  size_t serviceCount();
 
  private:
   /**
@@ -229,8 +227,6 @@ class Dispatcher : private boost::noncopyable {
   // Protection around service access.
   mutable Mutex mutex_;
 
-  // Protection around double joins.
-  mutable Mutex join_mutex_;
 
   /**
    * @brief Signal to the Dispatcher that no services should be created.

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -143,7 +143,8 @@ void Dispatcher::joinServices() {
   DLOG(INFO) << "Thread: " << std::this_thread::get_id()
              << " requesting a join";
 
-  // Stops when service_threads_ is empty. Before stopping and releasing of the lock, empties services_ .
+  // Stops when service_threads_ is empty. Before stopping and releasing of the
+  // lock, empties services_ .
   while (1) {
     InternalThreadRef thread = nullptr;
     {

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -143,7 +143,7 @@ void Dispatcher::joinServices() {
   DLOG(INFO) << "Thread: " << std::this_thread::get_id()
              << " requesting a join";
 
-  // Stops when service_threads_ is empty. Befor stopping and releasing of the lock, empties services_ .
+  // Stops when service_threads_ is empty. Before stopping and releasing of the lock, empties services_ .
   while (1) {
     InternalThreadRef thread = nullptr;
     {

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -143,7 +143,10 @@ void Dispatcher::joinServices() {
   DLOG(INFO) << "Thread: " << std::this_thread::get_id()
              << " requesting a join";
 
+  // Stops when service_threads_ is empty. Before exiting empties services_ while holding the lock.
   while (1) {
+
+    // Stops when service_threads_ is empty
     while (1) {
       InternalThreadRef thread = nullptr;
       {


### PR DESCRIPTION
the dispatcher had 2 race condition.
In joinServices it was accessing service_threads_ with different lock(join_lock). However, if by that time new service was added baad things would happen :) .

Also, the dispatcher was accessing services_.size() without the lock. ( If by that time service was removed or joined bad things would happen)