### PR TITLE
Remove platformStrncpy function from osquery/core/utils.h

### DIFF
--- a/osquery/core/posix/utils.cpp
+++ b/osquery/core/posix/utils.cpp
@@ -31,19 +31,6 @@ std::string platformStrerr(int errnum) {
   return ::strerror(errnum);
 }
 
-Status platformStrncpy(char* dst, size_t nelms, const char* src, size_t count) {
-  if (dst == nullptr || src == nullptr || nelms == 0) {
-    return Status(1, "Failed to strncpy: invalid arguments");
-  }
-
-  if (count > nelms) {
-    return Status(1, "Failed to strncpy: dst too small");
-  }
-
-  ::strncpy(dst, src, count);
-  return Status(0, "OK");
-}
-
 const std::string canonicalize_file_name(const char* name) {
 #ifdef PATH_MAX
   // On supported platforms where PATH_MAX is defined we can pass null

--- a/osquery/core/utils.h
+++ b/osquery/core/utils.h
@@ -27,9 +27,6 @@ std::string platformAsctime(const struct tm* timeptr);
 /// Returns a C++ string explaining the errnum
 std::string platformStrerr(int errnum);
 
-/// Copies src string into the dst string buffer with error checks
-Status platformStrncpy(char* dst, size_t nelms, const char* src, size_t count);
-
 #ifdef OSQUERY_POSIX
 /// Safer way to do realpath
 const std::string canonicalize_file_name(const char* name);

--- a/osquery/core/windows/utils.cpp
+++ b/osquery/core/windows/utils.cpp
@@ -46,12 +46,4 @@ std::string platformStrerr(int errnum) {
   return std::string(buffer.data());
 }
 
-Status platformStrncpy(char* dst, size_t nelms, const char* src, size_t count) {
-  auto status = ::strncpy_s(dst, nelms, src, count);
-  if (status != 0) {
-    return Status(1, "Failed to strncpy_s: " + status);
-  }
-
-  return Status(0, "OK");
-}
 }


### PR DESCRIPTION
On the one heand there is no place of use for it. And on the other, if code rely on all this checks it must be pretty unsafe and messy.