### PR TITLE
Remove container specific join implementation from conversions.h

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -11,7 +11,6 @@
 #include <iomanip>
 #include <locale>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -391,19 +390,9 @@ std::vector<std::string> split(const std::string& s,
   }
   // Join the optional accumulator.
   if (accumulator.size() > 0) {
-    elems.push_back(join(accumulator, delims));
+    elems.push_back(boost::algorithm::join(accumulator, delims));
   }
   return elems;
-}
-
-std::string join(const std::vector<std::string>& s, const std::string& tok) {
-  return boost::algorithm::join(s, tok);
-}
-
-std::string join(const std::set<std::string>& s, const std::string& tok) {
-  std::vector<std::string> toJoin;
-  toJoin.insert(toJoin.end(), s.begin(), s.end());
-  return boost::algorithm::join(toJoin, tok);
 }
 
 std::string getBufferSHA1(const char* buffer, size_t size) {

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/algorithm/string.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -108,17 +109,10 @@ inline void replaceAll(std::string& str,
  *
  * @return the joined string.
  */
-std::string join(const std::vector<std::string>& s, const std::string& tok);
-
-/**
- * @brief Join a set of strings inserting a token string between elements
- *
- * @param s the set of strings to be joined.
- * @param tok a token glue string to be inserted between elements.
- *
- * @return the joined string.
- */
-std::string join(const std::set<std::string>& s, const std::string& tok);
+template <typename SequenceType>
+inline std::string join(const SequenceType& s, const std::string& tok) {
+  return boost::algorithm::join(s, tok);
+}
 
 /**
  * @brief Decode a base64 encoded string.


### PR DESCRIPTION
Using templates generic version for any 'iterable' container could be done.
Also, definition for std::set were using a useless copy of data.