### PR TITLE
Avoid warnings about implicit conversion from wchar_t -> char

### DIFF
--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -267,9 +267,7 @@ QueryData genInterfaceAddresses(QueryContext& context) {
 
   const IP_ADAPTER_ADDRESSES* currAdapter = adapters.get();
   while (currAdapter != nullptr) {
-    std::wstring wsAdapterName = std::wstring(currAdapter->FriendlyName);
-    auto adapterName = std::string(wsAdapterName.begin(), wsAdapterName.end());
-
+    auto adapterName = wstringToString(currAdapter->FriendlyName);
     const IP_ADAPTER_UNICAST_ADDRESS* ipaddr = currAdapter->FirstUnicastAddress;
     while (ipaddr != nullptr) {
       Row r;

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -155,8 +155,7 @@ Status getDeviceProperty(const device_infoset_t& infoset,
   } else if (dev_prop_type == DEVPROP_TYPE_INT32) {
     result = std::to_string(*(PINT32)drv_buff.get());
   } else if (dev_prop_type == DEVPROP_TYPE_STRING) {
-    std::wstring name((PWCHAR)drv_buff.get());
-    result = std::string(name.begin(), name.end());
+    result = wstringToString((PWCHAR)drv_buff.get());
   } else if (dev_prop_type == DEVPROP_TYPE_FILETIME) {
     result =
         std::to_string(osquery::filetimeToUnixtime(*(PFILETIME)drv_buff.get()));


### PR DESCRIPTION
We (the Visual C++ team) got feedback from a customer that they were surprised that converting a wstring to a string by passing the wstring iterators in through string's range ctor didn't emit narrowing conversion warnings. It turns out we were accidentally suppressing such warnings with a static_cast. Removing the static_cast exposes the warning is OSQuery, fixed here.

This change calls the wstringToString API already present, rather than leaving the wchar_t -> char narrowing in place.