### PR TITLE
 `Expected::isValue` method, to make checks 'if expected is not an error then...'

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -144,8 +144,12 @@ class Expected final {
     return object_.which() == kErrorType_;
   }
 
-  explicit operator bool() const noexcept {
+  bool isValue() const noexcept {
     return !isError();
+  }
+
+  explicit operator bool() const noexcept {
+    return isValue();
   }
 
   ValueType& get() && = delete;

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -29,6 +29,7 @@ enum class TestError {
 GTEST_TEST(ExpectedTest, success_contructor_initialization) {
   Expected<std::string, TestError> value = std::string("Test");
   EXPECT_TRUE(value);
+  EXPECT_TRUE(value.isValue());
   EXPECT_FALSE(value.isError());
   EXPECT_EQ(value.get(), "Test");
 }
@@ -37,6 +38,7 @@ GTEST_TEST(ExpectedTest, failure_error_contructor_initialization) {
   Expected<std::string, TestError> error =
       Error<TestError>(TestError::Some, "Please try again");
   EXPECT_FALSE(error);
+  EXPECT_FALSE(error.isValue());
   EXPECT_TRUE(error.isError());
   EXPECT_EQ(error.getErrorCode(), TestError::Some);
 }

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -342,7 +342,7 @@ bool GetIntegerFieldFromMap(std::uint64_t& value,
   }
   auto exp = tryTo<std::uint64_t>(string_value, base);
   value = exp.getOr(default_value);
-  return !exp.isError();
+  return exp.isValue();
 }
 
 void CopyFieldFromMap(Row& row,

--- a/osquery/tables/applications/browser_utils.h
+++ b/osquery/tables/applications/browser_utils.h
@@ -33,7 +33,7 @@ QueryData genChromeBasedExtensions(QueryContext& context,
 /// A helper check to rename bool-type values as 1 or 0.
 inline void jsonBoolAsInt(std::string& s) {
   auto expected = tryTo<bool>(s);
-  if (!expected.isError()) {
+  if (expected.isValue()) {
     s = expected.get() ? "1" : "0";
   }
 }


### PR DESCRIPTION
To make checks 'if expected is not an error then...' less verbose but more clear

Inspired by PR #4768