### PR TITLE
clang flexible-array-extensions warnings fix

### DIFF
--- a/osquery/tables/system/darwin/packages.h
+++ b/osquery/tables/system/darwin/packages.h
@@ -65,7 +65,7 @@ struct BOMVar {
 
 struct BOMVars {
   uint32_t count;
-  BOMVar list[];
+  BOMVar* list;
 } __attribute__((packed));
 
 struct BOMPathIndices {


### PR DESCRIPTION
clang 1 out of 2 warning fixed. 