### PR TITLE
Fix make sync on centos7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -740,7 +740,7 @@ add_custom_target(
 # make sync
 add_custom_target(
   sync
-  "${CMAKE_SOURCE_DIR}/tools/sync.sh" "${CMAKE_BINARY_DIR}"
+  "${CMAKE_SOURCE_DIR}/tools/sync.sh" "${CMAKE_BINARY_DIR}" "${BUILD_DEPS}/lib:${BUILD_DEPS}/legacy/lib"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   COMMENT "Generating sdk sync: ${CMAKE_BINARY_DIR}/sync"
   DEPENDS osquery_extensions osquery_amalgamation

--- a/osquery/database/CMakeLists.txt
+++ b/osquery/database/CMakeLists.txt
@@ -22,20 +22,22 @@ ADD_OSQUERY_TEST(TRUE
   "${CMAKE_CURRENT_LIST_DIR}/tests/results_tests.cpp"
 )
 
-ADD_OSQUERY_LIBRARY(FALSE osquery_database_plugins "")
+if(NOT OSQUERY_BUILD_SDK_ONLY)
+  ADD_OSQUERY_LIBRARY(FALSE osquery_database_plugins "")
 
-target_sources(osquery_database_plugins
-  PRIVATE
-    "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.h"
-    "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.h"
-    "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.cpp"
-)
+  target_sources(osquery_database_plugins
+    PRIVATE
+      "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.cpp"
+      "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.h"
+      "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.h"
+      "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.cpp"
+  )
 
-target_compile_definitions(osquery_database_plugins
-  PRIVATE
-    "-DROCKSDB_LITE=1"
-)
+  target_compile_definitions(osquery_database_plugins
+    PRIVATE
+      "-DROCKSDB_LITE=1"
+  )
+endif()
 
 ADD_OSQUERY_TEST(FALSE
   "${CMAKE_CURRENT_LIST_DIR}/tests/plugin_tests.cpp"

--- a/osquery/database/CMakeLists.txt
+++ b/osquery/database/CMakeLists.txt
@@ -22,22 +22,20 @@ ADD_OSQUERY_TEST(TRUE
   "${CMAKE_CURRENT_LIST_DIR}/tests/results_tests.cpp"
 )
 
-if(NOT OSQUERY_BUILD_SDK_ONLY)
-  ADD_OSQUERY_LIBRARY(FALSE osquery_database_plugins "")
+ADD_OSQUERY_LIBRARY(FALSE osquery_database_plugins "")
 
-  target_sources(osquery_database_plugins
-    PRIVATE
-      "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.cpp"
-      "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.h"
-      "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.h"
-      "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.cpp"
-  )
+target_sources(osquery_database_plugins
+  PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.h"
+    "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.h"
+    "${CMAKE_CURRENT_LIST_DIR}/plugins/sqlite.cpp"
+)
 
-  target_compile_definitions(osquery_database_plugins
-    PRIVATE
-      "-DROCKSDB_LITE=1"
-  )
-endif()
+target_compile_definitions(osquery_database_plugins
+  PRIVATE
+    "-DROCKSDB_LITE=1"
+)
 
 ADD_OSQUERY_TEST(FALSE
   "${CMAKE_CURRENT_LIST_DIR}/tests/plugin_tests.cpp"

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -21,9 +21,9 @@ SYNC_DIR="$BUILD_DIR/sync"
 VERSION=`git describe --tags HEAD --always`
 
 if [ -f "$BUILD_DIR/generated" ]; then
-echo "Error: $BUILD_DIR/generated not found."
-echo "Run 'make sdk' first"
-exit 1
+  echo "Error: $BUILD_DIR/generated not found."
+  echo "Run 'make sdk' first"
+  exit 1
 fi
 
 mkdir -p "$SYNC_DIR"
@@ -44,10 +44,10 @@ find "$SYNC_DIR" -type f -name "CMakeLists.txt" -exec rm -f {} \;
 mkdir -p "$SYNC_DIR/code-analysis"
 (cd "$SYNC_DIR/code-analysis" && SDK=True cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $SOURCE)
 python tools/codegen/gentargets.py \
--v $VERSION --sdk $VERSION \
--i "$SYNC_DIR/code-analysis/compile_commands.json" \
--o $SYNC_DIR/osquery \
--s osquery
+  -v $VERSION --sdk $VERSION \
+  -i "$SYNC_DIR/code-analysis/compile_commands.json" \
+  -o $SYNC_DIR/osquery \
+  -s osquery
 
 cp osquery.thrift "$SYNC_DIR/osquery/extensions"
 

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -11,8 +11,8 @@
 set -e
 
 if [ "$#" -ne 2 ]; then
-echo "Usage: $0 BUILD_DIR LIBRARY_PATH"
-exit 1
+  echo "Usage: $0 BUILD_DIR LIBRARY_PATH"
+  exit 1
 fi
 
 SOURCE=$(pwd)
@@ -44,7 +44,7 @@ find "$SYNC_DIR" -type f -name "CMakeLists.txt" -exec rm -f {} \;
 mkdir -p "$SYNC_DIR/code-analysis"
 (cd "$SYNC_DIR/code-analysis" && SDK=True cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $SOURCE)
 python tools/codegen/gentargets.py \
-  -v $VERSION --sdk $VERSION \
+  -v $VERSION --sdk $VERSION \
   -i "$SYNC_DIR/code-analysis/compile_commands.json" \
   -o $SYNC_DIR/osquery \
   -s osquery

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -1,4 +1,4 @@
-  #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
@@ -10,9 +10,9 @@
 
 set -e
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 BUILD_DIR"
-  exit 1
+if [ "$#" -ne 2 ]; then
+echo "Usage: $0 BUILD_DIR LIBRARY_PATH"
+exit 1
 fi
 
 SOURCE=$(pwd)
@@ -21,14 +21,16 @@ SYNC_DIR="$BUILD_DIR/sync"
 VERSION=`git describe --tags HEAD --always`
 
 if [ -f "$BUILD_DIR/generated" ]; then
-  echo "Error: $BUILD_DIR/generated not found."
-  echo "Run 'make sdk' first"
-  exit 1
+echo "Error: $BUILD_DIR/generated not found."
+echo "Run 'make sdk' first"
+exit 1
 fi
 
 mkdir -p "$SYNC_DIR"
 rm -rf "$SYNC_DIR/osquery*"
 mkdir -p "$SYNC_DIR/osquery/generated"
+
+export LIBRARY_PATH=$2:$LIBRARY_PATH
 
 # merge the headers with the implementation files
 cp -R include/osquery "$SYNC_DIR"
@@ -42,10 +44,10 @@ find "$SYNC_DIR" -type f -name "CMakeLists.txt" -exec rm -f {} \;
 mkdir -p "$SYNC_DIR/code-analysis"
 (cd "$SYNC_DIR/code-analysis" && SDK=True cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON $SOURCE)
 python tools/codegen/gentargets.py \
-  -v $VERSION --sdk $VERSION \
-  -i "$SYNC_DIR/code-analysis/compile_commands.json" \
-  -o $SYNC_DIR/osquery \
-  -s osquery
+-v $VERSION --sdk $VERSION \
+-i "$SYNC_DIR/code-analysis/compile_commands.json" \
+-o $SYNC_DIR/osquery \
+-s osquery
 
 cp osquery.thrift "$SYNC_DIR/osquery/extensions"
 


### PR DESCRIPTION
When running make sync on centos7, when sync.sh runs, there is no default lib search directories for ld to search during linking. To fix, I added a second parameter to the sync.sh call with validation to allow the lib directories to be searched.

