### PR TITLE
Initd script

### DIFF
--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -188,6 +188,8 @@ function main() {
   if [[ $PACKAGE_TYPE = "deb" ]]; then
     #Change config path in service unit
     sed -i 's/sysconfig/default/g' $INSTALL_PREFIX$SYSTEMD_SERVICE_DST
+    #Change config path in initd script
+    sed -i 's/sysconfig/default/g' $INSTALL_PREFIX$INITD_DST
   fi
 
   log "creating $PACKAGE_TYPE package"

--- a/tools/deployment/osqueryd.initd
+++ b/tools/deployment/osqueryd.initd
@@ -85,7 +85,7 @@ start() {
   if [ -e $FLAGS_PATH ]; then ARGS="$ARGS --flagfile=$FLAGS_PATH"; fi
   if [ -e $REAL_CONFIG_PATH ]; then ARGS="$ARGS --config_path=$REAL_CONFIG_PATH"; fi
 
-  $PROG $ARGS \
+  $EXEC $ARGS \
         --pidfile=$PIDFILE \
         --daemonize=true
   RETVAL=$?


### PR DESCRIPTION
The PR provides:
- SysV init script to honor EXEC env variable
- applicable "/etc/default/osqueryd" config path in initd script for deb