### PR TITLE
rearrange initLogger disable capabilities

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -680,8 +680,8 @@ void Initializer::start() const {
   // Initialize the status and result plugin logger.
   if (!FLAGS_disable_logging) {
     initActivePlugin("logger", FLAGS_logger_plugin);
+    initLogger(binary_);
   }
-  initLogger(binary_);
 
   // Initialize the distributed plugin, if necessary
   if (!FLAGS_disable_distributed) {

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -321,11 +321,6 @@ void initStatusLogger(const std::string& name, bool init_glog) {
 }
 
 void initLogger(const std::string& name) {
-  // Check if logging is disabled, if so then no need to shuttle intermediates.
-  if (FLAGS_disable_logging) {
-    return;
-  }
-
   // Stop the buffering sink and store the intermediate logs.
   BufferedLogSink::get().disable();
   BufferedLogSink::get().resetPlugins();


### PR DESCRIPTION
In the effort to make logger less confusing,  initLogger would return immediately if FLAGS_disable_logging was true. However, this code could be pushed outside.

#4608 #4983