### PR TITLE
Fix up `stringFromCFString` bug related to non ascii strings

### DIFF
--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -25,7 +25,9 @@ std::string stringFromCFString(const CFStringRef& cf_string) {
     return "";
   }
   auto result = std::string(length + 1, '\0');
-  // According to documentation: "if there is an error in conversion, the buffer contains only partial results". And because of that we don't need to check up the return value.
+  // According to documentation: "if there is an error in conversion, the buffer
+  // contains only partial results". And because of that we don't need to check
+  // up the return value.
   CFStringGetCString(
       cf_string, &result.front(), result.size(), kCFStringEncodingUTF8);
   result.resize(result.find('\0'));

--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -18,21 +18,13 @@ namespace osquery {
 
 std::string stringFromCFString(const CFStringRef& cf_string) {
   // Access, then convert the CFString. CFStringGetCStringPtr is less-safe.
-  CFIndex length = CFStringGetLength(cf_string);
-  char* buffer = (char*)malloc(length + 1);
-  if (buffer == nullptr) {
-    return "";
-  }
-
-  if (!CFStringGetCString(
-          cf_string, buffer, length + 1, kCFStringEncodingASCII)) {
-    free(buffer);
-    return "";
-  }
-
-  // Cleanup allocations.
-  std::string result(buffer);
-  free(buffer);
+  auto const wlength = CFStringGetLength(cf_string);
+  auto const length =
+      CFStringGetMaximumSizeForEncoding(wlength, kCFStringEncodingUTF8);
+  auto result = std::string(length + 1, '\0');
+  CFStringGetCString(
+      cf_string, &result.front(), result.size(), kCFStringEncodingUTF8);
+  result.resize(result.find('\0'));
   return result;
 }
 

--- a/osquery/core/darwin/conversions.cpp
+++ b/osquery/core/darwin/conversions.cpp
@@ -21,7 +21,11 @@ std::string stringFromCFString(const CFStringRef& cf_string) {
   auto const wlength = CFStringGetLength(cf_string);
   auto const length =
       CFStringGetMaximumSizeForEncoding(wlength, kCFStringEncodingUTF8);
+  if (length == kCFNotFound) {
+    return "";
+  }
   auto result = std::string(length + 1, '\0');
+  // According to documentation: "if there is an error in conversion, the buffer contains only partial results". And because of that we don't need to check up the return value.
   CFStringGetCString(
       cf_string, &result.front(), result.size(), kCFStringEncodingUTF8);
   result.resize(result.find('\0'));

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -597,11 +597,12 @@ TEST_F(ConversionsTests, tryTo_string_to_boolean_invalid_args) {
 #ifdef DARWIN
 TEST_F(ConversionsTests, stringFromCFString) {
   auto const in_str = std::string{u8"空間"};
-  auto const cf_string_ref = CFStringCreateWithBytes(
-    kCFAllocatorDefault,
-    reinterpret_cast<const UInt8*>(in_str.data()),
-    in_str.size(), kCFStringEncodingUTF8, false
-  );
+  auto const cf_string_ref =
+      CFStringCreateWithBytes(kCFAllocatorDefault,
+                              reinterpret_cast<const UInt8*>(in_str.data()),
+                              in_str.size(),
+                              kCFStringEncodingUTF8,
+                              false);
   auto out_str = stringFromCFString(cf_string_ref);
   EXPECT_EQ(in_str, out_str);
 }

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -593,4 +593,18 @@ TEST_F(ConversionsTests, tryTo_string_to_boolean_invalid_args) {
     EXPECT_EQ(ConversionError::InvalidArgument, exp.getErrorCode());
   }
 }
+
+#ifdef DARWIN
+TEST_F(ConversionsTests, stringFromCFString) {
+  auto const in_str = std::string{u8"空間"};
+  auto const cf_string_ref = CFStringCreateWithBytes(
+    kCFAllocatorDefault,
+    reinterpret_cast<const UInt8*>(in_str.data()),
+    in_str.size(), kCFStringEncodingUTF8, false
+  );
+  auto out_str = stringFromCFString(cf_string_ref);
+  EXPECT_EQ(in_str, out_str);
+}
+#endif
+
 } // namespace osquery


### PR DESCRIPTION
You could see it in `wifi_networks` table with Chinese network name for instance.
```
osquery> select network_name from wifi_networks;
[
  {"network_name":""},
]
```
But is should be something like:
```
osquery> select network_name from wifi_networks;
[
  {"network_name":"星期天"},
]
```
The problem was in function `stringFromCFString`. It was designed to work only with ASCII strings, which is wrong. So, I fixed it.