### PR TITLE
get rid of aliased flag log_result_events

### DIFF
--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -229,7 +229,7 @@ Consider the following example:
 
 If a query identifies multiple state changes, the batched format will include all results in a single log line. If you're programmatically parsing lines and loading them into a backend datastore, this is probably the best solution.
 
-To enable batch log lines, launch osqueryd with the `--log_result_events=false` argument.
+To enable batch log lines, launch osqueryd with the `--logger_event_type=false` argument.
 
 Example output of `SELECT name, path, pid FROM processes;` (whitespace added for readability):
 

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -49,7 +49,6 @@ FLAG(string, logger_plugin, "filesystem", "Logger plugin name");
 
 /// Log each added or removed line individually, as an "event".
 FLAG(bool, logger_event_type, true, "Log scheduled results as events");
-FLAG_ALIAS(bool, log_result_events, logger_event_type);
 
 /// Log each row from a snapshot query individually, as an "event".
 FLAG(bool,


### PR DESCRIPTION
In the effort to make logger less confusing, removing aliased flag of the logger_event_type which was log_result_events. 
In one doc https://osquery.readthedocs.io/en/2.4.5/deployment/logging/ - log_result_events is mentioned
In the other one https://osquery.readthedocs.io/en/2.4.5/installation/cli-flags/ - logger_event_type

To make things less confusing removing one of them.


#4608 