### PR TITLE
udev resource protection

### DIFF
--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -68,25 +68,22 @@ Status UdevEventPublisher::run() {
       return Status(1);
     }
     fd = udev_monitor_get_fd(monitor_);
-  }
 
-  struct pollfd fds[1];
-  fds[0].fd = fd;
-  fds[0].events = POLLIN;
+    struct pollfd fds[1];
+    fds[0].fd = fd;
+    fds[0].events = POLLIN;
 
-  int selector = ::poll(fds, 1, 1000);
-  if (selector == -1 && errno != EINTR && errno != EAGAIN) {
-    LOG(ERROR) << "Could not read udev monitor";
-    return Status(1, "udev monitor failed.");
-  }
+    int selector = ::poll(fds, 1, 1000);
+    if (selector == -1 && errno != EINTR && errno != EAGAIN) {
+      LOG(ERROR) << "Could not read udev monitor";
+      return Status(1, "udev monitor failed.");
+    }
 
-  if (selector == 0 || !(fds[0].revents & POLLIN)) {
-    // Read timeout.
-    return Status(0, "Finished");
-  }
+    if (selector == 0 || !(fds[0].revents & POLLIN)) {
+      // Read timeout.
+      return Status(0, "Finished");
+    }
 
-  {
-    WriteLock lock(mutex_);
     struct udev_device* device = udev_monitor_receive_device(monitor_);
     if (device == nullptr) {
       LOG(ERROR) << "udev monitor returned invalid device";
@@ -180,4 +177,4 @@ bool UdevEventPublisher::shouldFire(const UdevSubscriptionContextRef& sc,
 
   return true;
 }
-}
+} // namespace osquery


### PR DESCRIPTION
It looks like udev is sometimes failing with message "udev monitor returned invalid device".
This happens when we receive NULL from udev_monitor_receive_device(monitor_).
I checked implementation, and one possible case of actually returning NULL is when the argument(monitor_) is NULL. https://github.com/systemd/systemd/blob/master/src/libudev/libudev-monitor.c#L591
Even though we are checking if monitor_ is NULL at the beginning of the run, lock is released afterward, so no assumption could be made during the udev_monitor_receive_device call.
Extending the locked area.