### PR TITLE
Support CDHash algorithms other than SHA-1 (Darwin)

### DIFF
--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -161,19 +161,18 @@ Status genSignatureForFileAndArch(const std::string& path,
   CFDataRef hashInfo =
       (CFDataRef)CFDictionaryGetValue(code_info, kSecCodeInfoUnique);
   if (hashInfo != nullptr) {
-    // Get the SHA-1 bytes
+    // Get the CDHash bytes
     std::stringstream ss;
     auto bytes = CFDataGetBytePtr(hashInfo);
-    if (bytes != nullptr &&
-        CFDataGetLength(hashInfo) == CC_SHA1_DIGEST_LENGTH) {
+    if (bytes != nullptr && CFDataGetLength(hashInfo) > 0) {
       // Write bytes as hex strings
-      for (size_t n = 0; n < CC_SHA1_DIGEST_LENGTH; n++) {
+      for (size_t n = 0; n < CFDataGetLength(hashInfo); n++) {
         ss << std::hex << std::setfill('0') << std::setw(2);
         ss << (unsigned int)bytes[n];
       }
       r["cdhash"] = ss.str();
     }
-    if (r["cdhash"].length() != CC_SHA1_DIGEST_LENGTH * 2) {
+    if (r["cdhash"].length() != CFDataGetLength(hashInfo) * 2) {
       VLOG(1) << "Error extracting code directory hash";
       r["cdhash"] = "";
     }

--- a/specs/darwin/signature.table
+++ b/specs/darwin/signature.table
@@ -6,7 +6,7 @@ schema([
     Column("arch", TEXT, "If applicable, the arch of the signed code"),
     Column("signed", INTEGER, "1 If the file is signed else 0"),
     Column("identifier", TEXT, "The signing identifier sealed into the signature"),
-    Column("cdhash", TEXT, "SHA1 hash of the application Code Directory"),
+    Column("cdhash", TEXT, "Hash of the application Code Directory"),
     Column("team_identifier", TEXT, "The team signing identifier sealed into the signature"),
     Column("authority", TEXT, "Certificate Common Name"),
 ])


### PR DESCRIPTION
Osquery currently fails to extract the CDHash for signed binaries which use
a CDHash produced by a different algorithm than SHA-1.

CDHash is not guaranteed to be SHA-1.  In fact, the algorithm is being
changed to SHA-256. Therefore, this pull req removes the dependency on
SHA-1 from the code in order to support CDHashes produced with other
hash algorithms, but still relies on the OS to decide which CDHash to select
if there are multiple hashes produced using different hash algorithms.

An alternative approach to the one I've chosen would be to extract all of
the available CDHashes and make them all available in separate columns.
This pull request is the least intrusive improvement over failing to extract
the CDHash entirely where the OS decides to serve up SHA-256 instead
of SHA-1.