### PR TITLE
Fix make sync

### DIFF
--- a/osquery/database/CMakeLists.txt
+++ b/osquery/database/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_OSQUERY_TEST_CORE(
   "${CMAKE_CURRENT_LIST_DIR}/tests/results_tests.cpp"
 )
 
+if(NOT OSQUERY_BUILD_SDK_ONLY)
 ADD_OSQUERY_LIBRARY(FALSE osquery_database_plugins
   "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/plugins/rocksdb.h"
@@ -31,6 +32,7 @@ target_compile_definitions(osquery_database_plugins
   PRIVATE
     "-DROCKSDB_LITE=1"
 )
+endif()
 
 ADD_OSQUERY_TEST_ADDITIONAL(
   "${CMAKE_CURRENT_LIST_DIR}/tests/plugin_tests.cpp"

--- a/osquery/logger/CMakeLists.txt
+++ b/osquery/logger/CMakeLists.txt
@@ -16,6 +16,7 @@ ADD_OSQUERY_TEST_CORE(
   "${CMAKE_CURRENT_LIST_DIR}/tests/logger_tests.cpp"
 )
 
+if(NOT OSQUERY_BUILD_SDK_ONLY)
 ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_logger_plugins
   "${CMAKE_CURRENT_LIST_DIR}/plugins/buffered.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/plugins/filesystem_logger.cpp"
@@ -36,6 +37,7 @@ elseif(WINDOWS)
     PRIVATE
       "${CMAKE_CURRENT_LIST_DIR}/plugins/windows_event_log.cpp"
   )
+endif()
 endif()
 
 # Keep the logger testing in the additional to test filesystem logging.

--- a/osquery/sql/CMakeLists.txt
+++ b/osquery/sql/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(libosquery
     "${CMAKE_CURRENT_LIST_DIR}/sql.cpp"
 )
 
+if(NOT OSQUERY_BUILD_SDK_ONLY)
 ADD_OSQUERY_LIBRARY_ADDITIONAL(osquery_sql_internal
   "${CMAKE_CURRENT_LIST_DIR}/sqlite_encoding.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/sqlite_filesystem.cpp"
@@ -34,6 +35,7 @@ if(NOT SKIP_CARVER)
     PRIVATE
        "${CMAKE_CURRENT_LIST_DIR}/sqlite_operations.cpp"
   )
+endif()
 endif()
 
 ADD_OSQUERY_TEST_ADDITIONAL(


### PR DESCRIPTION
Recent CMakeLists changes missed necessary didn't account for `make sync`
support. Add a workaround here.
