### PR TITLE
deps: Add bottle hashes for ssdeep-cpp

### DIFF
--- a/tools/provision/formula/ssdeep-cpp.rb
+++ b/tools/provision/formula/ssdeep-cpp.rb
@@ -8,6 +8,13 @@ class SsdeepCpp < AbstractOsqueryFormula
   sha256 "ff2eabc78106f009b4fb2def2d76fb0ca9e12acf624cbbfad9b3eb390d931313"
   revision 200
 
+  bottle do
+    root_url "https://osquery-packages.s3.amazonaws.com/bottles"
+    cellar :any_skip_relocation
+    sha256 "00ccb3820f19ca73e5cf553da5623d118843fad1516d5bf283eae403ae55298d" => :x86_64_linux
+    sha256 "64a6e3794335f0b24813ad3b22d40ed2bb32ad8040414e59022dfeb148e0c0e1" => :sierra
+  end
+
   def install
     append "CXXFLAGS", "-stdlib=libc++"
     system "./configure --prefix=#{prefix} --enable-static --enable-shared=no"


### PR DESCRIPTION
Add hashes for `ssdeep-cpp` so everyone does not have to build when installing deps.