### PR TITLE
stop overwriting logtostderr when --disable_logging is true

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -336,7 +336,7 @@ Built-in options include: **filesystem**, **tls**, **syslog**, and several Amazo
 
 `--disable_logging=false`
 
-Disable ERROR/WARNING/INFO (called status logs) and query result [logging](../deployment/logging.md).
+Disable logs forwarding to the logger plugins. However logs to the stderr are still forwarded and can be limited using the flag --logger_min_stderr (called status logs) and query result [logging](../deployment/logging.md).
 
 `--logger_event_type=true`
 

--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -336,7 +336,7 @@ Built-in options include: **filesystem**, **tls**, **syslog**, and several Amazo
 
 `--disable_logging=false`
 
-Disable logs forwarding to the logger plugins. However logs to the stderr are still forwarded and can be limited using the flag --logger_min_stderr (called status logs) and query result [logging](../deployment/logging.md).
+Disable forwarding of the status logs and the query results  to the logger plugins. Logs  are still forwarded to the stderr and can be filtered using the flag --logger_min_stderr(status) [logging](../deployment/logging.md).
 
 `--logger_event_type=true`
 

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -278,10 +278,6 @@ inline bool logStderrOnly() {
     return true;
   }
 
-  if (FLAGS_disable_logging) {
-    return true;
-  }
-
   return Flag::getValue("logger_plugin").find("filesystem") ==
          std::string::npos;
 }


### PR DESCRIPTION
In the effort to make error filtering by the severity possible, we need to make several changes and less flag overwriting.
When logger plugins were disabled osquery was just overwriting FLAGS_logtostderr to true. When FLAGS_logtostderr is true, it's impossible to filter logs written in GLOG, by severity.
#4608