### PR TITLE
Fix up MdFindTests check for the number of columns in query result

### DIFF
--- a/osquery/tables/system/darwin/tests/mdfind_tests.cpp
+++ b/osquery/tables/system/darwin/tests/mdfind_tests.cpp
@@ -38,10 +38,10 @@ TEST_F(MdFindTests, test_mdfind_finds_osquery) {
 
   EXPECT_GE(results.size(), 0UL);
 
-  long count;
-  s = safeStrtol(results[0]["count(*)"], 10, count);
-
-  EXPECT_GE(count, 0);
+  for (const auto& row : results) {
+    EXPECT_EQ(row.count("path"), 1);
+    EXPECT_EQ(row.count("query"), 1);
+  }
 }
 } // namespace tables
 } // namespace osquery


### PR DESCRIPTION
As far as I can understand, the intention was to check the number of columns in one record. But something goes wrong, or I didn't get the idea. Correct me if I'm wrong, please.