### PR TITLE
flags: Separate flags and flagalias

### DIFF
--- a/include/osquery/flags.h
+++ b/include/osquery/flags.h
@@ -11,10 +11,9 @@
 #pragma once
 
 #include <map>
-
-#include <boost/lexical_cast.hpp>
-#include <boost/noncopyable.hpp>
 #include <utility>
+
+#include <boost/noncopyable.hpp>
 
 #define GFLAGS_DLL_DEFINE_FLAG
 #define GFLAGS_DLL_DECLARE_FLAG
@@ -30,19 +29,7 @@
 #define GFLAGS_NAMESPACE google
 #endif
 
-namespace boost {
-/// We define a lexical_cast template for boolean for Gflags boolean string
-/// values.
-template <>
-bool lexical_cast<bool, std::string>(const std::string& arg);
-
-template <>
-std::string lexical_cast<std::string, bool>(const bool& arg);
-} // namespace boost
-
 namespace osquery {
-
-class Status;
 
 struct FlagDetail {
   std::string description;
@@ -163,37 +150,6 @@ class Flag : private boost::noncopyable {
   /// Configurations may set "custom_" flags.
   std::map<std::string, std::string> custom_;
 };
-
-/**
- * @brief Helper accessor/assignment alias class to support deprecated flags.
- *
- * This templated class wraps Flag::updateValue and Flag::getValue to 'alias'
- * a deprecated flag name as the updated name. The helper macro FLAG_ALIAS
- * will create a global variable instances of this wrapper using the same
- * Gflags naming scheme to prevent collisions and support existing callsites.
- */
-template <typename T>
-class FlagAlias {
- public:
-  FlagAlias& operator=(T const& v) {
-    Flag::updateValue(name_, boost::lexical_cast<std::string>(v));
-    return *this;
-  }
-
-  /*explicit*/ operator T() const {
-    return boost::lexical_cast<T>(Flag::getValue(name_));
-  }
-
-  FlagAlias(const std::string& /*alias*/,
-            const std::string& /*type*/,
-            std::string name,
-            T* /*storage*/)
-      : name_(std::move(name)) {}
-
- private:
-  /// Friendly flag name.
-  std::string name_;
-};
 } // namespace osquery
 
 /*
@@ -246,26 +202,3 @@ class FlagAlias {
 
 /// See FLAG, but HIDDEN_FLAGS%s are not shown in --help.
 #define HIDDEN_FLAG(t, n, v, d) OSQUERY_FLAG(t, n, v, d, 0, 0, 0, 1)
-
-/**
- * @brief Create an alias to a command line flag.
- *
- * Like OSQUERY_FLAG, do not use this in the osquery codebase. Use the derived
- * macros that abstract the tail of boolean arguments.
- */
-#define OSQUERY_FLAG_ALIAS(t, a, n, s, e)                                      \
-  FlagAlias<t> FLAGS_##a(#a, #t, #n, &FLAGS_##n);                              \
-  namespace flags {                                                            \
-  static GFLAGS_NAMESPACE::FlagRegisterer oflag_##a(                           \
-      #a, #a, #a, &FLAGS_##n, &FLAGS_##n);                                     \
-  const int flag_alias_##a = Flag::createAlias(#a, {#n, s, e, 0, 1});          \
-  }
-
-/// See FLAG, FLAG_ALIAS aliases a flag name to an existing FLAG.
-#define FLAG_ALIAS(t, a, n) OSQUERY_FLAG_ALIAS(t, a, n, 0, 0)
-
-/// See FLAG_ALIAS, SHELL_FLAG_ALIAS%es are only available in osqueryi.
-#define SHELL_FLAG_ALIAS(t, a, n) _OSQUERY_FLAG_ALIAS(t, a, n, 1, 0)
-
-/// See FLAG_ALIAS, EXTENSION_FLAG_ALIAS%es are only available to extensions.
-#define EXTENSION_FLAG_ALIAS(a, n) OSQUERY_FLAG_ALIAS(std::string, a, n, 0, 1)

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -28,6 +28,7 @@
 #include <osquery/tables.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/core/flagalias.h"
 
 namespace rj = rapidjson;
 

--- a/osquery/core/flagalias.h
+++ b/osquery/core/flagalias.h
@@ -1,0 +1,81 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <boost/lexical_cast.hpp>
+
+#include <osquery/flags.h>
+
+namespace boost {
+/// We define a lexical_cast template for boolean for Gflags boolean string
+/// values.
+template <>
+bool lexical_cast<bool, std::string>(const std::string& arg);
+
+template <>
+std::string lexical_cast<std::string, bool>(const bool& arg);
+} // namespace boost
+
+namespace osquery {
+/**
+ * @brief Helper accessor/assignment alias class to support deprecated flags.
+ *
+ * This templated class wraps Flag::updateValue and Flag::getValue to 'alias'
+ * a deprecated flag name as the updated name. The helper macro FLAG_ALIAS
+ * will create a global variable instances of this wrapper using the same
+ * Gflags naming scheme to prevent collisions and support existing callsites.
+ */
+template <typename T>
+class FlagAlias {
+ public:
+  FlagAlias& operator=(T const& v) {
+    Flag::updateValue(name_, boost::lexical_cast<std::string>(v));
+    return *this;
+  }
+
+  /*explicit*/ operator T() const {
+    return boost::lexical_cast<T>(Flag::getValue(name_));
+  }
+
+  FlagAlias(const std::string& /*alias*/,
+            const std::string& /*type*/,
+            std::string name,
+            T* /*storage*/)
+      : name_(std::move(name)) {}
+
+ private:
+  /// Friendly flag name.
+  std::string name_;
+};
+} // namespace osquery
+
+/**
+ * @brief Create an alias to a command line flag.
+ *
+ * Like OSQUERY_FLAG, do not use this in the osquery codebase. Use the derived
+ * macros that abstract the tail of boolean arguments.
+ */
+#define OSQUERY_FLAG_ALIAS(t, a, n, s, e)                                      \
+  FlagAlias<t> FLAGS_##a(#a, #t, #n, &FLAGS_##n);                              \
+  namespace flags {                                                            \
+  static GFLAGS_NAMESPACE::FlagRegisterer oflag_##a(                           \
+      #a, #a, #a, &FLAGS_##n, &FLAGS_##n);                                     \
+  const int flag_alias_##a = Flag::createAlias(#a, {#n, s, e, 0, 1});          \
+  }
+
+/// See FLAG, FLAG_ALIAS aliases a flag name to an existing FLAG.
+#define FLAG_ALIAS(t, a, n) OSQUERY_FLAG_ALIAS(t, a, n, 0, 0)
+
+/// See FLAG_ALIAS, SHELL_FLAG_ALIAS%es are only available in osqueryi.
+#define SHELL_FLAG_ALIAS(t, a, n) _OSQUERY_FLAG_ALIAS(t, a, n, 1, 0)
+
+/// See FLAG_ALIAS, EXTENSION_FLAG_ALIAS%es are only available to extensions.
+#define EXTENSION_FLAG_ALIAS(a, n) OSQUERY_FLAG_ALIAS(std::string, a, n, 0, 1)

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -12,6 +12,7 @@
 #include <osquery/registry.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/core/flagalias.h"
 
 namespace boost {
 template <>

--- a/osquery/core/tests/flags_tests.cpp
+++ b/osquery/core/tests/flags_tests.cpp
@@ -25,6 +25,8 @@
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 
+#include "osquery/core/flagalias.h"
+
 namespace osquery {
 
 DECLARE_string(test_string_flag);

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -16,6 +16,7 @@
 #include <osquery/logger.h>
 #include <osquery/registry.h>
 
+#include "osquery/core/flagalias.h"
 #include "osquery/core/json.h"
 
 namespace pt = boost::property_tree;

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -23,6 +23,7 @@
 #include <osquery/system.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/core/flagalias.h"
 #include "osquery/core/process.h"
 #include "osquery/core/watcher.h"
 #include "osquery/extensions/interface.h"

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -31,6 +31,7 @@
 #include <osquery/system.h>
 
 #include "osquery/core/conversions.h"
+#include "osquery/core/flagalias.h"
 #include "osquery/core/json.h"
 
 namespace pt = boost::property_tree;

--- a/osquery/logger/plugins/filesystem_logger.cpp
+++ b/osquery/logger/plugins/filesystem_logger.cpp
@@ -15,6 +15,8 @@
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 
+#include "osquery/core/flagalias.h"
+
 namespace fs = boost::filesystem;
 
 /**


### PR DESCRIPTION
The goal is to improve build times.

The boost lexical casting include requirement in `flags.h` is not needed in every implementation file that uses a google flag. Moving this to the several files that actually use it improves build times (+5% wall time). Measured with stopwatch and 2 builds (observational science).