### PR TITLE
Expand "opaque" values in system_controls table

### DIFF
--- a/specs/posix/system_controls.table
+++ b/specs/posix/system_controls.table
@@ -8,6 +8,10 @@ schema([
     Column("config_value", TEXT, "The MIB value set in /etc/sysctl.conf"),
     Column("type", TEXT, "Data type"),
 ])
+extended_schema(DARWIN, [
+    Column("field_name", TEXT, "Specific attribute of opaque type"),
+])
+
 implementation("system_controls@genSystemControls")
 fuzz_paths([
     "/run/sysctl.d/",


### PR DESCRIPTION
Task Description : On Posix systems (which includes macOS), the OSQuery system_controls table exposes various pieces of kernel state. It is the OSQuery equivalent of the sysctl command. Many of the state variables that can be read by sysctl are simple integers or strings. OSQuery handles these just fine. However, on macOS, some are so-called "opaque" values, typically structs that are specific to one or a few state variables. OSQuery does not know how to display these, and just shows them as null. This task is about teaching OSQuery to do something reasonable with these opaque values.

Changes : updated schema to include "field_name" column. This shows specific attribute of opaque struct.
systctl_utils.cpp logic now expands and pulls specific struct information similar to sysctl.c - https://opensource.apple.com/source/system_cmds/system_cmds-790.30.1/sysctl.tproj/sysctl.c.auto.html

Test Plan : Changes tested within darwin/osqueryi shell.