### PR TITLE
Compression/decompression silent error

### DIFF
--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -33,13 +33,15 @@ DECLARE_uint32(carver_block_size);
 Status compress(const boost::filesystem::path& in,
                 const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
-  if(!inFile.isValid()){
-    return Status::failure("Could not open in file :  " + in.string() + " for compression");
+  if (!inFile.isValid()) {
+    return Status::failure("Could not open in file :  " + in.string() +
+                           " for compression");
   }
 
   PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
-  if(!outFile.isValid()){
-    return Status::failure("Could not open out file :  " + out.string() + " for compression");
+  if (!outFile.isValid()) {
+    return Status::failure("Could not open out file :  " + out.string() +
+                           " for compression");
   }
 
   auto inFileSize = inFile.size();
@@ -107,13 +109,15 @@ Status compress(const boost::filesystem::path& in,
 Status decompress(const boost::filesystem::path& in,
                   const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
-  if(!inFile.isValid()){
-    return Status::failure("Could not open in file :  " + in.string() + " for decompression");
+  if (!inFile.isValid()) {
+    return Status::failure("Could not open in file :  " + in.string() +
+                           " for decompression");
   }
 
   PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
-  if(!outFile.isValid()){
-    return Status::failure("Could not open in file :  " + in.string() + " for decompression");
+  if (!outFile.isValid()) {
+    return Status::failure("Could not open in file :  " + in.string() +
+                           " for decompression");
   }
 
   auto inFileSize = inFile.size();

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -34,13 +34,13 @@ Status compress(const boost::filesystem::path& in,
                 const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
   if (!inFile.isValid()) {
-    return Status::failure("Could not open in file :  " + in.string() +
+    return Status::failure("Could not open in file: " + in.string() +
                            " for compression");
   }
 
   PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
   if (!outFile.isValid()) {
-    return Status::failure("Could not open out file :  " + out.string() +
+    return Status::failure("Could not open out file: " + out.string() +
                            " for compression");
   }
 
@@ -110,13 +110,13 @@ Status decompress(const boost::filesystem::path& in,
                   const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
   if (!inFile.isValid()) {
-    return Status::failure("Could not open in file :  " + in.string() +
+    return Status::failure("Could not open in file: " + in.string() +
                            " for decompression");
   }
 
   PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
   if (!outFile.isValid()) {
-    return Status::failure("Could not open in file :  " + in.string() +
+    return Status::failure("Could not open in file: " + in.string() +
                            " for decompression");
   }
 

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -33,7 +33,14 @@ DECLARE_uint32(carver_block_size);
 Status compress(const boost::filesystem::path& in,
                 const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
-  PlatformFile outFile(out, PF_CREATE_NEW | PF_WRITE);
+  if(!inFile.isValid()){
+    return Status::failure("Could not open in file :  " + in.string() + " for compression");
+  }
+
+  PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
+  if(!outFile.isValid()){
+    return Status::failure("Could not open out file :  " + out.string() + " for compression");
+  }
 
   auto inFileSize = inFile.size();
   ZSTD_CStream* const cstream = ZSTD_createCStream();
@@ -100,7 +107,14 @@ Status compress(const boost::filesystem::path& in,
 Status decompress(const boost::filesystem::path& in,
                   const boost::filesystem::path& out) {
   PlatformFile inFile(in, PF_OPEN_EXISTING | PF_READ);
-  PlatformFile outFile(out, PF_CREATE_NEW | PF_WRITE);
+  if(!inFile.isValid()){
+    return Status::failure("Could not open in file :  " + in.string() + " for decompression");
+  }
+
+  PlatformFile outFile(out, PF_CREATE_ALWAYS | PF_WRITE);
+  if(!outFile.isValid()){
+    return Status::failure("Could not open in file :  " + in.string() + " for decompression");
+  }
 
   auto inFileSize = inFile.size();
   size_t const buffInSize = ZSTD_DStreamInSize();

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -85,9 +85,13 @@ const PlatformHandle kInvalidHandle = (PlatformHandle)-1;
 
 #define PF_OPTIONS_MASK 0x001c
 #define PF_GET_OPTIONS(x) ((x & PF_OPTIONS_MASK) >> 2)
+//Create new fail only if it does not exist, or else fail.
 #define PF_CREATE_NEW (0 << 2)
+//If file exists truncate it, or else create new one.
 #define PF_CREATE_ALWAYS (1 << 2)
+//If file exists open it, or else fail.
 #define PF_OPEN_EXISTING (2 << 2)
+//If file exists open it, or else create new one.
 #define PF_OPEN_ALWAYS (3 << 2)
 #define PF_TRUNCATE (4 << 2)
 

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -85,13 +85,13 @@ const PlatformHandle kInvalidHandle = (PlatformHandle)-1;
 
 #define PF_OPTIONS_MASK 0x001c
 #define PF_GET_OPTIONS(x) ((x & PF_OPTIONS_MASK) >> 2)
-//Create new fail only if it does not exist, or else fail.
+// Create new fail only if it does not exist, or else fail.
 #define PF_CREATE_NEW (0 << 2)
-//If file exists truncate it, or else create new one.
+// If file exists truncate it, or else create new one.
 #define PF_CREATE_ALWAYS (1 << 2)
-//If file exists open it, or else fail.
+// If file exists open it, or else fail.
 #define PF_OPEN_EXISTING (2 << 2)
-//If file exists open it, or else create new one.
+// If file exists open it, or else create new one.
 #define PF_OPEN_ALWAYS (3 << 2)
 #define PF_TRUNCATE (4 << 2)
 

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -85,7 +85,7 @@ const PlatformHandle kInvalidHandle = (PlatformHandle)-1;
 
 #define PF_OPTIONS_MASK 0x001c
 #define PF_GET_OPTIONS(x) ((x & PF_OPTIONS_MASK) >> 2)
-// Create new fail only if it does not exist, or else fail.
+// Create new file only if it does not exist, or else fail.
 #define PF_CREATE_NEW (0 << 2)
 // If file exists truncate it, or else create new one.
 #define PF_CREATE_ALWAYS (1 << 2)


### PR DESCRIPTION
Compress and decompress were silently failing if in or out file could not be opened/created.
Also, compress and decompress were just silently failing if out file already existed.

In fileops.h added comments to the flags to get rid of the future confusion.