### PR TITLE
Get column type info, and use it in serialization.

### DIFF
--- a/include/osquery/distributed.h
+++ b/include/osquery/distributed.h
@@ -86,12 +86,18 @@ struct DistributedQueryResult {
   DistributedQueryResult(const DistributedQueryRequest& req,
                          const QueryData& res,
                          const ColumnNames& cols,
+                         const ColumnTypes& cTypes,
                          const Status& s)
-      : request(req), results(res), columns(cols), status(s) {}
+      : request(req),
+        results(res),
+        columns(cols),
+        colTypes(cTypes),
+        status(s) {}
 
   DistributedQueryRequest request;
   QueryData results;
   ColumnNames columns;
+  ColumnTypes colTypes;
   Status status;
 };
 

--- a/include/osquery/sql.h
+++ b/include/osquery/sql.h
@@ -79,6 +79,13 @@ class SQL : private only_movable {
   const ColumnNames& columns() const;
 
   /**
+   * @brief Column type information for the query
+   *
+   * @return A TableColumns object for the query
+   */
+  const ColumnTypes& columnTypes() const;
+
+  /**
    * @brief Accessor to switch off of when checking the success of a query.
    *
    * @return A bool indicating the success or failure of the operation.
@@ -160,6 +167,9 @@ class SQL : private only_movable {
 
   /// The internal member which holds the column names and order for the query
   ColumnNames columns_;
+
+  /// The internal member which holds the column type information
+  ColumnTypes columnTypes_;
 };
 
 /**

--- a/include/osquery/tables.h
+++ b/include/osquery/tables.h
@@ -131,15 +131,6 @@ inline std::string __sqliteField(const std::string& source) noexcept {
 /// See the literal type documentation for TEXT_LITERAL.
 #define DOUBLE_LITERAL double
 
-enum ColumnType {
-  UNKNOWN_TYPE = 0,
-  TEXT_TYPE,
-  INTEGER_TYPE,
-  BIGINT_TYPE,
-  UNSIGNED_BIGINT_TYPE,
-  DOUBLE_TYPE,
-  BLOB_TYPE,
-};
 
 /// Map of type constant to the SQLite string-name representation.
 extern const std::map<ColumnType, std::string> kColumnTypeNames;

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -201,6 +201,56 @@ void JSON::add(const std::string& key, int value) {
   add(key, value, doc());
 }
 
+void JSON::add(const std::string& key, long long value, rj::Value& obj) {
+  assert(obj.IsObject());
+  auto itr = obj.FindMember(key);
+  if (itr != obj.MemberEnd()) {
+    obj.RemoveMember(itr);
+  }
+
+  obj.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                rj::Value(value).Move(),
+                doc_.GetAllocator());
+}
+
+void JSON::add(const std::string& key, long long value) {
+  add(key, value, doc());
+}
+
+void JSON::add(const std::string& key,
+               unsigned long long value,
+               rj::Value& obj) {
+  assert(obj.IsObject());
+  auto itr = obj.FindMember(key);
+  if (itr != obj.MemberEnd()) {
+    obj.RemoveMember(itr);
+  }
+
+  obj.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                rj::Value(value).Move(),
+                doc_.GetAllocator());
+}
+
+void JSON::add(const std::string& key, unsigned long long value) {
+  add(key, value, doc());
+}
+
+void JSON::add(const std::string& key, double value, rj::Value& obj) {
+  assert(obj.IsObject());
+  auto itr = obj.FindMember(key);
+  if (itr != obj.MemberEnd()) {
+    obj.RemoveMember(itr);
+  }
+
+  obj.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                rj::Value(value).Move(),
+                doc_.GetAllocator());
+}
+
+void JSON::add(const std::string& key, double value) {
+  add(key, value, doc());
+}
+
 void JSON::add(const std::string& key, bool value, rj::Value& obj) {
   assert(obj.IsObject());
   auto itr = obj.FindMember(key);

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -206,6 +206,60 @@ class JSON : private only_movable {
   void add(const std::string& key, int value);
 
   /**
+   * @brief Add a long long value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document. If the key exists
+   * the value will be replaced.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, long long value, rapidjson::Value& obj);
+
+  /**
+   * @brief Add a long long value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document. If the key exists
+   * the value will be replaced.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, long long value);
+
+  /**
+   * @brief Add an unsigned long long value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document. If the key exists
+   * the value will be replaced.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, unsigned long long value, rapidjson::Value& obj);
+
+  /**
+   * @brief Add an unsigned long long value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document. If the key exists
+   * the value will be replaced.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, unsigned long long value);
+
+  /**
+   * @brief Add a double value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document. If the key exists
+   * the value will be replaced.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, double value, rapidjson::Value& obj);
+
+  /**
+   * @brief Add an double value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document. If the key exists
+   * the value will be replaced.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, double value);
+
+  /**
    * @brief Add a bool value to a JSON object by copying the contents.
    *
    * This will add the key and value to an input document. If the key exists

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -235,6 +235,11 @@ Status deserializeRow(const rj::Value& doc, Row& r) {
   for (const auto& i : doc.GetObject()) {
     std::string name(i.name.GetString());
     if (!name.empty() && i.value.IsString()) {
+      // TODO This is going crash, as it is, provided we are deserializing any
+      // maps that happen to have values serialized numerically (I'm not sure we
+      // do, we seem to only deserialize into "Row" objects (maps) from
+      // EventSubscriberPlugin::get).  I'm afraid we need to convert our numbers
+      // back into strings.  :(
       r[name] = i.value.GetString();
     }
   }
@@ -466,7 +471,7 @@ Status serializeEvent(const QueryLogItem& item,
   auto columns_obj = doc.getObject();
   for (const auto& i : event_obj.GetObject()) {
     // Yield results as a "columns." map to avoid namespace collisions.
-    doc.addCopy(i.name.GetString(), i.value.GetString(), columns_obj);
+    doc.add(i.name.GetString(), i.value, columns_obj);
   }
 
   doc.add("columns", columns_obj, obj);

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -229,7 +229,7 @@ void TablePlugin::setCache(size_t step,
 
   // Serialize QueryData and save to database.
   std::string content;
-  if (serializeQueryDataJSON(results, content)) {
+  if (serializeQueryDataJSON(results, {}, content)) {
     last_cached_ = step;
     last_interval_ = interval;
     setDatabaseValue(kQueries, "cache." + getName(), content);

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -35,7 +35,7 @@ TEST_F(QueryTests, test_add_and_get_current_results) {
   auto query = getOsqueryScheduledQuery();
   auto cf = Query("foobar", query);
   uint64_t counter = 128;
-  auto status = cf.addNewResults(getTestDBExpectedResults(), 0, counter);
+  auto status = cf.addNewResults(getTestDBExpectedResults(), {}, 0, counter);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(status.toString(), "OK");
   EXPECT_EQ(counter, 0UL);
@@ -52,7 +52,7 @@ TEST_F(QueryTests, test_add_and_get_current_results) {
     // Add the "current" results and output the differentials.
     DiffResults dr;
     counter = 128;
-    auto s = cf.addNewResults(result.second, 0, counter, dr, true);
+    auto s = cf.addNewResults(result.second, {}, 0, counter, dr, true);
     EXPECT_TRUE(s.ok());
     EXPECT_EQ(counter, expected_counter++);
 
@@ -118,7 +118,7 @@ TEST_F(QueryTests, test_query_name_updated) {
   DiffResults dr;
   uint64_t counter = 128;
   auto results = getTestDBExpectedResults();
-  cf.addNewResults(results, 0, counter, dr);
+  cf.addNewResults(results, {}, 0, counter, dr);
   EXPECT_FALSE(cf.isNewQuery());
   EXPECT_EQ(counter, 0UL);
 
@@ -127,7 +127,7 @@ TEST_F(QueryTests, test_query_name_updated) {
   auto cf2 = Query("will_update_query", query);
   EXPECT_TRUE(cf2.isQueryNameInDatabase());
   EXPECT_TRUE(cf2.isNewQuery());
-  cf2.addNewResults(results, 0, counter, dr);
+  cf2.addNewResults(results, {}, 0, counter, dr);
   EXPECT_FALSE(cf2.isNewQuery());
   EXPECT_EQ(counter, 0UL);
 }

--- a/osquery/database/benchmarks/database_benchmarks.cpp
+++ b/osquery/database/benchmarks/database_benchmarks.cpp
@@ -1,4 +1,4 @@
-/**
+ /**
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
@@ -61,7 +61,7 @@ static void DATABASE_serialize(benchmark::State& state) {
   auto qd = getExampleQueryData(state.range(0), state.range(1));
   while (state.KeepRunning()) {
     auto doc = JSON::newArray();
-    serializeQueryData(qd, {}, doc, doc.doc());
+    serializeQueryData(qd, {}, {}, doc, doc.doc());
   }
 }
 
@@ -72,7 +72,7 @@ static void DATABASE_serialize_column_order(benchmark::State& state) {
   auto cn = getExampleColumnNames(state.range(0));
   while (state.KeepRunning()) {
     auto doc = JSON::newArray();
-    serializeQueryData(qd, cn, doc, doc.doc());
+    serializeQueryData(qd, cn, {}, doc, doc.doc());
   }
 }
 
@@ -86,7 +86,7 @@ static void DATABASE_serialize_json(benchmark::State& state) {
   auto qd = getExampleQueryData(state.range(0), state.range(1));
   while (state.KeepRunning()) {
     std::string content;
-    serializeQueryDataJSON(qd, content);
+    serializeQueryDataJSON(qd, {}, content);
   }
 }
 
@@ -112,7 +112,7 @@ static void DATABASE_query_results(benchmark::State& state) {
     DiffResults diff_results;
     uint64_t counter;
     auto dbq = Query("default", query);
-    dbq.addNewResults(std::move(qd), 0, counter, diff_results);
+    dbq.addNewResults(std::move(qd), {}, 0, counter, diff_results);
   }
 }
 
@@ -147,7 +147,7 @@ static void DATABASE_store_large(benchmark::State& state) {
   // Serialize the example result set into a string.
   std::string content;
   auto qd = getExampleQueryData(20, 100);
-  serializeQueryDataJSON(qd, content);
+  serializeQueryDataJSON(qd, {}, content);
 
   while (state.KeepRunning()) {
     setDatabaseValue(kPersistentSettings, "benchmark", content);
@@ -162,7 +162,7 @@ static void DATABASE_store_append(benchmark::State& state) {
   // Serialize the example result set into a string.
   std::string content;
   auto qd = getExampleQueryData(20, 100);
-  serializeQueryDataJSON(qd, content);
+  serializeQueryDataJSON(qd, {}, content);
 
   size_t k = 0;
   while (state.KeepRunning()) {

--- a/osquery/database/tests/results_tests.cpp
+++ b/osquery/database/tests/results_tests.cpp
@@ -40,7 +40,7 @@ TEST_F(ResultsTests, test_simple_diff) {
 TEST_F(ResultsTests, test_serialize_row) {
   auto results = getSerializedRow();
   auto doc = JSON::newObject();
-  auto s = serializeRow(results.second, {}, doc, doc.doc());
+  auto s = serializeRow(results.second, {}, {}, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(doc.doc()["meaning_of_life"], "meaning_of_life_value");
@@ -50,7 +50,7 @@ TEST_F(ResultsTests, test_serialize_row) {
 TEST_F(ResultsTests, test_deserialize_row_json) {
   auto results = getSerializedRow();
   std::string input;
-  serializeRowJSON(results.second, input);
+  serializeRowJSON(results.second, {}, input);
 
   // Pull the serialized JSON back into a Row output container.
   Row output;
@@ -63,7 +63,7 @@ TEST_F(ResultsTests, test_deserialize_row_json) {
 TEST_F(ResultsTests, test_serialize_query_data) {
   auto results = getSerializedQueryData();
   auto doc = JSON::newArray();
-  auto s = serializeQueryData(results.second, {}, doc, doc.doc());
+  auto s = serializeQueryData(results.second, {}, {}, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first.doc(), doc.doc());
@@ -72,8 +72,10 @@ TEST_F(ResultsTests, test_serialize_query_data) {
 TEST_F(ResultsTests, test_serialize_query_data_in_column_order) {
   auto results = getSerializedQueryDataWithColumnOrder();
   auto column_names = getSerializedRowColumnNames(true);
+  auto column_types = getSerializedRowColumnTypes();
   auto doc = JSON::newArray();
-  auto s = serializeQueryData(results.second, column_names, doc, doc.doc());
+  auto s = serializeQueryData(
+      results.second, column_names, column_types, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first.doc(), doc.doc());
@@ -81,8 +83,9 @@ TEST_F(ResultsTests, test_serialize_query_data_in_column_order) {
 
 TEST_F(ResultsTests, test_serialize_query_data_json) {
   auto results = getSerializedQueryDataJSON();
+  auto column_types = getSerializedRowColumnTypes();
   std::string json;
-  auto s = serializeQueryDataJSON(results.second, json);
+  auto s = serializeQueryDataJSON(results.second, column_types, json);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first, json);
@@ -102,7 +105,7 @@ TEST_F(ResultsTests, test_deserialize_query_data_json) {
 TEST_F(ResultsTests, test_serialize_diff_results) {
   auto results = getSerializedDiffResults();
   auto doc = JSON::newObject();
-  auto s = serializeDiffResults(results.second, {}, doc, doc.doc());
+  auto s = serializeDiffResults(results.second, {}, {}, doc, doc.doc());
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first.doc(), doc.doc());
@@ -111,7 +114,7 @@ TEST_F(ResultsTests, test_serialize_diff_results) {
 TEST_F(ResultsTests, test_serialize_diff_results_json) {
   auto results = getSerializedDiffResultsJSON();
   std::string json;
-  auto s = serializeDiffResultsJSON(results.second, json);
+  auto s = serializeDiffResultsJSON(results.second, {}, json);
   EXPECT_TRUE(s.ok());
   EXPECT_EQ(s.toString(), "OK");
   EXPECT_EQ(results.first, json);

--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -136,7 +136,7 @@ void jsonPrint(const QueryData& q) {
   for (size_t i = 0; i < q.size(); ++i) {
     std::string row_string;
 
-    if (serializeRowJSON(q[i], row_string).ok()) {
+    if (serializeRowJSON(q[i], {}, row_string).ok()) {
       printf("  %s", row_string.c_str());
       if (i < q.size() - 1) {
         printf(",\n");

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -113,6 +113,7 @@ inline Status launchQuery(const std::string& name,
   item.name = name;
   item.identifier = ident;
   item.columns = sql.columns();
+  item.columnTypes = sql.columnTypes();
   item.time = osquery::getUnixTime();
   item.epoch = FLAGS_schedule_epoch;
   item.calendar_time = osquery::getAsciiTime();
@@ -136,8 +137,11 @@ inline Status launchQuery(const std::string& name,
   // We can then ask for a differential from the last time this named query
   // was executed by exact matching each row.
   if (!FLAGS_events_optimize || !sql.eventBased()) {
-    status = dbQuery.addNewResults(
-        std::move(sql.rows()), item.epoch, item.counter, diff_results);
+    status = dbQuery.addNewResults(std::move(sql.rows()),
+                                   item.columnTypes,
+                                   item.epoch,
+                                   item.counter,
+                                   diff_results);
     if (!status.ok()) {
       std::string line =
           "Error adding new results to database: " + status.what();

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -96,7 +96,8 @@ Status Distributed::serializeResults(std::string& json) {
   auto statuses_obj = doc.getObject();
   for (const auto& result : results_) {
     auto arr = doc.getArray();
-    auto s = serializeQueryData(result.results, result.columns, doc, arr);
+    auto s = serializeQueryData(
+        result.results, result.columns, result.colTypes, doc, arr);
     if (!s.ok()) {
       return s;
     }
@@ -129,7 +130,7 @@ Status Distributed::runQueries() {
     }
 
     DistributedQueryResult result(
-        request, sql.rows(), sql.columns(), sql.getStatus());
+        request, sql.rows(), sql.columns(), sql.columnTypes(), sql.getStatus());
     addResult(result);
   }
   return flushCompleted();
@@ -307,7 +308,7 @@ Status serializeDistributedQueryResult(const DistributedQueryResult& r,
   }
 
   auto results_arr = doc.getArray();
-  s = serializeQueryData(r.results, r.columns, doc, results_arr);
+  s = serializeQueryData(r.results, r.columns, r.colTypes, doc, results_arr);
   if (!s.ok()) {
     return s;
   }

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -591,7 +591,8 @@ Status EventSubscriberPlugin::addBatch(std::vector<Row>& row_list,
 
     // Serialize and store the row data, for query-time retrieval.
     std::string serialized_row;
-    auto status = serializeRowJSON(row, serialized_row);
+    ColumnTypes colTypes; // Empty type map for all-string serialization
+    auto status = serializeRowJSON(row, colTypes, serialized_row);
     if (!status.ok()) {
       VLOG(1) << status.getMessage();
       continue;

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -47,6 +47,10 @@ const ColumnNames& SQL::columns() const {
   return columns_;
 }
 
+const ColumnTypes& SQL::columnTypes() const {
+  return columnTypes_;
+}
+
 bool SQL::ok() const {
   return status_.ok();
 }

--- a/osquery/tests/test_util.cpp
+++ b/osquery/tests/test_util.cpp
@@ -255,6 +255,15 @@ ColumnNames getSerializedRowColumnNames(bool unordered_and_repeated) {
   return cn;
 }
 
+ColumnTypes getSerializedRowColumnTypes() {
+  ColumnTypes ct;
+  ct["alphabetical"] = TEXT_TYPE;
+  ct["foo"] = BIGINT_TYPE;
+  ct["meaning_of_life"] = BIGINT_TYPE;
+  ct["repeated_column"] = DOUBLE_TYPE;
+  return ct;
+}
+
 std::pair<JSON, Row> getSerializedRow(bool unordered_and_repeated) {
   auto cns = getSerializedRowColumnNames(unordered_and_repeated);
 

--- a/osquery/tests/test_util.h
+++ b/osquery/tests/test_util.h
@@ -98,6 +98,9 @@ std::vector<std::pair<std::string, QueryData>> getTestDBResultStream();
 // vector includes a repeated column name and is in non-alphabetical order
 ColumnNames getSerializedRowColumnNames(bool unordered_and_repeated);
 
+// getSerializedRowColumnTypes TODO Add some tests that use this
+ColumnTypes getSerializedRowColumnTypes();
+
 // getSerializedRow() return an std::pair where pair->first is a string which
 // should serialize to pair->second. pair->second should deserialize
 // to pair->first


### PR DESCRIPTION
Tracking issue is [Use JSON number syntax for columns data in logger](https://github.com/facebook/osquery/issues/4799)
