### PR TITLE
[aws-sqs] adding support logging to AWS SQS queue

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -4,7 +4,7 @@ As of version 1.7.4, osquery can log results directly to Amazon AWS [Kinesis Str
 
 The Kinesis Streams, Kinesis Firehose, and SQS logger plugins are named `aws_kinesis`, `aws_firehose`, and `aws_sqs` respectively. They can be enabled as with other logger plugins using the config flag `logger_plugin`.
 
-Some configuration is shared between the two plugins:
+Some configuration is shared between the three plugins:
 
 ```
 --aws_access_key_id VALUE               AWS access key ID override

--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -1,8 +1,8 @@
-As of version 1.7.4, osquery can log results directly to Amazon AWS [Kinesis Streams](https://aws.amazon.com/kinesis/streams/) and [Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/). For users of these services, `osqueryd` can eliminate the need for a separate log forwarding daemon running in your deployments.
+As of version 1.7.4, osquery can log results directly to Amazon AWS [Kinesis Streams](https://aws.amazon.com/kinesis/streams/) and [Kinesis Firehose](https://aws.amazon.com/kinesis/firehose/). Additionally, osquery supports logging to an [SQS Queue](https://aws.amazon.com/sqs/). For users of these services, `osqueryd` can eliminate the need for a separate log forwarding daemon running in your deployments.
 
 ## Configuration
 
-The Kinesis Streams and Kinesis Firehose logger plugins are named `aws_kinesis` and `aws_firehose` respectively. They can be enabled as with other logger plugins using the config flag `logger_plugin`.
+The Kinesis Streams, Kinesis Firehose, and SQS logger plugins are named `aws_kinesis`, `aws_firehose`, and `aws_sqs` respectively. They can be enabled as with other logger plugins using the config flag `logger_plugin`.
 
 Some configuration is shared between the two plugins:
 
@@ -37,6 +37,10 @@ Setting aws_kinesis_random_partition_key to true will use random partition keys 
 
 Similarly for Kinesis Firehose delivery streams, the stream name must be specified with `aws_firehose_stream`, and the period can be configured with `aws_firehose_period`.
 
+### SQS Queue
+
+When logging to an SQS queue, the queue url must be specified with `aws_sqs_queue_url`, and the period can be configured with `aws_sqs_period`.
+
 ### Sample Config File
 ```
 {
@@ -46,6 +50,7 @@ Similarly for Kinesis Firehose delivery streams, the stream name must be specifi
     "logger_plugin": "aws_kinesis,aws_firehose",
     "aws_kinesis_stream": "foo_stream",
     "aws_firehose_stream": "bar_delivery_stream",
+    "aws_sqs_queue_url": "baz_queue_url"
     "aws_access_key_id": "ACCESS_KEY",
     "aws_secret_access_key": "SECRET_KEY",
     "aws_region": "us-east-1"
@@ -60,4 +65,4 @@ Similarly for Kinesis Firehose delivery streams, the stream name must be specifi
 }
 ```
 
-**Note**: Kinesis services have a maximum 1MB record size. Result logs bigger than this will not be forwarded by **osqueryd** as they will be rejected by the Kinesis services.
+**Note**: Kinesis services have a maximum 1MB record size, and the SQS service has a maximum 256KB record size. Result logs bigger than this will not be forwarded by **osqueryd** as they will be rejected by the respective services.

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -19,7 +19,7 @@ On Windows this directory defaults to `C:\ProgramData\osquery\log`.
 
 ## Logger plugins
 
-osquery includes logger plugins that support configurable logging to a variety of interfaces. The built in logger plugins are **filesystem** (default), **tls**, **syslog** (for POSIX), **windows_event_log** (for Windows), **kinesis**, **firehose**, and **kafka_producer**. Multiple logger plugins may be used simultaneously, effectively copying logs to each interface. To enable multiple loggers set the `--logger_plugin` option to a comma separated list, do not include spaces, of the requested plugins.
+osquery includes logger plugins that support configurable logging to a variety of interfaces. The built in logger plugins are **filesystem** (default), **tls**, **syslog** (for POSIX), **windows_event_log** (for Windows), **kinesis**, **firehose**, **sqs**, and **kafka_producer**. Multiple logger plugins may be used simultaneously, effectively copying logs to each interface. To enable multiple loggers set the `--logger_plugin` option to a comma separated list, do not include spaces, of the requested plugins.
 
 For information on configuring logger plugins, see [logging/results flags](../installation/cli-flags.md#loggingresults-flags). Developing new logger plugins is explored in the [development docs](../development/logger-plugins.md). We recommend setting the logger plugin and logger settings via the osquery *flagfile*.
 

--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -69,6 +69,7 @@ if(NOT SKIP_AWS)
   ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_logger_aws_plugins
     "${CMAKE_CURRENT_LIST_DIR}/plugins/aws_firehose.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/plugins/aws_kinesis.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/plugins/aws_sqs.cpp"
   )
 
   ADD_OSQUERY_TEST_ADDITIONAL(
@@ -81,6 +82,7 @@ if(NOT SKIP_AWS)
     ADD_OSQUERY_LINK_CORE("wevtapi.lib")
   endif()
 
+  ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-sqs")
   ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-kinesis")
   ADD_OSQUERY_LINK_ADDITIONAL("aws-cpp-sdk-firehose")
 endif()

--- a/osquery/logger/plugins/aws_sqs.cpp
+++ b/osquery/logger/plugins/aws_sqs.cpp
@@ -67,7 +67,8 @@ void SQSLoggerPlugin::init(const std::string& name,
 
 Status SQSLogForwarder::internalSetup() {
   if (FLAGS_aws_sqs_queue_url.empty()) {
-    return Status::failure("Queue URL must be specified with --aws_sqs_queue_url");
+    return Status::failure(
+        "Queue URL must be specified with --aws_sqs_queue_url");
   }
 
   VLOG(1) << "SQS logging initialized with queue URL: "
@@ -76,15 +77,14 @@ Status SQSLogForwarder::internalSetup() {
   return Status::success();
 }
 
-SQSLogForwarder::Outcome SQSLogForwarder::internalSend(
-    const Batch& batch) {
+SQSLogForwarder::Outcome SQSLogForwarder::internalSend(const Batch& batch) {
   Aws::SQS::Model::SendMessageBatchRequest request;
   request.WithQueueUrl(FLAGS_aws_sqs_queue_url).SetEntries(batch);
   return client_->SendMessageBatch(request);
 }
 
-void SQSLogForwarder::initializeRecord(
-    Record& record, Aws::Utils::ByteBuffer& buffer) const {
+void SQSLogForwarder::initializeRecord(Record& record,
+                                       Aws::Utils::ByteBuffer& buffer) const {
   record.SetBody(buffer);
 }
 
@@ -116,8 +116,7 @@ size_t SQSLogForwarder::getFailedRecordCount(Outcome& outcome) const {
   return static_cast<size_t>(outcome.GetResult().GetFailed());
 }
 
-SQSLogForwarder::Result SQSLogForwarder::getResult(
-    Outcome& outcome) const {
+SQSLogForwarder::Result SQSLogForwarder::getResult(Outcome& outcome) const {
   return outcome.GetResult().GetEntries();
 }
-}
+} // namespace osquery

--- a/osquery/logger/plugins/aws_sqs.cpp
+++ b/osquery/logger/plugins/aws_sqs.cpp
@@ -1,0 +1,118 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <algorithm>
+
+#include <aws/core/client/AWSError.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/sqs/model/SendMessageBatchRequest.h>
+#include <aws/sqs/model/SendMessageBatchResult.h>
+
+#include <boost/algorithm/string/join.hpp>
+
+#include <osquery/flags.h>
+#include <osquery/registry.h>
+#include <osquery/system.h>
+
+#include "osquery/logger/plugins/aws_sqs.h"
+
+namespace osquery {
+
+REGISTER(SQSLoggerPlugin, "logger", "aws_sqs");
+
+FLAG(uint64,
+     aws_sqs_period,
+     10,
+     "Seconds between flushing logs to SQS (default 10)");
+
+FLAG(string, aws_sqs_queue_url, "", "Name of SQS queue URL for logging")
+
+Status SQSLoggerPlugin::setUp() {
+  initAwsSdk();
+  forwarder_ = std::make_shared<SQSLogForwarder>(
+      "aws_sqs", aws_sqs_queue_url, 500);
+  Status s = forwarder_->setUp();
+  if (!s.ok()) {
+    LOG(ERROR) << "Error initializing SQS logger: " << s.getMessage();
+    return s;
+  }
+  Dispatcher::addService(forwarder_);
+  return Status(0, "OK");
+}
+
+Status SQSLoggerPlugin::logString(const std::string& s) {
+  return forwarder_->logString(s);
+}
+
+Status SQSLoggerPlugin::logStatus(const std::vector<StatusLogLine>& log) {
+  return forwarder_->logStatus(log);
+}
+
+void SQSLoggerPlugin::init(const std::string& name,
+                               const std::vector<StatusLogLine>& log) {
+  logStatus(log);
+}
+
+Status SQSLogForwarder::internalSetup() {
+  if (FLAGS_aws_sqs_queue_url.empty()) {
+    return Status(1, "Queue URL must be specified with --aws_sqs_queue_url");
+  }
+
+  VLOG(1) << "SQS logging initialized with queue URL: "
+          << FLAGS_aws_sqs_queue_url;
+
+  return Status(0, "OK");
+}
+
+SQSLogForwarder::Outcome SQSLogForwarder::internalSend(
+    const Batch& batch) {
+  Aws::SQS::Model::SendMessageBatchRequest request;
+  request.WithQueueUrl(FLAGS_aws_sqs_queue_url).SetEntries(batch);
+  return client_->SendMessageBatch(request);
+}
+
+void SQSLogForwarder::initializeRecord(
+    Record& record, Aws::Utils::ByteBuffer& buffer) const {
+  record.SetBody(buffer);
+}
+
+size_t SQSLogForwarder::getMaxBytesPerRecord() const {
+  return 262144U;
+}
+
+size_t SQSLogForwarder::getMaxRecordsPerBatch() const {
+  return 10U;
+}
+
+size_t SQSLogForwarder::getMaxBytesPerBatch() const {
+  return 262144U;
+}
+
+size_t SQSLogForwarder::getMaxRetryCount() const {
+  return 100U;
+}
+
+size_t SQSLogForwarder::getInitialRetryDelay() const {
+  return 3000U;
+}
+
+bool SQSLogForwarder::appendNewlineSeparators() const {
+  return false;
+}
+
+size_t SQSLogForwarder::getFailedRecordCount(Outcome& outcome) const {
+  return static_cast<size_t>(outcome.GetResult().GetFailed());
+}
+
+SQSLogForwarder::Result SQSLogForwarder::getResult(
+    Outcome& outcome) const {
+  return outcome.GetResult().GetEntries();
+}
+}

--- a/osquery/logger/plugins/aws_sqs.h
+++ b/osquery/logger/plugins/aws_sqs.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <chrono>
-#include <memory>
 #include <vector>
 
 #include <aws/sqs/SQSClient.h>
@@ -19,7 +17,6 @@
 #include <aws/sqs/model/Message.h>
 
 #include <osquery/core.h>
-#include <osquery/dispatcher.h>
 #include <osquery/logger.h>
 
 #include "osquery/logger/plugins/aws_log_forwarder.h"
@@ -55,9 +52,6 @@ class SQSLogForwarder final : public ISQSLogForwarder {
 
   size_t getFailedRecordCount(Outcome& outcome) const override;
   Result getResult(Outcome& outcome) const override;
-
- private:
-  FRIEND_TEST(SQSTests, test_send);
 };
 
 class SQSLoggerPlugin : public LoggerPlugin {

--- a/osquery/logger/plugins/aws_sqs.h
+++ b/osquery/logger/plugins/aws_sqs.h
@@ -1,0 +1,85 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include <aws/sqs/SQSClient.h>
+#include <aws/sqs/model/SendMessageBatchRequestEntry.h>
+#include <aws/sqs/model/Message.h>
+
+#include <osquery/core.h>
+#include <osquery/dispatcher.h>
+#include <osquery/logger.h>
+
+#include "osquery/logger/plugins/aws_log_forwarder.h"
+
+namespace osquery {
+DECLARE_uint64(aws_sqs_period);
+
+using ISQSLogForwarder =
+    AwsLogForwarder<Aws::SQS::Model::Message,
+                    Aws::SQS::SQSClient,
+                    Aws::SQS::Model::SendMessageBatchOutcome,
+                    Aws::Vector<Aws::SQS::Model::SendMessageBatchResultEntry>>;
+
+class SQSLogForwarder final : public ISQSLogForwarder {
+ public:
+  SQSLogForwarder(const std::string& name,
+                  size_t log_period,
+                  size_t max_lines)
+      : ISQSLogForwarder(name, log_period, max_lines) {}
+
+ protected:
+  Status internalSetup() override;
+  Outcome internalSend(const Batch& batch) override;
+  void initializeRecord(Record& record,
+                        Aws::Utils::ByteBuffer& buffer) const override;
+
+  size_t getMaxBytesPerRecord() const override;
+  size_t getMaxRecordsPerBatch() const override;
+  size_t getMaxBytesPerBatch() const override;
+  size_t getMaxRetryCount() const override;
+  size_t getInitialRetryDelay() const override;
+  bool appendNewlineSeparators() const override;
+
+  size_t getFailedRecordCount(Outcome& outcome) const override;
+  Result getResult(Outcome& outcome) const override;
+
+ private:
+  FRIEND_TEST(SQSTests, test_send);
+};
+
+class SQSLoggerPlugin : public LoggerPlugin {
+ public:
+  SQSLoggerPlugin() : LoggerPlugin() {}
+
+  Status setUp() override;
+
+  bool usesLogStatus() override {
+    return true;
+  }
+
+ private:
+  void init(const std::string& name,
+            const std::vector<StatusLogLine>& log) override;
+
+  Status logString(const std::string& s) override;
+
+  /// Log a status (ERROR/WARNING/INFO) message.
+  Status logStatus(const std::vector<StatusLogLine>& log) override;
+
+ private:
+  std::shared_ptr<SQSLogForwarder> forwarder_{nullptr};
+};
+}

--- a/osquery/logger/plugins/aws_sqs.h
+++ b/osquery/logger/plugins/aws_sqs.h
@@ -13,8 +13,8 @@
 #include <vector>
 
 #include <aws/sqs/SQSClient.h>
-#include <aws/sqs/model/SendMessageBatchRequestEntry.h>
 #include <aws/sqs/model/Message.h>
+#include <aws/sqs/model/SendMessageBatchRequestEntry.h>
 
 #include <osquery/core.h>
 #include <osquery/logger.h>
@@ -32,9 +32,7 @@ using ISQSLogForwarder =
 
 class SQSLogForwarder final : public ISQSLogForwarder {
  public:
-  SQSLogForwarder(const std::string& name,
-                  size_t log_period,
-                  size_t max_lines)
+  SQSLogForwarder(const std::string& name, size_t log_period, size_t max_lines)
       : ISQSLogForwarder(name, log_period, max_lines) {}
 
  protected:
@@ -76,4 +74,4 @@ class SQSLoggerPlugin : public LoggerPlugin {
  private:
   std::shared_ptr<SQSLogForwarder> forwarder_{nullptr};
 };
-}
+} // namespace osquery

--- a/tools/provision/chocolatey/aws-sdk-cpp.ps1
+++ b/tools/provision/chocolatey/aws-sdk-cpp.ps1
@@ -23,7 +23,8 @@ $libs = @(
   'aws-cpp-sdk-ec2',
   'aws-cpp-sdk-sts',
   'aws-cpp-sdk-firehose',
-  'aws-cpp-sdk-kinesis'
+  'aws-cpp-sdk-kinesis',
+  'aws-cpp-sdk-sqs'
 )
 
 # Keep current loc to restore later

--- a/tools/provision/formula/aws-sdk-cpp.rb
+++ b/tools/provision/formula/aws-sdk-cpp.rb
@@ -28,7 +28,7 @@ class AwsSdkCpp < AbstractOsqueryFormula
     args << "-DENABLE_TESTING=OFF"
     args << "-DAUTORUN_UNIT_TESTS=OFF"
 
-    args << "-DBUILD_ONLY=ec2;firehose;kinesis;sts"
+    args << "-DBUILD_ONLY=ec2;firehose;kinesis;sqs;sts"
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
There are osquery logger plugins for Kinesis Streams and Firehose, but not for SQS. This (hopefully) adds support for the AWS SQS service.

My cpp is pretty rusty, but I hope this is a good jumping off point for a review. It looks like the dummy class will take care of testing the core functionality for me, but if there is anything I've missed please let me know!!

### Changes

* Adding aws sqs queue logger support via plugin
* Updates toolchain for sqs support (I may have missed something here)
* Documentation updates to includes sqs support and config how-to

cc @guliashvili 
resolves: #4757 