### PR TITLE
[Docs] Kafka logging plugin is called kafka_producer not kafka

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -19,7 +19,7 @@ On Windows this directory defaults to `C:\ProgramData\osquery\log`.
 
 ## Logger plugins
 
-osquery includes logger plugins that support configurable logging to a variety of interfaces. The built in logger plugins are **filesystem** (default), **tls**, **syslog** (for POSIX), **windows_event_log** (for Windows), **kinesis**, **firehose**, and **kafka**. Multiple logger plugins may be used simultaneously, effectively copying logs to each interface. To enable multiple loggers set the `--logger_plugin` option to a comma separated list, do not include spaces, of the requested plugins.
+osquery includes logger plugins that support configurable logging to a variety of interfaces. The built in logger plugins are **filesystem** (default), **tls**, **syslog** (for POSIX), **windows_event_log** (for Windows), **kinesis**, **firehose**, and **kafka_producer**. Multiple logger plugins may be used simultaneously, effectively copying logs to each interface. To enable multiple loggers set the `--logger_plugin` option to a comma separated list, do not include spaces, of the requested plugins.
 
 For information on configuring logger plugins, see [logging/results flags](../installation/cli-flags.md#loggingresults-flags). Developing new logger plugins is explored in the [development docs](../development/logger-plugins.md). We recommend setting the logger plugin and logger settings via the osquery *flagfile*.
 


### PR DESCRIPTION
Reading the [osquery docs](https://osquery.readthedocs.io/en/stable/deployment/logging/#logger-plugins) about logging plugins one would assume that in order to enable kafka logging the correct flag would be `--logger_plugin=kafka` (given that the other plugin names appear as their corresponding flags AFAIK).

Using `kafka` though will return the error

```
Cannot activate kafka logger plugin: Unknown registry plugin: kafka
```

This is caused by the fact that the plugin seems to be actually called `kafka_producer` (since setting this has osquery publishing data to kafka properly).

