### PR TITLE
fixed move assignment operator for expected

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -104,7 +104,14 @@ class Expected final {
   Expected(const Expected&) = delete;
   Expected(ErrorBase* error) = delete;
 
-  Expected& operator=(Expected&& other) = default;
+  Expected& operator=(Expected&& other) {
+    if (this != &other) {
+      object_ = std::move(other.object_);
+      other.errorChecked_ = true;
+    }
+    return *this;
+  }
+
   Expected& operator=(const Expected& other) = delete;
 
   ~Expected() {

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -107,6 +107,7 @@ class Expected final {
   Expected& operator=(Expected&& other) {
     if (this != &other) {
       object_ = std::move(other.object_);
+      errorChecked_ = other.errorChecked_;
       other.errorChecked_ = true;
     }
     return *this;

--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -106,6 +106,8 @@ class Expected final {
 
   Expected& operator=(Expected&& other) {
     if (this != &other) {
+      errorChecked_.verify("Error was not checked");
+
       object_ = std::move(other.object_);
       errorChecked_ = other.errorChecked_;
       other.errorChecked_ = true;


### PR DESCRIPTION
Expected was failing on debug mode for a while because of default move assignment operator did not update error_checked flag.
Use case is following:

Expected x = func1();
if (x) {
}
x = func2();
^======== failing here, code will assert on func2 result destructor
