### PR TITLE
deps: Update Vagrant macOS target to 10.13

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,9 @@ targets = {
   "macos10.12" => {
     "box" => "jhcook/macos-sierra"
   },
+  "macos10.13" => {
+    "box" => "monsenso/macos-10.13"
+  },
   "debian7" => {
     "box" => "bento/debian-7"
   },
@@ -187,7 +190,7 @@ Vagrant.configure("2") do |config|
           ]
       end
 
-      if name == 'macos10.12'
+      if name.start_with?('macos')
         config.vm.provision "shell",
           inline: "dseditgroup -o read vagrant || dseditgroup -o create vagrant"
         build.vm.synced_folder ".", "/vagrant", group: "staff", type: "rsync",

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -12,7 +12,7 @@ DARWIN_SETUP="\
 if [[ ! -f /var/.osquery_build ]]; then \
 touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress; \
 PROD=\$(softwareupdate -l | grep \"\\*.*Command Line\" | \
-  head -n 1 | awk -F\"*\" '{print \$2}' | sed -e 's/^ *//' | tr -d '\n' \
+  tail -n 1 | awk -F\"*\" '{print \$2}' | sed -e 's/^ *//' | tr -d '\n' \
 ); \
 softwareupdate -i \"\$PROD\" --verbose; \
 sudo touch /var/.osquery_build; \

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -12,7 +12,7 @@ set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-DARWIN_BOX="macos10.12"
+DARWIN_BOX="macos10.13"
 LINUX_BOX="ubuntu16.04"
 
 function usage() {

--- a/tools/release/deps_release.sh
+++ b/tools/release/deps_release.sh
@@ -13,7 +13,7 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VAGRANT="/vagrant"
 
-DARWIN_BOX="macos10.12"
+DARWIN_BOX="macos10.13"
 LINUX_BOX="ubuntu16.04"
 
 function usage() {


### PR DESCRIPTION
This is part of #5072.

The change from `head` to `tail` for selecting macOS command line tools may be concerning. This used to install 10.10 tools, which are still available on 10.13. This might include support for older SDKs to build against.

If this is a problem then it should be visible at compile time when we select the minimum-supported-build.