### PR TITLE
Remove linux undents

### DIFF
--- a/tools/provision/formula/ccache.rb
+++ b/tools/provision/formula/ccache.rb
@@ -42,7 +42,7 @@ class Ccache < AbstractOsqueryFormula
     end
   end
 
-  def caveats; <<-EOS
+  def caveats; <<~EOS
     To install symlinks for compilers that will automatically use
     ccache, prepend this directory to your PATH:
       #{opt_libexec}

--- a/tools/provision/formula/fbthrift-mstch.rb
+++ b/tools/provision/formula/fbthrift-mstch.rb
@@ -17,7 +17,7 @@ class FbthriftMstch < AbstractOsqueryFormula
     (lib/"pkgconfig/mstch.pc").write pc_file
   end
 
-  def pc_file; <<-EOS
+  def pc_file; <<~EOS
     prefix=#{HOMEBREW_PREFIX}
     exec_prefix=${prefix}
     libdir=${exec_prefix}/lib

--- a/tools/provision/formula/fbthrift-mstch.rb
+++ b/tools/provision/formula/fbthrift-mstch.rb
@@ -17,7 +17,7 @@ class FbthriftMstch < AbstractOsqueryFormula
     (lib/"pkgconfig/mstch.pc").write pc_file
   end
 
-  def pc_file; <<-EOS.undent
+  def pc_file; <<-EOS
     prefix=#{HOMEBREW_PREFIX}
     exec_prefix=${prefix}
     libdir=${exec_prefix}/lib

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -168,7 +168,7 @@ class Gcc < AbstractOsqueryFormula
     # to be available and backward compatible on the system.
     glibc = Formula["glibc-legacy"]
     libgcc = lib/"gcc/x86_64-unknown-linux-gnu"/version
-    specs.write specs_string + <<-EOS.undent
+    specs.write specs_string + <<-EOS
       *link_libgcc:
       #{glibc.installed? ? "-nostdlib -L#{libgcc}" : "+"} -L#{legacy_prefix}/lib -L#{default_prefix}/lib -lrt -lpthread
 

--- a/tools/provision/formula/gcc.rb
+++ b/tools/provision/formula/gcc.rb
@@ -168,7 +168,7 @@ class Gcc < AbstractOsqueryFormula
     # to be available and backward compatible on the system.
     glibc = Formula["glibc-legacy"]
     libgcc = lib/"gcc/x86_64-unknown-linux-gnu"/version
-    specs.write specs_string + <<-EOS
+    specs.write specs_string + <<~EOS
       *link_libgcc:
       #{glibc.installed? ? "-nostdlib -L#{libgcc}" : "+"} -L#{legacy_prefix}/lib -L#{default_prefix}/lib -lrt -lpthread
 

--- a/tools/provision/formula/openssl.rb
+++ b/tools/provision/formula/openssl.rb
@@ -82,7 +82,7 @@ class Openssl < AbstractOsqueryFormula
     (etc/"openssl").install resource("cacert").files("cacert-2018-03-07.pem" => "cert.pem")
   end
 
-  def caveats; <<-EOS
+  def caveats; <<~EOS
     A CA file has been bootstrapped using certificates from the system
     keychain. To add additional certificates, place .pem files in
       #{openssldir}/certs

--- a/tools/provision/formula/python.rb
+++ b/tools/provision/formula/python.rb
@@ -62,7 +62,7 @@ class Python < AbstractOsqueryFormula
   # setuptools remembers the build flags python is built with and uses them to
   # build packages later. Xcode-only systems need different flags.
   pour_bottle? do
-    reason <<-EOS
+    reason <<~EOS
     The bottle needs the Apple Command Line Tools to be installed.
       You can install them, if desired, with:
         xcode-select --install
@@ -224,7 +224,7 @@ class Python < AbstractOsqueryFormula
     ]
 
     cfg = lib_cellar/"distutils/distutils.cfg"
-    cfg.atomic_write <<-EOF
+    cfg.atomic_write <<~EOF
       [install]
       prefix=#{HOMEBREW_PREFIX}
 
@@ -235,7 +235,7 @@ class Python < AbstractOsqueryFormula
   end
 
   def sitecustomize
-    <<-EOF
+    <<~EOF
       # This file is created by Homebrew and is executed on each python startup.
       # Don't print from here, or else python command line scripts may fail!
       # <https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Homebrew-and-Python.md>
@@ -284,7 +284,7 @@ class Python < AbstractOsqueryFormula
     EOF
   end
 
-  def caveats; <<-EOS
+  def caveats; <<~EOS
     Pip and setuptools have been installed. To update them
       pip install --upgrade pip setuptools
 

--- a/tools/provision/formula/zlib-legacy.rb
+++ b/tools/provision/formula/zlib-legacy.rb
@@ -27,7 +27,7 @@ class ZlibLegacy < AbstractOsqueryFormula
 
     mkdir_p "#{legacy_prefix}/lib/pkgconfig"
     config = Pathname.new("#{prefix}/lib/pkgconfig/zlib.pc")
-    config.write <<-EOS
+    config.write <<~EOS
       prefix=#{prefix}
       exec_prefix=\$\{prefix\}
       libdir=\$\{exec_prefix\}/lib

--- a/tools/provision/formula/zlib-legacy.rb
+++ b/tools/provision/formula/zlib-legacy.rb
@@ -27,7 +27,7 @@ class ZlibLegacy < AbstractOsqueryFormula
 
     mkdir_p "#{legacy_prefix}/lib/pkgconfig"
     config = Pathname.new("#{prefix}/lib/pkgconfig/zlib.pc")
-    config.write <<-EOS.undent
+    config.write <<-EOS
       prefix=#{prefix}
       exec_prefix=\$\{prefix\}
       libdir=\$\{exec_prefix\}/lib


### PR DESCRIPTION
Removing the undents before only applied to macOS but the Linux taps were pulled forward as well and thus have the same errors. This removes the rest of the undents and should fix building on Linux.