### PR TITLE
treat warnings as error [posix]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ if(NOT WIN32)
 endif()
 
 if(POSIX)
+  add_compile_options(
+    -Werror
+  )
   if(CLANG)
     add_compile_options(
       -Qunused-arguments

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -588,9 +588,9 @@ Status setThreadName(const std::string& name) {
       return Status();
     }
   }
-  return Status::failure();
+  return Status::failure("setThreadName failed due GetProcAddress returning null");
 #else
-  return Status::failure();
+  return Status::failure("setThreadName requested for unknown OS");
 #endif
 }
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -483,7 +483,11 @@ bool DropPrivileges::dropTo(const std::string& user) {
 
 bool setThreadEffective(uid_t uid, gid_t gid) {
 #if defined(__APPLE__)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated"
   return (pthread_setugid_np(uid, gid) == 0);
+#pragma GCC diagnostic pop
 #elif defined(__linux__)
   return (syscall(SYS_setresgid, -1, gid, -1) == 0 &&
           syscall(SYS_setresuid, -1, uid, -1) == 0);

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -588,7 +588,9 @@ Status setThreadName(const std::string& name) {
       return Status();
     }
   }
-  return Status(1);
+  return Status::failure();
+#else
+  return Status::failure();
 #endif
 }
 

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -588,7 +588,8 @@ Status setThreadName(const std::string& name) {
       return Status();
     }
   }
-  return Status::failure("setThreadName failed due GetProcAddress returning null");
+  return Status::failure(
+      "setThreadName failed due GetProcAddress returning null");
 #else
   return Status::failure("setThreadName requested for unknown OS");
 #endif

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -570,7 +570,10 @@ DropPrivileges::~DropPrivileges() {
 Status setThreadName(const std::string& name) {
 #if defined(__APPLE__)
   int return_code = pthread_setname_np(name.c_str());
-  return Status(return_code == 0 ? 0 : 1);
+  return return_code == 0 ? Status::success()
+                          : Status::failure(
+                                "In setThreadName pthread_setname_np failed to "
+                                "set the name");
 #elif defined(__linux__)
   int return_code = pthread_setname_np(pthread_self(), name.c_str());
   return Status(return_code == 0 ? 0 : 1);

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -568,11 +568,12 @@ DropPrivileges::~DropPrivileges() {
 #endif
 
 Status setThreadName(const std::string& name) {
-  int return_code;
 #if defined(__APPLE__)
-  return_code = pthread_setname_np(name.c_str());
+  int return_code = pthread_setname_np(name.c_str());
+  return Status(return_code == 0 ? 0 : 1);
 #elif defined(__linux__)
-  return_code = pthread_setname_np(pthread_self(), name.c_str());
+  int return_code = pthread_setname_np(pthread_self(), name.c_str());
+  return Status(return_code == 0 ? 0 : 1);
 #elif defined(WIN32)
   // SetThreadDescription is available in builds newer than 1607 of windows 10
   // and works even if there is no debugger.
@@ -589,7 +590,6 @@ Status setThreadName(const std::string& name) {
   }
   return Status(1);
 #endif
-  return Status(return_code == 0 ? 0 : 1);
 }
 
 bool checkPlatform(const std::string& platform) {

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -347,8 +347,8 @@ QueryData genDeviceHash(QueryContext& context) {
       dh.inodes(inodes,
                 fs,
                 ([&results, &address, &dev](const std::string& inode,
-                                                      TskFsFile* file,
-                                                      const std::string& path) {
+                                            TskFsFile* file,
+                                            const std::string& path) {
                   Row r;
                   r["device"] = dev;
                   r["partition"] = address;
@@ -387,7 +387,7 @@ QueryData genDeviceFile(QueryContext& context) {
     // image, checks the volume, and allows partition iteration.
     DeviceHelper dh(dev);
     dh.partitions(([&results, &dh, &parts, &inodes, &paths](
-        const TskVsPartInfo* part) {
+                       const TskVsPartInfo* part) {
       // The table also requires a partition for searching.
       auto address = std::to_string(part->getAddr());
       if (address != *parts.begin()) {

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -346,7 +346,7 @@ QueryData genDeviceHash(QueryContext& context) {
 
       dh.inodes(inodes,
                 fs,
-                ([&results, &address, &dev, &dh, &fs](const std::string& inode,
+                ([&results, &address, &dev](const std::string& inode,
                                                       TskFsFile* file,
                                                       const std::string& path) {
                   Row r;
@@ -386,7 +386,7 @@ QueryData genDeviceFile(QueryContext& context) {
     // For each require device path, open a device helper that checks the
     // image, checks the volume, and allows partition iteration.
     DeviceHelper dh(dev);
-    dh.partitions(([&results, &dev, &dh, &parts, &inodes, &paths](
+    dh.partitions(([&results, &dh, &parts, &inodes, &paths](
         const TskVsPartInfo* part) {
       // The table also requires a partition for searching.
       auto address = std::to_string(part->getAddr());

--- a/osquery/tables/system/posix/ulimit_info.cpp
+++ b/osquery/tables/system/posix/ulimit_info.cpp
@@ -74,10 +74,10 @@ void getLimit(QueryData& results) {
     }
     Row r;
     r["type"] = it.first;
-    r["soft_limit"] = (rlp.rlim_cur == ULONG_MAX)
+    r["soft_limit"] = (rlp.rlim_cur == RLIM_INFINITY)
                           ? "unlimited"
                           : std::to_string(rlp.rlim_cur);
-    r["hard_limit"] = (rlp.rlim_max == ULONG_MAX)
+    r["hard_limit"] = (rlp.rlim_max == RLIM_INFINITY)
                           ? "unlimited"
                           : std::to_string(rlp.rlim_max);
     results.push_back(r);


### PR DESCRIPTION
Treating warnings as errors in posix 

- makes osquery coding style better. 
- In our current setup, it is hard to check if PR is causing additional warnings/problems and reviewer time was spent on pointing out pedantic things.
- makes review faster (Less ping pong between the reviewer and the author)

I had to disable single macOS warning. Discussed with @obelisk . Looks like we can not easily replace pthread_setugid_np and also it should not be removed any time soon. So, it is okay to ignore this warning.