### PR TITLE
stop overwriting logtostderr for external osquery

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -274,10 +274,6 @@ static void deserializeIntermediateLog(const PluginRequest& request,
 
 inline bool logStderrOnly() {
   // Do not write logfiles if filesystem is not included as a plugin.
-  if (Registry::get().external()) {
-    return true;
-  }
-
   if (FLAGS_disable_logging) {
     return true;
   }


### PR DESCRIPTION
In the effort to make error filtering by the severity possible, we need to make several changes and less flag overwriting.
When osquery process was external, osquery was just overwriting FLAGS_logtostderr to true. When FLAGS_logtostderr is true, it's impossible to filter logs written in GLOG, by severity.
#4608