### PR TITLE
Connecte expected.h and error.h tests to build system

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -59,6 +59,8 @@ endif()
 
 ADD_OSQUERY_TEST_CORE(
   "${CMAKE_CURRENT_LIST_DIR}/tests/conversions_tests.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/tests/error_tests.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/tests/exptected_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/flags_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/process_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/query_tests.cpp"

--- a/osquery/core/tests/error_tests.cpp
+++ b/osquery/core/tests/error_tests.cpp
@@ -17,8 +17,13 @@ GTEST_TEST(ErrorTest, initialization) {
   auto error = osquery::Error<TestError>(TestError::SomeError, "TestMessage");
   EXPECT_EQ(error.getUnderlyingError(), nullptr);
   EXPECT_TRUE(error == TestError::SomeError);
-  EXPECT_EQ(error.getShortMessage(), "TestError 1");
-  EXPECT_EQ(error.getFullMessage(), "TestError 1 (TestMessage)");
+
+  auto shortMsg = error.getShortMessageRecursive();
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError 1"));
+
+  auto fullMsg = error.getFullMessageRecursive();
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestMessage"));
 }
 
 GTEST_TEST(ErrorTest, recursive) {
@@ -27,7 +32,14 @@ GTEST_TEST(ErrorTest, recursive) {
   auto error = osquery::Error<TestError>(
       TestError::AnotherError, "TestMessage", orignalError);
   EXPECT_NE(error.getUnderlyingError(), nullptr);
-  EXPECT_EQ(error.getShortMessageRecursive(), "TestError 2 <- TestError 1");
-  EXPECT_EQ(error.getFullMessageRecursive(),
-            "TestError 2 (TestMessage) <- TestError 1 (SuperTestMessage)");
+
+  auto shortMsg = error.getShortMessageRecursive();
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError 2"));
+
+  auto fullMsg = error.getFullMessageRecursive();
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, fullMsg.find("SuperTestMessage"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError 2"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestMessage"));
 }


### PR DESCRIPTION
```
% ./build/darwin/osquery/osquery_tests --gtest_filter='Expected*'
Note: Google Test filter = Expected*
[==========] Running 0 tests from 0 test cases.
[==========] 0 tests from 0 test cases ran. (0 ms total)
[  PASSED  ] 0 tests.

% ./build/darwin/osquery/osquery_tests --gtest_filter='Expected*'
Note: Google Test filter = Expected*
[==========] Running 2 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from ExpectedValueTest
[ RUN      ] ExpectedValueTest.initialization
[       OK ] ExpectedValueTest.initialization (0 ms)
[----------] 1 test from ExpectedValueTest (0 ms total)
[----------] 1 test from ExpectedPointerTest
[ RUN      ] ExpectedPointerTest.initialization
[       OK ] ExpectedPointerTest.initialization (0 ms)
[----------] 1 test from ExpectedPointerTest (0 ms total)
[----------] Global test environment tear-down
[==========] 2 tests from 2 test cases ran. (0 ms total)
[  PASSED  ] 2 tests.
```