### PR TITLE
Remove dead code from conversions module

### DIFF
--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -12,14 +12,12 @@
 
 #include <limits.h>
 
-#include <memory>
-#include <set>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
-#include <boost/shared_ptr.hpp>
+#include <boost/core/demangle.hpp>
 
 #include <osquery/expected.h>
 #include <osquery/logger.h>
@@ -30,30 +28,6 @@
 #endif
 
 namespace osquery {
-
-template <typename T>
-void do_release_boost(typename boost::shared_ptr<T> const&, T*) {}
-
-/**
- * @brief Convert a boost::shared_ptr to a std::shared_ptr
- */
-template <typename T>
-typename std::shared_ptr<T> boost_to_std_shared_ptr(
-    typename boost::shared_ptr<T> const& p) {
-  return std::shared_ptr<T>(p.get(), boost::bind(&do_release_boost<T>, p, _1));
-}
-
-template <typename T>
-void do_release_std(typename std::shared_ptr<T> const&, T*) {}
-
-/**
- * @brief Convert a std::shared_ptr to a boost::shared_ptr
- */
-template <typename T>
-typename boost::shared_ptr<T> std_to_boost_shared_ptr(
-    typename std::shared_ptr<T> const& p) {
-  return boost::shared_ptr<T>(p.get(), boost::bind(&do_release_std<T>, p, _1));
-}
 
 /**
  * @brief Split a given string based on an optional delimiter.
@@ -80,27 +54,6 @@ std::vector<std::string> split(const std::string& s,
 std::vector<std::string> split(const std::string& s,
                                char delim,
                                size_t occurences);
-
-/**
- * @brief In-line replace all instances of from with to.
- *
- * @param str The input/output mutable string.
- * @param from Search string
- * @param to Replace string
- */
-inline void replaceAll(std::string& str,
-                       const std::string& from,
-                       const std::string& to) {
-  if (from.empty()) {
-    return;
-  }
-
-  size_t start_pos = 0;
-  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length();
-  }
-}
 
 /**
  * @brief Join a vector of strings inserting a token string between elements

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -8,39 +8,21 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <cstdint>
 #include <string>
-
-#include <boost/make_shared.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <gtest/gtest.h>
 
-#include <osquery/core.h>
 #include <osquery/flags.h>
-#include <osquery/system.h>
+
+#include <osquery/tests/test_util.h>
 
 #include "osquery/core/conversions.h"
-
-#include "osquery/tests/test_util.h"
 
 namespace osquery {
 
 DECLARE_bool(utc);
 
 class ConversionsTests : public testing::Test {};
-
-class Foobar {};
-
-TEST_F(ConversionsTests, test_conversion) {
-  boost::shared_ptr<Foobar> b1 = boost::make_shared<Foobar>();
-  std::shared_ptr<Foobar> s1 = boost_to_std_shared_ptr(b1);
-  EXPECT_EQ(s1.get(), b1.get());
-
-  std::shared_ptr<Foobar> s2 = std::make_shared<Foobar>();
-  boost::shared_ptr<Foobar> b2 = std_to_boost_shared_ptr(s2);
-  EXPECT_EQ(s2.get(), b2.get());
-}
 
 TEST_F(ConversionsTests, test_base64) {
   std::string unencoded = "HELLO";


### PR DESCRIPTION
  - `boost_to_std_shared_ptr` and `std_to_boost_shared_ptr` as far as we don't use boost::shared_ptr in `osquery` anymore.
  - `replaceAll`
  - and remove useless includes