### PR TITLE
Fixing Bugs introduced by #4742

### DIFF
--- a/include/osquery/dispatcher.h
+++ b/include/osquery/dispatcher.h
@@ -130,7 +130,7 @@ using InternalThreadRef = std::unique_ptr<std::thread>;
  */
 class Dispatcher : private boost::noncopyable {
  public:
-  virtual ~Dispatcher();
+  virtual ~Dispatcher() = default;
   /**
    * @brief The primary way to access the Dispatcher factory facility.
    *

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -146,11 +146,6 @@ void Dispatcher::joinServices() {
   DLOG(INFO) << "Services and threads have been cleared";
 }
 
-Dispatcher::~Dispatcher() {
-  stopServices();
-  joinServices();
-}
-
 void Dispatcher::stopServices() {
   auto& self = instance();
   self.stopping_ = true;

--- a/osquery/dispatcher/io_service.cpp
+++ b/osquery/dispatcher/io_service.cpp
@@ -15,11 +15,11 @@
 namespace osquery {
 
 void IOContextRunner::start() {
-  while (!interrupted()) {
+  while (true) {
     try {
       boost::asio::executor_work_guard<boost::asio::io_context::executor_type>
           work = boost::asio::make_work_guard(IOContext::get());
-      work.reset();
+      IOContext::get().run();
       return;
     } catch (const std::exception& e) {
       LOG(WARNING) << "IOContextRunner: handler exception: " << e.what();

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -172,10 +172,10 @@ int startOsquery(int argc, char* argv[], std::function<void()> shutdown) {
   // In either case the watcher may start optionally loaded extensions.
   runner.initWorkerWatcher(kWatcherWorkerName);
 
-  // Begin adhoc io service thread.
-  startIOContext();
 
   if (runner.isDaemon()) {
+    // Begin adhoc io service thread.
+    startIOContext();
     return startDaemon(runner);
   }
   return startShell(runner, argc, argv);


### PR DESCRIPTION
There are two bug introduced by the pr https://github.com/facebook/osquery/pull/4742
1. IOContext::get().run() is missing. At least one thread to call this function.
    In absense of this fucntion io service thread exits immediatly. 
2.  
Dispatcher::~Dispatcher() {
  stopServices();
  joinServices();
}

Threads are still running while static destruction started. There might be possiblity is that threads are using already freed resource( memory etc...). 
In other words program might subject to static destunction order fiasco .

Simple rule a program should follow -
enter the main 
go multithreaded
wait
go single threaded 
exit the main

Now io service thread will start if osquery is running in daemon mode.



./tools/analysis/profile.py --leaks --query "select * from curl_certificate where hostname='google.com'"
Analyzing leaks in query: select * from curl_certificate where hostname='google.com'

  possibly: 0 bytes in 0 blocks; definitely: 0 bytes in 0 blocks; indirectly: 0 bytes in 0 blocks
