### PR TITLE
Prefer /etc/os-release to identify Arch Linux

### DIFF
--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -63,15 +63,15 @@ def _platform():
                 if fileContents.find("DISTRIB_ID=Ubuntu") != -1:
                     return ("debian", "ubuntu")
 
-                if fileContents.find("DISTRIB_ID=Arch") != -1:
-                    return ("arch", "arch")
-
                 if fileContents.find("DISTRIB_ID=ManjaroLinux") != -1:
                     return ("arch", "manjaro")
 
         if os.path.exists(OS_RELEASE):
             with open(OS_RELEASE, "r") as fd:
                 fileContents = fd.read()
+
+                if fileContents.find("ID=arch") != -1:
+                    return ("arch", "arch")
 
                 if fileContents.find("ID=nixos") != -1:
                     return ("nixos", "nixos")


### PR DESCRIPTION
It is possible to identify Arch Linux without needing to install
`lsb-release` - we just use `/etc/os-release` which provides the same
level of information for what we need (and is available as part of the
base install).