### PR TITLE
Fix up usage of debug_only::Var in expected assign operator

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -110,7 +110,7 @@ class Expected final {
 
       object_ = std::move(other.object_);
       errorChecked_ = other.errorChecked_;
-      other.errorChecked_ = true;
+      other.errorChecked_.set(true);
     }
     return *this;
   }


### PR DESCRIPTION
`debug_only::Var` debug version doesn't have assign operator. So, assigning couldn't be used to set up new value.