### PR TITLE
Implement make format_check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ CMAKE := $(PATH_SET) LDFLAGS="-L$(DEPS_DIR)/legacy/lib -L$(DEPS_DIR)/lib $(LINK_
 CTEST := $(PATH_SET) ctest $(SOURCE_DIR)/
 FORMAT_COMMAND := python tools/formatting/git-clang-format.py \
 	"--commit" "master" "-f" "--style=file"
+FORMAT_CHECK_COMMAND := python tools/formatting/format-check.py
 
 ANALYSIS := ${SOURCE_DIR}/tools/analysis
 DEFINES := CTEST_OUTPUT_ON_FAILURE=1 \
@@ -146,6 +147,10 @@ docs: .setup
 	@mkdir -p docs
 	@cd build/docs && DOCS=True $(CMAKE) && \
 		$(DEFINES) $(MAKE) docs --no-print-directory $(MAKEFLAGS)
+
+format_check:
+	@echo "[+] clang-format (`$(PATH_SET) which clang-format`) version: `$(PATH_SET) clang-format --version`"
+	@$(PATH_SET) $(FORMAT_CHECK_COMMAND)
 
 format_master:
 	@echo "[+] clang-format (`$(PATH_SET) which clang-format`) version: `$(PATH_SET) clang-format --version`"

--- a/tools/audit.sh
+++ b/tools/audit.sh
@@ -20,15 +20,8 @@ function check_format() {
     git branch master FETCH_HEAD &> /dev/null || true
   fi
 
-  # Format and show the status
-  make format_master
-
-  if [[ `git diff --name-only | wc -l | awk '{print $1}'` = "0" ]]; then
-    return 0
-  else
-    git --no-pager diff || true
-    return 1
-  fi
+  # Check formatting
+  make format_check
 }
 
 function check_executable() {

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def check(base_commit):
+    try:
+        p = subprocess.Popen(
+                [
+                    "python",
+                    os.path.join("tools", "formatting", "git-clang-format.py"),
+                    "--style=file",
+                    "--diff",
+                    "--commit",
+                    base_commit,
+                    ],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+        out, err = p.communicate()
+    except OSError as e:
+        print("{}\n\n{}".format("Failed to call git-clang-format.py", str(e)))
+        return False
+
+    if p.returncode:
+        print("{}\n\n{}\n{}".format(
+            "Failed to run formatting script", out, err
+            ))
+        return False
+    elif out.startswith("no modified files to format"):
+        print("No code changes found!")
+        return True
+    elif out.startswith("clang-format did not modify any files"):
+        print("Code passes formatting tests!")
+        return True
+    else:
+        print("{}\n\n{}".format(
+            "Modifications failed code formatting requirements", out
+            ))
+        return False
+
+def get_base_commit(base_branch):
+    try:
+        return subprocess.check_output(
+                ["git", "merge-base", "HEAD", base_branch]
+                ).strip()
+    except OSError as e:
+        print("{}\n\n{}".format("Failed to execut git", str(e)))
+    except subprocess.CalledProcessError as e:
+        print("{}\n\n{}".format("Failed to determine merge-base", str(e)))
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check code changes formatting.")
+    parser.add_argument(
+            "base_branch",
+            metavar="base_branch",
+            type=str,
+            nargs="?",
+            default="master",
+            help="The base branch to compare to.",
+            )
+
+    args = parser.parse_args()
+
+    base_commit = get_base_commit(args.base_branch)
+
+    return check(base_commit) if base_commit is not None else False
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -29,7 +29,7 @@ def check(base_commit):
                 )
         out, err = p.communicate()
     except OSError as e:
-        print("{}\n\n{}".format("Failed to call git-clang-format.py", str(e)))
+        print("{}\n\n{!r}".format("Failed to call git-clang-format.py", e))
         return False
 
     if p.returncode:

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
 import argparse
 import os
 import subprocess


### PR DESCRIPTION
The tool tools/formatting/format-check.py is a wrapper around tools/formatting/git-clang-format.py which (1) caculates the merge-base between your current branch and master or the passed branch (2) runs git-clang-format.py with the result and (3) analyses the output and exits with an appropriate code, printing an message and if necessary the diff representing the changes required.

This will make code auditing performance code format checks only for the commits on your feature branch, so they won't be affected in case master advanced.