### PR TITLE
Adding OSX Dummy malware to osx-attacks query pack

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -571,9 +571,25 @@
     },
     "MacSearch_Adware": {
       "query": "SELECT * FROM launchd WHERE path='/Library/LaunchAgents/tapufind.plist';",
+      "interval" : "3600",
       "version" : "1.4.5",
       "description" : "MacSearch OSX Adware (https://www.virustotal.com/latest-scan/15966224C4E25C9787A4A8C984A863E9)",
       "value" : "Artifacts created by this adware"
+    },
+    "OSX_Dummy_Launchd": {
+      "query": "select * from launchd where name = 'com.startup.plist';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html)",
+      "value": "Artifacts created by this malware"
+    },
+    "OSX_Dummy_Files": {
+      "query" : "select * from file \
+        where path = '/var/root/script.sh';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html)",
+      "value": "Artifacts created by this malware"
     }
   }
 }

--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -577,18 +577,23 @@
       "value" : "Artifacts created by this adware"
     },
     "OSX_Dummy_Launchd": {
-      "query": "select * from launchd where name = 'com.startup.plist';",
+      "query": "SELECT * FROM launchd WHERE name = 'com.startup.plist';",
       "interval" : "3600",
       "version": "1.4.5",
-      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html)",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
       "value": "Artifacts created by this malware"
     },
     "OSX_Dummy_Files": {
-      "query" : "select * from file \
-        where path = '/var/root/script.sh';",
+      "query" : "SELECT * FROM file \
+         WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR \
+           path = '/var/root/script.sh' OR \
+           path = '/Users/Shared/dumpdummy' OR \
+           path = '/tmp/script.sh' OR \
+           path = '/tmp/com.startup.plist' OR \
+           path = '/tmp/dumpdummy';",
       "interval" : "3600",
       "version": "1.4.5",
-      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html)",
+      "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
       "value": "Artifacts created by this malware"
     }
   }


### PR DESCRIPTION
## Changes

Adding detection for the recently discovered`OSX Dummy` malware. More information can be found [here](https://isc.sans.edu/diary/23816) and [here](https://objective-see.com/blog/blog_0x32.html).

Basically the queries look for some files dropped by the malware, mostly to achieve some persistence in the targeted system. Here are the two added queries:
```
SELECT * FROM launchd WHERE name = 'com.startup.plist';

SELECT * FROM file \
  WHERE path = '/Library/LaunchDaemons/com.startup.plist' OR \
       path = '/var/root/script.sh' OR \
       path = '/Users/Shared/dumpdummy' OR \
       path = '/tmp/script.sh' OR \
       path = '/tmp/com.startup.plist' OR \
       path = '/tmp/dumpdummy';
```

Also added `interval` for the `MacSearch_Adware` detection, it appeared to be missing.
