### PR TITLE
tables: Remove lexical_cast include from tables

### DIFF
--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -24,7 +24,6 @@
 #endif
 
 #include <boost/coroutine2/coroutine.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <osquery/core.h>
 #include <osquery/plugin.h>
@@ -62,19 +61,30 @@ class Status;
  */
 template <typename Type>
 inline std::string __sqliteField(const Type& source) noexcept {
-  std::string dest;
-  if (!boost::conversion::try_lexical_convert(source, dest)) {
-    return SQL_NULL_RESULT;
-  }
-  return dest;
+  return std::to_string(source);
+}
+
+template <size_t N>
+inline std::string __sqliteField(const char (&source)[N]) noexcept {
+  return std::string(source);
+}
+
+inline std::string __sqliteField(const char* source) noexcept {
+  return std::string(source);
+}
+
+inline std::string __sqliteField(char* const source) noexcept {
+  return std::string(source);
+}
+
+inline std::string __sqliteField(const std::string& source) noexcept {
+  return source;
 }
 
 #ifdef WIN32
 // TEXT is also defined in windows.h, we should not re-define it
 #define SQL_TEXT(x) __sqliteField(x)
 #else
-// For everything except Windows, aldo define TEXT() to be compatible with
-// existing tables
 #define SQL_TEXT(x) __sqliteField(x)
 #define TEXT(x) __sqliteField(x)
 #endif
@@ -105,8 +115,6 @@ inline std::string __sqliteField(const Type& source) noexcept {
 #define UNSIGNED_BIGINT_LITERAL uint64_t
 /// See the literal type documentation for TEXT_LITERAL.
 #define DOUBLE_LITERAL double
-/// Cast an SQLite affinity type to the literal type.
-#define AS_LITERAL(literal, value) boost::lexical_cast<literal>(value)
 
 enum ColumnType {
   UNKNOWN_TYPE = 0,
@@ -384,14 +392,7 @@ struct ConstraintList : private boost::noncopyable {
 
   /// See ConstraintList::getAll, but as a selected literal type.
   template <typename T>
-  std::set<T> getAll(ConstraintOperator op) const {
-    std::set<T> literal_matches;
-    auto matches = getAll(op);
-    for (const auto& match : matches) {
-      literal_matches.insert(AS_LITERAL(T, match));
-    }
-    return literal_matches;
-  }
+  std::set<T> getAll(ConstraintOperator op) const;
 
   /// Constraint list accessor, types and operator.
   const std::vector<struct Constraint>& getAll() const {

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -66,12 +66,12 @@ inline std::string __sqliteField(const Type& source) noexcept {
 
 template <size_t N>
 inline std::string __sqliteField(const char (&source)[N]) noexcept {
-  return std::string(source);
+  return std::string(source, N - 1U);
 }
 
 template <size_t N>
 inline std::string __sqliteField(const unsigned char (&source)[N]) noexcept {
-  return std::string(reinterpret_cast<const char*>(source), N);
+  return std::string(reinterpret_cast<const char*>(source), N - 1U);
 }
 
 inline std::string __sqliteField(const char* source) noexcept {
@@ -84,6 +84,10 @@ inline std::string __sqliteField(char* const source) noexcept {
 
 inline std::string __sqliteField(const unsigned char* source) noexcept {
   return std::string(reinterpret_cast<const char*>(source));
+}
+
+inline std::string __sqliteField(unsigned char* const source) noexcept {
+  return std::string(reinterpret_cast<char* const>(source));
 }
 
 inline std::string __sqliteField(const std::string& source) noexcept {

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -69,12 +69,21 @@ inline std::string __sqliteField(const char (&source)[N]) noexcept {
   return std::string(source);
 }
 
+template <size_t N>
+inline std::string __sqliteField(const unsigned char (&source)[N]) noexcept {
+  return std::string(reinterpret_cast<const char*>(source), N);
+}
+
 inline std::string __sqliteField(const char* source) noexcept {
   return std::string(source);
 }
 
 inline std::string __sqliteField(char* const source) noexcept {
   return std::string(source);
+}
+
+inline std::string __sqliteField(const unsigned char* source) noexcept {
+  return std::string(reinterpret_cast<const char*>(source));
 }
 
 inline std::string __sqliteField(const std::string& source) noexcept {

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -870,24 +870,22 @@ void Config::recordQueryPerformance(const std::string& name,
   auto& query = performance_.at(name);
   BIGINT_LITERAL diff = 0;
   if (!r1.at("user_time").empty() && !r0.at("user_time").empty()) {
-    diff = AS_LITERAL(BIGINT_LITERAL, r1.at("user_time")) -
-           AS_LITERAL(BIGINT_LITERAL, r0.at("user_time"));
+    diff = std::stoll(r1.at("user_time")) - std::stoll(r0.at("user_time"));
     if (diff > 0) {
       query.user_time += diff;
     }
   }
 
   if (!r1.at("system_time").empty() && !r0.at("system_time").empty()) {
-    diff = AS_LITERAL(BIGINT_LITERAL, r1.at("system_time")) -
-           AS_LITERAL(BIGINT_LITERAL, r0.at("system_time"));
+    diff = std::stoll(r1.at("system_time")) - std::stoll(r0.at("system_time"));
     if (diff > 0) {
       query.system_time += diff;
     }
   }
 
   if (!r1.at("resident_size").empty() && !r0.at("resident_size").empty()) {
-    diff = AS_LITERAL(BIGINT_LITERAL, r1.at("resident_size")) -
-           AS_LITERAL(BIGINT_LITERAL, r0.at("resident_size"));
+    diff =
+        std::stoll(r1.at("resident_size")) - std::stoll(r0.at("resident_size"));
     if (diff > 0) {
       // Memory is stored as an average of RSS changes between query executions.
       query.average_memory = (query.average_memory * query.executions) + diff;

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -427,6 +427,17 @@ std::set<unsigned long long> ConstraintList::getAll<unsigned long long>(
   return cs;
 }
 
+template <>
+std::set<std::string> ConstraintList::getAll<std::string>(
+    ConstraintOperator op) const {
+  std::set<std::string> cs;
+  std::transform(constraints_.begin(),
+                 constraints_.end(),
+                 std::inserter(cs, cs.begin()),
+                 [](const Constraint& c) { return c.expr; });
+  return cs;
+}
+
 void ConstraintList::serialize(JSON& doc, rapidjson::Value& obj) const {
   auto expressions = doc.getArray();
   for (const auto& constraint : constraints_) {

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -8,13 +8,15 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include "osquery/core/json.h"
+
 #include <osquery/database.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 #include <osquery/tables.h>
 
-#include "osquery/core/json.h"
+#include <boost/lexical_cast.hpp>
 
 namespace osquery {
 
@@ -289,10 +291,9 @@ std::string columnDefinition(const PluginResponse& response, bool aliases) {
 
     if (column.at("id") == "column" && column.count("name") &&
         column.count("type")) {
-      auto options =
-          (column.count("op"))
-              ? (ColumnOptions)AS_LITERAL(INTEGER_LITERAL, column.at("op"))
-              : ColumnOptions::DEFAULT;
+      auto options = (column.count("op"))
+                         ? (ColumnOptions)std::stol(column.at("op"))
+                         : ColumnOptions::DEFAULT;
       auto column_type = columnTypeName(column.at("type"));
       columns.push_back(make_tuple(column.at("name"), column_type, options));
       if (aliases) {
@@ -340,13 +341,13 @@ bool ConstraintList::matches(const std::string& expr) const {
     if (affinity == TEXT_TYPE) {
       return literal_matches<TEXT_LITERAL>(expr);
     } else if (affinity == INTEGER_TYPE) {
-      INTEGER_LITERAL lexpr = AS_LITERAL(INTEGER_LITERAL, expr);
+      auto lexpr = boost::lexical_cast<INTEGER_LITERAL>(expr);
       return literal_matches<INTEGER_LITERAL>(lexpr);
     } else if (affinity == BIGINT_TYPE) {
-      BIGINT_LITERAL lexpr = AS_LITERAL(BIGINT_LITERAL, expr);
+      auto lexpr = boost::lexical_cast<BIGINT_LITERAL>(expr);
       return literal_matches<BIGINT_LITERAL>(lexpr);
     } else if (affinity == UNSIGNED_BIGINT_TYPE) {
-      UNSIGNED_BIGINT_LITERAL lexpr = AS_LITERAL(UNSIGNED_BIGINT_LITERAL, expr);
+      auto lexpr = boost::lexical_cast<UNSIGNED_BIGINT_LITERAL>(expr);
       return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr);
     }
   } catch (const boost::bad_lexical_cast& /* e */) {
@@ -360,7 +361,7 @@ template <typename T>
 bool ConstraintList::literal_matches(const T& base_expr) const {
   bool aggregate = true;
   for (size_t i = 0; i < constraints_.size(); ++i) {
-    T constraint_expr = AS_LITERAL(T, constraints_[i].expr);
+    auto constraint_expr = boost::lexical_cast<T>(constraints_[i].expr);
     if (constraints_[i].op == EQUALS) {
       aggregate = aggregate && (base_expr == constraint_expr);
     } else if (constraints_[i].op == GREATER_THAN) {
@@ -392,6 +393,38 @@ std::set<std::string> ConstraintList::getAll(ConstraintOperator op) const {
     }
   }
   return set;
+}
+
+template <>
+std::set<int> ConstraintList::getAll<int>(ConstraintOperator op) const {
+  std::set<int> cs;
+  std::transform(constraints_.begin(),
+                 constraints_.end(),
+                 std::inserter(cs, cs.begin()),
+                 [](const Constraint& c) { return std::stoi(c.expr); });
+  return cs;
+}
+
+template <>
+std::set<long long> ConstraintList::getAll<long long>(
+    ConstraintOperator op) const {
+  std::set<long long> cs;
+  std::transform(constraints_.begin(),
+                 constraints_.end(),
+                 std::inserter(cs, cs.begin()),
+                 [](const Constraint& c) { return std::stoll(c.expr); });
+  return cs;
+}
+
+template <>
+std::set<unsigned long long> ConstraintList::getAll<unsigned long long>(
+    ConstraintOperator op) const {
+  std::set<unsigned long long> cs;
+  std::transform(constraints_.begin(),
+                 constraints_.end(),
+                 std::inserter(cs, cs.begin()),
+                 [](const Constraint& c) { return std::stoull(c.expr); });
+  return cs;
 }
 
 void ConstraintList::serialize(JSON& doc, rapidjson::Value& obj) const {

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -276,9 +276,7 @@ TEST_F(WatcherTests, test_watcherrunner_unhealthy_delay) {
 
   // Set up a fake test process and place it into an healthy state.
   Row r;
-  r["parent"] = isPlatform(PlatformType::TYPE_WINDOWS)
-                    ? INTEGER(test_process->pid())
-                    : INTEGER(test_process->nativeHandle());
+  r["parent"] = INTEGER(test_process->pid());
   r["user_time"] = INTEGER(100);
   r["system_time"] = INTEGER(100);
   r["resident_size"] = INTEGER(100);

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -368,8 +368,8 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
     change.parent = static_cast<pid_t>(std::stoll(r.at("parent")));
-    user_time = std::stoll(r.at("user_time")) / change.iv;
-    system_time = std::stoll(r.at("system_time")) / change.iv;
+    user_time = std::stoll(r.at("user_time"));
+    system_time = std::stoll(r.at("system_time"));
     change.footprint = std::stoll(r.at("resident_size"));
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -367,11 +367,18 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
+<<<<<<< Updated upstream
     change.parent =
         static_cast<pid_t>(AS_LITERAL(BIGINT_LITERAL, r.at("parent")));
     user_time = AS_LITERAL(BIGINT_LITERAL, r.at("user_time"));
     system_time = AS_LITERAL(BIGINT_LITERAL, r.at("system_time"));
     change.footprint = AS_LITERAL(BIGINT_LITERAL, r.at("resident_size"));
+=======
+    change.parent = static_cast<pid_t>(std::stoll(r.at("parent")));
+    user_time = std::stoll(r.at("user_time")) / change.iv;
+    system_time = std::stoll(r.at("system_time")) / change.iv;
+    change.footprint = std::stoll(r.at("resident_size"));
+>>>>>>> Stashed changes
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -367,18 +367,10 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
-<<<<<<< Updated upstream
-    change.parent =
-        static_cast<pid_t>(AS_LITERAL(BIGINT_LITERAL, r.at("parent")));
-    user_time = AS_LITERAL(BIGINT_LITERAL, r.at("user_time"));
-    system_time = AS_LITERAL(BIGINT_LITERAL, r.at("system_time"));
-    change.footprint = AS_LITERAL(BIGINT_LITERAL, r.at("resident_size"));
-=======
     change.parent = static_cast<pid_t>(std::stoll(r.at("parent")));
     user_time = std::stoll(r.at("user_time")) / change.iv;
     system_time = std::stoll(r.at("system_time")) / change.iv;
     change.footprint = std::stoll(r.at("resident_size"));
->>>>>>> Stashed changes
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -78,9 +78,8 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
   JSON params;
   params.add(FLAGS_tls_enroll_override, getEnrollSecret());
   params.add("host_identifier", getHostIdentifier());
-  params.add(
-      "platform_type",
-      std::to_string(static_cast<uint64_t>(kPlatformType)));
+  params.add("platform_type",
+             std::to_string(static_cast<uint64_t>(kPlatformType)));
 
   // Select from each table describing host details.
   JSON host_details;

--- a/osquery/remote/enroll/plugins/tls_enroll.cpp
+++ b/osquery/remote/enroll/plugins/tls_enroll.cpp
@@ -80,7 +80,7 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
   params.add("host_identifier", getHostIdentifier());
   params.add(
       "platform_type",
-      boost::lexical_cast<std::string>(static_cast<uint64_t>(kPlatformType)));
+      std::to_string(static_cast<uint64_t>(kPlatformType)));
 
   // Select from each table describing host details.
   JSON host_details;

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -8,14 +8,16 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include "osquery/sql/sqlite_util.h"
+#include "osquery/sql/virtual_table.h"
+
 #include <osquery/core.h>
 #include <osquery/flags.h>
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 #include <osquery/sql.h>
 
-#include "osquery/sql/sqlite_util.h"
-#include "osquery/sql/virtual_table.h"
+#include <boost/lexical_cast.hpp>
 
 namespace osquery {
 

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -207,10 +207,10 @@ int xCreate(sqlite3* db,
         column.count("type")) {
       // This is a malformed column definition.
       // Populate the virtual table specific persistent column information.
-      pVtab->content->columns.push_back(std::make_tuple(
-          column.at("name"),
-          columnTypeName(column.at("type")),
-          (ColumnOptions)AS_LITERAL(INTEGER_LITERAL, column.at("op"))));
+      pVtab->content->columns.push_back(
+          std::make_tuple(column.at("name"),
+                          columnTypeName(column.at("type")),
+                          (ColumnOptions)std::stol(column.at("op"))));
     } else if (column.at("id") == "alias" && column.count("alias")) {
       // Create associated views for table aliases.
       views.insert(column.at("alias"));
@@ -234,7 +234,7 @@ int xCreate(sqlite3* db,
     } else if (column.at("id") == "attributes") {
       // Store the attributes locally so they may be passed to the SQL object.
       pVtab->content->attributes =
-          (TableAttributes)AS_LITERAL(INTEGER_LITERAL, column.at("attributes"));
+          (TableAttributes)std::stol(column.at("attributes"));
     }
   }
 

--- a/osquery/tables/events/darwin/disk_events.cpp
+++ b/osquery/tables/events/darwin/disk_events.cpp
@@ -8,13 +8,15 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include "osquery/events/darwin/diskarbitration.h"
+
 #include <osquery/core.h>
 #include <osquery/events.h>
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 #include <osquery/tables.h>
 
-#include "osquery/events/darwin/diskarbitration.h"
+#include <boost/lexical_cast.hpp>
 
 namespace osquery {
 

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -235,7 +235,7 @@ QueryData genCPUID(QueryContext& context) {
       r["value"] = isBitSet(feature_bit, regs[feature_register]) ? "1" : "0";
       r["output_register"] = feature.second.first;
       r["output_bit"] = INTEGER(feature_bit);
-      r["input_eax"] = boost::lexical_cast<std::string>(eax);
+      r["input_eax"] = std::to_string(eax);
       results.push_back(r);
     }
   }

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -109,7 +109,7 @@ void genOSXPrefValues(const CFTypeRef& value,
   } else if (CFGetTypeID(value) == CFDateGetTypeID()) {
     auto unix_time = CFDateGetAbsoluteTime(static_cast<CFDateRef>(value)) +
                      kCFAbsoluteTimeIntervalSince1970;
-    r["value"] = boost::lexical_cast<std::string>(std::llround(unix_time));
+    r["value"] = std::to_string(std::llround(unix_time));
   } else if (CFGetTypeID(value) == CFBooleanGetTypeID()) {
     r["value"] = (CFBooleanGetValue(static_cast<CFBooleanRef>(value)) == TRUE)
                      ? "true"

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -31,19 +31,12 @@ namespace tables {
 std::set<std::string> kCheckedArches{"", "i386", "ppc", "arm", "x86_64"};
 
 int getOSMinorVersion() {
-  using boost::lexical_cast;
-  using boost::bad_lexical_cast;
-
   auto qd = SQL::selectAllFrom("os_version");
   if (qd.size() != 1) {
     return -1;
   }
 
-  try {
-    return lexical_cast<int>(qd.front().at("minor"));
-  } catch (const bad_lexical_cast& e) {
-    return -1;
-  }
+  return std::stol(qd.front().at("minor"));
 }
 
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on

--- a/osquery/tables/system/freebsd/os_version.cpp
+++ b/osquery/tables/system/freebsd/os_version.cpp
@@ -48,8 +48,8 @@ QueryData genOSVersion(QueryContext& context) {
   xp::smatch matches;
   for (auto& line : osquery::split(result[0]["current_value"], "\n")) {
     if (xp::regex_search(line, matches, rx)) {
-      r["major"] = INTEGER(matches["major"]);
-      r["minor"] = INTEGER(matches["minor"]);
+      r["major"] = matches["major"];
+      r["minor"] = matches["minor"];
       r["build"] = matches["build"];
       r["patch"] = matches["patch"];
       break;

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -123,11 +123,13 @@ QueryData genOSVersion(QueryContext& context) {
   xp::smatch matches;
   for (const auto& line : osquery::split(content, "\n")) {
     if (xp::regex_search(line, matches, rx)) {
-      r["major"] = INTEGER(matches["major"]);
-      r["minor"] = INTEGER(matches["minor"]);
-      r["patch"] =
-          (matches["patch"].length() > 0) ? INTEGER(matches["patch"]) : "0";
       r["name"] = matches["name"];
+      r["major"] = matches["major"];
+      r["minor"] = matches["minor"];
+      r["patch"] = matches["patch"];
+      if (r["patch"].empty()) {
+        r["patch"] = "0";
+      }
       break;
     }
   }

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -257,11 +257,7 @@ SimpleProcStat::SimpleProcStat(const std::string& pid) {
     this->system_time = details.at(12);
     this->nice = details.at(16);
     this->threads = details.at(17);
-    try {
-      this->start_time = TEXT(AS_LITERAL(BIGINT_LITERAL, details.at(19)) / 100);
-    } catch (const boost::bad_lexical_cast& e) {
-      this->start_time = "-1";
-    }
+    this->start_time = TEXT(std::stol(details.at(19)) / 100);
   }
 
   // /proc/N/status may be not available, or readable by this user.

--- a/osquery/tables/system/posix/shell_history.cpp
+++ b/osquery/tables/system/posix/shell_history.cpp
@@ -60,7 +60,8 @@ void genShellHistoryFromFile(const std::string& uid,
         prev_bash_timestamp.clear();
       } else if (xp::regex_search(
                      line, zsh_timestamp_matches, zsh_timestamp_rx)) {
-        r["time"] = INTEGER(zsh_timestamp_matches["timestamp"]);
+        std::string timestamp = zsh_timestamp_matches["timestamp"];
+        r["time"] = INTEGER(timestamp);
         r["command"] = zsh_timestamp_matches["command"];
       } else {
         r["time"] = INTEGER(0);

--- a/osquery/tables/system/posix/suid_bin.cpp
+++ b/osquery/tables/system/posix/suid_bin.cpp
@@ -46,14 +46,14 @@ Status genBin(const fs::path& path, int perms, QueryData& results) {
   if (pw != nullptr) {
     user = std::string(pw->pw_name);
   } else {
-    user = boost::lexical_cast<std::string>(info.st_uid);
+    user = std::to_string(info.st_uid);
   }
 
   std::string group;
   if (gr != nullptr) {
     group = std::string(gr->gr_name);
   } else {
-    group = boost::lexical_cast<std::string>(info.st_gid);
+    group = std::to_string(info.st_gid);
   }
 
   r["username"] = user;

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -105,7 +105,8 @@ QueryData genLoggedInUsers(QueryContext& context) {
                   std::to_string(wtsClient->ClientAddress[3]);
     } else if (wtsClient->ClientAddressFamily == AF_INET6) {
       // TODO: IPv6 addresses are given as an array of byte values.
-      r["host"] = SQL_TEXT(wtsClient->ClientAddress);
+      auto addr = reinterpret_cast<const char*>(wtsClient->ClientAddress);
+      r["host"] = std::string(addr, CLIENTADDRESS_LENGTH);
     }
 
     r["pid"] = INTEGER(-1);


### PR DESCRIPTION
The goal is to improve build times.

This removes `boost::lexical_cast` from `tables.h`.

This is a work in progress as there are plenty of things that relied on the implicit availability. And if someone has a better approach, please feel free to commandeer/close this.