### PR TITLE
get rid of alias verbose_debug and debug

### DIFF
--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -27,8 +27,6 @@ namespace osquery {
  */
 const std::set<std::string> kVerboseOptions{
     "verbose",
-    "verbose_debug",
-    "debug",
     "minloglevel",
     "logger_min_status",
     "stderrthreshold",

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -39,7 +39,6 @@ namespace rj = rapidjson;
 namespace osquery {
 
 FLAG(bool, verbose, false, "Enable verbose informational messages");
-FLAG_ALIAS(bool, verbose_debug, verbose);
 FLAG_ALIAS(bool, debug, verbose);
 
 /// Despite being a configurable option, this is only read/used at load.

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -39,7 +39,6 @@ namespace rj = rapidjson;
 namespace osquery {
 
 FLAG(bool, verbose, false, "Enable verbose informational messages");
-FLAG_ALIAS(bool, debug, verbose);
 
 /// Despite being a configurable option, this is only read/used at load.
 FLAG(bool, disable_logging, false, "Disable ERROR/INFO logging");


### PR DESCRIPTION
In the effort to make logger less confusing, removing aliased flag of the verbose which was verbose_debug.

#4608 