### PR TITLE
pauseMili to pause transform

### DIFF
--- a/include/osquery/config.h
+++ b/include/osquery/config.h
@@ -243,7 +243,7 @@ class Config : private boost::noncopyable {
   Status refresh();
 
   /// Update the refresh rate.
-  void setRefresh(size_t refresh, size_t mod = 0);
+  void setRefresh(size_t refresh_sec);
 
   /// Inspect the refresh rate.
   size_t getRefresh() const;

--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -50,12 +50,7 @@ class InterruptableRunnable {
   virtual void stop() = 0;
 
   /// Put the runnable into an interruptible sleep.
-  inline void pauseMilli(size_t milli) {
-    pauseMilli(std::chrono::milliseconds(milli));
-  }
-
-  /// Put the runnable into an interruptible sleep.
-  void pauseMilli(std::chrono::milliseconds milli);
+  void pause(std::chrono::milliseconds milli);
 
   /// Name of the InterruptableRunnable which is also the thread name
   std::string runnable_name_;

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -1,4 +1,4 @@
-   /**
+/**
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -9,11 +9,11 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <map>
 #include <string>
 #include <vector>
-#include <chrono>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -1,4 +1,4 @@
-/**
+   /**
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
@@ -249,8 +250,7 @@ class ConfigRefreshRunner : public InternalRunnable {
 
  private:
   /// The current refresh rate in seconds.
-  std::atomic<size_t> refresh_{0};
-  std::atomic<size_t> mod_{1000};
+  std::atomic<size_t> refresh_sec_{0};
 
  private:
   friend class Config;
@@ -482,15 +482,12 @@ Status Config::refresh() {
   return status;
 }
 
-void Config::setRefresh(size_t refresh, size_t mod) {
-  refresh_runner_->refresh_ = refresh;
-  if (mod > 0) {
-    refresh_runner_->mod_ = mod;
-  }
+void Config::setRefresh(size_t refresh_sec) {
+  refresh_runner_->refresh_sec_ = refresh_sec;
 }
 
 size_t Config::getRefresh() const {
-  return refresh_runner_->refresh_;
+  return refresh_runner_->refresh_sec_;
 }
 
 Status Config::load() {
@@ -1026,7 +1023,7 @@ void ConfigRefreshRunner::start() {
   while (!interrupted()) {
     // Cool off and time wait the configured period.
     // Apply this interruption initially as at t=0 the config was read.
-    pauseMilli(refresh_ * mod_);
+    pause(std::chrono::seconds(refresh_sec_));
     // Since the pause occurs before the logic, we need to check for an
     // interruption request.
     if (interrupted()) {

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -511,7 +511,7 @@ TEST_F(ConfigTests, test_config_refresh) {
   // Set a config_refresh value to convince the Config to start the thread.
   FLAGS_config_refresh = 2;
   FLAGS_config_accelerated_refresh = 1;
-  get().setRefresh(FLAGS_config_refresh, 10);
+  get().setRefresh(FLAGS_config_refresh);
 
   // Fail the first config load.
   plugin->fail_ = true;

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <cstring>
+#include <chrono>
 
 #include <math.h>
 #include <signal.h>
@@ -247,7 +248,7 @@ void WatcherRunner::start() {
       // A test harness can end the thread immediately.
       break;
     }
-    pauseMilli(getWorkerLimit(WatchdogLimitType::INTERVAL) * 1000);
+    pause(std::chrono::seconds(getWorkerLimit(WatchdogLimitType::INTERVAL)));
   } while (!interrupted() && ok());
 }
 
@@ -287,7 +288,7 @@ void WatcherRunner::watchExtensions() {
         systemLog(error.str());
         LOG(WARNING) << error.str();
         stopChild(*extension.second);
-        pauseMilli(getWorkerLimit(WatchdogLimitType::INTERVAL) * 1000);
+        pause(std::chrono::seconds(getWorkerLimit(WatchdogLimitType::INTERVAL)));
       }
 
       // The extension manager also watches for extension-related failures.
@@ -530,7 +531,7 @@ void WatcherRunner::createWorker() {
       // Exponential back off for quickly-respawning clients.
       delay += static_cast<size_t>(pow(2, watcher.workerRestartCount()));
       delay = std::min(static_cast<size_t>(FLAGS_watchdog_max_delay), delay);
-      pauseMilli(delay * 1000);
+      pause(std::chrono::seconds(delay));
     }
   }
 
@@ -638,7 +639,7 @@ void WatcherWatcherRunner::start() {
       Initializer::requestShutdown();
       break;
     }
-    pauseMilli(getWorkerLimit(WatchdogLimitType::INTERVAL) * 1000);
+    pause(std::chrono::seconds(getWorkerLimit(WatchdogLimitType::INTERVAL)));
   }
 }
 

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -8,8 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <cstring>
 #include <chrono>
+#include <cstring>
 
 #include <math.h>
 #include <signal.h>
@@ -288,7 +288,8 @@ void WatcherRunner::watchExtensions() {
         systemLog(error.str());
         LOG(WARNING) << error.str();
         stopChild(*extension.second);
-        pause(std::chrono::seconds(getWorkerLimit(WatchdogLimitType::INTERVAL)));
+        pause(
+            std::chrono::seconds(getWorkerLimit(WatchdogLimitType::INTERVAL)));
       }
 
       // The extension manager also watches for extension-related failures.

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -37,7 +37,7 @@ bool InterruptableRunnable::interrupted() {
   return interrupted_;
 }
 
-void InterruptableRunnable::pauseMilli(std::chrono::milliseconds milli) {
+void InterruptableRunnable::pause(std::chrono::milliseconds milli) {
   std::unique_lock<std::mutex> lock(condition_lock);
   if (!interrupted_) {
     condition_.wait_for(lock, milli);

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -8,6 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <chrono>
+
 #include <osquery/database.h>
 #include <osquery/distributed.h>
 #include <osquery/flags.h>
@@ -43,9 +45,9 @@ void DistributedRunner::start() {
     Status conversion = safeStrtoul(str_acu, 10, accelerate_checkins_expire);
     if (!database.ok() || !conversion.ok() ||
         getUnixTime() > accelerate_checkins_expire) {
-      pauseMilli(FLAGS_distributed_interval * 1000);
+      pause(std::chrono::seconds(FLAGS_distributed_interval));
     } else {
-      pauseMilli(kDistributedAccelerationInterval * 1000);
+      pause(std::chrono::seconds(kDistributedAccelerationInterval));
     }
   }
 }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -217,7 +217,8 @@ void SchedulerRunner::start() {
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - start_time_point);
     if (loop_step_duration + time_drift_ < interval_) {
-      pause(std::chrono::milliseconds(interval_ - loop_step_duration - time_drift_));
+      pause(std::chrono::milliseconds(interval_ - loop_step_duration -
+                                      time_drift_));
       time_drift_ = std::chrono::milliseconds::zero();
     } else {
       time_drift_ += loop_step_duration - interval_;

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -217,7 +217,7 @@ void SchedulerRunner::start() {
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - start_time_point);
     if (loop_step_duration + time_drift_ < interval_) {
-      pauseMilli(interval_ - loop_step_duration - time_drift_);
+      pause(std::chrono::milliseconds(interval_ - loop_step_duration - time_drift_));
       time_drift_ = std::chrono::milliseconds::zero();
     } else {
       time_drift_ += loop_step_duration - interval_;

--- a/osquery/dispatcher/tests/dispatcher_tests.cpp
+++ b/osquery/dispatcher/tests/dispatcher_tests.cpp
@@ -8,6 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
+#include <chrono>
+
 #include <gtest/gtest.h>
 
 #include <osquery/dispatcher.h>
@@ -121,7 +123,7 @@ class BlockingTestRunnable : public InternalTestableRunnable {
 
   virtual void start() override {
     // Wow that's a long sleep!
-    pauseMilli(100 * 1000);
+    pause(std::chrono::seconds(100));
   }
 };
 

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -795,7 +795,7 @@ Status EventFactory::run(const std::string& type_id) {
     // This is a 'default' cool-off implemented in InterruptableRunnable.
     // If a publisher fails to perform some sort of interruption point, this
     // prevents the thread from thrashing through exiting checks.
-    publisher->pauseMilli(200);
+    publisher->pause(std::chrono::milliseconds(200));
   }
   if (!status.ok()) {
     // The runloop status is not reflective of the event type's.

--- a/osquery/events/kernel.cpp
+++ b/osquery/events/kernel.cpp
@@ -148,7 +148,7 @@ Status KernelEventPublisher::run() {
   }
 
   // Pause for a cool-off since we implement comms in a no-blocking mode.
-  pauseMilli(1000);
+  pause(std::chrono::seconds(1));
   return Status(0, "Continue");
 }
 

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -98,7 +98,7 @@ Status UdevEventPublisher::run() {
     udev_device_unref(device);
   }
 
-  pauseMilli(kUdevMLatency);
+  pause(std::chrono::milliseconds(kUdevMLatency));
   return Status(0, "OK");
 }
 

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -63,7 +63,7 @@ void WindowsEventLogEventPublisher::configure() {
 }
 
 Status WindowsEventLogEventPublisher::run() {
-  pauseMilli(100);
+  pause(std::chrono::milliseconds(100));
   return Status(0, "OK");
 }
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -196,7 +196,7 @@ void ExtensionWatcher::start() {
   // service is added and started.
   while (!interrupted()) {
     watch();
-    pauseMilli(interval_);
+    pause(std::chrono::milliseconds(interval_));
   }
 }
 
@@ -204,7 +204,7 @@ void ExtensionManagerWatcher::start() {
   // Watch each extension.
   while (!interrupted()) {
     watch();
-    pauseMilli(interval_);
+    pause(std::chrono::milliseconds(interval_));
   }
 
   // When interrupted, request each extension tear down.

--- a/osquery/killswitch/killswitch_refreshable_plugin.cpp
+++ b/osquery/killswitch/killswitch_refreshable_plugin.cpp
@@ -30,7 +30,7 @@ class KillswitchRefresher : public InternalRunnable {
   /// A simple wait/interruptible lock.
   void start() override {
     while (!interrupted()) {
-      pauseMilli(std::chrono::milliseconds(update_interval_));
+      pause(std::chrono::milliseconds(update_interval_));
       osquery::Killswitch::get().refresh();
     }
   }

--- a/osquery/logger/plugins/aws_log_forwarder.h
+++ b/osquery/logger/plugins/aws_log_forwarder.h
@@ -200,7 +200,7 @@ class AwsLogForwarder : public BufferedLogForwarder {
       size_t retry_delay =
           (retry == 0 ? 0 : base_retry_delay) + (retry * 1000U);
       if (retry_delay != 0) {
-        pauseMilli(retry_delay);
+        pause(std::chrono::milliseconds(retry_delay));
       }
 
       // Attempt to send the batch

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -170,7 +170,7 @@ void BufferedLogForwarder::start() {
     check();
 
     // Cool off and time wait the configured period.
-    pauseMilli(log_period_);
+    pause(std::chrono::milliseconds(log_period_));
   }
 }
 

--- a/osquery/logger/plugins/kafka_producer.cpp
+++ b/osquery/logger/plugins/kafka_producer.cpp
@@ -146,7 +146,7 @@ void KafkaProducerPlugin::pollKafka() {
 
 void KafkaProducerPlugin::start() {
   while (!interrupted() && running_.load()) {
-    pauseMilli(kKafkaPollDuration);
+    pause(std::chrono::milliseconds(kKafkaPollDuration));
     if (interrupted()) {
       return;
     }

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -182,8 +182,7 @@ class PreAggregationFlusher : public InternalRunnable {
   void start() override {
     while (!interrupted() &&
            0 != FLAGS_numeric_monitoring_pre_aggregation_time) {
-      pauseMilli(
-          std::chrono::seconds(FLAGS_numeric_monitoring_pre_aggregation_time));
+      pause(std::chrono::seconds(FLAGS_numeric_monitoring_pre_aggregation_time));
       PreAggregationBuffer::get().flush();
     }
   }

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -182,7 +182,8 @@ class PreAggregationFlusher : public InternalRunnable {
   void start() override {
     while (!interrupted() &&
            0 != FLAGS_numeric_monitoring_pre_aggregation_time) {
-      pause(std::chrono::seconds(FLAGS_numeric_monitoring_pre_aggregation_time));
+      pause(
+          std::chrono::seconds(FLAGS_numeric_monitoring_pre_aggregation_time));
       PreAggregationBuffer::get().flush();
     }
   }


### PR DESCRIPTION
pauseMili renamed to pause. Removed pause without chrono time to get rid of the confusion. 
Improved use of pause by getting rid of multipliers.