### PR TITLE
setThreadName boilerplate removal

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -146,7 +146,6 @@ Carver::~Carver() {
 }
 
 void Carver::start() {
-  
   // If status_ is not Ok, the creation of our tmp FS failed
   if (!status_.ok()) {
     LOG(WARNING) << "Carver has not been properly constructed";

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -146,7 +146,7 @@ Carver::~Carver() {
 }
 
 void Carver::start() {
-  setThreadName(name());
+  
   // If status_ is not Ok, the creation of our tmp FS failed
   if (!status_.ok()) {
     LOG(WARNING) << "Carver has not been properly constructed";

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -1023,7 +1023,6 @@ Status ConfigParserPlugin::setUp() {
 }
 
 void ConfigRefreshRunner::start() {
-  
   while (!interrupted()) {
     // Cool off and time wait the configured period.
     // Apply this interruption initially as at t=0 the config was read.

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -1023,7 +1023,7 @@ Status ConfigParserPlugin::setUp() {
 }
 
 void ConfigRefreshRunner::start() {
-  setThreadName(name());
+  
   while (!interrupted()) {
     // Cool off and time wait the configured period.
     // Apply this interruption initially as at t=0 the config was read.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -196,7 +196,6 @@ bool WatcherRunner::ok() const {
 }
 
 void WatcherRunner::start() {
-  
   // Hold the current process (watcher) for inspection too.
   auto& watcher = Watcher::get();
   auto self = PlatformProcess::getCurrentProcess();
@@ -630,7 +629,6 @@ void WatcherRunner::createExtension(const std::string& extension) {
 }
 
 void WatcherWatcherRunner::start() {
-  
   while (!interrupted()) {
     if (isLauncherProcessDead(*watcher_)) {
       // Watcher died, the worker must follow.

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -196,7 +196,7 @@ bool WatcherRunner::ok() const {
 }
 
 void WatcherRunner::start() {
-  setThreadName(name());
+  
   // Hold the current process (watcher) for inspection too.
   auto& watcher = Watcher::get();
   auto self = PlatformProcess::getCurrentProcess();
@@ -630,7 +630,7 @@ void WatcherRunner::createExtension(const std::string& extension) {
 }
 
 void WatcherWatcherRunner::start() {
-  setThreadName(name());
+  
   while (!interrupted()) {
     if (isLauncherProcessDead(*watcher_)) {
       // Watcher died, the worker must follow.

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -46,6 +46,7 @@ void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
 
 void InternalRunnable::run() {
   run_ = true;
+  setThreadName(name());
   start();
 
   // The service is complete.

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -29,7 +29,6 @@ DECLARE_string(distributed_plugin);
 const size_t kDistributedAccelerationInterval = 5;
 
 void DistributedRunner::start() {
-  
   auto dist = Distributed();
   while (!interrupted()) {
     dist.pullUpdates();

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -29,7 +29,7 @@ DECLARE_string(distributed_plugin);
 const size_t kDistributedAccelerationInterval = 5;
 
 void DistributedRunner::start() {
-  setThreadName(name());
+  
   auto dist = Distributed();
   while (!interrupted()) {
     dist.pullUpdates();

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -168,7 +168,7 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
 }
 
 void SchedulerRunner::start() {
-  setThreadName(name());
+
   // Start the counter at the second.
   auto i = osquery::getUnixTime();
   for (; (timeout_ == 0) || (i <= timeout_); ++i) {

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -168,7 +168,6 @@ inline void launchQuery(const std::string& name, const ScheduledQuery& query) {
 }
 
 void SchedulerRunner::start() {
-
   // Start the counter at the second.
   auto i = osquery::getUnixTime();
   for (; (timeout_ == 0) || (i <= timeout_); ++i) {

--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -52,7 +52,7 @@ void DiskArbitrationEventPublisher::restart() {
 }
 
 Status DiskArbitrationEventPublisher::run() {
-  setThreadName(name());
+
   restart();
   CFRunLoopRun();
   return Status(0, "OK");

--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -52,7 +52,6 @@ void DiskArbitrationEventPublisher::restart() {
 }
 
 Status DiskArbitrationEventPublisher::run() {
-
   restart();
   CFRunLoopRun();
   return Status(0, "OK");

--- a/osquery/events/darwin/event_taps.cpp
+++ b/osquery/events/darwin/event_taps.cpp
@@ -105,7 +105,7 @@ Status EventTappingEventPublisher::restart() {
 }
 
 Status EventTappingEventPublisher::run() {
-  setThreadName(name());
+  
   Status s = restart();
   if (s.ok()) {
     CFRunLoopRun();

--- a/osquery/events/darwin/event_taps.cpp
+++ b/osquery/events/darwin/event_taps.cpp
@@ -105,7 +105,6 @@ Status EventTappingEventPublisher::restart() {
 }
 
 Status EventTappingEventPublisher::run() {
-  
   Status s = restart();
   if (s.ok()) {
     CFRunLoopRun();

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -233,7 +233,7 @@ void FSEventsEventPublisher::configure() {
 }
 
 Status FSEventsEventPublisher::run() {
-  setThreadName(name());
+  
   // The run entrypoint executes in a dedicated thread.
   bool needs_reset = false;
   {

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -233,7 +233,6 @@ void FSEventsEventPublisher::configure() {
 }
 
 Status FSEventsEventPublisher::run() {
-  
   // The run entrypoint executes in a dedicated thread.
   bool needs_reset = false;
   {

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -198,7 +198,7 @@ void IOKitEventPublisher::deviceDetach(void* refcon,
 }
 
 Status IOKitEventPublisher::run() {
-  setThreadName(name());
+  
   // The run entrypoint executes in a dedicated thread.
   if (run_loop_ == nullptr) {
     run_loop_ = CFRunLoopGetCurrent();

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -198,7 +198,6 @@ void IOKitEventPublisher::deviceDetach(void* refcon,
 }
 
 Status IOKitEventPublisher::run() {
-  
   // The run entrypoint executes in a dedicated thread.
   if (run_loop_ == nullptr) {
     run_loop_ = CFRunLoopGetCurrent();

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -48,7 +48,6 @@ void OpenBSMEventPublisher::tearDown() {
 }
 
 Status OpenBSMEventPublisher::run() {
-  
   if (audit_pipe_ == nullptr) {
     return Status(1, "No open audit_pipe");
   }

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -48,7 +48,7 @@ void OpenBSMEventPublisher::tearDown() {
 }
 
 Status OpenBSMEventPublisher::run() {
-  setThreadName(name());
+  
   if (audit_pipe_ == nullptr) {
     return Status(1, "No open audit_pipe");
   }

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -173,7 +173,7 @@ void SCNetworkEventPublisher::stop() {
 }
 
 Status SCNetworkEventPublisher::run() {
-  setThreadName(name());
+  
   if (run_loop_ == nullptr) {
     run_loop_ = CFRunLoopGetCurrent();
     restart();

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -173,7 +173,6 @@ void SCNetworkEventPublisher::stop() {
 }
 
 Status SCNetworkEventPublisher::run() {
-  
   if (run_loop_ == nullptr) {
     run_loop_ = CFRunLoopGetCurrent();
     restart();

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -788,6 +788,7 @@ Status EventFactory::run(const std::string& type_id) {
   } else if (publisher->hasStarted()) {
     return Status(1, "Cannot restart an event publisher");
   }
+  setThreadName(publisher->name());
   VLOG(1) << "Starting event publisher run loop: " + type_id;
   publisher->hasStarted(true);
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -191,7 +191,7 @@ ExtensionWatcher::ExtensionWatcher(const std::string& path,
 }
 
 void ExtensionWatcher::start() {
-  setThreadName(name());
+  
   // Watch the manager, if the socket is removed then the extension will die.
   // A check for sane paths and activity is applied before the watcher
   // service is added and started.
@@ -202,7 +202,7 @@ void ExtensionWatcher::start() {
 }
 
 void ExtensionManagerWatcher::start() {
-  setThreadName(name());
+  
   // Watch each extension.
   while (!interrupted()) {
     watch();

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -191,7 +191,6 @@ ExtensionWatcher::ExtensionWatcher(const std::string& path,
 }
 
 void ExtensionWatcher::start() {
-  
   // Watch the manager, if the socket is removed then the extension will die.
   // A check for sane paths and activity is applied before the watcher
   // service is added and started.
@@ -202,7 +201,6 @@ void ExtensionWatcher::start() {
 }
 
 void ExtensionManagerWatcher::start() {
-  
   // Watch each extension.
   while (!interrupted()) {
     watch();

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -260,7 +260,7 @@ ExtensionManagerRunner::~ExtensionManagerRunner() {
 }
 
 void ExtensionManagerRunner::start() {
-  setThreadName(name());
+  
   init(0, true);
 
   VLOG(1) << "Extension manager service starting: " << path_;

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -260,7 +260,6 @@ ExtensionManagerRunner::~ExtensionManagerRunner() {
 }
 
 void ExtensionManagerRunner::start() {
-  
   init(0, true);
 
   VLOG(1) << "Extension manager service starting: " << path_;

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -166,7 +166,7 @@ void BufferedLogForwarder::purge() {
 }
 
 void BufferedLogForwarder::start() {
-  setThreadName(name());
+  
   while (!interrupted()) {
     check();
 

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -166,7 +166,6 @@ void BufferedLogForwarder::purge() {
 }
 
 void BufferedLogForwarder::start() {
-  
   while (!interrupted()) {
     check();
 

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -249,7 +249,7 @@ static void SQL_virtual_table_internal_wide(benchmark::State& state) {
   attachTableInternal(
       "wide_benchmark", columnDefinition(res, false, false), dbc, false);
 
-  kWideCount = state.range_y();
+  kWideCount = state.range(1);
   while (state.KeepRunning()) {
     QueryData results;
     queryInternal("select * from wide_benchmark", results, dbc);
@@ -276,7 +276,7 @@ static void SQL_virtual_table_internal_wide_yield(benchmark::State& state) {
   attachTableInternal(
       "wide_benchmark_yield", columnDefinition(res, false, false), dbc, false);
 
-  kWideCount = state.range_y();
+  kWideCount = state.range(1);
   while (state.KeepRunning()) {
     QueryData results;
     queryInternal("select * from wide_benchmark_yield", results, dbc);


### PR DESCRIPTION
setThreadName moved to thread entry points.
Also corrected our long-standing compilation warning

> /osquery/osquery/sql/benchmarks/sql_benchmarks.cpp:252:22: warning: 'range_y' is deprecated: use 'range(1)' instead [-Wdeprecated-declarations]
>   kWideCount = state.range_y();