### PR TITLE
Killswitch TLS plugin improved interface

### DIFF
--- a/osquery/killswitch/plugins/killswitch_tls.cpp
+++ b/osquery/killswitch/plugins/killswitch_tls.cpp
@@ -64,6 +64,17 @@ TLSKillswitchPlugin::refresh() {
         "Could not retreive config file from network");
   }
 
+  JSON tree;
+  Status parse_status = tree.fromString(content);
+  if (!parse_status.ok()) {
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
+                       "Could not parse JSON from TLS killswitch node API");
+  }
+
+  // Extract config map from json
+  auto it = tree.doc().FindMember("config");
+  content = (it != tree.doc().MemberEnd() && it->value.IsString()) ? it->value.GetString() : "");
+
   auto result = KillswitchPlugin::parseMapJSON(content);
   if (result) {
     setCache(*result);

--- a/osquery/killswitch/plugins/killswitch_tls.cpp
+++ b/osquery/killswitch/plugins/killswitch_tls.cpp
@@ -73,7 +73,12 @@ TLSKillswitchPlugin::refresh() {
 
   // Extract config map from json
   auto it = tree.doc().FindMember("config");
-  content = (it != tree.doc().MemberEnd() && it->value.IsString()) ? it->value.GetString() : "");
+  if (it == tree.doc().MemberEnd()) {
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
+                       "killswitch member config is not string");
+  }
+
+  content = it->value.GetString();
 
   auto result = KillswitchPlugin::parseMapJSON(content);
   if (result) {

--- a/osquery/killswitch/plugins/killswitch_tls.cpp
+++ b/osquery/killswitch/plugins/killswitch_tls.cpp
@@ -46,7 +46,10 @@ Status TLSKillswitchPlugin::setUp() {
   }
 
   uri_ = TLSRequestHelper::makeURI(FLAGS_killswitch_tls_endpoint);
-  return Status(0, "OK");
+  uri_ += ((uri_.find('?') != std::string::npos) ? "&" : "?");
+  uri_ += "request=killswitch";
+
+  return KillswitchRefreshablePlugin::setUp();
 }
 
 ExpectedSuccess<KillswitchRefreshablePlugin::RefreshError>


### PR DESCRIPTION
Killswitch content schema changed. Now killswitch map resides in "config"
In post request, killswitch plugin adds request=killswitch to make it more apparent what it's asking for and also to make it possible having same config and killswitch endpoint.
TLS plugin needed to call refreshable setup