### PR TITLE
Audit fixes

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -669,7 +669,8 @@ void AuditdNetlinkParser::start() {
           auditd_context_->unprocessed_records_mutex);
 
       while (auditd_context_->unprocessed_records.empty() && !interrupted()) {
-        auditd_context_->unprocessed_records_cv.wait(lock);
+        auditd_context_->unprocessed_records_cv.wait_for(
+            lock, std::chrono::seconds(1));
       }
 
       queue = std::move(auditd_context_->unprocessed_records);

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -669,8 +669,7 @@ void AuditdNetlinkParser::start() {
           auditd_context_->unprocessed_records_mutex);
 
       while (auditd_context_->unprocessed_records.empty() && !interrupted()) {
-        auditd_context_->unprocessed_records_cv.wait_for(
-            lock, std::chrono::seconds(1));
+        auditd_context_->unprocessed_records_cv.wait(lock);
       }
 
       queue = std::move(auditd_context_->unprocessed_records);

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -84,7 +84,7 @@ class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
     r["uptime"] = INTEGER(10);
 
     std::vector<Row> row_list;
-    for (int i = 0; i < 10; i++) {
+    for (size_t i = 0U; i < 10U; i++) {
       row_list.push_back(r);
     }
 

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -69,7 +69,7 @@ class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
   Status testAdd(time_t t, size_t num_of_events = 1) {
     auto indexes = getIndexes(0, t);
     auto records = getRecords(indexes);
-    const int old_records_size = records.size();
+    const size_t old_records_size = records.size();
 
     Row r;
     r["testing"] = "hello from space";

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -83,7 +83,6 @@ class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
 
     auto status = addBatch(row_list, t);
     if (!status.ok()) {
-      EXPECT_EQ(1, 0);
       return Status::failure(
           "Failed to save the batch to the database, with error: " +
           status.getMessage());
@@ -93,7 +92,6 @@ class DBFakeEventSubscriber : public EventSubscriber<DBFakeEventPublisher> {
     records = getRecords(indexes);
 
     if (records.size() != row_list.size() + old_records_size) {
-      EXPECT_EQ(1, 2);
       return Status::failure("We expected " + std::to_string(row_list.size()) +
                              " records but only " +
                              std::to_string(records.size()) + " were found!");


### PR DESCRIPTION
@clong is investing some time testing the patch to make sure that everything works as intended (thanks!).

## Batched writes
Event records were not being saved correctly when writing batches, causing some events to get lost (how bad it was depended on how fast/slow the machine was).

A new test has been added to to prevent further regressions on this part of the code.

This only affected the Audit publishers.
