### PR TITLE
Add etc/hosts.ics data to the etc_hosts table.

### DIFF
--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -32,6 +32,7 @@ namespace tables {
 fs::path kEtcHosts = "/etc/hosts";
 #else
 fs::path kEtcHosts = (getSystemRoot() / "system32\\drivers\\etc\\hosts");
+fs::path kEtcHostsIcs = (getSystemRoot() / "system32\\drivers\\etc\\hosts.ics");
 #endif
 QueryData parseEtcHostsContent(const std::string& content) {
   QueryData results;
@@ -62,11 +63,22 @@ QueryData parseEtcHostsContent(const std::string& content) {
 
 QueryData genEtcHosts(QueryContext& context) {
   std::string content;
+  QueryData qres = {};
+
   if (readFile(kEtcHosts, content).ok()) {
-    return parseEtcHostsContent(content);
-  } else {
-    return {};
+    qres = parseEtcHostsContent(content);
   }
+
+#ifdef WIN32
+  content.clear();
+  QueryData qres_ics = {};
+  if (readFile(kEtcHostsIcs, content).ok()) {
+    qres_ics = parseEtcHostsContent(content);
+    qres.insert(qres.end(), qres_ics.begin(), qres_ics.end());
+  }
+#endif
+
+  return qres;
 }
 }
 }

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -29,6 +29,11 @@ TEST_F(NetworkingTablesTests, test_parse_etc_hosts_content) {
             getEtcHostsExpectedResults());
 }
 
+TEST_F(NetworkingTablesTests, test_parse_etc_hosts_ics_content) {
+  EXPECT_EQ(parseEtcHostsContent(getEtcHostsIcsContent()),
+            getEtcHostsIcsExpectedResults());
+}
+
 TEST_F(NetworkingTablesTests, test_parse_etc_protocols_content) {
   EXPECT_EQ(parseEtcProtocolsContent(getEtcProtocolsContent()),
             getEtcProtocolsExpectedResults());

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -387,6 +387,12 @@ std::string getEtcHostsContent() {
   return content;
 }
 
+std::string getEtcHostsIcsContent() {
+  std::string content;
+  readFile(fs::path(kTestDataPath) / "test_hosts_ics.txt", content);
+  return content;
+}
+
 std::string getEtcProtocolsContent() {
   std::string content;
   readFile(fs::path(kTestDataPath) / "test_protocols.txt", content);
@@ -414,6 +420,14 @@ QueryData getEtcHostsExpectedResults() {
   row6["address"] = "127.0.0.1";
   row6["hostnames"] = "example.net";
   return {row1, row2, row3, row4, row5, row6};
+}
+
+QueryData getEtcHostsIcsExpectedResults() {
+  Row row1;
+
+  row1["address"] = "192.168.11.81";
+  row1["hostnames"] = "VM-q27rkc8son.mshome.net";
+  return {row1};
 }
 
 ::std::ostream& operator<<(::std::ostream& os, const Status& s) {

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -132,11 +132,17 @@ std::string getCACertificateContent();
 // generate the content that would be found in an /etc/hosts file
 std::string getEtcHostsContent();
 
+// generate the content that would be found in an /etc/hosts.ics file
+std::string getEtcHostsIcsContent();
+
 // generate the content that would be found in an /etc/protocols file
 std::string getEtcProtocolsContent();
 
 // generate the expected data that getEtcHostsContent() should parse into
 QueryData getEtcHostsExpectedResults();
+
+// generate the expected data that getEtcHostsIcsContent() should parse into
+QueryData getEtcHostsIcsExpectedResults();
 
 // generate the expected data that getEtcProtocolsContent() should parse into
 QueryData getEtcProtocolsExpectedResults();

--- a/tools/tests/test_hosts_ics.txt
+++ b/tools/tests/test_hosts_ics.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 1993-2001 Microsoft Corp.
+#
+# This file has been automatically generated for use by Microsoft Internet
+# Connection Sharing. It contains the mappings of IP addresses to host names
+# for the home network. Please do not make changes to the HOSTS.ICS file.
+# Any changes may result in a loss of connectivity between machines on the
+# local network.
+#
+
+192.168.11.81 VM-q27rkc8son.mshome.net # 2023 7 6 8 20 49 1 850
+
+


### PR DESCRIPTION
With this change, on Windows etc_hosts table will include data from etc/hosts.ics file in addition to etc/hosts.

Tested by querying the table manually:
![screen shot 2018-07-09 at 4 50 27 pm](https://user-images.githubusercontent.com/3753267/42481629-3d5de434-8398-11e8-9b94-55514a69d414.png)


Added a test for the new file as well.