### PR TITLE
cleanup: Migrate calls to tryTo from 4683

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -842,24 +842,28 @@ void Config::recordQueryPerformance(const std::string& name,
 
   // Grab access to the non-const schedule item.
   auto& query = performance_.at(name);
-  BIGINT_LITERAL diff = 0;
   if (!r1.at("user_time").empty() && !r0.at("user_time").empty()) {
-    diff = std::stoll(r1.at("user_time")) - std::stoll(r0.at("user_time"));
+    auto ut1 = tryTo<long long>(r1.at("user_time"));
+    auto ut0 = tryTo<long long>(r0.at("user_time"));
+    auto diff = (ut1 && ut0) ? ut1.take() - ut0.take() : 0;
     if (diff > 0) {
       query.user_time += diff;
     }
   }
 
   if (!r1.at("system_time").empty() && !r0.at("system_time").empty()) {
-    diff = std::stoll(r1.at("system_time")) - std::stoll(r0.at("system_time"));
+    auto st1 = tryTo<long long>(r1.at("system_time"));
+    auto st0 = tryTo<long long>(r0.at("system_time"));
+    auto diff = (st1 && st0) ? st1.take() - st0.take() : 0;
     if (diff > 0) {
       query.system_time += diff;
     }
   }
 
   if (!r1.at("resident_size").empty() && !r0.at("resident_size").empty()) {
-    diff =
-        std::stoll(r1.at("resident_size")) - std::stoll(r0.at("resident_size"));
+    auto rs1 = tryTo<long long>(r1.at("resident_size"));
+    auto rs0 = tryTo<long long>(r0.at("resident_size"));
+    auto diff = (rs1 && rs0) ? rs1.take() - rs0.take() : 0;
     if (diff > 0) {
       // Memory is stored as an average of RSS changes between query executions.
       query.average_memory = (query.average_memory * query.executions) + diff;

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -432,14 +432,12 @@ std::set<std::string> ConstraintList::getAll(ConstraintOperator op) const {
 template <typename T>
 std::set<T> ConstraintList::getAll(ConstraintOperator op) const {
   std::set<T> cs;
-  auto mc_ = constraints_;
-  std::transform(
-      mc_.begin(),
-      std::remove_if(mc_.begin(),
-                     mc_.end(),
-                     [](const Constraint& c) { return !tryTo<T>(c.expr); }),
-      std::inserter(cs, cs.begin()),
-      [](const Constraint& c) { return tryTo<T>(c.expr).take(); });
+  for (const auto& item : constraints_) {
+    auto exp = tryTo<T>(item.expr);
+    if (exp) {
+      cs.insert(exp.take());
+    }
+  }
   return cs;
 }
 

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -8,6 +8,7 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include "osquery/core/conversions.h"
 #include "osquery/core/json.h"
 
 #include <osquery/database.h>
@@ -15,8 +16,6 @@
 #include <osquery/logger.h>
 #include <osquery/registry_factory.h>
 #include <osquery/tables.h>
-
-#include <boost/lexical_cast.hpp>
 
 namespace osquery {
 namespace {
@@ -304,29 +303,39 @@ std::string columnDefinition(const PluginResponse& response,
   // Maintain a map of column to the type, for alias type lookups.
   std::map<std::string, ColumnType> column_types;
   for (const auto& column : response) {
-    if (column.count("id") == 0) {
+    auto id = column.find("id");
+    if (id == column.end()) {
       continue;
     }
 
-    if (column.at("id") == "column" && column.count("name") &&
-        column.count("type")) {
-      auto options = (column.count("op"))
-                         ? (ColumnOptions)std::stol(column.at("op"))
-                         : ColumnOptions::DEFAULT;
-      auto column_type = columnTypeName(column.at("type"));
-      columns.push_back(make_tuple(column.at("name"), column_type, options));
+    auto cname = column.find("name");
+    auto ctype = column.find("type");
+    if (id->second == "column" && cname != column.end() &&
+        ctype != column.end()) {
+      auto options = ColumnOptions::DEFAULT;
+
+      auto cop = column.find("op");
+      if (cop != column.end()) {
+        auto op = tryTo<int>(cop->second);
+        if (op) {
+          options = static_cast<ColumnOptions>(op.take());
+        }
+      }
+      auto column_type = columnTypeName(ctype->second);
+      columns.push_back(make_tuple(cname->second, column_type, options));
       if (aliases) {
-        column_types[column.at("name")] = column_type;
+        column_types[cname->second] = column_type;
       }
-    } else if (column.at("id") == "columnAlias" && column.count("name") &&
-               column.count("target") && aliases) {
-      const auto& target = column.at("target");
-      if (column_types.count(target) == 0) {
-        // No type was defined for the alias target.
-        continue;
+    } else if (id->second == "columnAlias" && cname != column.end() &&
+               aliases) {
+      auto ctarget = column.find("target");
+      if (ctarget != column.end()) {
+        auto target_ctype = column_types.find(ctarget->second);
+        if (target_ctype != column_types.end()) {
+          columns.push_back(make_tuple(
+              cname->second, target_ctype->second, ColumnOptions::HIDDEN));
+        }
       }
-      columns.push_back(make_tuple(
-          column.at("name"), column_types.at(target), ColumnOptions::HIDDEN));
     }
   }
   return columnDefinition(columns, is_extension);
@@ -356,21 +365,23 @@ bool ConstraintList::exists(const ConstraintOperatorFlag ops) const {
 
 bool ConstraintList::matches(const std::string& expr) const {
   // Support each SQL affinity type casting.
-  try {
-    if (affinity == TEXT_TYPE) {
-      return literal_matches<TEXT_LITERAL>(expr);
-    } else if (affinity == INTEGER_TYPE) {
-      auto lexpr = boost::lexical_cast<INTEGER_LITERAL>(expr);
-      return literal_matches<INTEGER_LITERAL>(lexpr);
-    } else if (affinity == BIGINT_TYPE) {
-      auto lexpr = boost::lexical_cast<BIGINT_LITERAL>(expr);
-      return literal_matches<BIGINT_LITERAL>(lexpr);
-    } else if (affinity == UNSIGNED_BIGINT_TYPE) {
-      auto lexpr = boost::lexical_cast<UNSIGNED_BIGINT_LITERAL>(expr);
-      return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr);
+  if (affinity == TEXT_TYPE) {
+    return literal_matches<TEXT_LITERAL>(expr);
+  } else if (affinity == INTEGER_TYPE) {
+    auto lexpr = tryTo<INTEGER_LITERAL>(expr);
+    if (lexpr) {
+      return literal_matches<INTEGER_LITERAL>(lexpr.take());
     }
-  } catch (const boost::bad_lexical_cast& /* e */) {
-    // Unsupported affinity type or unable to cast content type.
+  } else if (affinity == BIGINT_TYPE) {
+    auto lexpr = tryTo<BIGINT_LITERAL>(expr);
+    if (lexpr) {
+      return literal_matches<BIGINT_LITERAL>(lexpr.take());
+    }
+  } else if (affinity == UNSIGNED_BIGINT_TYPE) {
+    auto lexpr = tryTo<UNSIGNED_BIGINT_LITERAL>(expr);
+    if (lexpr) {
+      return literal_matches<UNSIGNED_BIGINT_LITERAL>(lexpr.take());
+    }
   }
 
   return false;
@@ -380,17 +391,21 @@ template <typename T>
 bool ConstraintList::literal_matches(const T& base_expr) const {
   bool aggregate = true;
   for (size_t i = 0; i < constraints_.size(); ++i) {
-    auto constraint_expr = boost::lexical_cast<T>(constraints_[i].expr);
+    auto constraint_expr = tryTo<T>(constraints_[i].expr);
+    if (!constraint_expr) {
+      // Cannot cast input constraint to column type.
+      return false;
+    }
     if (constraints_[i].op == EQUALS) {
-      aggregate = aggregate && (base_expr == constraint_expr);
+      aggregate = aggregate && (base_expr == constraint_expr.take());
     } else if (constraints_[i].op == GREATER_THAN) {
-      aggregate = aggregate && (base_expr > constraint_expr);
+      aggregate = aggregate && (base_expr > constraint_expr.take());
     } else if (constraints_[i].op == LESS_THAN) {
-      aggregate = aggregate && (base_expr < constraint_expr);
+      aggregate = aggregate && (base_expr < constraint_expr.take());
     } else if (constraints_[i].op == GREATER_THAN_OR_EQUALS) {
-      aggregate = aggregate && (base_expr >= constraint_expr);
+      aggregate = aggregate && (base_expr >= constraint_expr.take());
     } else if (constraints_[i].op == LESS_THAN_OR_EQUALS) {
-      aggregate = aggregate && (base_expr <= constraint_expr);
+      aggregate = aggregate && (base_expr <= constraint_expr.take());
     } else {
       // Unsupported constraint. Should match every thing.
       return true;
@@ -414,48 +429,38 @@ std::set<std::string> ConstraintList::getAll(ConstraintOperator op) const {
   return set;
 }
 
-template <>
-std::set<int> ConstraintList::getAll<int>(ConstraintOperator op) const {
-  std::set<int> cs;
-  std::transform(constraints_.begin(),
-                 constraints_.end(),
-                 std::inserter(cs, cs.begin()),
-                 [](const Constraint& c) { return std::stoi(c.expr); });
+template <typename T>
+std::set<T> ConstraintList::getAll(ConstraintOperator op) const {
+  std::set<T> cs;
+  auto mc_ = constraints_;
+  std::transform(
+      mc_.begin(),
+      std::remove_if(mc_.begin(),
+                     mc_.end(),
+                     [](const Constraint& c) { return !tryTo<T>(c.expr); }),
+      std::inserter(cs, cs.begin()),
+      [](const Constraint& c) { return tryTo<T>(c.expr).take(); });
   return cs;
 }
 
 template <>
-std::set<long long> ConstraintList::getAll<long long>(
-    ConstraintOperator op) const {
-  std::set<long long> cs;
-  std::transform(constraints_.begin(),
-                 constraints_.end(),
-                 std::inserter(cs, cs.begin()),
-                 [](const Constraint& c) { return std::stoll(c.expr); });
-  return cs;
+std::set<std::string> ConstraintList::getAll(ConstraintOperator op) const {
+  return getAll(op);
 }
 
-template <>
-std::set<unsigned long long> ConstraintList::getAll<unsigned long long>(
-    ConstraintOperator op) const {
-  std::set<unsigned long long> cs;
-  std::transform(constraints_.begin(),
-                 constraints_.end(),
-                 std::inserter(cs, cs.begin()),
-                 [](const Constraint& c) { return std::stoull(c.expr); });
-  return cs;
-}
+/// Explicit getAll for INTEGER.
+template std::set<INTEGER_LITERAL> ConstraintList::getAll<int>(
+    ConstraintOperator) const;
 
-template <>
-std::set<std::string> ConstraintList::getAll<std::string>(
-    ConstraintOperator op) const {
-  std::set<std::string> cs;
-  std::transform(constraints_.begin(),
-                 constraints_.end(),
-                 std::inserter(cs, cs.begin()),
-                 [](const Constraint& c) { return c.expr; });
-  return cs;
-}
+/// Explicit getAll for BIGINT.
+template std::set<long long> ConstraintList::getAll<long long>(
+    ConstraintOperator) const;
+
+/// Explicit getAll for UNSIGNED_BIGINT.
+template std::set<unsigned long long>
+    ConstraintList::getAll<unsigned long long>(ConstraintOperator) const;
+
+/// Explicit getAll for UNSIGNED_BIGINT.
 
 void ConstraintList::serialize(JSON& doc, rapidjson::Value& obj) const {
   auto expressions = doc.getArray();

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -458,8 +458,6 @@ template std::set<long long> ConstraintList::getAll<long long>(
 template std::set<unsigned long long>
     ConstraintList::getAll<unsigned long long>(ConstraintOperator) const;
 
-/// Explicit getAll for UNSIGNED_BIGINT.
-
 void ConstraintList::serialize(JSON& doc, rapidjson::Value& obj) const {
   auto expressions = doc.getArray();
   for (const auto& constraint : constraints_) {

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -366,16 +366,13 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
 
   // IV is the check interval in seconds, and utilization is set per-second.
   change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
-  UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
+  long long user_time = 0, system_time = 0;
   try {
-    auto cchange = tryTo<long long>(r.at("parent"));
-    change.parent = (cchange) ? static_cast<pid_t>(cchange.take()) : 0;
-    cchange = tryTo<long long>(r.at("user_time"));
-    user_time = (cchange) ? cchange.take() : 0;
-    cchange = tryTo<long long>(r.at("system_time"));
-    system_time = (cchange) ? cchange.take() : 0;
-    cchange = tryTo<long long>(r.at("resident_size"));
-    change.footprint = (cchange) ? cchange.take() : 0;
+    change.parent =
+        static_cast<pid_t>(tryTo<long long>(r.at("parent")).take_or(0));
+    user_time = tryTo<long long>(r.at("user_time")).take_or(0);
+    system_time = tryTo<long long>(r.at("system_time")).take_or(0);
+    change.footprint = tryTo<long long>(r.at("resident_size")).take_or(0);
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -26,6 +26,7 @@
 #include <osquery/sql.h>
 #include <osquery/system.h>
 
+#include "osquery/core/conversions.h"
 #include "osquery/core/process.h"
 #include "osquery/core/watcher.h"
 #include "osquery/filesystem/fileops.h"
@@ -367,10 +368,14 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   change.iv = std::max(getWorkerLimit(WatchdogLimitType::INTERVAL), 1_sz);
   UNSIGNED_BIGINT_LITERAL user_time = 0, system_time = 0;
   try {
-    change.parent = static_cast<pid_t>(std::stoll(r.at("parent")));
-    user_time = std::stoll(r.at("user_time"));
-    system_time = std::stoll(r.at("system_time"));
-    change.footprint = std::stoll(r.at("resident_size"));
+    auto cchange = tryTo<long long>(r.at("parent"));
+    change.parent = (cchange) ? static_cast<pid_t>(cchange.take()) : 0;
+    cchange = tryTo<long long>(r.at("user_time"));
+    user_time = (cchange) ? cchange.take() : 0;
+    cchange = tryTo<long long>(r.at("system_time"));
+    system_time = (cchange) ? cchange.take() : 0;
+    cchange = tryTo<long long>(r.at("resident_size"));
+    change.footprint = (cchange) ? cchange.take() : 0;
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -369,10 +369,10 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   long long user_time = 0, system_time = 0;
   try {
     change.parent =
-        static_cast<pid_t>(tryTo<long long>(r.at("parent")).take_or(0));
-    user_time = tryTo<long long>(r.at("user_time")).take_or(0);
-    system_time = tryTo<long long>(r.at("system_time")).take_or(0);
-    change.footprint = tryTo<long long>(r.at("resident_size")).take_or(0);
+        static_cast<pid_t>(tryTo<long long>(r.at("parent")).take_or(0LL));
+    user_time = tryTo<long long>(r.at("user_time")).take_or(0LL);
+    system_time = tryTo<long long>(r.at("system_time")).take_or(0LL);
+    change.footprint = tryTo<long long>(r.at("resident_size")).take_or(0LL);
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -36,8 +36,7 @@ int getOSMinorVersion() {
     return -1;
   }
 
-  auto minor = tryTo<long>(qd.front.at("minor"));
-  return (minor) ? minor.take() : -1;
+  return tryTo<long>(qd.front.at("minor")).take_or(-1);
 }
 
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -36,7 +36,7 @@ int getOSMinorVersion() {
     return -1;
   }
 
-  return tryTo<long>(qd.front.at("minor")).take_or(-1);
+  return tryTo<int>(qd.front().at("minor")).take_or(-1);
 }
 
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on
@@ -157,15 +157,16 @@ Status genSignatureForFileAndArch(const std::string& path,
     // Get the CDHash bytes
     std::stringstream ss;
     auto bytes = CFDataGetBytePtr(hashInfo);
-    if (bytes != nullptr && CFDataGetLength(hashInfo) > 0) {
+    auto bytes_length = static_cast<size_t>(CFDataGetLength(hashInfo));
+    if (bytes != nullptr && bytes_length > 0) {
       // Write bytes as hex strings
-      for (size_t n = 0; n < CFDataGetLength(hashInfo); n++) {
+      for (size_t n = 0; n < bytes_length; n++) {
         ss << std::hex << std::setfill('0') << std::setw(2);
         ss << (unsigned int)bytes[n];
       }
       r["cdhash"] = ss.str();
     }
-    if (r["cdhash"].length() != CFDataGetLength(hashInfo) * 2) {
+    if (r["cdhash"].length() != bytes_length * 2) {
       VLOG(1) << "Error extracting code directory hash";
       r["cdhash"] = "";
     }

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -16,12 +16,12 @@
 #include <Security/CodeSigning.h>
 
 #include <osquery/core.h>
-#include <osquery/core/conversions.h>
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 
+#include "osquery/core/conversions.h"
 #include "osquery/tables/system/darwin/keychain.h"
 
 namespace osquery {
@@ -36,7 +36,8 @@ int getOSMinorVersion() {
     return -1;
   }
 
-  return std::stol(qd.front().at("minor"));
+  auto minor = tryTo<long>(qd.front.at("minor"));
+  return (minor) ? minor.take() : -1;
 }
 
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on


### PR DESCRIPTION
This applies @akindyakov's `tryTo` conversions to the refactor away from `lexical_cast` in #4683. This PR's scope is a little wider in that it replaces all `std::sto*`'s in the nearby code.

If fixes 1 bug AFAIK in the Linux `process_memory_map` table where `offset` conversions were failing for `00000` base16.