### PR TITLE
build: gating osquery build hosts to VS 2015 builds

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -19,7 +19,7 @@ if (-not (Test-Path $utils)) {
 function Invoke-OsqueryCmake {
   $vsinfo = Get-VSInfo
   $cmake = (Get-Command 'cmake').Source
-  if ($vsinfo.version -eq '15'){
+  if ($vsinfo.version -eq '15' -and -not (Test-Path env:OSQUERY_BUILD_HOST)){
     $cmakeArgs = @(
       '-G "Visual Studio 15 2017 Win64"',
       '-T v141'


### PR DESCRIPTION
This offers us a gate to prevent full 2017 builds until we can sort out the 3rd party dependency failures with the migration.