### PR TITLE
Fix up naming style for the Expected methods takeOr and getOr

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -155,7 +155,7 @@ class Expected final {
     return boost::get<ValueType>(object_);
   }
 
-  const ValueType& get_or(const ValueType& defaultValue) const {
+  const ValueType& getOr(const ValueType& defaultValue) const {
     if (isError()) {
       return defaultValue;
     }
@@ -170,7 +170,7 @@ class Expected final {
   template <typename ValueTypeUniversal = ValueType>
   typename std::enable_if<std::is_same<ValueTypeUniversal, ValueType>::value,
                           ValueType>::type
-  take_or(ValueTypeUniversal&& defaultValue) {
+  takeOr(ValueTypeUniversal&& defaultValue) {
     if (isError()) {
       return std::forward<ValueTypeUniversal>(defaultValue);
     }

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -295,7 +295,7 @@ const rj::Document& JSON::doc() const {
 
 size_t JSON::valueToSize(const rj::Value& value) {
   if (value.IsString()) {
-    return tryTo<std::size_t>(std::string{value.GetString()}).get_or(0_sz);
+    return tryTo<std::size_t>(std::string{value.GetString()}).getOr(0_sz);
   } else if (value.IsNumber()) {
     return static_cast<size_t>(value.GetUint64());
   }

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -221,19 +221,19 @@ GTEST_TEST(ExpectedTest, take_value_from_expected_with_error) {
 #endif
 }
 
-GTEST_TEST(ExpectedTest, value__get_or) {
+GTEST_TEST(ExpectedTest, value__getOr) {
   const auto expectedValue = Expected<int, TestError>(225);
-  EXPECT_EQ(expectedValue.get_or(29), 225);
-  EXPECT_EQ(expectedValue.get_or(-29), 225);
+  EXPECT_EQ(expectedValue.getOr(29), 225);
+  EXPECT_EQ(expectedValue.getOr(-29), 225);
 }
 
-GTEST_TEST(ExpectedTest, error__get_or) {
+GTEST_TEST(ExpectedTest, error__getOr) {
   const auto err = Expected<int, TestError>(TestError::Semantic, "message");
-  EXPECT_EQ(err.get_or(37), 37);
-  EXPECT_EQ(err.get_or(-59), -59);
+  EXPECT_EQ(err.getOr(37), 37);
+  EXPECT_EQ(err.getOr(-59), -59);
 }
 
-GTEST_TEST(ExpectedTest, value__take_or) {
+GTEST_TEST(ExpectedTest, value__takeOr) {
   const auto text = std::string{"some text"};
   auto callable = [&text]() -> Expected<std::string, TestError> {
     return text;
@@ -241,16 +241,16 @@ GTEST_TEST(ExpectedTest, value__take_or) {
   auto expected = callable();
   EXPECT_EQ(expected ? expected.take() : std::string{"default text"}, text);
 
-  EXPECT_EQ(callable().take_or(std::string{"default text"}), text);
+  EXPECT_EQ(callable().takeOr(std::string{"default text"}), text);
 }
 
-GTEST_TEST(ExpectedTest, error__take_or) {
+GTEST_TEST(ExpectedTest, error__takeOr) {
   auto expected =
       Expected<std::string, TestError>(TestError::Semantic, "error message");
-  EXPECT_EQ(expected.take_or(std::string{"default text"}), "default text");
+  EXPECT_EQ(expected.takeOr(std::string{"default text"}), "default text");
 }
 
-GTEST_TEST(ExpectedTest, error__take_or_with_user_defined_class) {
+GTEST_TEST(ExpectedTest, error__takeOr_with_user_defined_class) {
   class SomeTestClass {
    public:
     explicit SomeTestClass(const std::string& prefix, const std::string& sufix)
@@ -261,7 +261,7 @@ GTEST_TEST(ExpectedTest, error__take_or_with_user_defined_class) {
   auto callable = []() -> Expected<SomeTestClass, TestError> {
     return createError(TestError::Semantic, "error message");
   };
-  EXPECT_EQ(callable().take_or(SomeTestClass("427 BC", "347 BC")).text,
+  EXPECT_EQ(callable().takeOr(SomeTestClass("427 BC", "347 BC")).text,
             "427 BC - 347 BC");
 }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -369,10 +369,10 @@ PerformanceChange getChange(const Row& r, PerformanceState& state) {
   long long user_time = 0, system_time = 0;
   try {
     change.parent =
-        static_cast<pid_t>(tryTo<long long>(r.at("parent")).take_or(0LL));
-    user_time = tryTo<long long>(r.at("user_time")).take_or(0LL);
-    system_time = tryTo<long long>(r.at("system_time")).take_or(0LL);
-    change.footprint = tryTo<long long>(r.at("resident_size")).take_or(0LL);
+        static_cast<pid_t>(tryTo<long long>(r.at("parent")).takeOr(0LL));
+    user_time = tryTo<long long>(r.at("user_time")).takeOr(0LL);
+    system_time = tryTo<long long>(r.at("system_time")).takeOr(0LL);
+    change.footprint = tryTo<long long>(r.at("resident_size")).takeOr(0LL);
   } catch (const std::exception& /* e */) {
     state.sustained_latency = 0;
   }

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1055,7 +1055,7 @@ static int booleanValue(char* zArg) {
     fprintf(
         stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n", zArg);
   }
-  return expected.get_or(false) ? 1 : 0;
+  return expected.getOr(false) ? 1 : 0;
 }
 
 inline void meta_tables(int nArg, char** azArg) {

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -69,24 +69,24 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       std::string sPlaceHolder;
 
       results[0].GetString("PacketsReceivedPerSec", sPlaceHolder);
-      r["ipackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["ipackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
       results[0].GetString("PacketsSentPerSec", sPlaceHolder);
-      r["opackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["opackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
       results[0].GetString("BytesReceivedPerSec", sPlaceHolder);
-      r["ibytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["ibytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
       results[0].GetString("BytesSentPerSec", sPlaceHolder);
-      r["obytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["obytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
       results[0].GetString("PacketsReceivedErrors", sPlaceHolder);
-      r["ierrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["ierrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
       results[0].GetString("PacketsOutboundErrors", sPlaceHolder);
-      r["oerrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["oerrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
       results[0].GetString("PacketsReceivedDiscarded", sPlaceHolder);
-      r["idrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["idrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
       results[0].GetString("PacketsOutboundDiscarded", sPlaceHolder);
-      r["odrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+      r["odrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
     } else {
       LOG(INFO) << "Failed to retrieve network statistics for interface "
                 << r["interface"];

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -36,7 +36,7 @@ int getOSMinorVersion() {
     return -1;
   }
 
-  return tryTo<int>(qd.front().at("minor")).take_or(-1);
+  return tryTo<int>(qd.front().at("minor")).takeOr(-1);
 }
 
 // Get the flags to pass to SecStaticCodeCheckValidityWithErrors, depending on

--- a/osquery/tables/system/windows/physical_disk_performance.cpp
+++ b/osquery/tables/system/windows/physical_disk_performance.cpp
@@ -33,43 +33,43 @@ QueryData genPhysicalDiskPerformance(QueryContext& context) {
 
     disk.GetString("AvgDiskBytesPerRead", sPlaceHolder);
     r["avg_disk_bytes_per_read"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
     disk.GetString("AvgDiskBytesPerWrite", sPlaceHolder);
     r["avg_disk_bytes_per_write"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("AvgDiskReadQueueLength", sPlaceHolder);
     r["avg_disk_read_queue_length"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
     disk.GetString("AvgDiskWriteQueueLength", sPlaceHolder);
     r["avg_disk_write_queue_length"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("AvgDiskSecPerRead", sPlaceHolder);
     r["avg_disk_sec_per_read"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
     disk.GetString("AvgDiskSecPerWrite", sPlaceHolder);
     r["avg_disk_sec_per_write"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("PercentDiskReadTime", sPlaceHolder);
     r["percent_disk_read_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
     disk.GetString("PercentDiskWriteTime", sPlaceHolder);
     r["percent_disk_write_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("CurrentDiskQueueLength", sPlaceHolder);
     r["current_disk_queue_length"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("PercentDiskTime", sPlaceHolder);
     r["percent_disk_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     disk.GetString("PercentIdleTime", sPlaceHolder);
     r["percent_idle_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).get_or(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
 
     results.push_back(r);
   }


### PR DESCRIPTION
according to the osquery c++ style guide. Until it's not too late.