### PR TITLE
gracefully shutdown -  AuditdNetlinkParser will not wait indefinitely

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -669,7 +669,8 @@ void AuditdNetlinkParser::start() {
           auditd_context_->unprocessed_records_mutex);
 
       while (auditd_context_->unprocessed_records.empty() && !interrupted()) {
-        auditd_context_->unprocessed_records_cv.wait(lock);
+        auditd_context_->unprocessed_records_cv.wait_for(
+            lock, std::chrono::seconds(1));
       }
 
       queue = std::move(auditd_context_->unprocessed_records);


### PR DESCRIPTION
Split of the PR @4714 
Thanks @alessandrogario 
@alessandrogario  text for this part of the PR

## Delay when terminating osqueryi
A 1-second timeout has been added to the wait call inside the  `AuditdNetlinkParser` service so that it now has a chance to check for the `interrupted()` status and correctly terminate even if the `AuditdNetlinkReader` service is no longer running and sending notifications.

The bug did not affect the osqueryd daemon because the signal sent on termination was able to wake up the service.
