### PR TITLE
Add constness for the methods of class `WmiRequest`

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -182,8 +182,8 @@ std::string generateHostUUID() {
     hardware_uuid = std::string(out);
   }
 #elif WIN32
-  WmiRequest wmiUUIDReq("Select UUID from Win32_ComputerSystemProduct");
-  std::vector<WmiResultItem>& wmiUUIDResults = wmiUUIDReq.results();
+  const WmiRequest wmiUUIDReq("Select UUID from Win32_ComputerSystemProduct");
+  const std::vector<WmiResultItem>& wmiUUIDResults = wmiUUIDReq.results();
   if (wmiUUIDResults.size() != 0) {
     wmiUUIDResults[0].GetString("UUID", hardware_uuid);
   }

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -185,7 +185,7 @@ class WmiRequest {
   WmiRequest(WmiRequest&& src);
   ~WmiRequest();
 
-  const std::vector<WmiResultItem>& results() const{
+  const std::vector<WmiResultItem>& results() const {
     return results_;
   }
 
@@ -194,7 +194,7 @@ class WmiRequest {
   *
   * @returns the status of the WMI request.
   */
-  Status getStatus() const{
+  Status getStatus() const {
     return status_;
   }
 

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -185,7 +185,7 @@ class WmiRequest {
   WmiRequest(WmiRequest&& src);
   ~WmiRequest();
 
-  std::vector<WmiResultItem>& results() {
+  const std::vector<WmiResultItem>& results() const{
     return results_;
   }
 
@@ -194,7 +194,7 @@ class WmiRequest {
   *
   * @returns the status of the WMI request.
   */
-  Status getStatus() {
+  Status getStatus() const{
     return status_;
   }
 

--- a/osquery/tables/networking/windows/arp_cache.cpp
+++ b/osquery/tables/networking/windows/arp_cache.cpp
@@ -42,7 +42,7 @@ QueryData genIPv4ArpCache(QueryContext& context) {
   QueryData results;
   auto interfaces = genInterfaceDetails(context);
   const WmiRequest wmiSystemReq("select * from MSFT_NetNeighbor",
-                          (BSTR)L"ROOT\\StandardCimv2");
+                                (BSTR)L"ROOT\\StandardCimv2");
   const auto& wmiResults = wmiSystemReq.results();
   std::map<long, std::string> mapOfInterfaces = {
       {1, ""}, // loopback

--- a/osquery/tables/networking/windows/arp_cache.cpp
+++ b/osquery/tables/networking/windows/arp_cache.cpp
@@ -41,9 +41,9 @@ const std::map<unsigned char, const std::string> kMapOfState = {
 QueryData genIPv4ArpCache(QueryContext& context) {
   QueryData results;
   auto interfaces = genInterfaceDetails(context);
-  WmiRequest wmiSystemReq("select * from MSFT_NetNeighbor",
+  const WmiRequest wmiSystemReq("select * from MSFT_NetNeighbor",
                           (BSTR)L"ROOT\\StandardCimv2");
-  auto& wmiResults = wmiSystemReq.results();
+  const auto& wmiResults = wmiSystemReq.results();
   std::map<long, std::string> mapOfInterfaces = {
       {1, ""}, // loopback
   };

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -62,9 +62,9 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       "Name = \"" +
       r["description"] + "\"";
 
-  WmiRequest req1(query);
+  const WmiRequest req1(query);
   if (req1.getStatus().ok()) {
-    auto& results = req1.results();
+    const auto& results = req1.results();
     if (!results.empty()) {
       std::string sPlaceHolder;
 
@@ -97,9 +97,9 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       "SELECT * FROM Win32_NetworkAdapter WHERE "
       "InterfaceIndex = " +
       r["interface"];
-  WmiRequest req2(query);
+  const WmiRequest req2(query);
   if (req2.getStatus().ok()) {
-    auto& results = req2.results();
+    const auto& results = req2.results();
     if (!results.empty()) {
       bool bPlaceHolder;
       long lPlaceHolder = 0;
@@ -125,9 +125,9 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       "SELECT * FROM win32_networkadapterconfiguration WHERE "
       "InterfaceIndex = " +
       r["interface"];
-  WmiRequest req3(query);
+  const WmiRequest req3(query);
   if (req3.getStatus().ok()) {
-    auto& results = req3.results();
+    const auto& results = req3.results();
     if (!results.empty()) {
       bool bPlaceHolder;
       std::vector<std::string> vPlaceHolder;

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -22,10 +22,10 @@ QueryData genBitlockerInfo(QueryContext& context) {
   Row r;
   QueryData results;
 
-  WmiRequest wmiSystemReq(
+  const WmiRequest wmiSystemReq(
       "SELECT * FROM Win32_EncryptableVolume",
       (BSTR)L"ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  const std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (wmiResults.empty()) {
     LOG(WARNING) << "Error retreiving information from WMI.";
     return results;

--- a/osquery/tables/system/windows/cpu_info.cpp
+++ b/osquery/tables/system/windows/cpu_info.cpp
@@ -22,8 +22,8 @@ QueryData genCpuInfo(QueryContext& context) {
   Row r;
   QueryData results;
 
-  WmiRequest wmiSystemReq("SELECT * FROM Win32_Processor");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  const WmiRequest wmiSystemReq("SELECT * FROM Win32_Processor");
+  const std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (wmiResults.empty()) {
     LOG(WARNING) << "Error retreiving information from WMI.";
     return results;

--- a/osquery/tables/system/windows/disk_info.cpp
+++ b/osquery/tables/system/windows/disk_info.cpp
@@ -23,8 +23,8 @@ QueryData genDiskInfo(QueryContext& context) {
   Row r;
   QueryData results;
 
-  WmiRequest wmiSystemReq("select * from Win32_DiskDrive");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  const WmiRequest wmiSystemReq("select * from Win32_DiskDrive");
+  const std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (wmiResults.empty()) {
     LOG(WARNING) << "Error retrieving information from WMI.";
     return results;

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -208,8 +208,8 @@ Status genServiceKeyMap(
 QueryData genDrivers(QueryContext& context) {
   QueryData results;
 
-  WmiRequest wmiSignedDriverReq("select * from Win32_PnPSignedDriver");
-  auto& wmi_results = wmiSignedDriverReq.results();
+  const WmiRequest wmiSignedDriverReq("select * from Win32_PnPSignedDriver");
+  const auto& wmi_results = wmiSignedDriverReq.results();
 
   // As our list relies on the WMI set we first query and bail if no results
   if (wmi_results.empty()) {

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -63,8 +63,8 @@ QueryData genLogicalDrives(QueryContext& context) {
         std::string("Associators of {Win32_LogicalDisk.DeviceID='") + deviceId +
         "'} where AssocClass=Win32_LogicalDiskToPartition";
 
-	const WmiRequest wmiLogicalDiskToPartitionReq(assocQuery);
-	const std::vector<WmiResultItem>& wmiLogicalDiskToPartitionResults =
+    const WmiRequest wmiLogicalDiskToPartitionReq(assocQuery);
+    const std::vector<WmiResultItem>& wmiLogicalDiskToPartitionResults =
         wmiLogicalDiskToPartitionReq.results();
 
     if (wmiLogicalDiskToPartitionResults.empty()) {
@@ -79,7 +79,7 @@ QueryData genLogicalDrives(QueryContext& context) {
         std::string(
             "SELECT BootPartition FROM Win32_DiskPartition WHERE DeviceID='") +
         partitionDeviceId + '\'';
-	const WmiRequest wmiPartitionReq(partitionQuery);
+    const WmiRequest wmiPartitionReq(partitionQuery);
 	const std::vector<WmiResultItem>& wmiPartitionResults = wmiPartitionReq.results();
 
     if (wmiPartitionResults.empty()) {

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -80,7 +80,8 @@ QueryData genLogicalDrives(QueryContext& context) {
             "SELECT BootPartition FROM Win32_DiskPartition WHERE DeviceID='") +
         partitionDeviceId + '\'';
     const WmiRequest wmiPartitionReq(partitionQuery);
-	const std::vector<WmiResultItem>& wmiPartitionResults = wmiPartitionReq.results();
+    const std::vector<WmiResultItem>& wmiPartitionResults =
+        wmiPartitionReq.results();
 
     if (wmiPartitionResults.empty()) {
       results.push_back(r);

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -17,10 +17,10 @@ namespace tables {
 QueryData genLogicalDrives(QueryContext& context) {
   QueryData results;
 
-  WmiRequest wmiLogicalDiskReq(
+  const WmiRequest wmiLogicalDiskReq(
       "select DeviceID, DriveType, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
-  std::vector<WmiResultItem>& wmiResults = wmiLogicalDiskReq.results();
+  const std::vector<WmiResultItem>& wmiResults = wmiLogicalDiskReq.results();
   for (unsigned int i = 0; i < wmiResults.size(); ++i) {
     Row r;
     unsigned int driveType = 0;
@@ -63,8 +63,8 @@ QueryData genLogicalDrives(QueryContext& context) {
         std::string("Associators of {Win32_LogicalDisk.DeviceID='") + deviceId +
         "'} where AssocClass=Win32_LogicalDiskToPartition";
 
-    WmiRequest wmiLogicalDiskToPartitionReq(assocQuery);
-    std::vector<WmiResultItem>& wmiLogicalDiskToPartitionResults =
+	const WmiRequest wmiLogicalDiskToPartitionReq(assocQuery);
+	const std::vector<WmiResultItem>& wmiLogicalDiskToPartitionResults =
         wmiLogicalDiskToPartitionReq.results();
 
     if (wmiLogicalDiskToPartitionResults.empty()) {
@@ -79,8 +79,8 @@ QueryData genLogicalDrives(QueryContext& context) {
         std::string(
             "SELECT BootPartition FROM Win32_DiskPartition WHERE DeviceID='") +
         partitionDeviceId + '\'';
-    WmiRequest wmiPartitionReq(partitionQuery);
-    std::vector<WmiResultItem>& wmiPartitionResults = wmiPartitionReq.results();
+	const WmiRequest wmiPartitionReq(partitionQuery);
+	const std::vector<WmiResultItem>& wmiPartitionResults = wmiPartitionReq.results();
 
     if (wmiPartitionResults.empty()) {
       results.push_back(r);

--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -134,8 +134,8 @@ QueryData genOSVersion(QueryContext& context) {
   const std::string kWmiQuery =
       "SELECT CAPTION,VERSION FROM Win32_OperatingSystem";
 
-  WmiRequest wmiRequest(kWmiQuery);
-  std::vector<WmiResultItem>& wmiResults = wmiRequest.results();
+  const WmiRequest wmiRequest(kWmiQuery);
+  const std::vector<WmiResultItem>& wmiResults = wmiRequest.results();
 
   if (wmiResults.empty()) {
     return {};

--- a/osquery/tables/system/windows/patches.cpp
+++ b/osquery/tables/system/windows/patches.cpp
@@ -18,8 +18,8 @@ namespace tables {
 QueryData genInstalledPatches(QueryContext& context) {
   QueryData results;
 
-  WmiRequest wmiSystemReq("select * from Win32_QuickFixEngineering");
-  auto& wmiResults = wmiSystemReq.results();
+  const WmiRequest wmiSystemReq("select * from Win32_QuickFixEngineering");
+  const auto& wmiResults = wmiSystemReq.results();
 
   if (wmiResults.size() != 0) {
     Row r;

--- a/osquery/tables/system/windows/physical_disk_performance.cpp
+++ b/osquery/tables/system/windows/physical_disk_performance.cpp
@@ -20,11 +20,11 @@ QueryData genPhysicalDiskPerformance(QueryContext& context) {
   QueryData results;
 
   auto query = "SELECT * FROM Win32_PerfFormattedData_PerfDisk_PhysicalDisk";
-  WmiRequest perfReq(query);
+  const WmiRequest perfReq(query);
   if (!perfReq.getStatus().ok()) {
     return results;
   }
-  auto& perfRes = perfReq.results();
+  const auto& perfRes = perfReq.results();
   for (const auto& disk : perfRes) {
     Row r;
     std::string sPlaceHolder;

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -300,7 +300,7 @@ QueryData genProcesses(QueryContext& context) {
     }
   }
 
-  WmiRequest request(query);
+  const WmiRequest request(query);
   if (request.getStatus().ok()) {
     for (const auto& item : request.results()) {
       long pid = 0;

--- a/osquery/tables/system/windows/shared_resources.cpp
+++ b/osquery/tables/system/windows/shared_resources.cpp
@@ -22,9 +22,9 @@ namespace tables {
 QueryData genShares(QueryContext& context) {
   QueryData results_data;
 
-  WmiRequest request("SELECT * FROM Win32_Share");
+  const WmiRequest request("SELECT * FROM Win32_Share");
   if (request.getStatus().ok()) {
-    std::vector<WmiResultItem>& results = request.results();
+    const std::vector<WmiResultItem>& results = request.results();
     for (const auto& result : results) {
       Row r;
       long lPlaceHolder;

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -21,11 +21,11 @@ QueryData genPlatformInfo(QueryContext& context) {
   std::string query =
       "select Manufacturer, SMBIOSBIOSVersion, ReleaseDate, "
       "SystemBiosMajorVersion, SystemBiosMinorVersion from Win32_BIOS";
-  WmiRequest request(query);
+  const WmiRequest request(query);
   if (!request.getStatus().ok()) {
     return results;
   }
-  std::vector<WmiResultItem>& wmiResults = request.results();
+  const std::vector<WmiResultItem>& wmiResults = request.results();
   if (wmiResults.size() != 1) {
     return results;
   }

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -36,10 +36,10 @@ QueryData genSystemInfo(QueryContext& context) {
     }
   }
 
-  WmiRequest wmiSystemReq("select * from Win32_ComputerSystem");
-  WmiRequest wmiSystemReqProc("select * from Win32_Processor");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
-  std::vector<WmiResultItem>& wmiResultsProc = wmiSystemReqProc.results();
+  const WmiRequest wmiSystemReq("select * from Win32_ComputerSystem");
+  const WmiRequest wmiSystemReqProc("select * from Win32_Processor");
+  const std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  const std::vector<WmiResultItem>& wmiResultsProc = wmiSystemReqProc.results();
   if (!wmiResults.empty() && !wmiResultsProc.empty()) {
     long numProcs = 0;
     wmiResults[0].GetLong("NumberOfLogicalProcessors", numProcs);
@@ -73,8 +73,8 @@ QueryData genSystemInfo(QueryContext& context) {
     }
   }
 
-  WmiRequest wmiBiosReq("select * from Win32_Bios");
-  std::vector<WmiResultItem>& wmiBiosResults = wmiBiosReq.results();
+  const WmiRequest wmiBiosReq("select * from Win32_Bios");
+  const std::vector<WmiResultItem>& wmiBiosResults = wmiBiosReq.results();
   if (wmiBiosResults.size() != 0) {
     wmiBiosResults[0].GetString("SerialNumber", r["hardware_serial"]);
   } else {

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -25,8 +25,8 @@ QueryData genVideoInfo(QueryContext& context) {
   Row r;
   QueryData results;
 
-  WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
-  std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
+  const WmiRequest wmiSystemReq("SELECT * FROM Win32_VideoController");
+  const std::vector<WmiResultItem>& wmiResults = wmiSystemReq.results();
   if (wmiResults.empty()) {
     LOG(WARNING) << "Failed to retrieve video information";
     return {};

--- a/osquery/tables/system/windows/wmi_bios_info.cpp
+++ b/osquery/tables/system/windows/wmi_bios_info.cpp
@@ -57,7 +57,7 @@ std::string getManufacturer(std::string manufacturer) {
   return manufacturer;
 }
 
-Row getHPBiosInfo(WmiResultItem& item) {
+Row getHPBiosInfo(const WmiResultItem& item) {
   Row r;
 
   std::string value;
@@ -74,7 +74,7 @@ Row getHPBiosInfo(WmiResultItem& item) {
   return r;
 }
 
-Row getLenovoBiosInfo(WmiResultItem& item) {
+Row getLenovoBiosInfo(const WmiResultItem& item) {
   Row r;
 
   std::string currentSetting;
@@ -91,7 +91,7 @@ Row getLenovoBiosInfo(WmiResultItem& item) {
   return r;
 }
 
-Row getDellBiosInfo(WmiResultItem& item) {
+Row getDellBiosInfo(const WmiResultItem& item) {
   Row r;
 
   std::vector<std::string> vCurrentValue;
@@ -132,9 +132,9 @@ QueryData genBiosInfo(QueryContext& context) {
   QueryData results;
   std::string manufacturer;
 
-  WmiRequest wmiComputerSystemReq(
+  const WmiRequest wmiComputerSystemReq(
       "select Manufacturer from Win32_ComputerSystem");
-  std::vector<WmiResultItem>& wmiComputerSystemResults =
+  const std::vector<WmiResultItem>& wmiComputerSystemResults =
       wmiComputerSystemReq.results();
 
   if (!wmiComputerSystemResults.empty()) {
@@ -145,9 +145,9 @@ QueryData genBiosInfo(QueryContext& context) {
   }
 
   if (kQueryMap.find(manufacturer) != kQueryMap.end()) {
-    WmiRequest wmiBiosReq(std::get<0>(kQueryMap.at(manufacturer)),
+    const WmiRequest wmiBiosReq(std::get<0>(kQueryMap.at(manufacturer)),
                           (std::get<1>(kQueryMap.at(manufacturer))));
-    std::vector<WmiResultItem>& wmiResults = wmiBiosReq.results();
+	const std::vector<WmiResultItem>& wmiResults = wmiBiosReq.results();
 
     for (unsigned int i = 0; i < wmiResults.size(); ++i) {
       Row r;

--- a/osquery/tables/system/windows/wmi_bios_info.cpp
+++ b/osquery/tables/system/windows/wmi_bios_info.cpp
@@ -146,8 +146,8 @@ QueryData genBiosInfo(QueryContext& context) {
 
   if (kQueryMap.find(manufacturer) != kQueryMap.end()) {
     const WmiRequest wmiBiosReq(std::get<0>(kQueryMap.at(manufacturer)),
-                          (std::get<1>(kQueryMap.at(manufacturer))));
-	const std::vector<WmiResultItem>& wmiResults = wmiBiosReq.results();
+                                (std::get<1>(kQueryMap.at(manufacturer))));
+    const std::vector<WmiResultItem>& wmiResults = wmiBiosReq.results();
 
     for (unsigned int i = 0; i < wmiResults.size(); ++i) {
       Row r;

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -24,11 +24,11 @@ QueryData genWmiCliConsumers(QueryContext& context) {
   ss << "SELECT * FROM CommandLineEventConsumer";
 
   BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  WmiRequest request(ss.str(), bstr);
+  const WmiRequest request(ss.str(), bstr);
   ::SysFreeString(bstr);
 
   if (request.getStatus().ok()) {
-    auto& results = request.results();
+    const auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -24,11 +24,11 @@ QueryData genWmiFilters(QueryContext& context) {
   ss << "SELECT * FROM __EventFilter";
 
   BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  WmiRequest request(ss.str(), bstr);
+  const WmiRequest request(ss.str(), bstr);
   ::SysFreeString(bstr);
 
   if (request.getStatus().ok()) {
-    auto& results = request.results();
+    const auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -24,11 +24,11 @@ QueryData genFilterConsumer(QueryContext& context) {
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
   BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  WmiRequest request(ss.str(), bstr);
+  const WmiRequest request(ss.str(), bstr);
   ::SysFreeString(bstr);
 
   if (request.getStatus().ok()) {
-    auto& results = request.results();
+    const auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -24,11 +24,11 @@ QueryData genScriptConsumers(QueryContext& context) {
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
   BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  WmiRequest request(ss.str(), bstr);
+  const WmiRequest request(ss.str(), bstr);
   ::SysFreeString(bstr);
 
   if (request.getStatus().ok()) {
-    auto& results = request.results();
+    const auto& results = request.results();
     for (const auto& result : results) {
       Row r;
 


### PR DESCRIPTION
_There is a class WmiRequest in osquery/core/windows/wmi.h. It perform a WMI requests and do it during the construction. And it has only two methods, both to read the result of the query (results, getStatus). So, there are no reasons to be non-const for them. Let's mark them as const. And fix all the places which use them as non-const._

Added const keyword to functions and all the places which use them as non-const.

Issue:  #4731