### PR TITLE
incorrect assumption about reserve behavior

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -172,9 +172,6 @@ Status DatabasePlugin::call(const PluginRequest& request,
 
     DatabaseStringValueList data;
     data.reserve(json_object_list.MemberCount());
-    if (data.capacity() != json_object_list.MemberCount()) {
-      return Status(1, "Memory allocation failure");
-    }
 
     for (auto& item : json_object_list) {
       if (!item.value.IsString()) {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -438,9 +438,6 @@ Status EventSubscriberPlugin::recordEvents(
 
   DatabaseStringValueList database_data;
   database_data.reserve(event_id_list.size());
-  if (database_data.capacity() != event_id_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   std::string index_key = "indexes." + dbNamespace() + ".60";
   std::string record_key = "records." + dbNamespace() + ".60.";
@@ -590,15 +587,9 @@ Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
                                        EventTime custom_event_time) {
   DatabaseStringValueList database_data;
   database_data.reserve(row_list.size());
-  if (database_data.capacity() != row_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   std::vector<std::string> event_id_list;
   event_id_list.reserve(row_list.size());
-  if (event_id_list.capacity() != row_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   auto event_time = custom_event_time != 0 ? custom_event_time : getUnixTime();
   auto event_time_str = std::to_string(event_time);

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -690,10 +690,6 @@ void AuditdNetlinkParser::start() {
 
     std::vector<AuditEventRecord> audit_event_record_queue;
     audit_event_record_queue.reserve(queue.size());
-    if (audit_event_record_queue.capacity() != queue.size()) {
-      VLOG(1) << "Memory allocation failure";
-      return;
-    }
 
     for (auto& reply : queue) {
       if (interrupted()) {

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -93,9 +93,6 @@ Status AuditEventPublisher::run() {
   // records
   auto event_count_estimate = audit_event_record_queue.size() / 4U;
   event_context->audit_events.reserve(event_count_estimate);
-  if (event_context->audit_events.capacity() != event_count_estimate) {
-    return Status(1, "Memory allocation failure");
-  }
 
   ProcessEvents(event_context, audit_event_record_queue, audit_trace_context_);
   if (!event_context->audit_events.empty()) {

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -69,9 +69,6 @@ Status AuditProcessEventSubscriber::ProcessEvents(
   emitted_row_list.clear();
 
   emitted_row_list.reserve(event_list.size());
-  if (emitted_row_list.capacity() != event_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::Syscall) {

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -1183,9 +1183,6 @@ Status ProcessFileEventSubscriber::ProcessEvents(
   emitted_row_list.clear();
 
   emitted_row_list.reserve(event_list.size());
-  if (emitted_row_list.capacity() != event_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   auto L_ShouldHandle = [](std::uint64_t syscall_number) -> bool {
     const auto& syscall_set = ProcessFileEventSubscriber::GetSyscallSet();

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -122,9 +122,6 @@ Status SocketEventSubscriber::ProcessEvents(
   emitted_row_list.clear();
 
   emitted_row_list.reserve(event_list.size());
-  if (emitted_row_list.capacity() != event_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::Syscall) {

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -69,9 +69,6 @@ Status UserEventSubscriber::ProcessEvents(
   emitted_row_list.clear();
 
   emitted_row_list.reserve(event_list.size());
-  if (emitted_row_list.capacity() != event_list.size()) {
-    return Status(1, "Memory allocation error");
-  }
 
   for (const auto& event : event_list) {
     if (event.type != AuditEvent::Type::UserEvent) {


### PR DESCRIPTION
http://www.cplusplus.com/reference/vector/vector/reserve/
By documentation, vector can allocate more than requested by the reserve. If it can not allocate the minimum size bad_alloc is thrown.  ( This  kind of behavior actually makes sense, when reserve is optimized enough...)
Also, there is no point of checking if vector capacity is less then requested, as it's prohibited by the documentation.