### PR TITLE
Changing algorithm of pathset to support more patterns

### DIFF
--- a/osquery/events/darwin/tests/fsevents_tests.cpp
+++ b/osquery/events/darwin/tests/fsevents_tests.cpp
@@ -181,8 +181,14 @@ TEST_F(FSEventsTests, test_fsevents_match_subscription) {
   EXPECT_TRUE(status.ok());
   event_pub->configure();
 
-  std::vector<std::string> exclude_paths = {
-      "/etc/ssh/%%", "/etc/", "/etc/ssl/openssl.cnf", "/"};
+  std::vector<std::string> exclude_paths = {"/etc/ssh/%%",
+                                            "/etc/",
+                                            "/etc/ssl/openssl.cnf",
+                                            "/",
+                                            "/etc/pam.d/su%",
+                                            "/etc/pam.d/%asswd",
+                                            "/etc/%/%udit_%"};
+
   for (const auto& path : exclude_paths) {
     event_pub->exclude_paths_.insert(path);
   }
@@ -199,6 +205,16 @@ TEST_F(FSEventsTests, test_fsevents_match_subscription) {
     EXPECT_FALSE(event_pub->shouldFire(sc, ec));
     ec->path = "/private/etc/ssl/certs/";
     EXPECT_TRUE(event_pub->shouldFire(sc, ec));
+    ec->path = "/private/etc/pam.d/su";
+    EXPECT_FALSE(event_pub->shouldFire(sc, ec));
+    ec->path = "/private/etc/pam.d/sudo";
+    EXPECT_FALSE(event_pub->shouldFire(sc, ec));
+    ec->path = "/private/etc/pam.d/sshd";
+    EXPECT_TRUE(event_pub->shouldFire(sc, ec));
+    ec->path = "/private/etc/pam.d/passwd";
+    EXPECT_FALSE(event_pub->shouldFire(sc, ec));
+    ec->path = "/private/etc/security/audit_control";
+    EXPECT_FALSE(event_pub->shouldFire(sc, ec));
   }
   EventFactory::deregisterEventPublisher("fsevents");
 }

--- a/osquery/events/linux/tests/inotify_tests.cpp
+++ b/osquery/events/linux/tests/inotify_tests.cpp
@@ -238,8 +238,13 @@ TEST_F(INotifyTests, test_inotify_match_subscription) {
     EXPECT_TRUE(event_pub_->shouldFire(sc, ec));
   }
 
-  std::vector<std::string> exclude_paths = {
-      "/etc/ssh/%%", "/etc/", "/etc/ssl/openssl.cnf", "/"};
+  std::vector<std::string> exclude_paths = {"/etc/ssh/%%",
+                                            "/etc/",
+                                            "/etc/ssl/openssl.cnf",
+                                            "/",
+                                            "/home/not_to_monitor%/%%",
+                                            "/dir/%/%%",
+                                            "/tmp/%abc%/%%"};
   for (const auto& path : exclude_paths) {
     event_pub_->exclude_paths_.insert(path);
   }
@@ -260,6 +265,20 @@ TEST_F(INotifyTests, test_inotify_match_subscription) {
     EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
     ec->path = "/etc/ssl/certs/";
     EXPECT_TRUE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/home/not_to_monitor/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/home/not_to_monitor2/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/home/not_to_monitor3/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/home/not_to_monito4/abc";
+    EXPECT_TRUE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/tmp/XabcY/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/dir/dir2/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
+    ec->path = "/dir/dir3/abc";
+    EXPECT_FALSE(event_pub_->shouldFire(sc, ec));
   }
 }
 

--- a/osquery/events/pathset.h
+++ b/osquery/events/pathset.h
@@ -11,12 +11,12 @@
 #pragma once
 
 #include <mutex>
-#include <set>
 #include <string>
 #include <vector>
 
 #include <boost/noncopyable.hpp>
 #include <boost/tokenizer.hpp>
+#include <boost/utility/string_view.hpp>
 
 #include <osquery/core.h>
 #include <osquery/filesystem.h>
@@ -24,20 +24,16 @@
 namespace osquery {
 
 /**
- * @brief multiset based implementation for path search.
+ * @brief Vector based implemention for path search.
  *
- * 'multiset' is used because with patterns we can serach for equivalent keys.
- * Since  '/This/Path/is' ~= '/This/Path/%' ~= '/This/Path/%%' (equivalent).
+ * PathSet applies the following policy -
+ * patternedPath -    Path can contain pattern '%' and '%%'.
+ *                    Path components containing partial patterns are also
+ *                    supported e.g. '/This/Path/xyz%' or '/This/Path/%xyz'
+ *                    or '/This/Path/%xyz%' but '/This/Path/xy%z'
+ *                    is not supported i.e. 'xy%z' is considered as normal
+ *                    string.
  *
- * multiset is protected by lock. It is threadsafe.
- *
- * PathSet can take any of the two policies -
- * 1. patternedPath - Path can contain pattern '%' and '%%'.
- *                    Path components containing only '%' and '%%' are supported
- *                    e.g. '/This/Path/%'.
- *                    Path components containing partial patterns are not
- *                    supported e.g. '/This/Path/xyz%' ('xyz%' will not be
- *                    treated as pattern).
  */
 template <typename PathType>
 class PathSet : private boost::noncopyable {
@@ -45,80 +41,100 @@ class PathSet : private boost::noncopyable {
   void insert(const std::string& str) {
     auto pattern = str;
     replaceGlobWildcards(pattern);
-    auto vpath = PathType::createVPath(pattern);
+    auto path = PathType::createPath(std::move(pattern));
 
     WriteLock lock(mset_lock_);
-    for (auto& path : vpath) {
-      paths_.insert(std::move(path));
-    }
+    patterns_.push_back(std::move(path));
   }
 
   bool find(const std::string& str) const {
     auto path = PathType::createPath(str);
 
     ReadLock lock(mset_lock_);
-    if (paths_.find(path) != paths_.end()) {
-      return true;
+    for (auto& pattern : patterns_) {
+      if (compare(pattern, path)) {
+        return true;
+      }
     }
     return false;
   }
 
   void clear() {
     WriteLock lock(mset_lock_);
-    paths_.clear();
+    patterns_.clear();
   }
 
   bool empty() const {
     ReadLock lock(mset_lock_);
-    return paths_.empty();
+    return patterns_.empty();
   }
 
  private:
   typedef typename PathType::Path Path;
   typedef typename PathType::Compare Compare;
-  std::multiset<Path, Compare> paths_;
+  std::vector<Path> patterns_;
   mutable Mutex mset_lock_;
+  Compare compare;
 };
 
 class patternedPath {
  public:
   typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
   typedef std::vector<std::string> Path;
-  typedef std::vector<Path> VPath;
   struct Compare {
-    bool operator()(const Path& lhs, const Path& rhs) const {
-      size_t psize = (lhs.size() < rhs.size()) ? lhs.size() : rhs.size();
-      unsigned ndx;
-      for (ndx = 0; ndx < psize; ++ndx) {
-        if (lhs[ndx] == "**" || rhs[ndx] == "**") {
+    bool compareStrings(boost::string_view vlhs,
+                        boost::string_view vrhs) const {
+      if (vlhs[0] == '*' && vlhs[vlhs.size() - 1] == '*') {
+        vlhs = vlhs.substr(1, vlhs.size() - 2);
+        if (vrhs.size() >= vlhs.size() &&
+            vrhs.find(vlhs) != boost::string_view::npos) {
+          return true;
+        }
+        return false;
+      } else if (vlhs[0] == '*') {
+        vlhs = vlhs.substr(1);
+        if (vlhs.size() <= vrhs.size()) {
+          vrhs = vrhs.substr(vrhs.size() - vlhs.size());
+        } else {
           return false;
         }
+      } else if (vlhs[vlhs.size() - 1] == '*') {
+        vlhs = vlhs.substr(0, vlhs.size() - 1);
+        if (vlhs.size() <= vrhs.size()) {
+          vrhs = vrhs.substr(0, vlhs.size());
+        } else {
+          return false;
+        }
+      }
 
-        if (lhs[ndx] == "*" || rhs[ndx] == "*") {
+      return (vlhs.compare(vrhs) == 0);
+    }
+
+    bool operator()(const Path& lhs, const Path& rhs) const {
+      auto psize = std::min(lhs.size(), rhs.size());
+      unsigned ndx;
+      for (ndx = 0; ndx < psize; ++ndx) {
+        if (lhs[ndx] == "**") {
+          return true;
+        }
+
+        if (lhs[ndx] == "*") {
           continue;
         }
 
-        int rc = lhs[ndx].compare(rhs[ndx]);
-
-        if (rc > 0) {
+        // compare with partial patterns
+        if (compareStrings(lhs[ndx], rhs[ndx]) == true) {
+          continue;
+        } else {
           return false;
         }
-
-        if (rc < 0) {
-          return true;
-        }
       }
 
-      if ((ndx == rhs.size() && rhs[ndx - 1] == "*") ||
-          (ndx == lhs.size() && lhs[ndx - 1] == "*")) {
-        return false;
-      }
-
-      return (lhs.size() < rhs.size());
+      return (lhs.size() == rhs.size());
     }
   };
 
-  static Path createPath(const std::string& str) {
+  static Path createPath(std::string str) {
     boost::char_separator<char> sep{"/"};
     tokenizer tokens(str, sep);
     Path path;
@@ -132,28 +148,5 @@ class patternedPath {
     }
     return path;
   }
-
-  static VPath createVPath(const std::string& str) {
-    boost::char_separator<char> sep{"/"};
-    tokenizer tokens(str, sep);
-    VPath vpath;
-    Path path;
-
-    if (str == "/") {
-      path.push_back("");
-    }
-
-    for (std::string component : tokens) {
-      if (component == "**") {
-        vpath.push_back(path);
-        path.push_back(std::move(component));
-        break;
-      }
-      path.push_back(std::move(component));
-    }
-    vpath.push_back(std::move(path));
-    return vpath;
-  }
 };
-
 } // namespace osquery


### PR DESCRIPTION
Matching wildcard rules for exclude path -

%: Match all files and folders for one level.
%%: Match all files and folders recursively.
%abc: Match all within-level ending in "abc".
abc%: Match all within-level starting with "abc".
%abc%: Match all within-level containing sub-string "abc" anywhere.

This patch fixes https://github.com/facebook/osquery/issues/3692 and https://github.com/facebook/osquery/issues/4750

