### PR TITLE
Remove useless include of <iostream> from status.h

### DIFF
--- a/osquery/core/status.cpp
+++ b/osquery/core/status.cpp
@@ -13,8 +13,6 @@
 
 #include <cassert>
 
-#include <iostream>
-
 namespace osquery {
 
 constexpr int Status::kSuccessCode;


### PR DESCRIPTION
Dead code, let's get rid it off