### PR TITLE
Remove using instance() from serviceCount()

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -145,7 +145,7 @@ class Dispatcher : private boost::noncopyable {
   static void stopServices();
 
   /// Return number of services.
-  size_t serviceCount();
+  size_t serviceCount() const;
 
  private:
   /**

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -57,9 +57,8 @@ Dispatcher& Dispatcher::instance() {
   return instance;
 }
 
-size_t Dispatcher::serviceCount() {
-  auto& self = Dispatcher::instance();
-  ReadLock lock(self.mutex_);
+size_t Dispatcher::serviceCount() const {
+  ReadLock lock(mutex_);
   return services_.size();
 }
 


### PR DESCRIPTION
As far serviceCount is not a static function there is absolutely legal to use `this` in it