### PR TITLE
remove unused force_permissions

### DIFF
--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -98,8 +98,7 @@ Status readFile(const boost::filesystem::path& path,
  */
 Status writeTextFile(const boost::filesystem::path& path,
                      const std::string& content,
-                     int permissions = 0660,
-                     bool force_permissions = false);
+                     int permissions = 0660);
 
 /**
  * @brief Check if a path is writable.

--- a/include/osquery/filesystem.h
+++ b/include/osquery/filesystem.h
@@ -92,7 +92,6 @@ Status readFile(const boost::filesystem::path& path,
  * @param path the path of the file that you would like to write.
  * @param content the text that should be written exactly to disk.
  * @param permissions the filesystem permissions to request when opening.
- * @param force_permissions always `chmod` the path after opening.
  *
  * @return an instance of Status, indicating success or failure.
  */

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -51,8 +51,7 @@ static const size_t kMaxRecursiveGlobs = 64;
 
 Status writeTextFile(const fs::path& path,
                      const std::string& content,
-                     int permissions,
-                     bool force_permissions) {
+                     int permissions) {
   // Open the file with the request permissions.
   PlatformFile output_fd(
       path, PF_OPEN_ALWAYS | PF_WRITE | PF_APPEND, permissions);

--- a/osquery/filesystem/tests/filesystem_tests.cpp
+++ b/osquery/filesystem/tests/filesystem_tests.cpp
@@ -114,7 +114,7 @@ TEST_F(FilesystemTests, test_write_file) {
   ASSERT_TRUE(isWritable(test_file).ok());
   ASSERT_TRUE(removePath(test_file).ok());
 
-  EXPECT_TRUE(writeTextFile(test_file, content, 0400, true));
+  EXPECT_TRUE(writeTextFile(test_file, content, 0400));
   ASSERT_TRUE(pathExists(test_file).ok());
 
   // On POSIX systems, root can still read/write.
@@ -123,7 +123,7 @@ TEST_F(FilesystemTests, test_write_file) {
   EXPECT_TRUE(isReadable(test_file).ok());
   ASSERT_TRUE(removePath(test_file).ok());
 
-  EXPECT_TRUE(writeTextFile(test_file, content, 0000, true));
+  EXPECT_TRUE(writeTextFile(test_file, content, 0000));
   ASSERT_TRUE(pathExists(test_file).ok());
 
   // On POSIX systems, root can still read/write.

--- a/osquery/logger/plugins/filesystem_logger.cpp
+++ b/osquery/logger/plugins/filesystem_logger.cpp
@@ -104,8 +104,7 @@ Status FilesystemLoggerPlugin::logStringToFile(const std::string& s,
   try {
     status = writeTextFile((log_path_ / filename).string(),
                            (empty) ? "" : s + '\n',
-                           FLAGS_logger_mode,
-                           true);
+                           FLAGS_logger_mode);
   } catch (const std::exception& e) {
     return Status(1, e.what());
   }

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -46,7 +46,7 @@ TEST_F(EnrollTests, test_enroll_secret_retrieval) {
   FLAGS_enroll_secret_path =
     (fs::path(kTestWorkingDirectory) / "secret.txt").
     make_preferred().string();
-  writeTextFile(FLAGS_enroll_secret_path, "test_secret\n", 0600, false);
+  writeTextFile(FLAGS_enroll_secret_path, "test_secret\n", 0600);
   // Make sure the file content was read and trimmed.
   auto secret = getEnrollSecret();
   EXPECT_EQ(secret, "test_secret");


### PR DESCRIPTION
force_permissions argument is not used.  I checked the initial PR introducing this function and looks like was like that from the beginning.