### PR TITLE
remove primary logger concept

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -358,10 +358,6 @@ The minimum level for status logs written to stderr. Use the following values: `
 
 The default behavior is to also write status logs to stderr. Set this flag to false to disable writing (copying) status logs to stderr. In this case `--verbose` is respected.
 
-`--logger_secondary_status_only=false`
-
-This is a rarely used logger plugin option. When enabled, the "secondary" logger plugins will only receive status logs. For an example if your `-logger_plugin=tls,firehose,syslog` then status logs would be sent to all 3 plugins, and query results will only be sent to `tls`.
-
 `--host_identifier=hostname`
 
 Field used to identify the host running osquery: **hostname**, **uuid**, **ephemeral**, **instance**, **specified**.

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -339,25 +339,6 @@ TEST_F(LoggerTests, test_multiple_loggers) {
   // Now that the "test" logger is initialized, the status log will be
   // forwarded.
   EXPECT_EQ(1U, LoggerTests::statuses_logged);
-
-  // Multiple logger plugins have a 'primary' concept.
-  auto flag_default = FLAGS_logger_secondary_status_only;
-  FLAGS_logger_secondary_status_only = true;
-  logString("this is another test", "added");
-  // Only one log line will be appended since 'second_test' is secondary.
-  EXPECT_EQ(3U, LoggerTests::log_lines.size());
-  // Only one status line will be forwarded.
-  LOG(WARNING) << "Logger test is generating another warning (6)";
-  EXPECT_EQ(2U, LoggerTests::statuses_logged);
-  FLAGS_logger_secondary_status_only = flag_default;
-  logString("this is a third test", "added");
-  EXPECT_EQ(5U, LoggerTests::log_lines.size());
-
-  // Reconfigure the second logger to forward status logs.
-  test_logger->shouldLogStatus = true;
-  initLogger("logger_test");
-  LOG(WARNING) << "Logger test is generating another warning (7)";
-  EXPECT_EQ(4U, LoggerTests::statuses_logged);
 }
 
 TEST_F(LoggerTests, test_logger_scheduled_query) {


### PR DESCRIPTION
Split #4745 
Could not find any important use case for primary concept.

Noticed community about the PR mentioned(slack). Only thing which is still needed is logger logging events. No one has mentioned primary logger.