### PR TITLE
default logtostderr to true (remove logStderrOnly)

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -278,12 +278,7 @@ inline bool logStderrOnly() {
     return true;
   }
 
-  if (FLAGS_disable_logging) {
-    return true;
-  }
-
-  return Flag::getValue("logger_plugin").find("filesystem") ==
-         std::string::npos;
+  return FLAGS_disable_logging;
 }
 
 void setVerboseLevel() {

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -272,14 +272,6 @@ static void deserializeIntermediateLog(const PluginRequest& request,
   }
 }
 
-inline bool logStderrOnly() {
-  if (Registry::get().external()) {
-    return true;
-  }
-
-  return FLAGS_disable_logging;
-}
-
 void setVerboseLevel() {
   auto default_level = google::GLOG_INFO;
   if (Initializer::isShell()) {
@@ -315,9 +307,7 @@ void setVerboseLevel() {
     FLAGS_alsologtostderr = false;
   }
 
-  if (logStderrOnly()) {
-    FLAGS_logtostderr = true;
-  }
+  FLAGS_logtostderr = true;
 }
 
 void initStatusLogger(const std::string& name, bool init_glog) {

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -273,7 +273,6 @@ static void deserializeIntermediateLog(const PluginRequest& request,
 }
 
 inline bool logStderrOnly() {
-  // Do not write logfiles if filesystem is not included as a plugin.
   if (Registry::get().external()) {
     return true;
   }


### PR DESCRIPTION
In the effort to make error filtering by the severity possible, we need to make several changes and less flag overwriting.
When plugin was not named filesystem osquery was just overwriting FLAGS_logtostderr to true. When FLAGS_logtostderr is true, it's impossible to filter logs written in GLOG by severity.
#4608 