### PR TITLE
Dont bring up any dispatcher controlled service in profile mode

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -115,7 +115,7 @@ class InternalRunnable : private boost::noncopyable,
 
 /// An internal runnable used throughout osquery as dispatcher services.
 using InternalRunnableRef = std::shared_ptr<InternalRunnable>;
-using InternalThreadRef = std::shared_ptr<std::thread>;
+using InternalThreadRef = std::unique_ptr<std::thread>;
 
 /**
  * @brief Singleton for queuing asynchronous tasks to be executed in parallel

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -75,7 +75,7 @@ Status Dispatcher::addService(InternalRunnableRef service) {
     return Status(1, "Cannot add service, dispatcher is stopping");
   }
 
-  auto thread = std::make_shared<std::thread>(
+  auto thread = std::make_unique<std::thread>(
       std::bind(&InternalRunnable::run, &*service));
 
   DLOG(INFO) << "Adding new service: " << service->name() << " ("

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -172,8 +172,11 @@ int startOsquery(int argc, char* argv[], std::function<void()> shutdown) {
   // In either case the watcher may start optionally loaded extensions.
   runner.initWorkerWatcher(kWatcherWorkerName);
 
-  // Begin adhoc io service thread.
-  startIOService();
+  // In profile mode dont start io service thread
+  if (FLAGS_profile == 0) {
+    // Begin adhoc io service thread.
+    startIOService();
+  }
 
   if (runner.isDaemon()) {
     return startDaemon(runner);


### PR DESCRIPTION
Dont bring up any dispatcher controlled service in profile mode.

IO Service is coming up  in profile mode but join is not being called on the io service thread, which leads to the terminate getting called ( https://en.cppreference.com/w/cpp/thread/thread/~thread). Which makes valgrind think that there are memory leaks. 

Hope this fix answers the question asked here -
https://github.com/facebook/osquery/pull/4597

After applying this fix 
nishant@nishant-VirtualBox:~/osquery_contri/osquery$ ./tools/analysis/profile.py --leaks
Analyzing leaks in query: SELECT * FROM crontab;
  possibly: 0 bytes in 0 blocks; definitely: 0 bytes in 0 blocks; indirectly: 0 bytes in 0 blocks

