### PR TITLE
database: changing default path of the database for pathing uniformity

### DIFF
--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -81,7 +81,7 @@
  * OSQUERY_LOG_HOME: Location of log data when the filesystem plugin is used.
  */
 #if defined(__linux__)
-#define OSQUERY_HOME "/etc/osquery"
+#define OSQUERY_HOME "/etc/osquery/"
 #define OSQUERY_DB_HOME "/var/osquery/"
 #define OSQUERY_SOCKET OSQUERY_DB_HOME
 #define OSQUERY_PIDFILE "/var/run/"
@@ -95,19 +95,19 @@
 #define OSQUERY_LOG_HOME OSQUERY_HOME "log\\"
 #define OSQUERY_CERTS_HOME OSQUERY_HOME "certs\\"
 #elif defined(FREEBSD)
-#define OSQUERY_HOME "/var/db/osquery"
+#define OSQUERY_HOME "/var/db/osquery/"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "/var/run/"
 #define OSQUERY_PIDFILE "/var/run/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/etc/ssl/"
 #else
-#define OSQUERY_HOME "/var/osquery"
-#define OSQUERY_DB_HOME OSQUERY_HOME "/"
+#define OSQUERY_HOME "/var/osquery/"
+#define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET OSQUERY_DB_HOME
 #define OSQUERY_PIDFILE OSQUERY_DB_HOME
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
-#define OSQUERY_CERTS_HOME OSQUERY_HOME "/certs/"
+#define OSQUERY_CERTS_HOME OSQUERY_HOME "certs/"
 #endif
 
 /// A configuration error is catastrophic and should exit the watcher.

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -88,12 +88,12 @@
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
-#define OSQUERY_HOME "\\ProgramData\\osquery"
-#define OSQUERY_DB_HOME OSQUERY_HOME "\\"
+#define OSQUERY_HOME "\\ProgramData\\osquery\\"
+#define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
 #define OSQUERY_PIDFILE OSQUERY_DB_HOME
-#define OSQUERY_LOG_HOME OSQUERY_HOME "\\log\\"
-#define OSQUERY_CERTS_HOME OSQUERY_HOME "\\certs\\"
+#define OSQUERY_LOG_HOME OSQUERY_HOME "log\\"
+#define OSQUERY_CERTS_HOME OSQUERY_HOME "certs\\"
 #elif defined(FREEBSD)
 #define OSQUERY_HOME "/var/db/osquery"
 #define OSQUERY_DB_HOME OSQUERY_HOME

--- a/include/osquery/core.h
+++ b/include/osquery/core.h
@@ -82,16 +82,16 @@
  */
 #if defined(__linux__)
 #define OSQUERY_HOME "/etc/osquery"
-#define OSQUERY_DB_HOME "/var/osquery"
-#define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
+#define OSQUERY_DB_HOME "/var/osquery/"
+#define OSQUERY_SOCKET OSQUERY_DB_HOME
 #define OSQUERY_PIDFILE "/var/run/"
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
 #define OSQUERY_HOME "\\ProgramData\\osquery"
-#define OSQUERY_DB_HOME OSQUERY_HOME
+#define OSQUERY_DB_HOME OSQUERY_HOME "\\"
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
-#define OSQUERY_PIDFILE OSQUERY_DB_HOME "\\"
+#define OSQUERY_PIDFILE OSQUERY_DB_HOME
 #define OSQUERY_LOG_HOME OSQUERY_HOME "\\log\\"
 #define OSQUERY_CERTS_HOME OSQUERY_HOME "\\certs\\"
 #elif defined(FREEBSD)
@@ -103,9 +103,9 @@
 #define OSQUERY_CERTS_HOME "/etc/ssl/"
 #else
 #define OSQUERY_HOME "/var/osquery"
-#define OSQUERY_DB_HOME OSQUERY_HOME
-#define OSQUERY_SOCKET OSQUERY_DB_HOME "/"
-#define OSQUERY_PIDFILE OSQUERY_DB_HOME "/"
+#define OSQUERY_DB_HOME OSQUERY_HOME "/"
+#define OSQUERY_SOCKET OSQUERY_DB_HOME
+#define OSQUERY_PIDFILE OSQUERY_DB_HOME
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME OSQUERY_HOME "/certs/"
 #endif

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -210,7 +210,7 @@ static std::thread::id kMainThreadId;
 unsigned long kLegacyThreadId;
 
 /// When no flagfile is provided via CLI, attempt to read flag 'defaults'.
-const std::string kBackupDefaultFlagfile{OSQUERY_HOME "/osquery.flags.default"};
+const std::string kBackupDefaultFlagfile{OSQUERY_HOME "osquery.flags.default"};
 
 const size_t kDatabaseMaxRetryCount{25};
 const size_t kDatabaseRetryDelay{200};

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -32,7 +32,7 @@ CLI_FLAG(bool, database_dump, false, "Dump the contents of the backing store");
 
 CLI_FLAG(string,
          database_path,
-         OSQUERY_DB_HOME "/osquery.db",
+         OSQUERY_DB_HOME "osquery.db",
          "If using a disk-based backing store, specify a path");
 FLAG_ALIAS(std::string, db_path, database_path);
 

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -58,7 +58,7 @@ CLI_FLAG(string,
 
 CLI_FLAG(string,
          extensions_autoload,
-         OSQUERY_HOME "/extensions.load",
+         OSQUERY_HOME "extensions.load",
          "Optional path to a list of autoloaded & managed extensions");
 
 CLI_FLAG(string,

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -26,7 +26,7 @@ DECLARE_string(flagfile);
 
 namespace osquery {
 
-static const std::string kDefaultFlagsFile{OSQUERY_HOME "\\osquery.flags"};
+static const std::string kDefaultFlagsFile{OSQUERY_HOME "osquery.flags"};
 static const std::string kServiceName{"osqueryd"};
 static const std::string kServiceDisplayName{"osquery daemon service"};
 

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -24,7 +24,7 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 
-const std::string kYARAHome{OSQUERY_HOME "/yara/"};
+const std::string kYARAHome{OSQUERY_HOME "yara/"};
 
 void YARACompilerCallback(int error_level,
                           const char* file_name,


### PR DESCRIPTION
On Windows we have some queries for monitoring the size of the database path, however with the default values of the DB path these queries don't quite work. This modifies how we do default database paths just a bit so that slashes are specific to the platform on which the path is defined. A sample of the logic is below, as well as the sample query:
```
SELECT db.db_size_mb AS database_size FROM osquery_info i, processes p, time, (SELECT (sum(size) / 1024) / 1024.0 AS db_size_mb FROM (SELECT value FROM osquery_flags WHERE name = 'database_path' limit 1 ) AS flags, file WHERE path LIKE flags.value || '%%' AND type = 'regular' ) AS db WHERE p.pid = i.pid;
```
Before the database path was defaulted to an invalid directory
```
{"snapshot":[{"database_size":""}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:04:48 2018 UTC","unixTime":1533704688,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery/osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:04:48 2018 UTC","unixTime":1533704688,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":""}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:04:57 2018 UTC","unixTime":1533704697,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery/osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:04:57 2018 UTC","unixTime":1533704697,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":""}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:05:06 2018 UTC","unixTime":1533704706,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery/osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 05:05:06 2018 UTC","unixTime":1533704706,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
```
After we update the default path of the database:
```
{"snapshot":[{"database_size":"0.7333984375"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:38 2018 UTC","unixTime":1533704078,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:38 2018 UTC","unixTime":1533704078,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.7333984375"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:47 2018 UTC","unixTime":1533704087,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:47 2018 UTC","unixTime":1533704087,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.734375"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:56 2018 UTC","unixTime":1533704096,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:54:56 2018 UTC","unixTime":1533704096,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.244140625"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:03 2018 UTC","unixTime":1533704103,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:03 2018 UTC","unixTime":1533704103,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.244140625"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:12 2018 UTC","unixTime":1533704112,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:13 2018 UTC","unixTime":1533704113,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.2451171875"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:21 2018 UTC","unixTime":1533704121,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:22 2018 UTC","unixTime":1533704122,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"database_size":"0.2451171875"}],"action":"snapshot","name":"database_monitoring","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:31 2018 UTC","unixTime":1533704131,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
{"snapshot":[{"value":"\\ProgramData\\osquery\\osquery.db"}],"action":"snapshot","name":"db_flag_value","hostIdentifier":"devbox","calendarTime":"Wed Aug  8 04:55:31 2018 UTC","unixTime":1533704131,"epoch":0,"counter":0,"decorations":{"host_uuid":"65694D56-6BD1-CA97-DCF9-AA673CB88E8B","username":"Nick"}}
```
