### PR TITLE
Reorder hashes in the ssdeep-cpp formula

### DIFF
--- a/tools/provision/formula/ssdeep-cpp.rb
+++ b/tools/provision/formula/ssdeep-cpp.rb
@@ -6,13 +6,13 @@ class SsdeepCpp < AbstractOsqueryFormula
   license "GPL-2.0+"
   url "https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz"
   sha256 "ff2eabc78106f009b4fb2def2d76fb0ca9e12acf624cbbfad9b3eb390d931313"
-  revision 200
+  revision 201
 
   bottle do
     root_url "https://osquery-packages.s3.amazonaws.com/bottles"
     cellar :any_skip_relocation
-    sha256 "00ccb3820f19ca73e5cf553da5623d118843fad1516d5bf283eae403ae55298d" => :x86_64_linux
-    sha256 "64a6e3794335f0b24813ad3b22d40ed2bb32ad8040414e59022dfeb148e0c0e1" => :sierra
+    sha256 "87b379ad5ac57c463644b93212a110ebd10ae6363d5a58b1b81d623ac5394cb0" => :sierra
+    sha256 "adf265c3b2c3a260c48be6fd8a5bedc0a99b39e836e874abe71373c84ddd693b" => :x86_64_linux
   end
 
   def install


### PR DESCRIPTION
So that macOS doesn't pick the Linux one

Fixes #4855