### PR TITLE
Remove preprocessor warning about undefined PATH_MAX

### DIFF
--- a/osquery/core/posix/utils.cpp
+++ b/osquery/core/posix/utils.cpp
@@ -42,7 +42,6 @@ const std::string canonicalize_file_name(const char* name) {
   std::string result = (resolved == nullptr) ? name : resolved;
   free(resolved);
 #else
-#warning PATH_MAX is undefined, please read comment below
   // PATH_MAX is not defined, very likely it's not officially supported
   // os, our best guess is _PC_PATH_MAX if available
   // In case of failure fallback to "safe" buffer of 8K


### PR DESCRIPTION
Accoring to osquery development guidelines every warning should reveal some actionable problem.
This warning just inform about failed attempt to determine max length of the file pathname for the system. There is nothing to do, because some "safe" big length will be taken instead. The only possible problem is it could be cause some performance penalty, which can be found without this warning.

I'd suggest to remove it.