### PR TITLE
to<Status>(const Expected&) implementation

### DIFF
--- a/include/osquery/status.h
+++ b/include/osquery/status.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <osquery/error.h>
+#include <osquery/expected.h>
 #include <sstream>
 #include <string>
 
@@ -159,4 +160,14 @@ class Status {
   /// the internal storage of the status message
   std::string message_;
 };
+
+template <typename ToType, typename ValueType, typename ErrorCodeEnumType>
+inline
+    typename std::enable_if<std::is_same<ToType, Status>::value, Status>::type
+    to(const Expected<ValueType, ErrorCodeEnumType>& expected) {
+  return expected
+             ? Status::success()
+             : Status::failure(expected.getError().getFullMessageRecursive());
+}
+
 } // namespace osquery

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -97,7 +97,8 @@ TEST_F(StatusTests, test_expected_to_status_failure) {
 }
 
 TEST_F(StatusTests, test_expected_to_status_success) {
-  const auto expected = Expected<std::string, TestError>("This is not a failure");
+  const auto expected =
+      Expected<std::string, TestError>("This is not a failure");
   auto s = to<Status>(expected);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s, Status::success());

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -10,6 +10,8 @@
 
 #include <osquery/status.h>
 
+#include <boost/algorithm/string.hpp>
+
 #include <gtest/gtest.h>
 
 namespace osquery {
@@ -72,5 +74,32 @@ TEST_F(StatusTests, test_failure_with_success_code) {
   ASSERT_DEATH(Status::failure(Status::kSuccessCode, "message"),
                "Using 'failure' to create Status object with a kSuccessCode");
 #endif
+}
+
+namespace {
+
+enum class TestError {
+  Semantic = 1,
+};
+
+bool stringContains(const std::string& where, const std::string& what) {
+  return boost::contains(where, what);
+};
+
+} // namespace
+
+TEST_F(StatusTests, test_expected_to_status_failure) {
+  const auto expected = Expected<std::string, TestError>(
+      TestError::Semantic, "The ultimate failure reason");
+  auto s = to<Status>(expected);
+  EXPECT_FALSE(s.ok());
+  EXPECT_PRED2(stringContains, s.toString(), "The ultimate failure reason");
+}
+
+TEST_F(StatusTests, test_expected_to_status_success) {
+  const auto expected = Expected<std::string, TestError>("under dust");
+  auto s = to<Status>(expected);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(s, Status::success());
 }
 }

--- a/osquery/core/tests/status_tests.cpp
+++ b/osquery/core/tests/status_tests.cpp
@@ -97,7 +97,7 @@ TEST_F(StatusTests, test_expected_to_status_failure) {
 }
 
 TEST_F(StatusTests, test_expected_to_status_success) {
-  const auto expected = Expected<std::string, TestError>("under dust");
+  const auto expected = Expected<std::string, TestError>("This is not a failure");
   auto s = to<Status>(expected);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s, Status::success());


### PR DESCRIPTION
To make transition from Status to Expected a bit easier.
For transition time there must be a lot of conversions from Expected to Status and back.
Conversion from Status to Expected is not simple, for many reasons.
Conversion from Expected to Status is trivial, but a bit verbose:
```c++
if (exp.isError()) {
  return Status::failure(
    exp.getError().getFullMessage()
  );
} else {
  return Status::success();
}
```
I'd suggest to use more laconic, clear and explicit way to convert.
```c++
return to<Status>(exp);
```