### PR TITLE
remove logger plugins event logging support

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -832,12 +832,6 @@ class EventFactory : private boost::noncopyable {
   /// Return a list of subscriber registry names,
   static std::vector<std::string> subscriberNames();
 
-  /// Set log forwarding by adding a logger receiver.
-  static void addForwarder(const std::string& logger);
-
-  /// Optionally forward events to loggers.
-  static void forwardEvent(const std::string& event);
-
   /**
    * @brief The event factory, subscribers, and publishers respond to updates.
    *
@@ -905,9 +899,6 @@ class EventFactory : private boost::noncopyable {
 
   /// Set of running EventPublisher run loop threads.
   std::vector<std::shared_ptr<std::thread>> threads_;
-
-  /// Set of logger plugins to forward events.
-  std::vector<std::string> loggers_;
 
   /// Factory publisher state manipulation.
   Mutex factory_lock_;

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -81,11 +81,7 @@ struct StatusLogLine {
  * A specific registry call action can be used to retrieve an overloaded Status
  * object containing all of the opt-in features.
  */
-enum LoggerFeatures {
-  LOGGER_FEATURE_BLANK = 0,
-  LOGGER_FEATURE_LOGSTATUS = 1,
-  LOGGER_FEATURE_LOGEVENT = 2,
-};
+enum LoggerFeatures { LOGGER_FEATURE_BLANK = 0, LOGGER_FEATURE_LOGSTATUS = 1 };
 
 /**
  * @brief Helper logging macro for table-generated verbose log lines.
@@ -159,17 +155,6 @@ class LoggerPlugin : public Plugin {
   }
 
   /**
-   * @brief A feature method to decide if events should be forwarded.
-   *
-   * See the optional logEvent method.
-   *
-   * @return false if this logger plugin should NOT handle events directly.
-   */
-  virtual bool usesLogEvent() {
-    return false;
-  }
-
-  /**
    * @brief Set the process name.
    */
   void setProcessName(const std::string& name) {
@@ -216,16 +201,6 @@ class LoggerPlugin : public Plugin {
    */
   virtual Status logSnapshot(const std::string& s) {
     return logString(s);
-  }
-
-  /**
-   * @brief Optionally handle each published event via the logger.
-   *
-   * It is possible to skip the database representation of event subscribers
-   * and instead forward each added event to the active logger plugin.
-   */
-  virtual Status logEvent(const std::string& /*s*/) {
-    return Status(1, "Not enabled");
   }
 
  protected:

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -34,7 +34,6 @@
 #include "osquery/core/flagalias.h"
 #include "osquery/core/json.h"
 
-namespace pt = boost::property_tree;
 namespace rj = rapidjson;
 
 namespace osquery {
@@ -416,10 +415,6 @@ void initLogger(const std::string& name) {
       // return a success status after initialization.
       BufferedLogSink::get().addPlugin(logger);
     }
-
-    if ((status.getCode() & LOGGER_FEATURE_LOGEVENT) > 0) {
-      EventFactory::addForwarder(logger);
-    }
   }
 
   if (forward) {
@@ -565,12 +560,9 @@ Status LoggerPlugin::call(const PluginRequest& request,
   } else if (request.count("status") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
     return this->logStatus(intermediate_logs);
-  } else if (request.count("event") > 0) {
-    return this->logEvent(request.at("event"));
   } else if (request.count("action") && request.at("action") == "features") {
     size_t features = 0;
     features |= (usesLogStatus()) ? LOGGER_FEATURE_LOGSTATUS : 0;
-    features |= (usesLogEvent()) ? LOGGER_FEATURE_LOGEVENT : 0;
     return Status(static_cast<int>(features));
   } else {
     return Status(1, "Unsupported call to logger plugin");

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -22,7 +22,6 @@
 #include <boost/noncopyable.hpp>
 
 #include <osquery/database.h>
-#include <osquery/events.h>
 #include <osquery/extensions.h>
 #include <osquery/filesystem.h>
 #include <osquery/flags.h>

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -58,7 +58,6 @@ class LoggerTests : public testing::Test {
 
   // Count calls to logStatus
   static size_t statuses_logged;
-  static size_t events_logged;
   // Count added and removed snapshot rows
   static size_t snapshot_rows_added;
   static size_t snapshot_rows_removed;
@@ -72,7 +71,6 @@ std::vector<std::string> LoggerTests::log_lines;
 StatusLogLine LoggerTests::last_status;
 std::vector<std::string> LoggerTests::status_messages;
 size_t LoggerTests::statuses_logged = 0;
-size_t LoggerTests::events_logged = 0;
 size_t LoggerTests::snapshot_rows_added = 0;
 size_t LoggerTests::snapshot_rows_removed = 0;
 
@@ -91,15 +89,6 @@ class TestLoggerPlugin : public LoggerPlugin {
  protected:
   bool usesLogStatus() override {
     return shouldLogStatus;
-  }
-
-  bool usesLogEvent() override {
-    return shouldLogEvent;
-  }
-
-  Status logEvent(const std::string& e) override {
-    LoggerTests::events_logged++;
-    return Status(0, "OK");
   }
 
   Status logString(const std::string& s) override {
@@ -126,9 +115,6 @@ class TestLoggerPlugin : public LoggerPlugin {
  public:
   /// Allow test methods to change status logging state.
   bool shouldLogStatus{true};
-
-  /// Allow test methods to change event logging state.
-  bool shouldLogEvent{true};
 };
 
 TEST_F(LoggerTests, test_plugin) {
@@ -235,7 +221,6 @@ TEST_F(LoggerTests, test_feature_request) {
   auto plugin = RegistryFactory::get().plugin("logger", "test");
   auto logger = std::dynamic_pointer_cast<TestLoggerPlugin>(plugin);
 
-  logger->shouldLogEvent = false;
   logger->shouldLogStatus = false;
   auto status = Registry::call("logger", "test", {{"action", "features"}});
   EXPECT_EQ(0, status.getCode());


### PR DESCRIPTION
removing support for logger plugins to log the events, as it found no use case.
Also other minor changes
1. removed boost::property_tree; as it was not used anymore
2. checking vector capacity after the reserve() is wrong http://www.cplusplus.com/reference/vector/vector/reserve/