### PR TITLE
memory leak resolve for dispatcher

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -115,7 +115,7 @@ class InternalRunnable : private boost::noncopyable,
 
 /// An internal runnable used throughout osquery as dispatcher services.
 using InternalRunnableRef = std::shared_ptr<InternalRunnable>;
-using InternalThreadRef = std::unique_ptr<std::thread>;
+using InternalThreadRef = std::shared_ptr<std::thread>;
 
 /**
  * @brief Singleton for queuing asynchronous tasks to be executed in parallel

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -75,7 +75,7 @@ Status Dispatcher::addService(InternalRunnableRef service) {
     return Status(1, "Cannot add service, dispatcher is stopping");
   }
 
-  auto thread = std::make_unique<std::thread>(
+  auto thread = std::make_shared<std::thread>(
       std::bind(&InternalRunnable::run, &*service));
 
   DLOG(INFO) << "Adding new service: " << service->name() << " ("


### PR DESCRIPTION
Reverting back InternalThreadRef to shared_ptr. #4592

It's still weird. If it's a problem, it should be on other platforms too. It looks to be connected to the weird interaction between this InternalRunnableRef function binded to the InternalThreadRef. If anyone comes up to more constructive explanation, please let me know. 