### PR TITLE
SMBIOS `oem_strings` table

### DIFF
--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -205,6 +205,25 @@ QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
   return results;
 }
 
+QueryData genOEMStrings(QueryContext& context) {
+  QueryData results;
+
+  DarwinSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           uint8_t* textAddrs,
+                           size_t size) {
+    genSMBIOSOEMStrings(hdr, address, textAddrs, size, results);
+  });
+
+  return results;
+}
+
 QueryData genPlatformInfo(QueryContext& context) {
   auto rom = IORegistryEntryFromPath(kIOMasterPortDefault, "IODeviceTree:/rom");
   if (rom == 0) {

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -223,6 +223,25 @@ QueryData genMemoryDeviceMappedAddresses(QueryContext& context) {
   return results;
 }
 
+QueryData genOEMStrings(QueryContext& context) {
+  QueryData results;
+
+  LinuxSMBIOSParser parser;
+  if (!parser.discover()) {
+    return results;
+  }
+
+  parser.tables([&results](size_t index,
+                           const SMBStructHeader* hdr,
+                           uint8_t* address,
+                           uint8_t* textAddrs,
+                           size_t size) {
+    genSMBIOSOEMStrings(hdr, address, textAddrs, size, results);
+  });
+
+  return results;
+}
+
 QueryData genPlatformInfo(QueryContext& context) {
   LinuxSMBIOSParser parser;
   if (!parser.discover()) {

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -52,6 +52,7 @@ extern const std::map<uint8_t, std::string> kSMBIOSTypeDescriptions;
 
 constexpr uint8_t kSMBIOSTypeBIOS = 0;
 constexpr uint8_t kSMBIOSTypeSystem = 1;
+constexpr uint8_t kSMBIOSTypeOEMStrings = 11;
 constexpr uint8_t kSMBIOSTypeMemoryArray = 16;
 constexpr uint8_t kSMBIOSTypeMemoryDevice = 17;
 constexpr uint8_t kSMBIOSTypeMemoryErrorInformation = 18;
@@ -127,6 +128,13 @@ void genSMBIOSMemoryDeviceMappedAddresses(size_t index,
                                           uint8_t* address,
                                           size_t size,
                                           QueryData& results);
+
+/// Helper, cross platform, table generator for OEM strings.
+void genSMBIOSOEMStrings(const SMBStructHeader* hdr,
+                         uint8_t* address,
+                         uint8_t* textAddrs,
+                         size_t size,
+                         QueryData& results);
 
 /**
  * @brief Return a 0-terminated strings from an SMBIOS address and handle.

--- a/specs/blacklist
+++ b/specs/blacklist
@@ -21,6 +21,7 @@ freebsd:memory_arrays
 freebsd:memory_error_info
 freebsd:memory_array_mapped_addresses
 freebsd:memory_device_mapped_addresses
+freebsd:oem_strings
 
 # Blacklisting as an example:
 example

--- a/specs/posix/oem_strings.table
+++ b/specs/posix/oem_strings.table
@@ -1,8 +1,8 @@
 table_name("oem_strings")
 description("OEM defined strings retrieved from SMBIOS.")
 schema([
-    Column("handle",  TEXT, "Handle, or instance number, associated with the Type 11 structure"),
-    Column("number",  INTEGER, "The string index of the structure"),
+    Column("handle", TEXT, "Handle, or instance number, associated with the Type 11 structure"),
+    Column("number", INTEGER, "The string index of the structure"),
     Column("value", TEXT, "The value of the OEM string"),
 ])
 

--- a/specs/posix/oem_strings.table
+++ b/specs/posix/oem_strings.table
@@ -1,0 +1,9 @@
+table_name("oem_strings")
+description("OEM defined strings retrieved from SMBIOS.")
+schema([
+    Column("handle",  TEXT, "Handle, or instance number, associated with the Type 11 structure"),
+    Column("number",  INTEGER, "The string index of the structure"),
+    Column("value", TEXT, "The value of the OEM string"),
+])
+
+implementation("smbios_tables@genOEMStrings")


### PR DESCRIPTION
This is the initial implementation of [SMBIOS type 11 structure, OEM strings](https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_2.7.1.pdf), which consists of free form strings defined by the OEM.

An real world example of the usefulness of this table could be when OEMs sell equipment to 3rd party suppliers, they sometimes do not fill out vendor and model information in the usual type 0 structure (retrieved in osquery table `system_info`) but include the data that reveals the original vendor and model in the type 11 structure.   This table will allow users to examine the true origin of the system.  In the case that information that can be missing altogether, an SQL statement like this can be made to fill in what should be there:
```sql
SELECT computer_name, 
       cpu_brand, 
       hardware_serial, 
       CASE 
         WHEN hardware_model = '' 
               OR hardware_model IS NULL THEN (SELECT value 
                                               FROM   oem_strings 
                                               WHERE  number = 1) 
         ELSE hardware_model 
       END AS hardware_model, 
       CASE 
         WHEN hardware_vendor = '' 
               OR hardware_vendor IS NULL THEN (SELECT value 
                                                FROM   oem_strings 
                                                WHERE  value LIKE '7[%]') 
         ELSE hardware_vendor 
       END AS hardware_vendor 
FROM   system_info; 
```