### PR TITLE
get rid of upgrade lock

### DIFF
--- a/include/osquery/mutex.h
+++ b/include/osquery/mutex.h
@@ -30,10 +30,4 @@ using RecursiveMutex = boost::recursive_mutex;
 /// Helper alias for write locking a recursive mutex.
 using RecursiveLock = boost::unique_lock<boost::recursive_mutex>;
 
-/// Helper alias for upgrade locking a mutex.
-using UpgradeLock = boost::upgrade_lock<Mutex>;
-
-/// Helper alias for write locking an upgrade lock.
-using WriteUpgradeLock = boost::upgrade_to_unique_lock<Mutex>;
-
 } // namespace osquery

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -65,20 +65,19 @@ size_t RegistryInterface::count() const {
 }
 
 Status RegistryInterface::setActive(const std::string& item_name) {
-  UpgradeLock lock(mutex_);
-
-  // Default support multiple active plugins.
-  for (const auto& item : osquery::split(item_name, ",")) {
-    if (items_.count(item) == 0 && external_.count(item) == 0) {
-      return Status(1, "Unknown registry plugin: " + item);
-    }
-  }
-
-  Status status;
   {
-    WriteUpgradeLock wlock(lock);
+    WriteLock lock(mutex_);
+
+    // Default support multiple active plugins.
+    for (const auto& item : osquery::split(item_name, ",")) {
+      if (items_.count(item) == 0 && external_.count(item) == 0) {
+        return Status(1, "Unknown registry plugin: " + item);
+      }
+    }
+
     active_ = item_name;
   }
+  Status status;
 
   // The active plugin is setup when initialized.
   for (const auto& item : osquery::split(item_name, ",")) {


### PR DESCRIPTION
Upgrade lock is the dangerous mechanism to use. It's been used in two cases and both of them look suspicious.

As upgrade lock, can not let it's read lock go and let someone else change the state, upgrade lock causes the legit deadlock when two or more read locks are trying to upgrade. ( None of them can release the read lot to let the other one get the write lock ). In both of the use case, this can happen.