### PR TITLE
Created an `enum ConversionError` for conversion errors

### DIFF
--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -21,6 +21,7 @@
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 
+#include <osquery/expected.h>
 #include <osquery/logger.h>
 #include <osquery/status.h>
 
@@ -306,4 +307,19 @@ std::string stringFromCFAbsoluteTime(const CFDataRef& cf_abstime);
 
 std::string stringFromCFData(const CFDataRef& cf_data);
 #endif
+
+enum class ConversionError {
+  InvalidArgument,
+  OutOfRange,
+};
+
+template <typename ToType, typename FromType>
+inline typename std::enable_if<
+    std::is_same<ToType,
+                 typename std::remove_cv<typename std::remove_reference<
+                     FromType>::type>::type>::value,
+    Expected<ToType, ConversionError>>::type
+tryTo(FromType&& from) {
+  return std::forward<FromType>(from);
+}
 }

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -309,4 +309,19 @@ TEST_F(ConversionsTests, test_json_bool_like) {
   EXPECT_FALSE(JSON::valueToBool(doc.doc()["false5"]));
   EXPECT_FALSE(JSON::valueToBool(doc.doc()["false6"]));
 }
+
+TEST_F(ConversionsTests, tryTo_same_type) {
+  class First {};
+  // rvalue
+  auto ret0 = tryTo<First>(First{});
+  ASSERT_FALSE(ret0.isError());
+
+  auto test_lvalue = First{};
+  auto ret1 = tryTo<First>(test_lvalue);
+  ASSERT_FALSE(ret1.isError());
+
+  const auto const_test_lvalue = First{};
+  auto ret2 = tryTo<First>(const_test_lvalue);
+  ASSERT_FALSE(ret2.isError());
 }
+} // namespace osquery


### PR DESCRIPTION
Also created a template implementation of `tryTo<>` for the variables of the same type (moving without conversion in case of rvalue, copying in case of lvalue), as an simplest example of using  such errors.