### PR TITLE
Update win64 openssl provisioning script

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -15,38 +15,6 @@ if (-not (Test-Path $utils)) {
 }
 . $utils
 
-# A helper function to derive the latest VS install and call vcvarsall.bat
-function Invoke-VcVarsAll {
-  $vsinfo = Get-VSInfo
-  $vsLoc = $vsinfo.location
-  $vsVersion = $vsinfo.version
-
-  if ($vsLoc -ne '') {
-    $vcvarsall = Join-Path $vsLoc 'VC'
-    if ($vsVersion -eq '15') {
-      $vcvarsall = Join-Path $vcvarsall '\Auxiliary\Build\vcvarsall.bat'
-    } else {
-      $vcvarsall = Join-Path $vcvarsall 'vcvarsall.bat'
-    }
-  
-    # Lastly invoke the environment provisioning script
-    $null = Invoke-BatchFile "$vcvarsall" "amd64"
-    return $true
-  }
-
-  # As a last ditch effort, attempt to find the env variables set by VS2015
-  # in order to derive the location of vcvarsall
-  $vsComnTools = [environment]::GetEnvironmentVariable("VS140COMNTOOLS")
-  if ($vsComnTools -eq '') {
-    return $false
-  }
-  $vcvarsall = Resolve-Path $(Join-Path "$vsComnTools" "..\..\VC")
-  $vcvarsall = Join-Path $vcvarsall 'vcvarsall.bat'
-  $null = Invoke-BatchFile "$vcvarsall" "amd64"
-  return $true
-}
-
-
 # A helper function to call CMake and generate our solution file
 function Invoke-OsqueryCmake {
   $vsinfo = Get-VSInfo

--- a/tools/provision/chocolatey/openssl.ps1
+++ b/tools/provision/chocolatey/openssl.ps1
@@ -31,7 +31,11 @@ $curlCertsShaSum =
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\osquery_utils.ps1"
 
 # Invoke the MSVC developer tools/env
-Invoke-BatchFile "$env:VS140COMNTOOLS\..\..\vc\vcvarsall.bat" amd64
+$ret = Invoke-VcVarsAll
+if ($ret -ne $true) {
+	Write-Host "[-] vcvarsall.bat failed to run" Red
+	exit
+}
 
 if (-not
      (
@@ -46,7 +50,8 @@ if (-not
 }
 
 # Check that Perl is installed
-if (-not (Get-Command 'perl' -ErrorAction SilentlyContinue)) {
+$checkPerl = Get-Command 'perl' -ErrorAction SilentlyContinue
+if (-not ($checkPerl -and $checkPerl.Source.StartsWith('C:\Perl64\bin\'))) {
   $msg = "[-] This build requires perl which was not found. Please install " +
          "perl from http://www.activestate.com/activeperl/downloads and add " +
          "to the SYSTEM path before continuing"

--- a/tools/provision/chocolatey/openssl.ps1
+++ b/tools/provision/chocolatey/openssl.ps1
@@ -36,8 +36,8 @@ $currentLoc = Get-Location
 # Invoke the MSVC developer tools/env
 $ret = Invoke-VcVarsAll
 if ($ret -ne $true) {
-	Write-Host "[-] vcvarsall.bat failed to run" -ForegroundColor Red
-	exit
+  Write-Host "[-] vcvarsall.bat failed to run" -ForegroundColor Red
+  exit
 }
 
 if (-not
@@ -97,8 +97,9 @@ if (-not (Test-Path $zipFile)) {
 }
 
 $7z = (Get-Command '7z' -ErrorAction SilentlyContinue).Source
-$7zargs = @('x',
-	$zipFile
+$7zargs = @(
+  'x',
+  $zipFile
 )
 $perl = (Get-Command 'perl' -ErrorAction SilentlyContinue).Source
 $nmake = (Get-Command 'nmake' -ErrorAction SilentlyContinue).Source

--- a/tools/provision/chocolatey/openssl.ps1
+++ b/tools/provision/chocolatey/openssl.ps1
@@ -93,15 +93,20 @@ if (-not (Test-Path $zipFile)) {
   Invoke-WebRequest $url -OutFile "$zipFile"
 }
 
+$7z = (Get-Command '7z').Source
+$7zargs = 'x ' + $zipFile
+$perl = (Get-Command 'perl').Source
+$nmake = (Get-Command 'nmake').Source
+
 # Extract the source
-7z x $zipFile
+Start-OsqueryProcess $7z $7zargs $false
 $sourceDir = "$packageName-OpenSSL_$version"
 Set-Location $sourceDir
 
 # Build the libraries
-perl Configure VC-WIN64A
-ms\do_win64a
-nmake -f ms\nt.mak
+Start-OsqueryProcess $perl 'Configure VC-WIN64A' $false
+Invoke-BatchFile 'ms\do_win64a.bat'
+Start-OsqueryProcess $nmake '-f ms\nt.mak' $false
 
 #$buildDir = New-Item -Force -ItemType Directory -Path 'osquery-win-build'
 #Set-Location $buildDir


### PR DESCRIPTION
Minor fixes to provisioning script:
* moved `Invoke-VcVarsAll` to `osquery_utils.ps1` so all provisioning scripts can use it
* Force set TLS 1.2 in `osquery_utils.ps1`
* Explicitly check Perl install to make sure incompatible version is not used
* Clean up external executions for things like `.bat` scripts and 7z, nmake, etc