### PR TITLE
route table: properly display the default IPv6 route on Linux

### DIFF
--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -27,6 +27,9 @@ namespace tables {
 #define MAX_NETLINK_SIZE 8192
 #define MAX_NETLINK_ATTEMPTS 8
 
+constexpr auto kDefaultIpv6Route = "::";
+constexpr auto kDefaultIpv4Route = "0.0.0.0";
+
 std::string getNetlinkIP(int family, const char* buffer) {
   char dst[INET6_ADDRSTRLEN] = {0};
 
@@ -136,7 +139,11 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   }
 
   if (!has_destination) {
-    r["destination"] = "0.0.0.0";
+    if (message->rtm_family == AF_INET) {
+      r["destination"] = kDefaultIpv4Route;
+    } else if (message->rtm_family == AF_INET6) {
+      r["destination"] = kDefaultIpv6Route;
+    }
     if (message->rtm_dst_len) {
       mask = (int)message->rtm_dst_len;
     }

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -33,11 +33,26 @@ constexpr auto kDefaultIpv4Route = "0.0.0.0";
 std::string getNetlinkIP(int family, const char* buffer) {
   char dst[INET6_ADDRSTRLEN] = {0};
 
-  inet_ntop(family, buffer, dst, INET6_ADDRSTRLEN);
+  if (inet_ntop(family, buffer, dst, INET6_ADDRSTRLEN) == nullptr) {
+    LOG(ERROR) << "Unsupported address family: " << family;
+    return "";
+  }
   std::string address(dst);
   boost::trim(address);
 
   return address;
+}
+
+std::string getDefaultRouteIP(int family) {
+  switch (family) {
+  case AF_INET:
+    return kDefaultIpv4Route;
+  case AF_INET6:
+    return kDefaultIpv6Route;
+  default:
+    LOG(ERROR) << "Unsupported address family: " << family;
+    return "";
+  }
 }
 
 Status readNetlink(int socket_fd, int seq, char* output, size_t* size) {
@@ -139,11 +154,7 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   }
 
   if (!has_destination) {
-    if (message->rtm_family == AF_INET) {
-      r["destination"] = kDefaultIpv4Route;
-    } else if (message->rtm_family == AF_INET6) {
-      r["destination"] = kDefaultIpv6Route;
-    }
+    r["destination"] = getDefaultRouteIP(message->rtm_family);
     if (message->rtm_dst_len) {
       mask = (int)message->rtm_dst_len;
     }


### PR DESCRIPTION
The routes table displays an IPv4 for the default IPv6 route:

   `osquery> SELECT destination,gateway FROM routes WHERE gateway <> "";`

   | destination | gateway               |
   | ----------- | --------------------- |
   | 0.0.0.0     | 172.17.208.1          |
   | 0.0.0.0     | fe80::5:73ff:fea0:514 |

New output:

   | destination | gateway               |
   | ----------- | --------------------- |
   | 0.0.0.0     | 172.17.208.1          |
   | ::          | fe80::5:73ff:fea0:514 |

Note: it works as expected on Darwin and FreeBSD.