### PR TITLE
support different version of the rapid json

### DIFF
--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -73,6 +73,8 @@ TARGETS_POSTSCRIPT = """    ],
         "-DOSQUERY_BUILD_DISTRO=centos7",
         "-DOSQUERY_PLATFORM_MASK=9",
         "-DFBTHRIFT",
+        "-DRAPIDJSON_HAS_STDSTRING=1",
+        "-DRAPIDJSON_NO_SIZETYPEDEFINE",
     ],
     deps = [
         ":if-cpp2",


### PR DESCRIPTION
osquery could not compile if we used different version of the rapidjson, which would have it's on typedef of the sizetype