### PR TITLE
bug: Fix SELinux events rebase

### DIFF
--- a/osquery/tables/events/linux/selinux_events.cpp
+++ b/osquery/tables/events/linux/selinux_events.cpp
@@ -12,6 +12,7 @@
 
 #include <osquery/flags.h>
 #include <osquery/logger.h>
+#include <osquery/registry_factory.h>
 
 #include "osquery/core/conversions.h"
 #include "osquery/events/linux/auditeventpublisher.h"


### PR DESCRIPTION
The recently merged: 9497df67cc31f7760a28c77215438b89deae2115 should have been tested after a rebase because of an includes path refactor.