### PR TITLE
events proof read

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -309,9 +309,7 @@ class EventPublisherPlugin : public Plugin,
    *
    * @return The number of events.
    */
-  EventContextID numEvents() const {
-    return next_ec_id_.load();
-  }
+  EventContextID numEvents() const;
 
   /// Check if the EventFactory is ending all publisher threads.
   bool isEnding() const {

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -302,9 +302,7 @@ class EventPublisherPlugin : public Plugin,
 
  public:
   /// Number of Subscription%s watching this EventPublisher.
-  size_t numSubscriptions() const {
-    return subscriptions_.size();
-  }
+  size_t numSubscriptions();
 
   /**
    * @brief The number of events fired by this EventPublisher.
@@ -312,7 +310,7 @@ class EventPublisherPlugin : public Plugin,
    * @return The number of events.
    */
   EventContextID numEvents() const {
-    return next_ec_id_;
+    return next_ec_id_.load();
   }
 
   /// Check if the EventFactory is ending all publisher threads.
@@ -361,7 +359,7 @@ class EventPublisherPlugin : public Plugin,
                             const EventContextRef& ec) const = 0;
 
   /// A lock for subscription manipulation.
-  Mutex subscription_lock_;
+  mutable Mutex subscription_lock_;
 
   /// The EventPublisher will keep track of Subscription%s that contain callins.
   SubscriptionVector subscriptions_;
@@ -376,9 +374,6 @@ class EventPublisherPlugin : public Plugin,
 
   /// Set to indicate whether the event run loop ever started.
   std::atomic<bool> started_{false};
-
-  /// A lock for incrementing the next EventContextID.
-  Mutex ec_id_lock_;
 
   /// A helper count of event publisher runloop iterations.
   std::atomic<size_t> restart_count_{0};

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -147,6 +147,10 @@ void EventSubscriberPlugin::genTable(RowYield& yield, QueryContext& context) {
   get(yield, start, stop);
 }
 
+EventContextID EventPublisherPlugin::numEvents() const {
+  return next_ec_id_.load();
+}
+
 size_t EventPublisherPlugin::numSubscriptions() {
   ReadLock lock(subscription_lock_);
   return subscriptions_.size();


### PR DESCRIPTION
ec_id_lock_ was not needed, because next_ec_id_  is atomic.
numSubscriptions need to acquire read lock.
fire does not need write lock(read is enough)
replaced obfuscated code with boost::ends_with. ( Also this obfuscated code would generate wrong log if subscriber name contained _events in the middle and also in the end)