### PR TITLE
Move out base64 decode/encode functions to separate file

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -23,6 +23,7 @@
 #include <osquery/system.h>
 
 #include "osquery/carver/carver.h"
+#include "osquery/core/base64.h"
 #include "osquery/core/conversions.h"
 #include "osquery/core/hashing.h"
 #include "osquery/core/json.h"
@@ -294,7 +295,7 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
     params.add("block_id", i);
     params.add("session_id", session_id);
     params.add("request_id", requestId_);
-    params.add("data", base64Encode(std::string(block.begin(), block.end())));
+    params.add("data", base64::encode(std::string(block.begin(), block.end())));
 
     // TODO: Error sending files.
     status = contRequest.call(params);

--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 target_sources(libosquery
   PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/base64.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/base64.h"
     "${CMAKE_CURRENT_LIST_DIR}/conversions.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/conversions.h"
     "${CMAKE_CURRENT_LIST_DIR}/flags.cpp"
@@ -59,6 +61,7 @@ if(WINDOWS)
 endif()
 
 ADD_OSQUERY_TEST_CORE(
+  "${CMAKE_CURRENT_LIST_DIR}/tests/base64_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/conversions_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/error_tests.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/tests/exptected_tests.cpp"

--- a/osquery/core/base64.cpp
+++ b/osquery/core/base64.cpp
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <boost/algorithm/string.hpp>
+#include <boost/archive/iterators/base64_from_binary.hpp>
+#include <boost/archive/iterators/binary_from_base64.hpp>
+#include <boost/archive/iterators/transform_width.hpp>
+
+#include <osquery/logger.h>
+
+#include "osquery/core/base64.h"
+
+namespace bai = boost::archive::iterators;
+
+namespace osquery {
+
+namespace base64 {
+
+namespace {
+
+typedef bai::binary_from_base64<const char*> base64_str;
+typedef bai::transform_width<base64_str, 8, 6> base64_dec;
+typedef bai::transform_width<std::string::const_iterator, 6, 8> base64_enc;
+typedef bai::base64_from_binary<base64_enc> it_base64;
+
+} // namespace
+
+std::string decode(std::string encoded) {
+  boost::erase_all(encoded, "\r\n");
+  boost::erase_all(encoded, "\n");
+  boost::trim_right_if(encoded, boost::is_any_of("="));
+
+  if (encoded.empty()) {
+    return encoded;
+  }
+
+  try {
+    return std::string(base64_dec(encoded.data()),
+                       base64_dec(encoded.data() + encoded.size()));
+  } catch (const boost::archive::iterators::dataflow_exception& e) {
+    LOG(INFO) << "Could not base64 decode string: " << e.what();
+    return "";
+  }
+}
+
+std::string encode(const std::string& unencoded) {
+  if (unencoded.empty()) {
+    return unencoded;
+  }
+
+  size_t writePaddChars = (3U - unencoded.length() % 3U) % 3U;
+  try {
+    auto encoded =
+        std::string(it_base64(unencoded.begin()), it_base64(unencoded.end()));
+    encoded.append(std::string(writePaddChars, '='));
+    return encoded;
+  } catch (const boost::archive::iterators::dataflow_exception& e) {
+    LOG(INFO) << "Could not base64 decode string: " << e.what();
+    return "";
+  }
+}
+
+} // namespace base64
+} // namespace osquery

--- a/osquery/core/base64.h
+++ b/osquery/core/base64.h
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace osquery {
+
+namespace base64 {
+
+/**
+ * @brief Decode a base64 encoded string.
+ *
+ * @param encoded The encode base64 string.
+ * @return Decoded string.
+ */
+std::string decode(std::string encoded);
+
+/**
+ * @brief Encode a  string.
+ *
+ * @param A string to encode.
+ * @return Encoded string.
+ */
+std::string encode(const std::string& unencoded);
+
+} // namespace base64
+
+} // namespace osquery

--- a/osquery/core/conversions.h
+++ b/osquery/core/conversions.h
@@ -69,22 +69,6 @@ inline std::string join(const SequenceType& s, const std::string& tok) {
 }
 
 /**
- * @brief Decode a base64 encoded string.
- *
- * @param encoded The encode base64 string.
- * @return Decoded string.
- */
-std::string base64Decode(std::string encoded);
-
-/**
- * @brief Encode a  string.
- *
- * @param A string to encode.
- * @return Encoded string.
- */
-std::string base64Encode(const std::string& unencoded);
-
-/**
  * @brief Check if a string is ASCII printable
  *
  * @param A string to check.

--- a/osquery/core/tests/base64_tests.cpp
+++ b/osquery/core/tests/base64_tests.cpp
@@ -1,0 +1,30 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/tests/test_util.h>
+
+#include "osquery/core/base64.h"
+
+namespace osquery {
+
+class Base64Tests : public testing::Test {};
+
+TEST_F(Base64Tests, test_base64) {
+  std::string unencoded = "HELLO";
+  auto encoded = base64::encode(unencoded);
+  EXPECT_NE(encoded.size(), 0U);
+
+  auto unencoded2 = base64::decode(encoded);
+  EXPECT_EQ(unencoded, unencoded2);
+}
+
+} // namespace osquery

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -24,15 +24,6 @@ DECLARE_bool(utc);
 
 class ConversionsTests : public testing::Test {};
 
-TEST_F(ConversionsTests, test_base64) {
-  std::string unencoded = "HELLO";
-  auto encoded = base64Encode(unencoded);
-  EXPECT_NE(encoded.size(), 0U);
-
-  auto unencoded2 = base64Decode(encoded);
-  EXPECT_EQ(unencoded, unencoded2);
-}
-
 TEST_F(ConversionsTests, test_ascii_true) {
   std::string unencoded = "HELLO";
   auto result = isPrintable(unencoded);

--- a/osquery/filesystem/darwin/plist.mm
+++ b/osquery/filesystem/darwin/plist.mm
@@ -20,6 +20,7 @@
 #include <osquery/system.h>
 
 #include "osquery/core/conversions.h"
+#include <osquery/core/base64.h>
 
 namespace fs = boost::filesystem;
 namespace pt = boost::property_tree;
@@ -240,7 +241,7 @@ static Status pathFromUnknownAlias(const CFDataRef& data, std::string& result) {
 
 /// Parse a Login Items Plist Alias data for bin path
 Status pathFromPlistAliasData(const std::string& data, std::string& result) {
-  auto decoded = base64Decode(data);
+  auto decoded = base64::decode(data);
   if (decoded.size() == 0) {
     // Base64 encoded data (from plist parsing) failed to decode.
     return Status(1, "Failed base64 decode");

--- a/osquery/filesystem/darwin/tests/plist_tests.cpp
+++ b/osquery/filesystem/darwin/tests/plist_tests.cpp
@@ -15,6 +15,7 @@
 #include <osquery/filesystem.h>
 #include <osquery/logger.h>
 
+#include "osquery/core/base64.h"
 #include "osquery/core/conversions.h"
 #include "osquery/tests/test_util.h"
 
@@ -97,7 +98,7 @@ TEST_F(PlistTests, test_parse_plist_content_with_blobs) {
   auto first_element =
       tree.get_child("SessionItems.CustomListItems").begin()->second;
   EXPECT_EQ(first_element.get<std::string>("Name"), "Flux");
-  std::string alias = base64Decode(first_element.get<std::string>("Alias"));
+  std::string alias = base64::decode(first_element.get<std::string>("Alias"));
 
   // Verify we parsed the binary blob correctly
   EXPECT_NE(alias.find("Applications/Flux.app"), std::string::npos);

--- a/osquery/sql/sqlite_encoding.cpp
+++ b/osquery/sql/sqlite_encoding.cpp
@@ -12,6 +12,7 @@
 
 #include <sqlite3.h>
 
+#include "osquery/core/base64.h"
 #include "osquery/core/conversions.h"
 
 namespace osquery {
@@ -43,10 +44,10 @@ static void b64SqliteValue(sqlite3_context* ctx,
       break;
     }
   case B64Type::B64_ENCODE:
-    result = base64Encode(input);
+    result = base64::encode(input);
     break;
   case B64Type::B64_DECODE:
-    result = base64Decode(input);
+    result = base64::decode(input);
     break;
   }
   sqlite3_result_text(

--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -19,6 +19,7 @@
 #include <osquery/sql.h>
 #include <osquery/tables.h>
 
+#include "osquery/core/base64.h"
 #include "osquery/core/conversions.h"
 
 namespace fs = boost::filesystem;
@@ -102,7 +103,7 @@ void setRow(QueryData& results,
   r["directory"] = boost::filesystem::path(path).parent_path().string();
   r["key"] = key;
   auto value_printable = isPrintable(value);
-  r["value"] = (value_printable) ? value : base64Encode(value);
+  r["value"] = (value_printable) ? value : base64::encode(value);
   r["base64"] = (value_printable) ? INTEGER(0) : INTEGER(1);
   results.push_back(r);
 }

--- a/osquery/tables/system/darwin/tests/certificates_tests.cpp
+++ b/osquery/tables/system/darwin/tests/certificates_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <osquery/logger.h>
 
+#include "osquery/core/base64.h"
 #include "osquery/tables/system/darwin/keychain.h"
 #include "osquery/tests/test_util.h"
 
@@ -24,7 +25,7 @@ class CACertsTests : public ::testing::Test {
     std::string raw;
     CFDataRef data;
 
-    raw = base64Decode(getCACertificateContent());
+    raw = base64::decode(getCACertificateContent());
     data =
         CFDataCreate(nullptr, (const UInt8 *)raw.c_str(), (CFIndex)raw.size());
     cert = SecCertificateCreateWithData(nullptr, data);

--- a/osquery/tables/system/darwin/time_machine.cpp
+++ b/osquery/tables/system/darwin/time_machine.cpp
@@ -15,6 +15,7 @@
 #include <osquery/filesystem.h>
 #include <osquery/tables.h>
 
+#include "osquery/core/base64.h"
 #include "osquery/core/conversions.h"
 
 namespace pt = boost::property_tree;
@@ -72,8 +73,7 @@ QueryData genTimeMachineDestinations(QueryContext& context) {
     r["bytes_available"] = dest.second.get("BytesAvailable", "");
     r["encryption"] = dest.second.get("LastKnownEncryptionState", "");
 
-    std::string alias_data =
-        osquery::base64Decode(dest.second.get("BackupAlias", ""));
+    std::string alias_data = base64::decode(dest.second.get("BackupAlias", ""));
     if (alias_data.size() < 11) {
       results.push_back(r);
       continue;


### PR DESCRIPTION
It barely related to type conversion functions, so it is a good reason to live outside of it.
Just movement and small renaming. There is no changes in functional part.

(There is a bug in encoding implementation, but let me fix it after this PR)