### PR TITLE
sqlite3_exec replaced by non serializing type aware osquery_exec

### DIFF
--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -8,8 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <boost/lexical_cast.hpp>
 #include <boost/variant.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/sql/virtual_table.h"
@@ -481,7 +481,7 @@ Status osquery_exec(
       columns.reserve(nCol);
 
       for (int i = 0; i < nCol; i++) {
-        columns.push_back(static_cast<int64_t>(sqlite3_column_name(pStmt, i)));
+        columns.push_back(sqlite3_column_name(pStmt, i));
       }
     }
 
@@ -491,7 +491,7 @@ Status osquery_exec(
     for (int i = 0; i < nCol; i++) {
       switch (sqlite3_column_type(pStmt, i)) {
       case SQLITE_INTEGER:
-        rows.back().push_back(sqlite3_column_int64(pStmt, i));
+        rows.back().push_back(static_cast<int64_t>(sqlite3_column_int64(pStmt, i)));
         break;
       case SQLITE_FLOAT:
         rows.back().push_back(sqlite3_column_double(pStmt, i));

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -485,8 +485,7 @@ Status osquery_exec(
       }
     }
 
-    rows.push_back(
-        std::vector<boost::variant<long long, double, std::string>>());
+    rows.push_back(std::vector<boost::variant<int64_t, double, std::string>>());
     rows.back().reserve(nCol);
 
     for (int i = 0; i < nCol; i++) {

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -8,8 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <boost/variant.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/variant.hpp>
 
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/sql/virtual_table.h"
@@ -491,7 +491,8 @@ Status osquery_exec(
     for (int i = 0; i < nCol; i++) {
       switch (sqlite3_column_type(pStmt, i)) {
       case SQLITE_INTEGER:
-        rows.back().push_back(static_cast<int64_t>(sqlite3_column_int64(pStmt, i)));
+        rows.back().push_back(
+            static_cast<int64_t>(sqlite3_column_int64(pStmt, i)));
         break;
       case SQLITE_FLOAT:
         rows.back().push_back(sqlite3_column_double(pStmt, i));

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -8,7 +8,7 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include "boost/variant.hpp"
+#include <boost/variant.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include "osquery/sql/sqlite_util.h"

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -8,8 +8,8 @@
  *  You may select, at your option, one of the above-listed licenses.
  */
 
-#include <boost/variant.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/variant.hpp>
 
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/sql/virtual_table.h"

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -465,7 +465,7 @@ Status osquery_exec(
     sqlite3* db,
     const std::string& q,
     std::vector<std::string>& columns,
-    std::vector<std::vector<boost::variant<long long, double, std::string>>>&
+    std::vector<std::vector<boost::variant<int64_t, double, std::string>>>&
         rows) {
   sqlite3_stmt* pStmt = nullptr;
   sqlite3_prepare_v2(db, q.c_str(), -1, &pStmt, nullptr);
@@ -524,7 +524,7 @@ Status queryInternal(const std::string& q,
                      const SQLiteDBInstanceRef& instance) {
   auto lock = instance->attachLock();
   std::vector<std::string> columns;
-  std::vector<std::vector<boost::variant<long long, double, std::string>>> rows;
+  std::vector<std::vector<boost::variant<int64_t, double, std::string>>> rows;
 
   auto status = osquery_exec(instance->db(), q, columns, rows);
 

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "boost/variant.hpp"
+#include <boost/lexical_cast.hpp>
 
 #include "osquery/sql/sqlite_util.h"
 #include "osquery/sql/virtual_table.h"
@@ -19,7 +20,6 @@
 #include <osquery/registry_factory.h>
 #include <osquery/sql.h>
 
-#include <boost/lexical_cast.hpp>
 
 namespace osquery {
 
@@ -481,7 +481,7 @@ Status osquery_exec(
       columns.reserve(nCol);
 
       for (int i = 0; i < nCol; i++) {
-        columns.push_back(sqlite3_column_name(pStmt, i));
+        columns.push_back(static_cast<int64_t>(sqlite3_column_name(pStmt, i)));
       }
     }
 

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -374,14 +374,6 @@ class SQLInternal : public SQL {
 std::string getStringForSQLiteReturnCode(int code);
 
 /**
- * @brief Accumulate rows from an SQLite exec into a QueryData struct.
- *
- * The callback for populating a std::vector<Row> set of results. "argument"
- * should be a non-const reference to a std::vector<Row>.
- */
-int queryDataCallback(void* argument, int argc, char* argv[], char* column[]);
-
-/**
  * @brief Register math-related 'custom' functions.
  */
 void registerMathExtensions(sqlite3* db);

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -92,16 +92,6 @@ TEST_F(SQLiteUtilTests, test_direct_query_execution) {
   EXPECT_EQ(results, getTestDBExpectedResults());
 }
 
-TEST_F(SQLiteUtilTests, test_passing_callback_no_data_param) {
-  char* err = nullptr;
-  auto dbc = getTestDBC();
-  sqlite3_exec(dbc->db(), kTestQuery.c_str(), queryDataCallback, nullptr, &err);
-  EXPECT_TRUE(err != nullptr);
-  if (err != nullptr) {
-    sqlite3_free(err);
-  }
-}
-
 TEST_F(SQLiteUtilTests, test_aggregate_query) {
   auto dbc = getTestDBC();
   QueryData results;


### PR DESCRIPTION
Enables #4828  #4799 
sqlite3_exec serializes everything into the string and does not give the information about the type. shell_exec serializes everything into the string but gives the original type information, however it's written in a low level C code.

osquery_exec does not lose information about the types, does no serialize things into the string(saving time) and is written in a more c++ like code. (Getting rid of callback mess and mallocs)

Currently osquery_exec results are still just serialized into the string, however #4828 we plan to use it soon.  

Please, let me know your thoughts about the improvements.