### PR TITLE
remove unused lambda argument

### DIFF
--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -346,9 +346,9 @@ QueryData genDeviceHash(QueryContext& context) {
 
       dh.inodes(inodes,
                 fs,
-                ([&results, &address, &dev, &dh, &fs](const std::string& inode,
-                                                      TskFsFile* file,
-                                                      const std::string& path) {
+                ([&results, &address, &dev](const std::string& inode,
+                                            TskFsFile* file,
+                                            const std::string& path) {
                   Row r;
                   r["device"] = dev;
                   r["partition"] = address;


### PR DESCRIPTION
Remove argument not used in lambda function. Reduce warnings.