### PR TITLE
Output stream operator `<<` for `Error`

### DIFF
--- a/include/osquery/error.h
+++ b/include/osquery/error.h
@@ -13,6 +13,7 @@
 #include <boost/core/demangle.hpp>
 #include <memory>
 #include <new>
+#include <sstream>
 #include <string>
 #include <typeinfo>
 
@@ -97,6 +98,10 @@ class Error final : public ErrorBase {
     return full_message;
   }
 
+  void appendToMessage(const std::string& text) {
+    message_.append(text);
+  }
+
  private:
   ErrorCodeEnumType errorCode_;
   std::string message_;
@@ -158,6 +163,17 @@ Error<ErrorCodeEnumType> createError(
       std::move(message),
       std::make_unique<Error<OtherErrorCodeEnumType>>(
           std::move(underlying_error)));
+}
+
+template <typename ErrorType,
+          typename ValueType,
+          typename = typename std::enable_if<
+              std::is_base_of<ErrorBase, ErrorType>::value>::type>
+inline ErrorType operator<<(ErrorType&& error, const ValueType& value) {
+  std::ostringstream ostr{};
+  ostr << value;
+  error.appendToMessage(ostr.str());
+  return std::forward<ErrorType>(error);
 }
 
 } // namespace osquery

--- a/osquery/core/tests/error_tests.cpp
+++ b/osquery/core/tests/error_tests.cpp
@@ -11,12 +11,14 @@
 #include <gtest/gtest.h>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/io/detail/quoted_manip.hpp>
 
 #include <osquery/error.h>
 
 enum class TestError {
   SomeError = 1,
   AnotherError = 2,
+  MusicError,
 };
 
 GTEST_TEST(ErrorTest, initialization) {
@@ -84,4 +86,19 @@ GTEST_TEST(ErrorTest, createErrorFromOtherError) {
   EXPECT_PRED2(stringContains, secondShortMsg, "TestError");
   EXPECT_PRED2(stringContains, secondShortMsg, firstMsg);
   EXPECT_PRED2(stringContains, secondShortMsg, secondMsg);
+}
+
+GTEST_TEST(ErrorTest, createErrorAndStreamToIt) {
+  const auto a4 = std::string{"A4"};
+  const auto err = osquery::createError(TestError::MusicError, "Do")
+                   << '-' << "Re"
+                   << "-Mi"
+                   << "-Fa"
+                   << "-Sol"
+                   << "-La"
+                   << "-Si La" << boost::io::quoted(a4) << ' ' << 440 << " Hz";
+  EXPECT_EQ(TestError::MusicError, err.getErrorCode());
+  auto fullMsg = err.getFullMessageRecursive();
+  EXPECT_PRED2(
+      stringContains, fullMsg, "Do-Re-Mi-Fa-Sol-La-Si La\"A4\" 440 Hz");
 }


### PR DESCRIPTION
To create an error, human readable message should be provided among other arguments. The message is good to better understanding what happened by log records. To make it more informative user should put in those message some data (numbers, strings etc).

This operator will help us to avoid using verbose constructions like `boost::format` or `std::ostringstream` or something similar to format a proper error message. We will be able just to "stream" in a created error any "printable" variables from the context.

Additionaly we will be able to use "fancy" tools for streams like boost::io::quoted or std::hex to format messages.

Example:
```c++
createError(SystemErorr::NoSuchFile, "Could not read pidfile: ")
  << boost::io::quoted(pidfile_path)
  << " " << read_status.toString();
```