### PR TITLE
Improving audit-based table performances

### DIFF
--- a/include/osquery/database.h
+++ b/include/osquery/database.h
@@ -17,6 +17,9 @@
 #include <osquery/plugin.h>
 
 namespace osquery {
+// A list of key/str pairs; used for write batching with setDatabaseBatch
+using DatabaseStringValueList =
+    std::vector<std::pair<std::string, std::string>>;
 
 class Status;
 /**
@@ -116,6 +119,9 @@ class DatabasePlugin : public Plugin {
   virtual Status put(const std::string& domain,
                      const std::string& key,
                      int value) = 0;
+
+  virtual Status putBatch(const std::string& domain,
+                          const DatabaseStringValueList& data) = 0;
 
   virtual void dumpDatabase() const = 0;
 
@@ -243,6 +249,9 @@ Status setDatabaseValue(const std::string& domain,
 Status setDatabaseValue(const std::string& domain,
                         const std::string& key,
                         int value);
+
+Status setDatabaseBatch(const std::string& domain,
+                        const DatabaseStringValueList& data);
 
 /// Remove a domain/key identified value from backing-store.
 Status deleteDatabaseValue(const std::string& domain, const std::string& key);

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -413,10 +413,7 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    *
    * @return Was the element added to the backing store.
    */
-  Status add(const Row& r) {
-    std::vector<Row> batch = {r};
-    return addBatch(batch, getUnixTime());
-  }
+  Status add(const Row& r);
 
   /**
    * @brief Store parsed event data from an EventCallback in a backing store.

--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -407,6 +407,20 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
   /**
    * @brief Store parsed event data from an EventCallback in a backing store.
    *
+   * This method stores a single event
+   *
+   * @param r The row to add
+   *
+   * @return Was the element added to the backing store.
+   */
+  Status add(const Row& r) {
+    std::vector<Row> batch = {r};
+    return addBatch(batch, getUnixTime());
+  }
+
+  /**
+   * @brief Store parsed event data from an EventCallback in a backing store.
+   *
    * Within a EventCallback the EventSubscriber has an opportunity to create
    * an osquery Row element, add the relevant table data for the EventSubscriber
    * and store that element in the osquery backing store. At query-time
@@ -414,13 +428,11 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * The backing store data retrieval is optimized by time-based indexes. It
    * is important to added EventTime as it relates to "when the event occurred".
    *
-   * @param r An osquery Row element.
+   * @param row_list A (writable) vector of osquery Row elements.
    *
    * @return Was the element added to the backing store.
    */
-  Status add(Row& r) {
-    return add(r, 0);
-  }
+  Status addBatch(std::vector<Row>& row_list);
 
   /**
    * @brief Return all events added by this EventSubscriber within start, stop.
@@ -436,7 +448,8 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
  private:
   /// Overload add for tests and allow them to override the event time.
-  virtual Status add(Row& r, EventTime event_time) final;
+  virtual Status addBatch(std::vector<Row>& row_list,
+                          EventTime custom_event_time) final;
 
  private:
   /*
@@ -520,12 +533,14 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
    * 60 seconds and 3600 seconds and `time` is 92, this pair will be added to
    * list type 1 bin 4 and list type 2 bin 1.
    *
-   * @param eid A unique EventID.
-   * @param time The time when this EventID%'s event occurred.
+   * @param event_id_list A vector of (unique) EventIDs
+   * @param event_time The event time for this batch
    *
    * @return Were the indexes recorded.
    */
-  Status recordEvent(const std::string& eid, EventTime time);
+
+  Status recordEvents(const std::vector<std::string>& event_id_list,
+                      EventTime event_time);
 
   /**
    * @brief Get the expiration timeout for this event type

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -242,8 +242,9 @@ Status sendPutBatchDatabaseRequest(const std::string& domain,
     return status;
   }
 
-  PluginRequest request = {
-      {"action", "putBatch"}, {"domain", domain}, {"json", serialized_data}};
+  PluginRequest request = {{"action", "putBatch"},
+                           {"domain", domain},
+                           {"json", std::move(serialized_data)}};
 
   status = Registry::call("database", request);
   if (!status.ok()) {

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -49,18 +49,43 @@ Status EphemeralDatabasePlugin::get(const std::string& domain,
                                     int& value) const {
   return this->getAny(domain, key, value);
 }
+
+void EphemeralDatabasePlugin::setValue(const std::string& domain,
+                                       const std::string& key,
+                                       const std::string& value) {
+  db_[domain][key] = value;
+}
+
+void EphemeralDatabasePlugin::setValue(const std::string& domain,
+                                       const std::string& key,
+                                       int value) {
+  db_[domain][key] = value;
+}
+
 Status EphemeralDatabasePlugin::put(const std::string& domain,
                                     const std::string& key,
                                     const std::string& value) {
-  db_[domain][key] = value;
+  setValue(domain, key, value);
   return Status(0);
 }
 
 Status EphemeralDatabasePlugin::put(const std::string& domain,
                                     const std::string& key,
                                     int value) {
-  db_[domain][key] = value;
+  setValue(domain, key, value);
   return Status(0);
+}
+
+Status EphemeralDatabasePlugin::putBatch(const std::string& domain,
+                                         const DatabaseStringValueList& data) {
+  for (const auto& p : data) {
+    const auto& key = p.first;
+    const auto& value = p.second;
+
+    setValue(domain, key, value);
+  }
+
+  return Status(0, "OK");
 }
 
 void EphemeralDatabasePlugin::dumpDatabase() const {
@@ -117,4 +142,4 @@ Status EphemeralDatabasePlugin::scan(const std::string& domain,
   }
   return Status(0);
 }
-}
+} // namespace osquery

--- a/osquery/database/plugins/ephemeral.h
+++ b/osquery/database/plugins/ephemeral.h
@@ -27,6 +27,13 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
                 const std::string& key,
                 T& value) const;
 
+ private:
+  void setValue(const std::string& domain,
+                const std::string& key,
+                const std::string& value);
+
+  void setValue(const std::string& domain, const std::string& key, int value);
+
  public:
   /// Data retrieval method.
 
@@ -43,6 +50,9 @@ class EphemeralDatabasePlugin : public DatabasePlugin {
   Status put(const std::string& domain,
              const std::string& key,
              int value) override;
+
+  Status putBatch(const std::string& domain,
+                  const DatabaseStringValueList& data) override;
 
   void dumpDatabase() const override;
 

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -52,6 +52,9 @@ class RocksDBDatabasePlugin : public DatabasePlugin {
              const std::string& key,
              int value) override;
 
+  Status putBatch(const std::string& domain,
+                  const DatabaseStringValueList& data) override;
+
   void dumpDatabase() const override;
 
   /// Data removal method.

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -210,7 +210,7 @@ Status SQLiteDatabasePlugin::putBatch(const std::string& domain,
   sqlite3_prepare_v2(db_, q.c_str(), -1, &stmt, nullptr);
 
   {
-    size_t i = 1U;
+    int i = 1;
 
     for (const auto& p : data) {
       const auto& key = p.first;
@@ -219,7 +219,7 @@ Status SQLiteDatabasePlugin::putBatch(const std::string& domain,
       sqlite3_bind_text(stmt, i, key.c_str(), -1, SQLITE_STATIC);
       sqlite3_bind_text(stmt, i + 1, value.c_str(), -1, SQLITE_STATIC);
 
-      i += 2U;
+      i += 2;
     }
   }
 

--- a/osquery/database/plugins/sqlite.h
+++ b/osquery/database/plugins/sqlite.h
@@ -39,6 +39,9 @@ class SQLiteDatabasePlugin : public DatabasePlugin {
              const std::string& key,
              int value) override;
 
+  Status putBatch(const std::string& domain,
+                  const DatabaseStringValueList& data) override;
+
   void dumpDatabase() const override;
 
   /// Data removal method.

--- a/osquery/database/tests/database_tests.cpp
+++ b/osquery/database/tests/database_tests.cpp
@@ -35,6 +35,14 @@ TEST_F(DatabaseTests, test_set_value_int) {
   EXPECT_TRUE(s.ok());
 }
 
+TEST_F(DatabaseTests, test_set_str_batch) {
+  DatabaseStringValueList batch = {
+      {"str1", "{}"}, {"str2", "{}"}, {"str3", "{}"}};
+
+  auto s = setDatabaseBatch(kLogs, batch);
+  EXPECT_TRUE(s.ok());
+}
+
 TEST_F(DatabaseTests, test_set_value_mix1) {
   auto s = setDatabaseValue(kLogs, "intstr", -1);
   EXPECT_TRUE(s.ok());
@@ -99,6 +107,24 @@ TEST_F(DatabaseTests, test_get_value_mix1) {
 
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(value, expected);
+}
+
+TEST_F(DatabaseTests, test_get_str_batch) {
+  DatabaseStringValueList batch = {
+      {"str1", "{}"}, {"str2", "{}"}, {"str3", "{}"}};
+  auto s = setDatabaseBatch(kLogs, batch);
+  EXPECT_TRUE(s.ok());
+
+  for (const auto& p : batch) {
+    const auto& key = p.first;
+    const auto& expected_value = p.second;
+
+    std::string value;
+    s = getDatabaseValue(kLogs, key, value);
+    EXPECT_TRUE(s.ok());
+
+    EXPECT_EQ(value, expected_value);
+  }
 }
 
 TEST_F(DatabaseTests, test_get_value_mix2) {
@@ -236,4 +262,4 @@ TEST_F(DatabaseTests, test_ptree_upgrade_to_rj_results_v0v1) {
   getDatabaseValue(kPersistentSettings, "results_version", db_results_version);
   EXPECT_EQ(db_results_version, kDatabaseResultsVersion);
 }
-}
+} // namespace osquery

--- a/osquery/database/tests/plugin_tests.cpp
+++ b/osquery/database/tests/plugin_tests.cpp
@@ -102,6 +102,63 @@ void DatabasePluginTests::testPut() {
   reset.get();
 }
 
+void DatabasePluginTests::testPutBatch() {
+  DatabaseStringValueList string_batch = {
+      {"test_put_str1", "test_put_str1_value"},
+      {"test_put_str2", "test_put_str2_value"}};
+
+  auto s = getPlugin()->putBatch(kQueries, string_batch);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s.getMessage(), "OK");
+
+  for (const auto& p : string_batch) {
+    const auto& key = p.first;
+    const auto& expected_value = p.second;
+
+    std::string value;
+    s = getDatabaseValue(kQueries, key, value);
+    EXPECT_EQ(s.getMessage(), "OK");
+
+    EXPECT_EQ(expected_value, value);
+  }
+
+  DatabaseStringValueList str_batch2 = {
+      {"test_plugin_put_json_str1", "test_put_str1_value"},
+      {"test_plugin_put_json_str2", "test_put_str2_value"}};
+
+  auto json_object = JSON::newObject();
+  for (const auto& p : str_batch2) {
+    const auto& key = p.first;
+    const auto& value = p.second;
+
+    json_object.addRef(key, value);
+  }
+
+  std::string serialized_data;
+  s = json_object.toString(serialized_data);
+  EXPECT_TRUE(s.ok());
+
+  PluginRequest request = {
+      {"action", "putBatch"}, {"domain", kQueries}, {"json", serialized_data}};
+
+  s = Registry::call("database", getName(), request);
+  EXPECT_TRUE(s.ok());
+
+  for (const auto& p : str_batch2) {
+    const auto& key = p.first;
+    const auto& expected_value = p.second;
+
+    std::string value;
+    s = getDatabaseValue(kQueries, key, value);
+    EXPECT_EQ(s.getMessage(), "OK");
+
+    EXPECT_EQ(expected_value, value);
+  }
+
+  auto reset = std::async(std::launch::async, kTestReseter);
+  reset.get();
+}
+
 void DatabasePluginTests::testGet() {
   getPlugin()->put(kQueries, "test_get", "bar");
 
@@ -191,4 +248,4 @@ void DatabasePluginTests::testScanLimit() {
   EXPECT_EQ(s.getMessage(), "OK");
   EXPECT_EQ(keys.size(), 2U);
 }
-}
+} // namespace osquery

--- a/osquery/database/tests/plugin_tests.h
+++ b/osquery/database/tests/plugin_tests.h
@@ -27,6 +27,9 @@
   TEST_F(n, test_put) {                                                        \
     testPut();                                                                 \
   }                                                                            \
+  TEST_F(n, test_putBatch) {                                                   \
+    testPutBatch();                                                            \
+  }                                                                            \
   TEST_F(n, test_get) {                                                        \
     testGet();                                                                 \
   }                                                                            \
@@ -86,10 +89,11 @@ class DatabasePluginTests : public testing::Test {
   void testPluginCheck();
   void testReset();
   void testPut();
+  void testPutBatch();
   void testGet();
   void testDelete();
   void testDeleteRange();
   void testScan();
   void testScanLimit();
 };
-}
+} // namespace osquery

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -63,7 +63,9 @@ class BenchmarkEventSubscriber
   void benchmarkAdd(int t) {
     Row r;
     r["testing"] = "hello";
-    add(r, t);
+
+    std::vector<Row> row_list = {std::move(r)};
+    addBatch(row_list, t);
   }
 
   void clearRows() {
@@ -190,4 +192,4 @@ BENCHMARK(EVENTS_add_and_gentable)
     ->ArgPair(0, 100)
     ->ArgPair(0, 1000)
     ->ArgPair(0, 10000);
-}
+} // namespace osquery

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -432,48 +432,61 @@ std::vector<EventRecord> EventSubscriberPlugin::getRecords(
   return records;
 }
 
-Status EventSubscriberPlugin::recordEvent(const std::string& eid,
-                                          EventTime et) {
-  std::string time_value = boost::lexical_cast<std::string>(et);
+Status EventSubscriberPlugin::recordEvents(
+    const std::vector<std::string>& event_id_list, EventTime event_time) {
+  WriteLock lock(event_record_lock_);
 
-  // The record is identified by the event type then module name.
-  std::string index_key = "indexes." + dbNamespace();
-  std::string record_key = "records." + dbNamespace();
+  DatabaseStringValueList database_data;
+  database_data.reserve(event_id_list.size());
+  if (database_data.capacity() != event_id_list.size()) {
+    return Status(1, "Memory allocation error");
+  }
+
+  std::string index_key = "indexes." + dbNamespace() + ".60";
+  std::string record_key = "records." + dbNamespace() + ".60.";
+
   // The list key includes the list type (bin size) and the list ID (bin).
-  std::string list_id;
-
+  //
   // The list_id is the MOST-Specific key ID, the bin for this list.
   // If the event time was 13 and the time_list is 5 seconds, lid = 2.
-  list_id = boost::lexical_cast<std::string>(et / 60);
+  auto list_id = boost::lexical_cast<std::string>(event_time / 60);
 
-  WriteLock lock(event_record_lock_);
-  // Append the record (eid, unix_time) to the list bin.
-  std::string record_value;
-  getDatabaseValue(kEvents, record_key + ".60." + list_id, record_value);
+  for (const auto& eid : event_id_list) {
+    std::string time_value = boost::lexical_cast<std::string>(event_time);
 
-  if (record_value.length() == 0) {
-    // This is a new list_id for list_key, append the ID to the indirect
-    // lookup for this list_key.
-    std::string index_value;
-    getDatabaseValue(kEvents, index_key + ".60", index_value);
-    if (index_value.length() == 0) {
-      // A new index.
-      index_value = list_id;
+    // The record is identified by the event type then module name.
+
+    // Append the record (eid, unix_time) to the list bin.
+    std::string record_value;
+    auto database_key = record_key + list_id;
+    getDatabaseValue(kEvents, database_key, record_value);
+
+    if (record_value.length() == 0) {
+      // This is a new list_id for list_key, append the ID to the indirect
+      // lookup for this list_key.
+      std::string index_value;
+      getDatabaseValue(kEvents, index_key, index_value);
+      if (index_value.length() == 0) {
+        // A new index.
+        index_value = list_id;
+      } else {
+        index_value += "," + list_id;
+      }
+      database_data.push_back(std::make_pair(index_key, index_value));
+      record_value = eid + ":" + time_value;
     } else {
-      index_value += "," + list_id;
+      // Tokenize a record using ',' and the EID/time using ':'.
+      record_value += "," + eid + ":" + time_value;
     }
-    setDatabaseValue(kEvents, index_key + ".60", index_value);
-    record_value = eid + ":" + time_value;
-  } else {
-    // Tokenize a record using ',' and the EID/time using ':'.
-    record_value += "," + eid + ":" + time_value;
+    database_data.push_back(std::make_pair(database_key, record_value));
   }
-  auto status =
-      setDatabaseValue(kEvents, record_key + ".60." + list_id, record_value);
+
+  auto status = setDatabaseBatch(kEvents, database_data);
   if (!status.ok()) {
-    LOG(ERROR) << "Could not put Event Record key: " << record_key;
+    LOG(ERROR) << "Could not put Event Records";
   }
-  return Status();
+
+  return status;
 }
 
 size_t EventSubscriberPlugin::getEventsExpiry() {
@@ -567,25 +580,58 @@ void EventSubscriberPlugin::get(RowYield& yield,
   }
 }
 
-Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
-  // Get and increment the EID for this module.
-  const std::string eid = getEventID();
-  // Without encouraging a missing event time, do not support a 0-time.
-  if (event_time == 0) {
-    event_time = getUnixTime();
+Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list) {
+  return addBatch(row_list, getUnixTime());
+}
+
+Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
+                                       EventTime custom_event_time) {
+  DatabaseStringValueList database_data;
+  database_data.reserve(row_list.size());
+  if (database_data.capacity() != row_list.size()) {
+    return Status(1, "Memory allocation error");
   }
 
-  r["time"] = std::to_string(event_time);
-  r["eid"] = eid;
-  // Serialize and store the row data, for query-time retrieval.
-  std::string data;
-  auto status = serializeRowJSON(r, data);
-  if (!status.ok()) {
-    return status;
+  std::vector<std::string> event_id_list;
+  event_id_list.reserve(row_list.size());
+  if (event_id_list.capacity() != row_list.size()) {
+    return Status(1, "Memory allocation error");
   }
-  // Then remove the newline.
-  if (data.size() > 0 && data.back() == '\n') {
-    data.pop_back();
+
+  auto event_time = custom_event_time != 0 ? custom_event_time : getUnixTime();
+  auto event_time_str = std::to_string(event_time);
+
+  for (auto& row : row_list) {
+    row["time"] = event_time_str;
+    row["eid"] = getEventID();
+
+    // Serialize and store the row data, for query-time retrieval.
+    std::string serialized_row;
+    auto status = serializeRowJSON(row, serialized_row);
+    if (!status.ok()) {
+      VLOG(1) << status.getMessage();
+      continue;
+    }
+
+    // Then remove the newline.
+    if (serialized_row.size() > 0 && serialized_row.back() == '\n') {
+      serialized_row.pop_back();
+    }
+
+    // Logger plugins may request events to be forwarded directly.
+    // If no active logger is marked 'usesLogEvent' then this is a no-op.
+    EventFactory::forwardEvent(serialized_row);
+
+    // Store the event data in the batch
+    database_data.push_back(std::make_pair(
+        "data." + dbNamespace() + "." + row["eid"], serialized_row));
+    event_id_list.push_back(std::move(row["eid"]));
+
+    event_count_++;
+  }
+
+  if (database_data.empty()) {
+    return Status(1, "Failed to process the rows");
   }
 
   // Use the last EventID and a checkpoint bucket size to periodically apply
@@ -594,17 +640,13 @@ Status EventSubscriberPlugin::add(Row& r, EventTime event_time) {
     expireCheck();
   }
 
-  // Logger plugins may request events to be forwarded directly.
-  // If no active logger is marked 'usesLogEvent' then this is a no-op.
-  EventFactory::forwardEvent(data);
+  // Save the batched data inside the database
+  auto status = setDatabaseBatch(kEvents, database_data);
+  if (!status.ok()) {
+    return status;
+  }
 
-  // Store the event data.
-  std::string event_key = "data." + dbNamespace() + "." + eid;
-  status = setDatabaseValue(kEvents, event_key, data);
-  // Record the event in the indexing bins, using the index time.
-  recordEvent(eid, event_time);
-  event_count_++;
-  return status;
+  return recordEvents(event_id_list, event_time);
 }
 
 EventPublisherRef EventSubscriberPlugin::getPublisher() const {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -446,16 +446,13 @@ Status EventSubscriberPlugin::recordEvents(
   std::string record_key = "records." + dbNamespace() + ".60.";
 
   // The list key includes the list type (bin size) and the list ID (bin).
-  //
   // The list_id is the MOST-Specific key ID, the bin for this list.
   // If the event time was 13 and the time_list is 5 seconds, lid = 2.
   auto list_id = boost::lexical_cast<std::string>(event_time / 60);
+  std::string time_value = boost::lexical_cast<std::string>(event_time);
 
   for (const auto& eid : event_id_list) {
-    std::string time_value = boost::lexical_cast<std::string>(event_time);
-
     // The record is identified by the event type then module name.
-
     // Append the record (eid, unix_time) to the list bin.
     std::string record_value;
     auto database_key = record_key + list_id;
@@ -578,6 +575,11 @@ void EventSubscriberPlugin::get(RowYield& yield,
   if (FLAGS_events_optimize) {
     setOptimizeData(optimize_time_, optimize_eid_, dbNamespace());
   }
+}
+
+Status EventSubscriberPlugin::add(const Row& r) {
+  std::vector<Row> batch = {r};
+  return addBatch(batch, getUnixTime());
 }
 
 Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list) {

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -689,6 +689,11 @@ void AuditdNetlinkParser::start() {
     }
 
     std::vector<AuditEventRecord> audit_event_record_queue;
+    audit_event_record_queue.reserve(queue.size());
+    if (audit_event_record_queue.capacity() != queue.size()) {
+      VLOG(1) << "Memory allocation failure";
+      return;
+    }
 
     for (auto& reply : queue) {
       if (interrupted()) {

--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -53,6 +53,9 @@ struct AuditEventRecord final {
   std::string raw_data;
 };
 
+static_assert(std::is_move_constructible<AuditEventRecord>::value,
+              "not move constructible");
+
 // This structure is used to share data between the reading and processing
 // services
 struct AuditdContext final {

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -71,7 +71,9 @@ class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
     r["testing"] = "hello from space";
     r["time"] = INTEGER(t);
     r["uptime"] = INTEGER(10);
-    return add(r, t);
+
+    std::vector<Row> row_list = {std::move(r)};
+    return addBatch(row_list, t);
   }
 
   size_t getEventsMax() override {

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -48,10 +48,7 @@ Status AuditProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : emitted_row_list) {
-    add(row);
-  }
-
+  addBatch(emitted_row_list);
   return Status(0, "Ok");
 }
 
@@ -70,6 +67,11 @@ Status AuditProcessEventSubscriber::ProcessEvents(
   // clang-format on
 
   emitted_row_list.clear();
+
+  emitted_row_list.reserve(event_list.size());
+  if (emitted_row_list.capacity() != event_list.size()) {
+    return Status(1, "Memory allocation error");
+  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::Syscall) {
@@ -171,4 +173,4 @@ const std::set<int>& AuditProcessEventSubscriber::GetSyscallSet() noexcept {
   static const std::set<int> syscall_set = {__NR_execve};
   return syscall_set;
 }
-}
+} // namespace osquery

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -112,10 +112,7 @@ Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : emitted_row_list) {
-    add(row);
-  }
-
+  addBatch(emitted_row_list);
   return Status(0, "Ok");
 }
 
@@ -123,6 +120,11 @@ Status SocketEventSubscriber::ProcessEvents(
     std::vector<Row>& emitted_row_list,
     const std::vector<AuditEvent>& event_list) noexcept {
   emitted_row_list.clear();
+
+  emitted_row_list.reserve(event_list.size());
+  if (emitted_row_list.capacity() != event_list.size()) {
+    return Status(1, "Memory allocation error");
+  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::Syscall) {

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -59,10 +59,7 @@ Status UserEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     return status;
   }
 
-  for (auto& row : emitted_row_list) {
-    add(row);
-  }
-
+  addBatch(emitted_row_list);
   return Status(0, "Ok");
 }
 
@@ -70,6 +67,11 @@ Status UserEventSubscriber::ProcessEvents(
     std::vector<Row>& emitted_row_list,
     const std::vector<AuditEvent>& event_list) noexcept {
   emitted_row_list.clear();
+
+  emitted_row_list.reserve(event_list.size());
+  if (emitted_row_list.capacity() != event_list.size()) {
+    return Status(1, "Memory allocation error");
+  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::UserEvent) {


### PR DESCRIPTION
This PR adds support for write batching to the database plugins and the events framework. 

We spent some time profiling osqueryd with perf, and the patch should remove RocksDB from the hot path, making Audit-based tables (process_events/user_events/sockets_events/process_file_events) a lot more reliable and faster.

When using the `system_stress.py` script on my system with a factor of 9, CPU usage went down from 80~90% to 20% max. Another key difference is that the machine never feels unresponsive now.

I would really love to get some feedback on this patch, and hear what you think!
