### PR TITLE
Remove unused function split for occurrences

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -374,29 +374,6 @@ std::vector<std::string> split(const std::string& s, const std::string& delim) {
   return elems;
 }
 
-std::vector<std::string> split(const std::string& s,
-                               char delim,
-                               size_t occurences) {
-  auto delims = std::string(1, delim);
-  // Split the string normally with the required delimiter.
-  auto content = split(s, delims);
-  // While the result split exceeds the number of requested occurrences, join.
-  std::vector<std::string> accumulator;
-  std::vector<std::string> elems;
-  for (size_t i = 0; i < content.size(); i++) {
-    if (i < occurences) {
-      elems.push_back(content.at(i));
-    } else {
-      accumulator.push_back(content.at(i));
-    }
-  }
-  // Join the optional accumulator.
-  if (accumulator.size() > 0) {
-    elems.push_back(boost::algorithm::join(accumulator, delims));
-  }
-  return elems;
-}
-
 std::string getBufferSHA1(const char* buffer, size_t size) {
   // SHA1 produces 160-bit digests, so allocate (5 * 32) bits.
   uint32_t digest[5] = {0};

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -43,19 +43,6 @@ std::vector<std::string> split(const std::string& s,
                                const std::string& delim = "\t ");
 
 /**
- * @brief Split a given string based on an delimiter.
- *
- * @param s the string that you'd like to split.
- * @param delim the delimiter which you'd like to split the string by.
- * @param occurrences the number of times to split by delim.
- *
- * @return a vector of strings split by delim for occurrences.
- */
-std::vector<std::string> split(const std::string& s,
-                               char delim,
-                               size_t occurences);
-
-/**
  * @brief Join a vector of strings inserting a token string between elements
  *
  * @param s the vector of strings to be joined.

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -76,14 +76,6 @@ TEST_F(ConversionsTests, test_join) {
   EXPECT_EQ(join(content, ", "), "one, two, three");
 }
 
-TEST_F(ConversionsTests, test_split_occurences) {
-  std::string content = "T: 'S:S'";
-  std::vector<std::string> expected = {
-      "T", "'S:S'",
-  };
-  EXPECT_EQ(split(content, ':', 1), expected);
-}
-
 TEST_F(ConversionsTests, test_buffer_sha1) {
   std::string test = "test\n";
   EXPECT_EQ("4e1243bd22c66e76c2ba9eddc1f91394e57f9f83",


### PR DESCRIPTION
There are some good reasons for it:
  - it is inefficient - split everything and join the tail back if number of strings more than limit
  - it less convinient than boost::split because dedicated only to byte strings and vectors of byte strings
  - there is no usage in the code