### PR TITLE
Use putBatch only for multiple puts, fix bug in setDatabaseVal

### DIFF
--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -256,7 +256,7 @@ Status sendPutBatchDatabaseRequest(const std::string& domain,
 Status sendPutDatabaseRequest(const std::string& domain,
                               const DatabaseStringValueList& data) {
   const auto& key = data[0].first;
-  const auto& value = data[1].second;
+  const auto& value = data[0].second;
 
   PluginRequest request = {
       {"action", "put"}, {"domain", domain}, {"key", key}, {"value", value}};
@@ -328,7 +328,7 @@ Status setDatabaseBatch(const std::string& domain,
   // External registries (extensions) do not have databases active.
   // It is not possible to use an extension-based database.
   if (RegistryFactory::get().external()) {
-    if (data.size() >= 1) {
+    if (data.size() > 1) {
       return sendPutBatchDatabaseRequest(domain, data);
     } else {
       return sendPutDatabaseRequest(domain, data);

--- a/osquery/database/tests/database_tests.cpp
+++ b/osquery/database/tests/database_tests.cpp
@@ -37,7 +37,7 @@ TEST_F(DatabaseTests, test_set_value_int) {
 
 TEST_F(DatabaseTests, test_set_str_batch) {
   DatabaseStringValueList batch = {
-      {"str1", "{}"}, {"str2", "{}"}, {"str3", "{}"}};
+      {"str1", "{a}"}, {"str2", "{b}"}, {"str3", "{c}"}};
 
   auto s = setDatabaseBatch(kLogs, batch);
   EXPECT_TRUE(s.ok());
@@ -111,7 +111,7 @@ TEST_F(DatabaseTests, test_get_value_mix1) {
 
 TEST_F(DatabaseTests, test_get_str_batch) {
   DatabaseStringValueList batch = {
-      {"str1", "{}"}, {"str2", "{}"}, {"str3", "{}"}};
+      {"str1", "{a}"}, {"str2", "{b}"}, {"str3", "{c}"}};
   auto s = setDatabaseBatch(kLogs, batch);
   EXPECT_TRUE(s.ok());
 


### PR DESCRIPTION
`sendPutDatabaseRequest` grabbed the value from the wrong data point.
Changed to use the batch db processing only for >1 values in the list, instead of always.