### PR TITLE
removing less useful things from logger

### DIFF
--- a/include/osquery/events.h
+++ b/include/osquery/events.h
@@ -832,12 +832,6 @@ class EventFactory : private boost::noncopyable {
   /// Return a list of subscriber registry names,
   static std::vector<std::string> subscriberNames();
 
-  /// Set log forwarding by adding a logger receiver.
-  static void addForwarder(const std::string& logger);
-
-  /// Optionally forward events to loggers.
-  static void forwardEvent(const std::string& event);
-
   /**
    * @brief The event factory, subscribers, and publishers respond to updates.
    *

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -71,22 +71,6 @@ struct StatusLogLine {
 };
 
 /**
- * @brief Logger plugin feature bits for complicated loggers.
- *
- * Logger plugins may opt-in to additional features like explicitly handling
- * Glog status events or requesting event subscribers to forward each event
- * directly to the logger. This enumeration tracks, and corresponds to, each
- * of the feature methods defined in a logger plugin.
- *
- * A specific registry call action can be used to retrieve an overloaded Status
- * object containing all of the opt-in features.
- */
-enum LoggerFeatures {
-  LOGGER_FEATURE_BLANK = 0,
-  LOGGER_FEATURE_LOGSTATUS = 1
-};
-
-/**
  * @brief Helper logging macro for table-generated verbose log lines.
  *
  * Since logging in tables does not always mean a critical warning or error
@@ -145,19 +129,6 @@ class LoggerPlugin : public Plugin {
   Status call(const PluginRequest& request, PluginResponse& response) override;
 
   /**
-   * @brief A feature method to decide if Glog should stop handling statuses.
-   *
-   * Return true if this logger plugin's #logStatus method should handle Glog
-   * statuses exclusively. If true then Glog will stop writing status lines
-   * to the configured log path.
-   *
-   * @return false if this logger plugin should NOT handle Glog statuses.
-   */
-  virtual bool usesLogStatus() {
-    return false;
-  }
-
-  /**
    * @brief Set the process name.
    */
   void setProcessName(const std::string& name) {
@@ -182,7 +153,7 @@ class LoggerPlugin : public Plugin {
   virtual Status logString(const std::string& s) = 0;
 
   /**
-   * @brief See the usesLogStatus method, log a Glog status.
+   * @brief log a Glog status.
    *
    * @param log A vector of parsed Glog log lines.
    * @return Status non-op indicating success or failure.

--- a/include/osquery/logger.h
+++ b/include/osquery/logger.h
@@ -83,8 +83,7 @@ struct StatusLogLine {
  */
 enum LoggerFeatures {
   LOGGER_FEATURE_BLANK = 0,
-  LOGGER_FEATURE_LOGSTATUS = 1,
-  LOGGER_FEATURE_LOGEVENT = 2,
+  LOGGER_FEATURE_LOGSTATUS = 1
 };
 
 /**
@@ -159,17 +158,6 @@ class LoggerPlugin : public Plugin {
   }
 
   /**
-   * @brief A feature method to decide if events should be forwarded.
-   *
-   * See the optional logEvent method.
-   *
-   * @return false if this logger plugin should NOT handle events directly.
-   */
-  virtual bool usesLogEvent() {
-    return false;
-  }
-
-  /**
    * @brief Set the process name.
    */
   void setProcessName(const std::string& name) {
@@ -216,16 +204,6 @@ class LoggerPlugin : public Plugin {
    */
   virtual Status logSnapshot(const std::string& s) {
     return logString(s);
-  }
-
-  /**
-   * @brief Optionally handle each published event via the logger.
-   *
-   * It is possible to skip the database representation of event subscribers
-   * and instead forward each added event to the active logger plugin.
-   */
-  virtual Status logEvent(const std::string& /*s*/) {
-    return Status(1, "Not enabled");
   }
 
  protected:

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -611,10 +611,6 @@ Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
       serialized_row.pop_back();
     }
 
-    // Logger plugins may request events to be forwarded directly.
-    // If no active logger is marked 'usesLogEvent' then this is a no-op.
-    EventFactory::forwardEvent(serialized_row);
-
     // Store the event data in the batch
     database_data.push_back(std::make_pair(
         "data." + dbNamespace() + "." + row["eid"], serialized_row));
@@ -694,16 +690,6 @@ void EventPublisherPlugin::removeSubscriptions(const std::string& subscriber) {
                        return (subscription->subscriber_name == subscriber);
                      });
   subscriptions_.erase(end, subscriptions_.end());
-}
-
-void EventFactory::addForwarder(const std::string& logger) {
-  getInstance().loggers_.push_back(logger);
-}
-
-void EventFactory::forwardEvent(const std::string& event) {
-  for (const auto& logger : getInstance().loggers_) {
-    Registry::call("logger", logger, {{"event", event}});
-  }
 }
 
 void EventFactory::configUpdate() {

--- a/osquery/logger/benchmarks/logger_benchmarks.cpp
+++ b/osquery/logger/benchmarks/logger_benchmarks.cpp
@@ -21,9 +21,6 @@ DECLARE_bool(disable_logging);
 
 class DummyLoggerPlugin : public LoggerPlugin {
  public:
-  bool usesLogStatus() override {
-    return true;
-  }
 
  protected:
   Status logString(const std::string& s) override {

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -469,8 +469,6 @@ Status LoggerPlugin::call(const PluginRequest& request,
   } else if (request.count("status") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
     return this->logStatus(intermediate_logs);
-  } else if (request.count("event") > 0) {
-    return this->logEvent(request.at("event"));
   } else {
     return Status(1, "Unsupported call to logger plugin");
   }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -469,6 +469,8 @@ Status LoggerPlugin::call(const PluginRequest& request,
   } else if (request.count("status") > 0) {
     deserializeIntermediateLog(request, intermediate_logs);
     return this->logStatus(intermediate_logs);
+  } else if (request.count("event") > 0) {
+    return this->logEvent(request.at("event"));
   } else {
     return Status(1, "Unsupported call to logger plugin");
   }

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -177,9 +177,6 @@ class BufferedLogSink : public google::LogSink, private boost::noncopyable {
   /**
    * @Brief Is the logger temporarily disabled.
    *
-   * This is an atomic because the friend class LoggerDisabler will toggle the
-   * enabled/disabled flag and call enable()/disable().
-   *
    * The Google Log Sink will still be active, but the send method also checks
    * enabled and drops log lines to the flood if the forwarder is not enabled.
    */
@@ -193,9 +190,6 @@ class BufferedLogSink : public google::LogSink, private boost::noncopyable {
 
   /// Mutex protecting activation and enabling of the buffered status logger.
   Mutex enable_mutex_;
-
- private:
-  friend class LoggerDisabler;
 };
 
 /// Mutex protecting accesses to buffered status logs.

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -573,7 +573,7 @@ size_t queuedSenders() {
   return BufferedLogSink::get().senders.size();
 }
 
-void relayStatusLogs(bool async) {
+void relayStatusLogs(bool sync) {
   if (FLAGS_disable_logging || !DatabasePlugin::kDBInitialized) {
     // The logger plugins may not be setUp if logging is disabled.
     // If the database is not setUp, or is in a reset, status logs continue
@@ -618,7 +618,7 @@ void relayStatusLogs(bool async) {
     }
   });
 
-  if (async) {
+  if (sync) {
     sender();
   } else {
     std::packaged_task<void()> task(std::move(sender));

--- a/osquery/logger/plugins/aws_firehose.h
+++ b/osquery/logger/plugins/aws_firehose.h
@@ -67,10 +67,6 @@ class FirehoseLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  protected:
   void init(const std::string& name,
             const std::vector<StatusLogLine>& log) override;

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -68,10 +68,6 @@ class KinesisLoggerPlugin : public LoggerPlugin {
 
   Status setUp() override;
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  private:
   void init(const std::string& name,
             const std::vector<StatusLogLine>& log) override;

--- a/osquery/logger/plugins/stdout.cpp
+++ b/osquery/logger/plugins/stdout.cpp
@@ -16,9 +16,6 @@ namespace osquery {
 
 class StdoutLoggerPlugin : public LoggerPlugin {
  public:
-  bool usesLogStatus() override {
-    return true;
-  }
 
  protected:
   Status logString(const std::string& s) override;

--- a/osquery/logger/plugins/syslog_logger.cpp
+++ b/osquery/logger/plugins/syslog_logger.cpp
@@ -28,9 +28,6 @@ FLAG(bool,
 
 class SyslogLoggerPlugin : public LoggerPlugin {
  public:
-  bool usesLogStatus() override {
-    return true;
-  }
 
  protected:
   Status logString(const std::string& s) override;

--- a/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger_tests.cpp
@@ -88,10 +88,6 @@ class FilesystemTestLoggerPlugin : public LoggerPlugin {
     return Status(0, "OK");
   }
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  protected:
   void init(const std::string& binary_name,
             const std::vector<StatusLogLine>& log) override {}

--- a/osquery/logger/plugins/tls_logger.h
+++ b/osquery/logger/plugins/tls_logger.h
@@ -56,10 +56,6 @@ class TLSLoggerPlugin : public LoggerPlugin {
   /// Setup node key and worker thread for sending logs.
   Status setUp() override;
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  protected:
   /// Log a result string. This is the basic catch-all for snapshots and events.
   Status logString(const std::string& s) override;

--- a/osquery/logger/plugins/windows_event_log.h
+++ b/osquery/logger/plugins/windows_event_log.h
@@ -23,10 +23,6 @@ class WindowsEventLoggerPlugin : public LoggerPlugin {
  public:
   virtual ~WindowsEventLoggerPlugin();
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  protected:
   Status logString(const std::string& s) override;
   void init(const std::string& name,

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -299,50 +299,50 @@ class SecondTestLoggerPlugin : public LoggerPlugin {
 };
 
 TEST_F(LoggerTests, test_multiple_loggers) {
-  auto& rf = RegistryFactory::get();
-  auto second = std::make_shared<SecondTestLoggerPlugin>();
-  rf.registry("logger")->add("second_test", second);
-  EXPECT_TRUE(rf.setActive("logger", "test,second_test").ok());
-
-  auto test_plugin = rf.registry("logger")->plugin("test");
-  auto test_logger = std::dynamic_pointer_cast<TestLoggerPlugin>(test_plugin);
-  test_logger->shouldLogStatus = false;
-
-  // With two active loggers, the string should be added twice.
-  logString("this is a test", "added");
-  EXPECT_EQ(2U, LoggerTests::log_lines.size());
-
-  LOG(WARNING) << "Logger test is generating a warning status (4)";
-  // Refer to the above notes about status logs not emitting until the logger
-  // it initialized. We do a 0-test to check for dead locks around attempting
-  // to forward Glog-based sinks recursively into our sinks.
-  EXPECT_EQ(0U, LoggerTests::statuses_logged);
-
-  // Now try to initialize multiple loggers (1) forwards, (2) does not.
-  initLogger("logger_test");
-  LOG(WARNING) << "Logger test is generating a warning status (5)";
-  // Now that the "test" logger is initialized, the status log will be
-  // forwarded.
-  EXPECT_EQ(1U, LoggerTests::statuses_logged);
-
-  // Multiple logger plugins have a 'primary' concept.
-  auto flag_default = FLAGS_logger_secondary_status_only;
-  FLAGS_logger_secondary_status_only = true;
-  logString("this is another test", "added");
-  // Only one log line will be appended since 'second_test' is secondary.
-  EXPECT_EQ(3U, LoggerTests::log_lines.size());
-  // Only one status line will be forwarded.
-  LOG(WARNING) << "Logger test is generating another warning (6)";
-  EXPECT_EQ(2U, LoggerTests::statuses_logged);
-  FLAGS_logger_secondary_status_only = flag_default;
-  logString("this is a third test", "added");
-  EXPECT_EQ(5U, LoggerTests::log_lines.size());
-
-  // Reconfigure the second logger to forward status logs.
-  test_logger->shouldLogStatus = true;
-  initLogger("logger_test");
-  LOG(WARNING) << "Logger test is generating another warning (7)";
-  EXPECT_EQ(4U, LoggerTests::statuses_logged);
+  // auto& rf = RegistryFactory::get();
+  // auto second = std::make_shared<SecondTestLoggerPlugin>();
+  // rf.registry("logger")->add("second_test", second);
+  // EXPECT_TRUE(rf.setActive("logger", "test,second_test").ok());
+  //
+  // auto test_plugin = rf.registry("logger")->plugin("test");
+  // auto test_logger = std::dynamic_pointer_cast<TestLoggerPlugin>(test_plugin);
+  // test_logger->shouldLogStatus = false;
+  //
+  // // With two active loggers, the string should be added twice.
+  // logString("this is a test", "added");
+  // EXPECT_EQ(2U, LoggerTests::log_lines.size());
+  //
+  // LOG(WARNING) << "Logger test is generating a warning status (4)";
+  // // Refer to the above notes about status logs not emitting until the logger
+  // // it initialized. We do a 0-test to check for dead locks around attempting
+  // // to forward Glog-based sinks recursively into our sinks.
+  // EXPECT_EQ(0U, LoggerTests::statuses_logged);
+  //
+  // // Now try to initialize multiple loggers (1) forwards, (2) does not.
+  // initLogger("logger_test");
+  // LOG(WARNING) << "Logger test is generating a warning status (5)";
+  // // Now that the "test" logger is initialized, the status log will be
+  // // forwarded.
+  // EXPECT_EQ(1U, LoggerTests::statuses_logged);
+  //
+  // // Multiple logger plugins have a 'primary' concept.
+  // auto flag_default = FLAGS_logger_secondary_status_only;
+  // FLAGS_logger_secondary_status_only = true;
+  // logString("this is another test", "added");
+  // // Only one log line will be appended since 'second_test' is secondary.
+  // EXPECT_EQ(3U, LoggerTests::log_lines.size());
+  // // Only one status line will be forwarded.
+  // LOG(WARNING) << "Logger test is generating another warning (6)";
+  // EXPECT_EQ(2U, LoggerTests::statuses_logged);
+  // FLAGS_logger_secondary_status_only = flag_default;
+  // logString("this is a third test", "added");
+  // EXPECT_EQ(5U, LoggerTests::log_lines.size());
+  //
+  // // Reconfigure the second logger to forward status logs.
+  // test_logger->shouldLogStatus = true;
+  // initLogger("logger_test");
+  // LOG(WARNING) << "Logger test is generating another warning (7)";
+  // EXPECT_EQ(4U, LoggerTests::statuses_logged);
 }
 
 TEST_F(LoggerTests, test_logger_scheduled_query) {

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -87,10 +87,6 @@ inline void placeStatuses(const std::vector<StatusLogLine>& log) {
 
 class TestLoggerPlugin : public LoggerPlugin {
  protected:
-  bool usesLogStatus() override {
-    return shouldLogStatus;
-  }
-
   Status logString(const std::string& s) override {
     LoggerTests::log_lines.push_back(s);
     return Status(0, s);
@@ -111,10 +107,6 @@ class TestLoggerPlugin : public LoggerPlugin {
     LoggerTests::snapshot_rows_removed += 0;
     return Status(0, "OK");
   }
-
- public:
-  /// Allow test methods to change status logging state.
-  bool shouldLogStatus{true};
 };
 
 TEST_F(LoggerTests, test_plugin) {
@@ -216,39 +208,6 @@ TEST_F(LoggerTests, test_logger_status_level) {
   FLAGS_logger_min_status = logger_min_status;
 }
 
-TEST_F(LoggerTests, test_feature_request) {
-  // Retrieve the test logger plugin.
-  auto plugin = RegistryFactory::get().plugin("logger", "test");
-  auto logger = std::dynamic_pointer_cast<TestLoggerPlugin>(plugin);
-
-  logger->shouldLogStatus = false;
-  auto status = Registry::call("logger", "test", {{"action", "features"}});
-  EXPECT_EQ(0, status.getCode());
-
-  logger->shouldLogStatus = true;
-  status = Registry::call("logger", "test", {{"action", "features"}});
-  EXPECT_EQ(LOGGER_FEATURE_LOGSTATUS, status.getCode());
-}
-
-TEST_F(LoggerTests, test_logger_variations) {
-  // Retrieve the test logger plugin.
-  auto plugin = RegistryFactory::get().plugin("logger", "test");
-  auto logger = std::dynamic_pointer_cast<TestLoggerPlugin>(plugin);
-  // Change the behavior.
-  logger->shouldLogStatus = false;
-
-  // Call the logger initialization again, then reset the behavior.
-  initLogger("duplicate_logger");
-  logger->shouldLogStatus = true;
-
-  // This will be printed to stdout.
-  LOG(WARNING) << "Logger test is generating a warning status (3)";
-
-  // Since the initLogger call triggered a failed init, meaning the logger
-  // does NOT handle Glog logs, there will be no statuses logged.
-  EXPECT_EQ(0U, LoggerTests::statuses_logged);
-}
-
 TEST_F(LoggerTests, test_logger_snapshots) {
   // A snapshot query should not include removed items.
   QueryLogItem item;
@@ -287,10 +246,6 @@ class SecondTestLoggerPlugin : public LoggerPlugin {
     return Status(0, "OK");
   }
 
-  bool usesLogStatus() override {
-    return true;
-  }
-
  protected:
   void init(const std::string& binary_name,
             const std::vector<StatusLogLine>& log) override {
@@ -299,50 +254,30 @@ class SecondTestLoggerPlugin : public LoggerPlugin {
 };
 
 TEST_F(LoggerTests, test_multiple_loggers) {
-  // auto& rf = RegistryFactory::get();
-  // auto second = std::make_shared<SecondTestLoggerPlugin>();
-  // rf.registry("logger")->add("second_test", second);
-  // EXPECT_TRUE(rf.setActive("logger", "test,second_test").ok());
-  //
-  // auto test_plugin = rf.registry("logger")->plugin("test");
-  // auto test_logger = std::dynamic_pointer_cast<TestLoggerPlugin>(test_plugin);
-  // test_logger->shouldLogStatus = false;
-  //
-  // // With two active loggers, the string should be added twice.
-  // logString("this is a test", "added");
-  // EXPECT_EQ(2U, LoggerTests::log_lines.size());
-  //
-  // LOG(WARNING) << "Logger test is generating a warning status (4)";
-  // // Refer to the above notes about status logs not emitting until the logger
-  // // it initialized. We do a 0-test to check for dead locks around attempting
-  // // to forward Glog-based sinks recursively into our sinks.
-  // EXPECT_EQ(0U, LoggerTests::statuses_logged);
-  //
-  // // Now try to initialize multiple loggers (1) forwards, (2) does not.
-  // initLogger("logger_test");
-  // LOG(WARNING) << "Logger test is generating a warning status (5)";
-  // // Now that the "test" logger is initialized, the status log will be
-  // // forwarded.
-  // EXPECT_EQ(1U, LoggerTests::statuses_logged);
-  //
-  // // Multiple logger plugins have a 'primary' concept.
-  // auto flag_default = FLAGS_logger_secondary_status_only;
-  // FLAGS_logger_secondary_status_only = true;
-  // logString("this is another test", "added");
-  // // Only one log line will be appended since 'second_test' is secondary.
-  // EXPECT_EQ(3U, LoggerTests::log_lines.size());
-  // // Only one status line will be forwarded.
-  // LOG(WARNING) << "Logger test is generating another warning (6)";
-  // EXPECT_EQ(2U, LoggerTests::statuses_logged);
-  // FLAGS_logger_secondary_status_only = flag_default;
-  // logString("this is a third test", "added");
-  // EXPECT_EQ(5U, LoggerTests::log_lines.size());
-  //
-  // // Reconfigure the second logger to forward status logs.
-  // test_logger->shouldLogStatus = true;
-  // initLogger("logger_test");
-  // LOG(WARNING) << "Logger test is generating another warning (7)";
-  // EXPECT_EQ(4U, LoggerTests::statuses_logged);
+  auto& rf = RegistryFactory::get();
+  auto second = std::make_shared<SecondTestLoggerPlugin>();
+  rf.registry("logger")->add("second_test", second);
+  EXPECT_TRUE(rf.setActive("logger", "test,second_test").ok());
+
+  auto test_plugin = rf.registry("logger")->plugin("test");
+  auto test_logger = std::dynamic_pointer_cast<TestLoggerPlugin>(test_plugin);
+
+  // With two active loggers, the string should be added twice.
+  logString("this is a test", "added");
+  EXPECT_EQ(2U, LoggerTests::log_lines.size());
+
+  LOG(WARNING) << "Logger test is generating a warning status (4)";
+  // Refer to the above notes about status logs not emitting until the logger
+  // it initialized. We do a 0-test to check for dead locks around attempting
+  // to forward Glog-based sinks recursively into our sinks.
+  EXPECT_EQ(1U, LoggerTests::statuses_logged);
+
+  // Now try to initialize multiple loggers (1) forwards, (2) does not.
+  initLogger("logger_test");
+  LOG(WARNING) << "Logger test is generating a warning status (5)";
+  // Now that the "test" logger is initialized, the status log will be
+  // forwarded.
+  EXPECT_EQ(3U, LoggerTests::statuses_logged);
 }
 
 TEST_F(LoggerTests, test_logger_scheduled_query) {
@@ -382,10 +317,6 @@ TEST_F(LoggerTests, test_logger_scheduled_query) {
 
 class RecursiveLoggerPlugin : public LoggerPlugin {
  protected:
-  bool usesLogStatus() override {
-    return true;
-  }
-
   Status logString(const std::string& s) override {
     return Status(0, s);
   }

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -58,7 +58,6 @@ class LoggerTests : public testing::Test {
 
   // Count calls to logStatus
   static size_t statuses_logged;
-  static size_t events_logged;
   // Count added and removed snapshot rows
   static size_t snapshot_rows_added;
   static size_t snapshot_rows_removed;
@@ -72,7 +71,6 @@ std::vector<std::string> LoggerTests::log_lines;
 StatusLogLine LoggerTests::last_status;
 std::vector<std::string> LoggerTests::status_messages;
 size_t LoggerTests::statuses_logged = 0;
-size_t LoggerTests::events_logged = 0;
 size_t LoggerTests::snapshot_rows_added = 0;
 size_t LoggerTests::snapshot_rows_removed = 0;
 
@@ -91,15 +89,6 @@ class TestLoggerPlugin : public LoggerPlugin {
  protected:
   bool usesLogStatus() override {
     return shouldLogStatus;
-  }
-
-  bool usesLogEvent() override {
-    return shouldLogEvent;
-  }
-
-  Status logEvent(const std::string& e) override {
-    LoggerTests::events_logged++;
-    return Status(0, "OK");
   }
 
   Status logString(const std::string& s) override {
@@ -126,9 +115,6 @@ class TestLoggerPlugin : public LoggerPlugin {
  public:
   /// Allow test methods to change status logging state.
   bool shouldLogStatus{true};
-
-  /// Allow test methods to change event logging state.
-  bool shouldLogEvent{true};
 };
 
 TEST_F(LoggerTests, test_plugin) {
@@ -235,7 +221,6 @@ TEST_F(LoggerTests, test_feature_request) {
   auto plugin = RegistryFactory::get().plugin("logger", "test");
   auto logger = std::dynamic_pointer_cast<TestLoggerPlugin>(plugin);
 
-  logger->shouldLogEvent = false;
   logger->shouldLogStatus = false;
   auto status = Registry::call("logger", "test", {{"action", "features"}});
   EXPECT_EQ(0, status.getCode());


### PR DESCRIPTION
Removed some capabilities of the osquery logger, which to my understanding did not find any important use case. 

- **No primary logger concept**. - Could not find any important use case for that, considering the fact that, a primary logger is the random one.
- **All the loggers receive statuses**. - All the logger plugins currently implemented, except Kafka one, receive statuses anyway. However, I found one logger, which even though implemented [logStatus](https://github.com/facebook/osquery/blob/master/osquery/logger/plugins/filesystem_logger.cpp#L115) Does not return true for usesLogStatus. (BUG)
- **No logger can ask for events.** - 1. No plugin was doing it anyway. 2. logger.cpp does not look the right place for it. As all it was doing, was subscribing plugin to the event in events.cpp . 3. Because of the high-frequency events, we are already missing the events. Actually serializing and sending it through thrift API will make things even slower.
- **Dead code**: LoggerDisabler was not used.
