### PR TITLE
Explicit use `ValueType` and `EnumErrorType` in `Expected` full type definition

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -16,26 +16,33 @@
 #include <type_traits>
 #include <utility>
 
+#include <boost/blank.hpp>
+#include <boost/variant.hpp>
+
 /**
  * Utility class that should be used in function that return
  * either error or value. Expected enforce developer to test for success and
  * check error if any.
  *
  * enum class TestError { SomeError = 1, AnotherError = 2 };
- * Expected<std::string> function() {
+ * Expected<std::string, TestError> function() {
  *   if (test) {
  *    return "ok";
  *   } else {
- *    return std::make_shared<Error<TestError>>(TestError::SomeError);
+ *    if (first_error) {
+ *      return Error<TestError>>(TestError::SomeError, "some error message");
+ *    } else {
+ *      return createError(TestError::SomeError, "one more error message");
+ *    }
  *   }
  * }
  *
  * Expected:
- * ExpectedUnique<PlatformProcess> function() {
+ * ExpectedUnique<PlatformProcess, TestError> function() {
  *   if (test) {
  *    return std::make_unique<PlatformProcess>(pid);
  *   } else {
- *    return std::make_shared<Error<TestError>>(TestError::AnotherError);
+ *    return createError(TestError::AnotherError, "something wrong");
  *   }
  * }
  *
@@ -43,98 +50,141 @@
  * if (result) {
  *   ...use *result
  * } else {
- *   auto error = result->getError();
+ *   switch (result.getErrorCode()) {
+ *     case TestError::SomeError:
+ *        ...do something with it
+ *        break;
+ *     case TestError::AnotherError:
+ *        ...do something with it
+ *        break;
+ *   }
  * }
+ * @see osquery/core/tests/exptected_tests.cpp for more examples
  */
 
 namespace osquery {
 
-template <class ErrorCodeEnumType>
+using Success = boost::blank;
+
+template <typename ValueType_, typename ErrorCodeEnumType>
 class Expected final {
  public:
-  Expected(ErrorCodeEnumType object)
-      : object_(std::move(object)), hasError_(false) {}
-  Expected(ErrorBase* error) = delete;
-  Expected() : error_(nullptr), hasError_(false) {}
-  Expected(std::shared_ptr<ErrorBase> error)
-      : error_(std::move(error)), hasError_(true) {}
-  Expected(std::unique_ptr<ErrorBase> error)
-      : error_(std::move(error)), hasError_(true) {}
-  template <class ErrorT>
-  Expected(std::shared_ptr<Error<ErrorT>> error)
-      : error_(std::static_pointer_cast<ErrorBase>(error)), hasError_(true){};
+  using ValueType = ValueType_;
+  using ErrorType = Error<ErrorCodeEnumType>;
+  using SelfType = Expected<ValueType, ErrorCodeEnumType>;
 
+ public:
+  Expected(ValueType value) : object_{std::move(value)} {}
+
+  Expected(ErrorType error) : object_{std::move(error)} {}
+
+  explicit Expected(ErrorCodeEnumType code, std::string message)
+      : object_{ErrorType(code, message)} {}
+
+  Expected(Expected&& other) = default;
+
+  Expected() = delete;
   Expected(const Expected&) = delete;
+  Expected(ErrorBase* error) = delete;
+
+  Expected& operator=(Expected&& other) = default;
+  Expected& operator=(const Expected& other) = delete;
 
   ~Expected() {
     assert(errorChecked_ && "Error was not checked");
   }
 
-  Expected& operator=(Expected&& other) {
-    if (this != &other) {
-      object_ = std::move(other.object_);
-      error_ = std::move(other.error_);
-      hasError_ = other.hasError_;
-    }
-    return *this;
+  static SelfType success(ValueType value) {
+    return SelfType{std::move(value)};
   }
 
-  Expected(Expected&& other) {
-    object_ = std::move(other.object_);
-    error_ = std::move(other.error_);
-    hasError_ = other.hasError_;
+  static SelfType failure(std::string message) {
+    auto defaultCode = ErrorCodeEnumType{};
+    return SelfType(defaultCode, std::move(message));
   }
 
-  std::shared_ptr<ErrorBase> getError() const {
-    return error_;
+  static SelfType failure(ErrorCodeEnumType code, std::string message) {
+    return SelfType(code, std::move(message));
+  }
+
+  ErrorType takeError() {
+    return std::move(boost::get<ErrorType>(object_));
+  }
+
+  const ErrorType& getError() const {
+    return boost::get<ErrorType>(object_);
+  }
+
+  ErrorCodeEnumType getErrorCode() const {
+    return getError().getErrorCode();
+  }
+
+  bool isOk() const {
+#ifndef NDEBUG
+    errorChecked_ = true;
+#endif
+    return object_.which() == kValueType_;
   }
 
   explicit operator bool() const {
-    errorChecked_ = true;
-    return !hasError_;
+    return isOk();
   }
 
-  ErrorCodeEnumType& get() {
-    return object_;
+  ValueType& get() {
+    return boost::get<ValueType>(object_);
   }
 
-  const ErrorCodeEnumType& get() const {
-    return object_;
+  const ValueType& get() const {
+    return boost::get<ValueType>(object_);
   }
 
-  ErrorCodeEnumType take() {
-    return std::move(object_);
+  ValueType take() {
+    return std::move(boost::get<ValueType>(object_));
   }
 
-  ErrorCodeEnumType* operator->() {
-    return object_;
+  ValueType* operator->() {
+    return &boost::get<ValueType>(object_);
   }
 
-  const ErrorCodeEnumType* operator->() const {
-    return object_;
+  const ValueType* operator->() const {
+    return &boost::get<ValueType>(object_);
   }
 
-  ErrorCodeEnumType& operator*() {
-    return object_;
+  ValueType& operator*() {
+    return get();
   }
 
-  const ErrorCodeEnumType& operator*() const {
-    return object_;
+  const ValueType& operator*() const {
+    return get();
   }
 
  private:
-  static const bool isPointer = std::is_pointer<ErrorCodeEnumType>::value;
-  static_assert(!isPointer, "Use shared/unique pointer");
+  static_assert(
+      !std::is_pointer<ValueType>::value,
+      "Please do not use raw pointers as expected value, "
+      "use smart pointers instead. See CppCoreGuidelines for explanation. "
+      "https://github.com/isocpp/CppCoreGuidelines/blob/master/"
+      "CppCoreGuidelines.md#Rf-unique_ptr");
+  static_assert(std::is_enum<ErrorCodeEnumType>::value,
+                "ErrorCodeEnumType template parameter must be enum");
 
-  ErrorCodeEnumType object_;
-  std::shared_ptr<ErrorBase> error_;
-  bool hasError_;
+  boost::variant<ValueType, ErrorType> object_;
+  enum ETypeId {
+    kValueType_ = 0,
+    kErrorType_ = 1,
+  };
+#ifndef NDEBUG
   mutable bool errorChecked_ = false;
+#endif
 };
 
-template <class T>
-using ExpectedShared = Expected<std::shared_ptr<T>>;
-template <class T>
-using ExpectedUnique = Expected<std::unique_ptr<T>>;
+template <typename ValueType, typename ErrorCodeEnumType>
+using ExpectedShared = Expected<std::shared_ptr<ValueType>, ErrorCodeEnumType>;
+
+template <typename ValueType, typename ErrorCodeEnumType>
+using ExpectedUnique = Expected<std::unique_ptr<ValueType>, ErrorCodeEnumType>;
+
+template <typename ErrorCodeEnumType>
+using ExpectedSuccess = Expected<Success, ErrorCodeEnumType>;
 
 } // namespace osquery

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -131,14 +131,16 @@ class Expected final {
 
   ValueType& get() {
 #ifndef NDEBUG
-    assert(isOk() && "Do not try to get value from Expected with error");
+    assert(object_.which() == kValueType_ &&
+           "Do not try to get value from Expected with error");
 #endif
     return boost::get<ValueType>(object_);
   }
 
   const ValueType& get() const {
 #ifndef NDEBUG
-    assert(isOk() && "Do not try to get value from Expected with error");
+    assert(object_.which() == kValueType_ &&
+           "Do not try to get value from Expected with error");
 #endif
     return boost::get<ValueType>(object_);
   }

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -118,15 +118,15 @@ class Expected final {
     return getError().getErrorCode();
   }
 
-  bool isOk() const noexcept {
+  bool isError() const noexcept {
 #ifndef NDEBUG
     errorChecked_ = true;
 #endif
-    return object_.which() == kValueType_;
+    return object_.which() == kErrorType_;
   }
 
   explicit operator bool() const noexcept {
-    return isOk();
+    return !isError();
   }
 
   ValueType& get() {

--- a/osquery/core/tests/error_tests.cpp
+++ b/osquery/core/tests/error_tests.cpp
@@ -11,11 +11,14 @@
 #include <gtest/gtest.h>
 #include <osquery/error.h>
 
-enum class TestError { SomeError = 1, AnotherError = 2 };
+enum class TestError {
+  SomeError = 1,
+  AnotherError = 2,
+};
 
 GTEST_TEST(ErrorTest, initialization) {
   auto error = osquery::Error<TestError>(TestError::SomeError, "TestMessage");
-  EXPECT_EQ(error.getUnderlyingError(), nullptr);
+  EXPECT_FALSE(error.hasUnderlyingError());
   EXPECT_TRUE(error == TestError::SomeError);
 
   auto shortMsg = error.getShortMessageRecursive();
@@ -27,11 +30,11 @@ GTEST_TEST(ErrorTest, initialization) {
 }
 
 GTEST_TEST(ErrorTest, recursive) {
-  auto orignalError = std::make_shared<osquery::Error<TestError>>(
+  auto orignalError = std::make_unique<osquery::Error<TestError>>(
       TestError::SomeError, "SuperTestMessage");
   auto error = osquery::Error<TestError>(
-      TestError::AnotherError, "TestMessage", orignalError);
-  EXPECT_NE(error.getUnderlyingError(), nullptr);
+      TestError::AnotherError, "TestMessage", std::move(orignalError));
+  EXPECT_TRUE(error.hasUnderlyingError());
 
   auto shortMsg = error.getShortMessageRecursive();
   EXPECT_NE(std::string::npos, shortMsg.find("TestError 1"));

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -29,7 +29,7 @@ enum class TestError {
 GTEST_TEST(ExpectedTest, success_contructor_initialization) {
   Expected<std::string, TestError> value = std::string("Test");
   EXPECT_TRUE(value);
-  EXPECT_TRUE(value.isOk());
+  EXPECT_FALSE(value.isError());
   EXPECT_EQ(value.get(), "Test");
 }
 
@@ -37,7 +37,7 @@ GTEST_TEST(ExpectedTest, failure_error_contructor_initialization) {
   Expected<std::string, TestError> error =
       Error<TestError>(TestError::Some, "Please try again");
   EXPECT_FALSE(error);
-  EXPECT_FALSE(error.isOk());
+  EXPECT_TRUE(error.isError());
   EXPECT_EQ(error.getErrorCode(), TestError::Some);
 }
 
@@ -50,7 +50,7 @@ GTEST_TEST(ExpectedTest, failure_error_str_contructor_initialization) {
       std::string{"\"#$%&'()*+,-./089:;<[=]>\" is it a valid error message?"};
   auto expected = Expected<std::string, TestError>::failure(msg);
   EXPECT_FALSE(expected);
-  EXPECT_FALSE(expected.isOk());
+  EXPECT_TRUE(expected.isError());
   EXPECT_EQ(expected.getErrorCode(), TestError::Some);
   auto fullMsg = expected.getError().getFullMessage();
   EXPECT_PRED2(stringContains, fullMsg, msg);
@@ -106,12 +106,12 @@ GTEST_TEST(ExpectedTest, createError_example) {
   };
   auto v = giveMeDozen(true);
   EXPECT_TRUE(v);
-  ASSERT_TRUE(v.isOk());
+  ASSERT_FALSE(v.isError());
   EXPECT_EQ(*v, 50011971);
 
   auto errV = giveMeDozen(false);
   EXPECT_FALSE(errV);
-  ASSERT_FALSE(errV.isOk());
+  ASSERT_TRUE(errV.isError());
   EXPECT_EQ(errV.getErrorCode(), TestError::Logical);
 }
 
@@ -125,11 +125,11 @@ GTEST_TEST(ExpectedTest, ExpectedSuccess_example) {
   };
   auto s = giveMeStatus(true);
   EXPECT_TRUE(s);
-  ASSERT_TRUE(s.isOk());
+  ASSERT_FALSE(s.isError());
 
   auto errS = giveMeStatus(false);
   EXPECT_FALSE(errS);
-  ASSERT_FALSE(errS.isOk());
+  ASSERT_TRUE(errS.isError());
 }
 
 GTEST_TEST(ExpectedTest, nested_errors_example) {
@@ -139,12 +139,12 @@ GTEST_TEST(ExpectedTest, nested_errors_example) {
   };
   auto giveMeNestedError = [&]() -> Expected<std::vector<int>, TestError> {
     auto ret = firstFailureSource();
-    ret.isOk();
+    ret.isError();
     return createError(TestError::Runtime, msg, ret.takeError());
   };
   auto ret = giveMeNestedError();
   EXPECT_FALSE(ret);
-  ASSERT_FALSE(ret.isOk());
+  ASSERT_TRUE(ret.isError());
   EXPECT_EQ(ret.getErrorCode(), TestError::Runtime);
   ASSERT_TRUE(ret.getError().hasUnderlyingError());
   EXPECT_PRED2(stringContains, ret.getError().getFullMessage(), msg);
@@ -155,7 +155,7 @@ GTEST_TEST(ExpectedTest, error_handling_example) {
     return createError(TestError::Runtime, "Test error message ()*+,-.");
   };
   auto ret = failureSource();
-  if (!ret.isOk()) {
+  if (ret.isError()) {
     switch (ret.getErrorCode()) {
     case TestError::Some:
     case TestError::Another:

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -15,48 +15,156 @@
 
 namespace osquery {
 
-enum class TestError { SomeError = 1, AnotherError = 2 };
+enum class TestError {
+  Some,
+  Another,
+  Semantic,
+  Logical,
+  Runtime,
+};
 
-GTEST_TEST(ExpectedValueTest, initialization) {
-  Expected<std::string> value = std::string("Test");
+GTEST_TEST(ExpectedTest, success_contructor_initialization) {
+  Expected<std::string, TestError> value = std::string("Test");
   EXPECT_TRUE(value);
+  EXPECT_TRUE(value.isOk());
   EXPECT_EQ(value.get(), "Test");
-
-  Expected<std::string> error =
-      std::make_shared<Error<TestError>>(TestError::SomeError);
-  EXPECT_FALSE(error);
-  EXPECT_EQ(*error.getError(), TestError::SomeError);
 }
 
-osquery::ExpectedUnique<std::string> testFunction() {
+GTEST_TEST(ExpectedTest, failure_error_contructor_initialization) {
+  Expected<std::string, TestError> error =
+      Error<TestError>(TestError::Some, "Please try again");
+  EXPECT_FALSE(error);
+  EXPECT_FALSE(error.isOk());
+  EXPECT_EQ(error.getErrorCode(), TestError::Some);
+}
+
+GTEST_TEST(ExpectedTest, failure_error_str_contructor_initialization) {
+  auto expected = Expected<std::string, TestError>::failure(
+      "error message !?#$%&'()*+,-./089:;<[=]>");
+  EXPECT_FALSE(expected);
+  EXPECT_FALSE(expected.isOk());
+  EXPECT_EQ(expected.getErrorCode(), TestError::Some);
+  auto fullMsg = expected.getError().getFullMessage();
+  EXPECT_NE(std::string::npos,
+            fullMsg.find("error message !?#$%&'()*+,-./089:;<[=]>)"));
+}
+
+osquery::ExpectedUnique<std::string, TestError> testFunction() {
   return std::make_unique<std::string>("Test");
 }
 
-GTEST_TEST(ExpectedPointerTest, initialization) {
-  osquery::Expected<std::shared_ptr<std::string>> sharedPointer =
+GTEST_TEST(ExpectedTest, ExpectedSharedTestFunction) {
+  osquery::Expected<std::shared_ptr<std::string>, TestError> sharedPointer =
       std::make_shared<std::string>("Test");
   EXPECT_TRUE(sharedPointer);
   EXPECT_EQ(**sharedPointer, "Test");
 
-  osquery::ExpectedUnique<std::string> uniquePointer = testFunction();
-  EXPECT_TRUE(uniquePointer);
-  EXPECT_EQ(**uniquePointer, "Test");
-
-  osquery::ExpectedShared<std::string> sharedPointer2 =
+  osquery::ExpectedShared<std::string, TestError> sharedPointer2 =
       std::make_shared<std::string>("Test");
-
   EXPECT_TRUE(sharedPointer2);
   EXPECT_EQ(**sharedPointer2, "Test");
+}
 
-  osquery::ExpectedShared<std::string> error =
-      std::make_shared<Error<TestError>>(TestError::AnotherError);
+GTEST_TEST(ExpectedTest, ExpectedUniqueTestFunction) {
+  auto uniquePointer = testFunction();
+  EXPECT_TRUE(uniquePointer);
+  EXPECT_EQ(**uniquePointer, "Test");
+}
+
+GTEST_TEST(ExpectedTest, ExpectedSharedWithError) {
+  osquery::ExpectedShared<std::string, TestError> error =
+      Error<TestError>(TestError::Another, "Some message");
   EXPECT_FALSE(error);
-  EXPECT_EQ(*error.getError(), TestError::AnotherError);
+  EXPECT_EQ(error.getErrorCode(), TestError::Another);
+}
 
+GTEST_TEST(ExpectedTest, ExpectedOptional) {
   boost::optional<std::string> optional = std::string("123");
-  osquery::Expected<boost::optional<std::string>> optionalExpected = optional;
+  osquery::Expected<boost::optional<std::string>, TestError> optionalExpected =
+      optional;
   EXPECT_TRUE(optionalExpected);
   EXPECT_EQ(**optionalExpected, "123");
+}
+
+template <typename ValueType>
+using LocalExpected = Expected<ValueType, TestError>;
+
+GTEST_TEST(ExpectedTest, createError_example) {
+  auto giveMeDozen = [](bool valid) -> LocalExpected<int> {
+    if (valid) {
+      return 12;
+    }
+    return createError(TestError::Logical, "error message");
+  };
+  auto v = giveMeDozen(true);
+  EXPECT_TRUE(v);
+  ASSERT_TRUE(v.isOk());
+  EXPECT_EQ(*v, 12);
+
+  auto errV = giveMeDozen(false);
+  EXPECT_FALSE(errV);
+  ASSERT_FALSE(errV.isOk());
+  EXPECT_EQ(errV.getErrorCode(), TestError::Logical);
+}
+
+GTEST_TEST(ExpectedTest, ExpectedSuccess_example) {
+  auto giveMeStatus = [](bool valid) -> ExpectedSuccess<TestError> {
+    if (valid) {
+      return Success{};
+    }
+    return Error<TestError>(TestError::Runtime, "error message");
+  };
+  auto v = giveMeStatus(true);
+  EXPECT_TRUE(v);
+  ASSERT_TRUE(v.isOk());
+
+  auto errV = giveMeStatus(false);
+  EXPECT_FALSE(errV);
+  ASSERT_FALSE(errV.isOk());
+}
+
+GTEST_TEST(ExpectedTest, nested_errors_example) {
+  auto firstFailureSource = []() -> Expected<std::vector<int>, TestError> {
+    return createError(TestError::Semantic, "Test error message b#$%&");
+  };
+  auto giveMeNestedError = [&]() -> Expected<std::vector<int>, TestError> {
+    auto ret = firstFailureSource();
+    ret.isOk();
+    return createError(
+        TestError::Runtime, "Test error message b#$%&", ret.takeError());
+  };
+  auto ret = giveMeNestedError();
+  EXPECT_FALSE(ret);
+  ASSERT_FALSE(ret.isOk());
+  EXPECT_EQ(ret.getErrorCode(), TestError::Runtime);
+  ASSERT_TRUE(ret.getError().hasUnderlyingError());
+}
+
+GTEST_TEST(ExpectedTest, error_handling_example) {
+  auto failureSource = []() -> Expected<std::vector<int>, TestError> {
+    return createError(TestError::Runtime, "Test error message ()*+,-.");
+  };
+  auto ret = failureSource();
+  if (!ret.isOk()) {
+    switch (ret.getErrorCode()) {
+    case TestError::Some:
+    case TestError::Another:
+    case TestError::Semantic:
+    case TestError::Logical:
+      FAIL() << "There is must be Runtime type";
+    case TestError::Runtime:
+      SUCCEED();
+    }
+  } else {
+    FAIL() << "There is must be error";
+  }
+}
+
+GTEST_TEST(ExpectedTest, error_was_not_checked) {
+  auto action = []() { auto expected = ExpectedSuccess<TestError>{Success()}; };
+#ifndef NDEBUG
+  ASSERT_DEATH(action(), "Error was not checked");
+#endif
 }
 
 } // namespace osquery


### PR DESCRIPTION
  - `Expected` is template from `ValueType` and `ErrorCodeEnumType`
  - `Error` is stored by value in `Expected` object, not by pointer
  - Changed storage mechanism for error and value - now it is a variant with both types
  - Changed type of smart pointer for underlying error object - from shared to unique
  - Added abstraction for new `Status` aka `Expected` with `boost::blank`
  - Added more tests for `Expected`
  - Added helper function to create `Error` object