### PR TITLE
Avoid verbosity of compiler complains in case of incorrect type for Expected value

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -83,10 +83,8 @@ class Expected final {
       "use smart pointers instead. See CppCoreGuidelines for explanation. "
       "https://github.com/isocpp/CppCoreGuidelines/blob/master/"
       "CppCoreGuidelines.md#Rf-unique_ptr");
-  static_assert(
-      !std::is_reference<ValueType>::value,
-      "Expected does not support reference as a value type"
-  );
+  static_assert(!std::is_reference<ValueType>::value,
+                "Expected does not support reference as a value type");
   static_assert(std::is_enum<ErrorCodeEnumType>::value,
                 "ErrorCodeEnumType template parameter must be enum");
 

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -204,6 +204,10 @@ class Expected final {
       "use smart pointers instead. See CppCoreGuidelines for explanation. "
       "https://github.com/isocpp/CppCoreGuidelines/blob/master/"
       "CppCoreGuidelines.md#Rf-unique_ptr");
+  static_assert(
+      !std::is_reference<ValueType>::value,
+      "Expected does not support reference as a value type"
+  );
   static_assert(std::is_enum<ErrorCodeEnumType>::value,
                 "ErrorCodeEnumType template parameter must be enum");
 

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -77,6 +77,19 @@ class Expected final {
   using ErrorType = Error<ErrorCodeEnumType>;
   using SelfType = Expected<ValueType, ErrorCodeEnumType>;
 
+  static_assert(
+      !std::is_pointer<ValueType>::value,
+      "Please do not use raw pointers as expected value, "
+      "use smart pointers instead. See CppCoreGuidelines for explanation. "
+      "https://github.com/isocpp/CppCoreGuidelines/blob/master/"
+      "CppCoreGuidelines.md#Rf-unique_ptr");
+  static_assert(
+      !std::is_reference<ValueType>::value,
+      "Expected does not support reference as a value type"
+  );
+  static_assert(std::is_enum<ErrorCodeEnumType>::value,
+                "ErrorCodeEnumType template parameter must be enum");
+
  public:
   Expected(ValueType value) : object_{std::move(value)} {}
 
@@ -198,19 +211,6 @@ class Expected final {
   }
 
  private:
-  static_assert(
-      !std::is_pointer<ValueType>::value,
-      "Please do not use raw pointers as expected value, "
-      "use smart pointers instead. See CppCoreGuidelines for explanation. "
-      "https://github.com/isocpp/CppCoreGuidelines/blob/master/"
-      "CppCoreGuidelines.md#Rf-unique_ptr");
-  static_assert(
-      !std::is_reference<ValueType>::value,
-      "Expected does not support reference as a value type"
-  );
-  static_assert(std::is_enum<ErrorCodeEnumType>::value,
-                "ErrorCodeEnumType template parameter must be enum");
-
   boost::variant<ValueType, ErrorType> object_;
   enum ETypeId {
     kValueType_ = 0,


### PR DESCRIPTION
To see something laconic and clear in case of incorrect usage in compiler error log. Like:
```
/Users/akindyakov/source/git.osquery/include/osquery/expected.h:86:3: error: static_assert failed "Expected does not support reference as a value type"
  static_assert(
  ^
/Users/akindyakov/source/git.osquery/osquery/core/tests/exptected_tests.cpp:267:12: note: in instantiation of template class 'osquery::Expected<int &, osquery::TestError>' requested
here
  auto e = Expected<int&, TestError>{i};
```
Instead of
```
/Users/akindyakov/source/git.osquery/include/osquery/expected.h:180:12: error: 'operator->' declared as a pointer to a reference of type 'osquery::Expected<int &, osquery::TestError>
::ValueType' (aka 'int &')
  ValueType* operator->() && = delete;
           ^
/Users/akindyakov/source/git.osquery/osquery/core/tests/exptected_tests.cpp:267:12: note: in instantiation of template class 'osquery::Expected<int &, osquery::TestError>' requested
here
  auto e = Expected<int&, TestError>{i};
           ^
In file included from /Users/akindyakov/source/git.osquery/osquery/core/tests/exptected_tests.cpp:17:
/Users/akindyakov/source/git.osquery/include/osquery/expected.h:181:12: error: 'operator->' declared as a pointer to a reference of type 'osquery::Expected<int &, osquery::TestError>
::ValueType' (aka 'int &')
  ValueType* operator->() & {
           ^
/Users/akindyakov/source/git.osquery/include/osquery/expected.h:185:18: error: 'operator->' declared as a pointer to a reference of type 'osquery::Expected<int &, osquery::TestError>
::ValueType' (aka 'int &')
  const ValueType* operator->() const&& = delete;
                 ^
/Users/akindyakov/source/git.osquery/include/osquery/expected.h:186:18: error: 'operator->' declared as a pointer to a reference of type 'osquery::Expected<int &, osquery::TestError>
::ValueType' (aka 'int &')
  const ValueType* operator->() const& {
                 ^
...
```