### PR TITLE
Log when an extension is registered or dies

### DIFF
--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -102,7 +102,7 @@ Status ExtensionManagerInterface::registerExtension(
   }
   // Every call to registerExtension is assigned a new RouteUUID.
   uuid = static_cast<uint16_t>(rand());
-  VLOG(1) << "Registering extension (" << info.name << ", " << uuid
+  LOG(INFO) << "Registering extension (" << info.name << ", " << uuid
           << ", version=" << info.version << ", sdk=" << info.sdk_version
           << ")";
 

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -103,8 +103,8 @@ Status ExtensionManagerInterface::registerExtension(
   // Every call to registerExtension is assigned a new RouteUUID.
   uuid = static_cast<uint16_t>(rand());
   LOG(INFO) << "Registering extension (" << info.name << ", " << uuid
-          << ", version=" << info.version << ", sdk=" << info.sdk_version
-          << ")";
+            << ", version=" << info.version << ", sdk=" << info.sdk_version
+            << ")";
 
   auto status = RegistryFactory::get().addBroadcast(uuid, registry);
   if (!status.ok()) {


### PR DESCRIPTION
This is useful information to have in the logs, not only verbose logs.