### PR TITLE
posix treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ if(NOT WIN32)
 endif()
 
 if(POSIX)
+  add_compile_options(
+    -Werror
+  )
   if(CLANG)
     add_compile_options(
       -Qunused-arguments


### PR DESCRIPTION
Treating warnings as errors in posix

- makes osquery coding style better.
- In our current setup, it is hard to check if PR is causing additional warnings/problems and reviewer time was spent on pointing out pedantic things.
- makes review faster (Less rounds of the review)