### PR TITLE
Match how logger_min_stderr  works to doc

### DIFF
--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -308,12 +308,7 @@ void setVerboseLevel() {
       FLAGS_minloglevel = default_level;
     }
 
-    if (!Flag::isDefault("logger_min_stderr")) {
-      auto i = Flag::getInt32Value("logger_min_stderr");
-      FLAGS_stderrthreshold = static_cast<decltype(FLAGS_logger_min_stderr)>(i);
-    } else if (Flag::isDefault("stderrthreshold")) {
-      FLAGS_stderrthreshold = default_level;
-    }
+    FLAGS_stderrthreshold = Flag::getInt32Value("logger_min_stderr");
   }
 
   if (!FLAGS_logger_stderr) {

--- a/osquery/logger/tests/logger_tests.cpp
+++ b/osquery/logger/tests/logger_tests.cpp
@@ -18,11 +18,11 @@
 #include <osquery/registry_factory.h>
 
 DECLARE_int32(minloglevel);
-DECLARE_int32(stderrthreshold);
 
 namespace osquery {
 
 DECLARE_int32(logger_min_status);
+DECLARE_int32(logger_min_stderr);
 DECLARE_bool(logger_secondary_status_only);
 DECLARE_bool(logger_status_sync);
 DECLARE_bool(logger_event_type);
@@ -211,13 +211,13 @@ TEST_F(LoggerTests, test_logger_status_level) {
   EXPECT_EQ(2U, LoggerTests::statuses_logged);
   FLAGS_minloglevel = minloglevel;
 
-  auto stderrthreshold = FLAGS_stderrthreshold;
-  FLAGS_stderrthreshold = 2;
+  const auto logger_min_stderr = FLAGS_logger_min_stderr;
+  FLAGS_logger_min_stderr = 2;
   setVerboseLevel();
 
   LOG(WARNING) << "Logger test is generating a warning status";
   EXPECT_EQ(3U, LoggerTests::statuses_logged);
-  FLAGS_stderrthreshold = stderrthreshold;
+  FLAGS_logger_min_stderr = logger_min_stderr;
 
   auto logger_min_status = FLAGS_logger_min_status;
   FLAGS_logger_min_status = 1;


### PR DESCRIPTION
Docs has never promised this kind of behavior currently implemented.
Even if we specify --logger_min_stderr=x and x matches with default value, logger_min_stderr could be overwritten.
#4608