### PR TITLE
A missing Gatekeeper prefs file indicates it is on

### DIFF
--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -76,7 +76,9 @@ QueryData genGateKeeper(QueryContext& context) {
   auto gke_status = SQL::selectAllFrom("plist", "path", EQUALS, kGkeStatusPath);
 
   if (gke_status.empty()) {
-    r["assessments_enabled"] = INTEGER(0);
+    // The absence of the file indicates that Gatekeeper is fully enabled
+    r["assessments_enabled"] = INTEGER(1);
+    r["dev_id_enabled"] = INTEGER(1);
   }
 
   for (const auto& row : gke_status) {


### PR DESCRIPTION
This PR fixes #4748. 

When I wrote the gatekeeper table, I did not correctly handle the case where `/var/db/SystemPolicy-prefs.plist` (the file that describes gatekeeper's settings) is missing.

When this file is missing (which is the default situation on macOS where the user has not modified gatekeeper's settings) macOS will fully enable Gatekeeper.

Before this commit, if the that file was missing, the gatekeeper table would incorrectly report the `assessments_enabled` column as `0` and `dev_id_enabled` as `NULL`. 

This change ensures the gatekeeper table reports `assessments_enabled` column as `1` and `dev_id_enabled` as `1`. This now correctly reports the state of the machine.



