### PR TITLE
[aws] adding aws proxy support in ClientConfiguration

### DIFF
--- a/docs/wiki/deployment/aws-logging.md
+++ b/docs/wiki/deployment/aws-logging.md
@@ -15,6 +15,11 @@ Some configuration is shared between the two plugins:
 --aws_sts_region VALUE                  AWS STS assume role region
 --aws_sts_session_name VALUE            AWS STS session name
 --aws_sts_timeout VALUE                 AWS STS temporary credential timeout period in seconds (900-3600)
+--aws_proxy_scheme VALUE                Proxy HTTP scheme for use in AWS client config (http or https)
+--aws_proxy_host VALUE                  Proxy host for use in AWS client config
+--aws_proxy_port VALUE                  Proxy port for use in AWS client config
+--aws_proxy_username VALUE              Proxy username for use in AWS client config
+--aws_proxy_password VALUE              Proxy password for use in AWS client config
 ```
 
 When working with AWS, osquery will look for credentials and region configuration in the following order:

--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -57,6 +57,21 @@ FLAG(uint64,
      aws_sts_timeout,
      3600,
      "AWS STS assume role credential validity in seconds (default 3600)");
+FLAG(string,
+     aws_proxy_scheme,
+     "https",
+     "Proxy HTTP scheme for use in AWS client config (http or https, default "
+     "https)");
+FLAG(string, aws_proxy_host, "", "Proxy host for use in AWS client config");
+FLAG(uint16, aws_proxy_port, 0, "Proxy port for use in AWS client config");
+FLAG(string,
+     aws_proxy_username,
+     "",
+     "Proxy username for use in AWS client config");
+FLAG(string,
+     aws_proxy_password,
+     "",
+     "Proxy password for use in AWS client config");
 
 /// Map of AWS region name to AWS::Region enum.
 static const std::set<std::string> kAwsRegions = {"us-east-1",
@@ -476,5 +491,14 @@ Status appendLogTypeToJson(const std::string& log_type, std::string& log) {
     log.pop_back();
   }
   return Status(0, "OK");
+}
+
+void setAWSProxy(Aws::Client::ClientConfiguration& config) {
+  config.proxyScheme =
+      Aws::Http::SchemeMapper::FromString(FLAGS_aws_proxy_scheme);
+  config.proxyHost = FLAGS_aws_proxy_host;
+  config.proxyPort = FLAGS_aws_proxy_port;
+  config.proxyUserName = FLAGS_aws_proxy_username;
+  config.proxyPassword = FLAGS_aws_proxy_password;
 }
 }

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -201,6 +201,10 @@ Status makeAWSClient(std::shared_ptr<Client>& client,
   } else {
     client_config.region = region;
   }
+
+  // Setup any proxy options on the config
+  setAWSProxy(client_config);
+
   client = std::make_shared<Client>(
       std::make_shared<OsqueryAWSCredentialsProviderChain>(sts), client_config);
   return Status(0);
@@ -217,4 +221,13 @@ Status makeAWSClient(std::shared_ptr<Client>& client,
  * @return 0 if successful, 1 if there were issues
  */
 Status appendLogTypeToJson(const std::string& log_type, std::string& log);
+
+/**
+ * @brief Set proxy information on the AWS ClientConfiguration using
+ * relevant flags for scheme, host, port, username, and password
+ *
+ * @param config Pointer to Aws::Client::ClientConfiguration struct
+ *  on which to set the proxy values
+ */
+void setAWSProxy(Aws::Client::ClientConfiguration& config);
 }


### PR DESCRIPTION
### Background
The aws sdk supports configurable proxy settings, via the `Aws::Client::ClientConfiguration`.  Osquery does not currently support this.

### Changes
Adding the ability to leverage a proxy for logging to AWS services via osquery with flags for host, port, etc.

### Testing
Added unit tests to ensure config gets setup properly.