### PR TITLE
round negative reported durations in query profiler to zero

### DIFF
--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -179,7 +179,11 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
         if timeout > 0 and delay >= timeout + 2:
             proc.kill()
             break
+
+    # there are two sleep(1) calls in the profiling code, so we subtract 2 here to account for it.
     duration = time.time() - start_time - 2
+    # occasionally this can lead to negative results, so max up to zero in case that happens
+    duration = max(duration, 0)
 
     utilization = [percent for percent in percents if percent != 0]
     if len(utilization) == 0:

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -180,9 +180,8 @@ def profile_cmd(cmd, proc=None, shell=False, timeout=0, count=1):
             proc.kill()
             break
 
-    # there are two sleep(1) calls in the profiling code, so we subtract 2 here to account for it.
+    # account for sleep(1) in profiling code
     duration = time.time() - start_time - 2
-    # occasionally this can lead to negative results, so max up to zero in case that happens
     duration = max(duration, 0)
 
     utilization = [percent for percent in percents if percent != 0]


### PR DESCRIPTION
- what?
  - rounds up negative durations reported by `tools/analysis/profile.py`, to zero

- why?
  - in #4657, i found that super fast queries were returning negative durations when profiled
  - looking a bit further, i see that we are subtracting 2 seconds from the wall time reported, but i don't see why we would do that
  - if that looks wrong to you folks as well, i'm happy to remove the subtraction by two
  - if not, then i'm happy to add a comment as to why we're doing it there, and keep the line i added in this PR
 