### PR TITLE
Create a `success` and `failure` static factory for Status

### DIFF
--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -33,14 +33,14 @@ namespace osquery {
 
 class Status {
  public:
-  static constexpr int success_code = 0;
+  static constexpr int kSuccessCode = 0;
   /**
    * @brief Default constructor
    *
    * Note that the default constructor initialized an osquery::Status instance
    * to a state such that a successful operation is indicated.
    */
-  explicit Status(int c = Status::success_code) : code_(c), message_("OK") {}
+  explicit Status(int c = Status::kSuccessCode) : code_(c), message_("OK") {}
 
   /**
    * @brief A constructor which can be used to concisely express the status of
@@ -82,7 +82,7 @@ class Status {
 
   /**
    * @brief A convenience method to check if the return code is
-   * Status::success_code
+   * Status::kSuccessCode
    *
    * @code{.cpp}
    *   auto s = doSomething();
@@ -93,11 +93,11 @@ class Status {
    *   }
    * @endcode
    *
-   * @return a boolean which is true if the status code is Status::success_code,
+   * @return a boolean which is true if the status code is Status::kSuccessCode,
    * false otherwise.
    */
   bool ok() const {
-    return getCode() == Status::success_code;
+    return getCode() == Status::kSuccessCode;
   }
 
   /**
@@ -128,7 +128,7 @@ class Status {
   }
 
   static Status success() {
-    return Status(success_code, std::string{"ok"});
+    return Status(kSuccessCode);
   }
 
   static Status failure(std::string message) {

--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -127,6 +127,16 @@ class Status {
     return ok();
   }
 
+  static Status success() {
+    return Status(success_code, std::string{"ok"});
+  }
+
+  static Status failure(std::string message) {
+    return Status(1, std::move(message));
+  }
+
+  static Status failure(int code, std::string message);
+
   // Below operator implementations useful for testing with gtest
 
   // Enables use of gtest (ASSERT|EXPECT)_EQ

--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -33,13 +33,14 @@ namespace osquery {
 
 class Status {
  public:
+  static constexpr int success_code = 0;
   /**
    * @brief Default constructor
    *
    * Note that the default constructor initialized an osquery::Status instance
    * to a state such that a successful operation is indicated.
    */
-  explicit Status(int c = 0) : code_(c), message_("OK") {}
+  explicit Status(int c = Status::success_code) : code_(c), message_("OK") {}
 
   /**
    * @brief A constructor which can be used to concisely express the status of
@@ -80,7 +81,8 @@ class Status {
   }
 
   /**
-   * @brief A convenience method to check if the return code is 0
+   * @brief A convenience method to check if the return code is
+   * Status::success_code
    *
    * @code{.cpp}
    *   auto s = doSomething();
@@ -91,10 +93,11 @@ class Status {
    *   }
    * @endcode
    *
-   * @return a boolean which is true if the status code is 0, false otherwise.
+   * @return a boolean which is true if the status code is Status::success_code,
+   * false otherwise.
    */
   bool ok() const {
-    return getCode() == 0;
+    return getCode() == Status::success_code;
   }
 
   /**

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(osquery_core
     "${CMAKE_CURRENT_LIST_DIR}/process.h"
     "${CMAKE_CURRENT_LIST_DIR}/query.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/system.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/status.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/tables.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/utils.h"
     "${CMAKE_CURRENT_LIST_DIR}/watcher.cpp"

--- a/osquery/core/status.cpp
+++ b/osquery/core/status.cpp
@@ -8,10 +8,19 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <osquery/logger.h>
 #include <osquery/status.h>
 
 namespace osquery {
 
 constexpr int Status::success_code;
+
+Status Status::failure(int code, std::string message) {
+  if (code == Status::success_code) {
+    LOG(ERROR) << "Using Status::failure to create Status object with "
+                  "a Status::success_code";
+  }
+  return Status(code, std::move(message));
+}
 
 } // namespace osquery

--- a/osquery/core/status.cpp
+++ b/osquery/core/status.cpp
@@ -17,12 +17,11 @@
 
 namespace osquery {
 
-constexpr int Status::success_code;
+constexpr int Status::kSuccessCode;
 
 Status Status::failure(int code, std::string message) {
-  assert(code != Status::success_code &&
-         "Using Status::failure to create Status object with a "
-         "Status::success_code");
+  assert(code != Status::kSuccessCode &&
+         "Using 'failure' to create Status object with a kSuccessCode");
   return Status(code, std::move(message));
 }
 

--- a/osquery/core/status.cpp
+++ b/osquery/core/status.cpp
@@ -11,15 +11,18 @@
 #include <osquery/logger.h>
 #include <osquery/status.h>
 
+#include <cassert>
+
+#include <iostream>
+
 namespace osquery {
 
 constexpr int Status::success_code;
 
 Status Status::failure(int code, std::string message) {
-  if (code == Status::success_code) {
-    LOG(ERROR) << "Using Status::failure to create Status object with "
-                  "a Status::success_code";
-  }
+  assert(code != Status::success_code &&
+         "Using Status::failure to create Status object with a "
+         "Status::success_code");
   return Status(code, std::move(message));
 }
 

--- a/osquery/core/status.cpp
+++ b/osquery/core/status.cpp
@@ -1,0 +1,17 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/status.h>
+
+namespace osquery {
+
+constexpr int Status::success_code;
+
+} // namespace osquery

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -66,4 +66,12 @@ TEST_F(StatusTests, test_failure_double_arg) {
   EXPECT_EQ(s.toString(), "One more proper error message!");
   EXPECT_FALSE(s.ok());
 }
+
+TEST_F(StatusTests, test_failure_with_success_code) {
+#ifndef NDEBUG
+  ASSERT_DEATH(Status::failure(Status::success_code, "message"),
+               "Using Status::failure to create Status object with a "
+               "Status::success_code");
+#endif
+}
 }

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -39,4 +39,31 @@ TEST_F(StatusTests, test_to_string) {
   auto s = Status(0, "foobar");
   EXPECT_EQ(s.toString(), "foobar");
 }
+
+TEST_F(StatusTests, test_default_constructor) {
+  auto s = Status{};
+  EXPECT_TRUE(s.ok());
+}
+
+TEST_F(StatusTests, test_success_code) {
+  auto s = Status(Status::success_code);
+  EXPECT_TRUE(s.ok());
+}
+
+TEST_F(StatusTests, test_success) {
+  auto s = Status::success();
+  EXPECT_TRUE(s.ok());
+}
+
+TEST_F(StatusTests, test_failure_single_arg) {
+  auto s = Status::failure("Some proper error message.");
+  EXPECT_EQ(s.toString(), "Some proper error message.");
+  EXPECT_FALSE(s.ok());
+}
+
+TEST_F(StatusTests, test_failure_double_arg) {
+  auto s = Status::failure(105, "One more proper error message!");
+  EXPECT_EQ(s.toString(), "One more proper error message!");
+  EXPECT_FALSE(s.ok());
+}
 }

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -46,7 +46,7 @@ TEST_F(StatusTests, test_default_constructor) {
 }
 
 TEST_F(StatusTests, test_success_code) {
-  auto s = Status(Status::success_code);
+  auto s = Status(Status::kSuccessCode);
   EXPECT_TRUE(s.ok());
 }
 
@@ -69,9 +69,8 @@ TEST_F(StatusTests, test_failure_double_arg) {
 
 TEST_F(StatusTests, test_failure_with_success_code) {
 #ifndef NDEBUG
-  ASSERT_DEATH(Status::failure(Status::success_code, "message"),
-               "Using Status::failure to create Status object with a "
-               "Status::success_code");
+  ASSERT_DEATH(Status::failure(Status::kSuccessCode, "message"),
+               "Using 'failure' to create Status object with a kSuccessCode");
 #endif
 }
 }


### PR DESCRIPTION
Consider this PR as a cosmetic one.
Creating Status class object in the code is not so clear. It is not so obvious that default constructed Status is success. Also it is not obvious that status with zero code is success and non-zero is failure.
I created 2 static methods to make construction of some particular status clear to reader.