### PR TITLE
Add the ability to specify file_paths with sql queries

### DIFF
--- a/docs/wiki/deployment/file-integrity-monitoring.md
+++ b/docs/wiki/deployment/file-integrity-monitoring.md
@@ -19,7 +19,7 @@ To get started with FIM, you must first identify which files and directories you
 
 For example, you may want to monitor `/etc` along with other files on a Linux system. After you identify your target files and directories you wish to monitor, add them to a new section in the config *file_paths*.
 
-**Note:** Many applications may replace a file instead of editing them in place. If you monitor the file directly, osquery will need to be restarted in order to monitor the replacement. This can be avoided by monitoring the containing directory instead. 
+**Note:** Many applications may replace a file instead of editing them in place. If you monitor the file directly, osquery will need to be restarted in order to monitor the replacement. This can be avoided by monitoring the containing directory instead.
 
 The three areas below that are relevant to FIM are the scheduled query against `file_events`, the added `file_paths` section and the `exclude_paths` sections. The `file_events` query is scheduled to collect all of the FIM events that have occurred on any files within the paths specified within `file_paths` but excluding the paths specified within `exclude_paths` on a five minute interval. At a high level this means events are buffered within osquery and sent to the configured _logger_ every five minutes.
 
@@ -67,6 +67,18 @@ One must not mention arbitrary category name under the exclude_paths node, only 
 
 * `valid category` - Categories which are mentioned under `file_paths` node. In the above example config `homes`, `etc` and `tmp` are termed as valid categories.
 * `invalid category` - Any other category name apart from `homes`, `etc` and `tmp` are considered as invalid categories.
+
+In addition to `file_paths` one can use `file_paths_query` to specify the file paths to monitor as `path` column of the results of the given query, for example:
+
+```json
+{
+    "file_paths_query": {
+        "category_name": [
+            "SELECT DISTINCT '/home/' || username || '/.gitconfig' as path FROM last WHERE username != '' AND username != 'root';"
+        ]
+    }
+}
+```
 
 **Note:** Invalid categories get dropped silently, i.e. they don't have any effect on the events generated.
 

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -115,8 +115,9 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
           for (const auto& query : category.value.GetArray()) {
             auto sql = SQL(query.GetString());
             if (!sql.ok()) {
-              LOG(ERROR) << "Could not add file_paths using file_paths_query: "
-                         << sql.getMessageString();
+              LOG(ERROR) << "Could not add file_paths using file_paths_query '"
+                         << query.GetString()
+                         << "': " << sql.getMessageString();
             } else {
               for (auto& row : sql.rows()) {
                 std::string name = category.name.GetString();

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -12,6 +12,7 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
+#include <osquery/sql.h>
 
 namespace pt = boost::property_tree;
 
@@ -25,7 +26,7 @@ class FilePathsConfigParserPlugin : public ConfigParserPlugin {
   virtual ~FilePathsConfigParserPlugin() = default;
 
   std::vector<std::string> keys() const override {
-    return {"file_paths", "file_accesses", "exclude_paths"};
+    return {"file_paths", "file_paths_query", "file_accesses", "exclude_paths"};
   }
 
   Status setUp() override;
@@ -40,6 +41,8 @@ class FilePathsConfigParserPlugin : public ConfigParserPlugin {
 Status FilePathsConfigParserPlugin::setUp() {
   auto paths_obj = data_.getObject();
   data_.add("file_paths", paths_obj);
+  auto paths_query_obj = data_.getObject();
+  data_.add("file_paths_query", paths_query_obj);
   auto accesses_arr = data_.getArray();
   data_.add("file_accesses", accesses_arr);
   auto exclude_obj = data_.getObject();
@@ -51,7 +54,8 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
                                            const ParserConfig& config) {
   Config::get().removeFiles(source);
   access_map_.erase(source);
-  if (config.count("file_paths") == 0) {
+  if (config.count("file_paths") == 0 &&
+      config.count("file_paths_query") == 0) {
     return Status();
   }
 
@@ -81,20 +85,47 @@ Status FilePathsConfigParserPlugin::update(const std::string& source,
     data_.add("file_accesses", arr);
   }
 
-  // We know this top-level is an Object.
-  const auto& file_paths = config.at("file_paths").doc();
-  if (file_paths.IsObject()) {
-    for (const auto& category : file_paths.GetObject()) {
-      if (category.value.IsArray()) {
-        for (const auto& path : category.value.GetArray()) {
-          std::string pattern = path.GetString();
-          if (pattern.empty()) {
-            continue;
-          }
+  if (config.count("file_paths") > 0) {
+    // We know this top-level is an Object.
+    const auto& file_paths = config.at("file_paths").doc();
+    if (file_paths.IsObject()) {
+      for (const auto& category : file_paths.GetObject()) {
+        if (category.value.IsArray()) {
+          for (const auto& path : category.value.GetArray()) {
+            std::string pattern = path.GetString();
+            if (pattern.empty()) {
+              continue;
+            }
 
-          std::string name = category.name.GetString();
-          replaceGlobWildcards(pattern);
-          Config::get().addFile(source, name, pattern);
+            std::string name = category.name.GetString();
+            replaceGlobWildcards(pattern);
+            Config::get().addFile(source, name, pattern);
+          }
+        }
+      }
+    }
+  }
+
+  if (config.count("file_paths_query") > 0) {
+    // We know this top-level is an Object.
+    const auto& path_query_node = config.at("file_paths_query").doc();
+    if (path_query_node.IsObject()) {
+      for (const auto& category : path_query_node.GetObject()) {
+        if (category.value.IsArray()) {
+          for (const auto& query : category.value.GetArray()) {
+            auto sql = SQL(query.GetString());
+            if (!sql.ok()) {
+              LOG(ERROR) << "Could not add file_paths using file_paths_query: "
+                         << sql.getMessageString();
+            } else {
+              for (auto& row : sql.rows()) {
+                std::string name = category.name.GetString();
+                std::string path = row["path"];
+                replaceGlobWildcards(path);
+                Config::get().addFile(source, name, path);
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This allows to use results of a query to add file event listeners to files.

Example config:
```
{
    "file_paths_query": {
        "category_name": [
            "select distinct '/Users/' || username || '/.gitconfig' as path from last where username != '' and username != 'root';"
        ]
    }
}
```