### PR TITLE
Add hopcount entry to the 'routes' table

### DIFF
--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -80,6 +80,7 @@ Status genRoute(const struct rt_msghdr *route,
                 Row &r) {
   r["flags"] = INTEGER(route->rtm_flags);
   r["mtu"] = INTEGER(route->rtm_rmx.rmx_mtu);
+  r["hopcount"] = INTEGER(route->rtm_rmx.rmx_hopcount);
 
   if ((route->rtm_addrs & RTA_DST) == RTA_DST) {
     r["destination"] = ipAsString(addr_map[RTAX_DST]);

--- a/osquery/tables/networking/freebsd/routes.cpp
+++ b/osquery/tables/networking/freebsd/routes.cpp
@@ -81,6 +81,7 @@ Status genRoute(const struct rt_msghdr* route,
                 Row& r) {
   r["flags"] = INTEGER(route->rtm_flags);
   r["mtu"] = INTEGER(route->rtm_rmx.rmx_mtu);
+  r["hopcount"] = INTEGER(route->rtm_rmx.rmx_hopcount);
 
   if ((route->rtm_addrs & RTA_DST) == RTA_DST) {
     r["destination"] = ipAsString(addr_map[RTAX_DST]);

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -134,7 +134,7 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
       break;
     case RTA_METRICS:
       struct rtattr* xattr = static_cast<struct rtattr*> RTA_DATA(attr);
-      uint32_t xattr_size = RTA_PAYLOAD(attr);
+      const auto xattr_size = RTA_PAYLOAD(attr);
       while (RTA_OK(xattr, xattr_size)) {
         switch (xattr->rta_type) {
         case RTAX_HOPLIMIT:

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -134,7 +134,7 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
       break;
     case RTA_METRICS:
       struct rtattr* xattr = static_cast<struct rtattr*> RTA_DATA(attr);
-      const auto xattr_size = RTA_PAYLOAD(attr);
+      auto xattr_size = RTA_PAYLOAD(attr);
       while (RTA_OK(xattr, xattr_size)) {
         switch (xattr->rta_type) {
         case RTAX_HOPLIMIT:

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -106,6 +106,7 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   // Iterate over each route in the netlink message
   bool has_destination = false;
   r["metric"] = "0";
+  r["hopcount"] = INTEGER(0);
   while (RTA_OK(attr, attr_size)) {
     switch (attr->rta_type) {
     case RTA_OIF:
@@ -130,6 +131,18 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
       break;
     case RTA_PRIORITY:
       r["metric"] = INTEGER(*(int*)RTA_DATA(attr));
+      break;
+    case RTA_METRICS:
+      struct rtattr* xattr = static_cast<struct rtattr*> RTA_DATA(attr);
+      uint32_t xattr_size = RTA_PAYLOAD(attr);
+      while (RTA_OK(xattr, xattr_size)) {
+        switch (xattr->rta_type) {
+        case RTAX_HOPLIMIT:
+          r["hopcount"] = INTEGER(*(int*)RTA_DATA(xattr));
+          break;
+        }
+        xattr = RTA_NEXT(xattr, xattr_size);
+      }
       break;
     }
     attr = RTA_NEXT(attr, attr_size);

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -76,7 +76,9 @@ QueryData genGateKeeper(QueryContext& context) {
   auto gke_status = SQL::selectAllFrom("plist", "path", EQUALS, kGkeStatusPath);
 
   if (gke_status.empty()) {
-    r["assessments_enabled"] = INTEGER(0);
+    // The absence of the file indicates that Gatekeeper is fully enabled
+    r["assessments_enabled"] = INTEGER(1);
+    r["dev_id_enabled"] = INTEGER(1);
   }
 
   for (const auto& row : gke_status) {

--- a/specs/routes.table
+++ b/specs/routes.table
@@ -11,5 +11,9 @@ schema([
     Column("metric", INTEGER, "Cost of route. Lowest is preferred"),
     Column("type", TEXT, "Type of route"),
 ])
+
+extended_schema(POSIX, [
+    Column("hopcount", INTEGER, "Max hops expected"),
+])
 attributes(cacheable=True)
 implementation("networking/routes@genRoutes")


### PR DESCRIPTION
Summary:
The 'hopcount' field exposes the TTL (or hop_limit in IPv6) associated to the route.

Tested on:
  - Linux 4.17.13
  - FreeBSD 11.2
  - Darwin 17.7.0