### PR TITLE
Remove `safeStrtoll` from conversions.h and change all use cases to `tryTo<>`

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -268,8 +268,8 @@ void restoreScheduleBlacklist(std::map<std::string, size_t>& blacklist) {
   size_t current_time = getUnixTime();
   for (size_t i = 0; i < blacklist_pairs.size() / 2; i++) {
     // Fill in a mapping of query name to time the blacklist expires.
-    long long expire = 0;
-    safeStrtoll(blacklist_pairs[(i * 2) + 1], 10, expire);
+    auto expire =
+        tryTo<long long>(blacklist_pairs[(i * 2) + 1], 10).takeOr(0ll);
     if (expire > 0 && current_time < (size_t)expire) {
       blacklist[blacklist_pairs[(i * 2)]] = (size_t)expire;
     }

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -117,18 +117,6 @@ inline Status safeStrtoul(const std::string& rep,
   return Status(0);
 }
 
-/// Safely convert a string representation of an integer base.
-inline Status safeStrtoll(const std::string& rep, size_t base, long long& out) {
-  char* end{nullptr};
-  out = strtoll(rep.c_str(), &end, static_cast<int>(base));
-  if (end == nullptr || end == rep.c_str() || *end != '\0' ||
-      ((out == LLONG_MIN || out == LLONG_MAX) && errno == ERANGE)) {
-    out = 0;
-    return Status(1);
-  }
-  return Status(0);
-}
-
 /// Safely convert unicode escaped ASCII.
 inline std::string unescapeUnicode(const std::string& escaped) {
   if (escaped.size() < 6) {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -52,11 +52,7 @@ FLAG(uint64, events_max, 50000, "Maximum number of events per type to buffer");
 
 static inline EventTime timeFromRecord(const std::string& record) {
   // Convert a stored index "as string bytes" to a time value.
-  long long afinite;
-  if (!safeStrtoll(record, 10, afinite)) {
-    return 0;
-  }
-  return afinite;
+  return static_cast<EventTime>(tryTo<long long>(record).takeOr(0ll));
 }
 
 static inline std::string toIndex(size_t i) {
@@ -82,17 +78,13 @@ static inline void getOptimizeData(EventTime& o_time,
   {
     std::string content;
     getDatabaseValue(kEvents, "optimize." + query_name, content);
-    long long optimize_time = 0;
-    safeStrtoll(content, 10, optimize_time);
-    o_time = static_cast<EventTime>(optimize_time);
+    o_time = timeFromRecord(content);
   }
 
   {
     std::string content;
     getDatabaseValue(kEvents, "optimize_eid." + query_name, content);
-    long long optimize_eid = 0;
-    safeStrtoll(content, 10, optimize_eid);
-    o_eid = static_cast<size_t>(optimize_eid);
+    o_eid = tryTo<std::size_t>(content).getOr(std::size_t{0});
   }
 }
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -285,12 +285,7 @@ void AuditEventPublisher::ProcessEvents(
     if (timestamp_it == timestamp_cache.end()) {
       std::string string_timestamp = audit_event_id.substr(0, 10);
 
-      long long int converted_value;
-      if (!safeStrtoll(string_timestamp, 10, converted_value)) {
-        event_timestamp = 0;
-      } else {
-        event_timestamp = static_cast<std::time_t>(converted_value);
-      }
+      event_timestamp = tryTo<long long>(string_timestamp).takeOr(0ll);
 
       timestamp_cache[audit_event_id] = event_timestamp;
 
@@ -345,15 +340,9 @@ bool GetIntegerFieldFromMap(std::uint64_t& value,
     value = default_value;
     return false;
   }
-
-  long long temp;
-  if (!safeStrtoll(string_value, base, temp)) {
-    value = default_value;
-    return false;
-  }
-
-  value = static_cast<std::uint64_t>(temp);
-  return true;
+  auto exp = tryTo<std::uint64_t>(string_value, base);
+  value = exp.getOr(default_value);
+  return !exp.isError();
 }
 
 void CopyFieldFromMap(Row& row,

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -441,12 +441,9 @@ void genProcess(const std::string& pid, QueryData& results) {
     VLOG(1) << proc_io.status.getMessage();
   } else {
     r["disk_bytes_read"] = proc_io.read_bytes;
-    long long write_bytes = 0;
-    long long cancelled_write_bytes = 0;
-
-    osquery::safeStrtoll(proc_io.write_bytes, 10, write_bytes);
-    osquery::safeStrtoll(
-        proc_io.cancelled_write_bytes, 10, cancelled_write_bytes);
+    long long write_bytes = tryTo<long long>(proc_io.write_bytes).takeOr(0ll);
+    long long cancelled_write_bytes =
+        tryTo<long long>(proc_io.cancelled_write_bytes).takeOr(0ll);
 
     r["disk_bytes_written"] =
         std::to_string(write_bytes - cancelled_write_bytes);

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -58,8 +58,7 @@ void LinuxSMBIOSParser::readFromSystab(const std::string& systab) {
     if (line.find("SMBIOS") == 0) {
       auto details = osquery::split(line, "=");
       if (details.size() == 2 && details[1].size() > 2) {
-        long long int address;
-        safeStrtoll(details[1], 16, address);
+        long long int address = tryTo<long long>(details[1], 16).takeOr(0ll);
 
         // Be sure not to read past the 0x000F0000 - 0x00100000 range.
         // Otherwise strict /dev/mem access will generate a log line.

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -102,14 +102,13 @@ TEST_F(SystemsTablesTests, test_users) {
 
 TEST_F(SystemsTablesTests, test_processes_memory_cpu) {
   SQL results("select * from osquery_info join processes using (pid)");
-  long long bytes;
-  safeStrtoll(results.rows()[0].at("resident_size"), 0, bytes);
+  long long bytes = std::stoll(results.rows()[0].at("resident_size"), 0, 0);
 
   // Now we expect the running test to use over 1M of RSS.
   bytes = bytes / (1024 * 1024);
   EXPECT_GT(bytes, 1U);
 
-  safeStrtoll(results.rows()[0].at("total_size"), 0, bytes);
+  bytes = std::stoll(results.rows()[0].at("total_size"), 0, 0);
   bytes = bytes / (1024 * 1024);
   EXPECT_GT(bytes, 1U);
 
@@ -117,14 +116,13 @@ TEST_F(SystemsTablesTests, test_processes_memory_cpu) {
   // more than 100 seconds of CPU.
   SQL results2("select * from osquery_info join processes using (pid)");
 
-  long long cpu_start, value;
-  safeStrtoll(results.rows()[0].at("user_time"), 0, cpu_start);
-  safeStrtoll(results2.rows()[0].at("user_time"), 0, value);
+  auto cpu_start = std::stoll(results.rows()[0].at("user_time"), 0, 0);
+  auto value = std::stoll(results2.rows()[0].at("user_time"), 0, 0);
   EXPECT_LT(value - cpu_start, 100U);
   EXPECT_GE(value - cpu_start, 0U);
 
-  safeStrtoll(results.rows()[0].at("user_time"), 0, cpu_start);
-  safeStrtoll(results2.rows()[0].at("user_time"), 0, value);
+  cpu_start = std::stoll(results.rows()[0].at("user_time"), 0, 0);
+  value = std::stoll(results2.rows()[0].at("user_time"), 0, 0);
   EXPECT_LT(value - cpu_start, 100U);
   EXPECT_GE(value - cpu_start, 0U);
 }
@@ -151,10 +149,10 @@ TEST_F(SystemsTablesTests, test_processes_disk_io) {
 
   SQL after("select * from osquery_info join processes using (pid)");
 
-  long long bytes_written_before, bytes_written_after;
-  safeStrtoll(
-      before.rows()[0].at("disk_bytes_written"), 0, bytes_written_before);
-  safeStrtoll(after.rows()[0].at("disk_bytes_written"), 0, bytes_written_after);
+  auto bytes_written_before =
+      std::stoll(before.rows()[0].at("disk_bytes_written"), 0, 0);
+  auto bytes_written_after =
+      std::stoll(after.rows()[0].at("disk_bytes_written"), 0, 0);
 
   EXPECT_GE(bytes_written_after - bytes_written_before, 1024 * 1024);
 }
@@ -202,9 +200,8 @@ TEST_F(SystemsTablesTests, test_win_drivers_query_time) {
     return;
   }
   SQL results("select * from osquery_info join processes using (pid)");
-  long long utime1, systime1;
-  safeStrtoll(results.rows()[0].at("user_time"), 0, utime1);
-  safeStrtoll(results.rows()[0].at("system_time"), 0, systime1);
+  auto utime1 = std::stoll(results.rows()[0].at("user_time"), 0, 0);
+  auto systime1 = std::stoll(results.rows()[0].at("system_time"), 0, 0);
 
   // Query the drivers table and ensure that we don't take too long to exec
   SQL drivers("select * from drivers");
@@ -213,10 +210,9 @@ TEST_F(SystemsTablesTests, test_win_drivers_query_time) {
   ASSERT_GT(drivers.rows().size(), 10U);
 
   // Get a rough idea of the time utilized by the query
-  long long utime2, systime2;
   SQL results2("select * from osquery_info join processes using (pid)");
-  safeStrtoll(results2.rows()[0].at("user_time"), 0, utime2);
-  safeStrtoll(results2.rows()[0].at("system_time"), 0, systime2);
+  auto utime2 = std::stoll(results2.rows()[0].at("user_time"), 0, 0);
+  auto systime2 = std::stoll(results2.rows()[0].at("system_time"), 0, 0);
 
   EXPECT_LT(utime2 - utime1, 10000U);
   EXPECT_LT(systime2 - systime1, 10000U);


### PR DESCRIPTION
Also, I've used a throwing `std::stoll` in tests. Because the tests should not be exception safety and must fail if something goes wrong.