### PR TITLE
tables: dmiString function param to use string index

### DIFF
--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -242,9 +242,9 @@ QueryData genPlatformInfo(QueryContext& context) {
 
     Row r;
 
-    r["vendor"] = dmiString(textAddrs, address, 0x04);
-    r["version"] = dmiString(textAddrs, address, 0x05);
-    r["date"] = dmiString(textAddrs, address, 0x08);
+    r["vendor"] = dmiString(textAddrs, address, address[0x04]);
+    r["version"] = dmiString(textAddrs, address, address[0x05]);
+    r["date"] = dmiString(textAddrs, address, address[0x08]);
 
     // Firmware load address as a WORD.
     size_t firmware_address = (address[0x07] << 8) + address[0x06];

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -242,9 +242,9 @@ QueryData genPlatformInfo(QueryContext& context) {
 
     Row r;
 
-    r["vendor"] = dmiString(textAddrs, address, address[0x04]);
-    r["version"] = dmiString(textAddrs, address, address[0x05]);
-    r["date"] = dmiString(textAddrs, address, address[0x08]);
+    r["vendor"] = dmiString(textAddrs, address[0x04]);
+    r["version"] = dmiString(textAddrs, address[0x05]);
+    r["date"] = dmiString(textAddrs, address[0x08]);
 
     // Firmware load address as a WORD.
     size_t firmware_address = (address[0x07] << 8) + address[0x06];

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -107,10 +107,10 @@ QueryData genSystemInfo(QueryContext& context) {
           return;
         }
 
-        r["hardware_vendor"] = dmiString(textAddrs, address, address[0x04]);
-        r["hardware_model"] = dmiString(textAddrs, address, address[0x05]);
-        r["hardware_version"] = dmiString(textAddrs, address, address[0x06]);
-        r["hardware_serial"] = dmiString(textAddrs, address, address[0x07]);
+        r["hardware_vendor"] = dmiString(textAddrs, address[0x04]);
+        r["hardware_model"] = dmiString(textAddrs, address[0x05]);
+        r["hardware_version"] = dmiString(textAddrs, address[0x06]);
+        r["hardware_serial"] = dmiString(textAddrs, address[0x07]);
       }));
     }
   }

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -107,10 +107,10 @@ QueryData genSystemInfo(QueryContext& context) {
           return;
         }
 
-        r["hardware_vendor"] = dmiString(textAddrs, address, 0x04);
-        r["hardware_model"] = dmiString(textAddrs, address, 0x05);
-        r["hardware_version"] = dmiString(textAddrs, address, 0x06);
-        r["hardware_serial"] = dmiString(textAddrs, address, 0x07);
+        r["hardware_vendor"] = dmiString(textAddrs, address, address[0x04]);
+        r["hardware_model"] = dmiString(textAddrs, address, address[0x05]);
+        r["hardware_version"] = dmiString(textAddrs, address, address[0x06]);
+        r["hardware_serial"] = dmiString(textAddrs, address, address[0x07]);
       }));
     }
   }

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -356,8 +356,8 @@ void genSMBIOSMemoryDevices(size_t index,
     r["set"] = INTEGER(static_cast<int>(address[0x0F]));
   }
 
-  r["device_locator"] = dmiString(textAddrs, address, address[0x10]);
-  r["bank_locator"] = dmiString(textAddrs, address, address[0x11]);
+  r["device_locator"] = dmiString(textAddrs, address[0x10]);
+  r["bank_locator"] = dmiString(textAddrs, address[0x11]);
 
   auto memoryType = kSMBIOSMemoryTypeTable.find(address[0x12]);
   if (memoryType != kSMBIOSMemoryTypeTable.end()) {
@@ -377,10 +377,10 @@ void genSMBIOSMemoryDevices(size_t index,
     r["configured_clock_speed"] = INTEGER(speed);
   }
 
-  r["manufacturer"] = dmiString(textAddrs, address, address[0x17]);
-  r["serial_number"] = dmiString(textAddrs, address, address[0x18]);
-  r["asset_tag"] = dmiString(textAddrs, address, address[0x19]);
-  r["part_number"] = dmiString(textAddrs, address, address[0x1A]);
+  r["manufacturer"] = dmiString(textAddrs, address[0x17]);
+  r["serial_number"] = dmiString(textAddrs, address[0x18]);
+  r["asset_tag"] = dmiString(textAddrs, address[0x19]);
+  r["part_number"] = dmiString(textAddrs, address[0x1A]);
 
   auto vt = dmiToWord(address, 0x22);
   if (vt != 0) {
@@ -551,7 +551,7 @@ void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
   results.push_back(std::move(r));
 }
 
-std::string dmiString(uint8_t* data, uint8_t* address, uint8_t index) {
+std::string dmiString(uint8_t* data, uint8_t index) {
   if (index == 0) {
     return "";
   }

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -356,8 +356,8 @@ void genSMBIOSMemoryDevices(size_t index,
     r["set"] = INTEGER(static_cast<int>(address[0x0F]));
   }
 
-  r["device_locator"] = dmiString(textAddrs, address, 0x10);
-  r["bank_locator"] = dmiString(textAddrs, address, 0x11);
+  r["device_locator"] = dmiString(textAddrs, address, address[0x10]);
+  r["bank_locator"] = dmiString(textAddrs, address, address[0x11]);
 
   auto memoryType = kSMBIOSMemoryTypeTable.find(address[0x12]);
   if (memoryType != kSMBIOSMemoryTypeTable.end()) {
@@ -377,10 +377,10 @@ void genSMBIOSMemoryDevices(size_t index,
     r["configured_clock_speed"] = INTEGER(speed);
   }
 
-  r["manufacturer"] = dmiString(textAddrs, address, 0x17);
-  r["serial_number"] = dmiString(textAddrs, address, 0x18);
-  r["asset_tag"] = dmiString(textAddrs, address, 0x19);
-  r["part_number"] = dmiString(textAddrs, address, 0x1A);
+  r["manufacturer"] = dmiString(textAddrs, address, address[0x17]);
+  r["serial_number"] = dmiString(textAddrs, address, address[0x18]);
+  r["asset_tag"] = dmiString(textAddrs, address, address[0x19]);
+  r["part_number"] = dmiString(textAddrs, address, address[0x1A]);
 
   auto vt = dmiToWord(address, 0x22);
   if (vt != 0) {
@@ -551,8 +551,7 @@ void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
   results.push_back(std::move(r));
 }
 
-std::string dmiString(uint8_t* data, uint8_t* address, size_t offset) {
-  auto index = address[offset];
+std::string dmiString(uint8_t* data, uint8_t* address, uint8_t index) {
   if (index == 0) {
     return "";
   }

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -133,14 +133,13 @@ void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
  *
  * SMBIOS strings are 0-terminated and 'stacked' at the end of the type
  * structure. Each structure identifies (loosely) the type of data within.
- * Using the structure field 'handle' or offset, the stacked data can be parsed
- * and a string returned.
+ * Using the structure location for where the strings start and the index of
+ * target string, the stacked data can be parsed and a string returned.
  *
- * @param data A pointer to the SMBIOS structure.
- * @param address A pointer to the stacked data following the structure.
+ * @param data A pointer to the stacked data suffixing the SMBIOS structure.
  * @Param index The index of the stacked string.
  */
-std::string dmiString(uint8_t* data, uint8_t* address, uint8_t index);
+std::string dmiString(uint8_t* data, uint8_t index);
 
 /**
  * @brief Return std::string representation of a bitfield.

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -138,9 +138,9 @@ void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
  *
  * @param data A pointer to the SMBIOS structure.
  * @param address A pointer to the stacked data following the structure.
- * @Param offset The field index into address.
+ * @Param index The index of the stacked string.
  */
-std::string dmiString(uint8_t* data, uint8_t* address, size_t offset);
+std::string dmiString(uint8_t* data, uint8_t* address, uint8_t index);
 
 /**
  * @brief Return std::string representation of a bitfield.


### PR DESCRIPTION
Currently there is a function `std::string dmiString(uint8_t* data, uint8_t* address, size_t offset)` for extracting null terminated strings at the end of a [SMBIOS](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.7.1.pdf) structure.  The 3rd parameter takes the offset of the structure that points to the index of where the string resides.  This is problematic in that structures like `OEM string` (type 11), which merely contain a count of total number of strings stacked at the end, will not be able to use this function as is.  It also feels a bit semantically incorrect for the function to accept an offset of the structure to get an index from as parameter rather than just taking in the index of the string the caller wants directly.  This PR makes that minor change of `dmiString` to:
```c++
std::string dmiString(uint8_t* data, uint8_t* address, uint8_t index);
```