### PR TITLE
Unbreak build against Boost 1.68

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -14,7 +14,11 @@
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
+#if (BOOST_VERSION >= 106600)
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 
 #include <osquery/logger.h>
 


### PR DESCRIPTION
After boostorg/uuid@33da3e2a5b87 (and boostorg/uuid@3d2f7758e9e1) build fails. See [error log](https://ptpb.pw/DwGV).

CC @ilovezfs
