### PR TITLE
Do not try to decode/encode utf-8 in python extensions

### DIFF
--- a/osquery/extensions/CMakeLists.txt
+++ b/osquery/extensions/CMakeLists.txt
@@ -14,7 +14,7 @@ if(LINUX OR DARWIN)
     add_custom_command(
       COMMAND
         LD_LIBRARY_PATH=${BUILD_DEPS}/lib:$ENV{LD_LIBRARY_PATH}
-        ${THRIFT_COMPILER} --gen mstch_cpp2:stack_arguments,include_prefix=generated --gen py
+        ${THRIFT_COMPILER} --gen mstch_cpp2:stack_arguments,include_prefix=generated --gen py:no_utf8strings
         --templates "${BUILD_DEPS}/include/thrift/templates"
         -o "${CMAKE_BINARY_DIR}/generated"
         "${CMAKE_SOURCE_DIR}/osquery.thrift"
@@ -42,7 +42,7 @@ if(LINUX OR DARWIN)
     add_custom_command(
       COMMAND
         LD_LIBRARY_PATH=${BUILD_DEPS}/lib:$ENV{LD_LIBRARY_PATH}
-        ${THRIFT_COMPILER} --gen cpp --gen py
+        ${THRIFT_COMPILER} --gen cpp --gen py:no_utf8strings
         "${CMAKE_SOURCE_DIR}/osquery.thrift"
       DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"
@@ -52,7 +52,7 @@ if(LINUX OR DARWIN)
 else()
   add_custom_command(
     COMMAND
-      ${THRIFT_COMPILER} --gen cpp --gen py
+      ${THRIFT_COMPILER} --gen cpp --gen py:no_utf8strings
         "${CMAKE_SOURCE_DIR}/osquery.thrift"
     DEPENDS "${CMAKE_SOURCE_DIR}/osquery.thrift"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/generated"


### PR DESCRIPTION
`osquery` itself does not care about unicode validity in table columns,
just takes it "as is". It definitely makes sense, because it could be broken.
But thrift extensions interface for python do decode/encode. Which doesn't look correct.

If, for instance, shell history contains broken unicode test `python_test_example_queries`
will fail.

```bash
% sed -n '5277p' < ~/.zsh_history | xxd -b                                                                                                                          [146]
00000000: 11000011 10000011 10111111 01101100 01110011 00001010  ...ls.
```