### PR TITLE
route table: get the value of the MTU on Linux

### DIFF
--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -125,6 +125,7 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   bool has_destination = false;
   r["metric"] = "0";
   r["hopcount"] = INTEGER(0);
+  r["mtu"] = INTEGER(0);
   while (RTA_OK(attr, attr_size)) {
     switch (attr->rta_type) {
     case RTA_OIF:
@@ -155,6 +156,9 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
       auto xattr_size = RTA_PAYLOAD(attr);
       while (RTA_OK(xattr, xattr_size)) {
         switch (xattr->rta_type) {
+        case RTAX_MTU:
+          r["mtu"] = INTEGER(*reinterpret_cast<int*>(RTA_DATA(xattr)));
+          break;
         case RTAX_HOPLIMIT:
           r["hopcount"] = INTEGER(*reinterpret_cast<int*>(RTA_DATA(xattr)));
           break;
@@ -191,8 +195,6 @@ void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {
   // This is the cidr-formatted mask
   r["netmask"] = INTEGER(mask);
 
-  // Fields not supported by Linux routes:
-  r["mtu"] = "0";
   results.push_back(r);
 }
 


### PR DESCRIPTION
Darwin, FreeBSD and Windows already supports this.
The value of the MTU is stored in an extended attribute of the netlink
message.
This field can be very useful to detect hosts that are using jumbo
frames.

Note that Linux has a different behaviour compared to the other OSs.
If the MTU was not configured, it will not display the default MTU value
(usually 1500), but 0, which means 'use the MTU of the interface'.

Test plan:
```
  $ ip route add default via 172.17.208.1 dev wlp58s0 mtu 1492
  $ osqueryi "select destination from routes where mtu=1492;"
```