### PR TITLE
Make error messages in Expected check different to distinguish problems

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -106,7 +106,7 @@ class Expected final {
 
   Expected& operator=(Expected&& other) {
     if (this != &other) {
-      errorChecked_.verify("Error was not checked");
+      errorChecked_.verify("Expected was not checked before assigning");
 
       object_ = std::move(other.object_);
       errorChecked_ = other.errorChecked_;
@@ -118,7 +118,7 @@ class Expected final {
   Expected& operator=(const Expected& other) = delete;
 
   ~Expected() {
-    errorChecked_.verify("Error was not checked");
+    errorChecked_.verify("Expected was not checked before destruction");
   }
 
   static SelfType success(ValueType value) {

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -172,13 +172,33 @@ GTEST_TEST(ExpectedTest, error_handling_example) {
   }
 }
 
-GTEST_TEST(ExpectedTest, error_was_not_checked) {
+GTEST_TEST(ExpectedTest, expected_was_not_checked_before_destruction_failure) {
   auto action = []() { auto expected = ExpectedSuccess<TestError>{Success()}; };
 #ifndef NDEBUG
-  ASSERT_DEATH(action(), "Error was not checked");
+  ASSERT_DEATH(action(), "Expected was not checked before destruction");
 #else
   boost::ignore_unused(action);
 #endif
+}
+
+GTEST_TEST(ExpectedTest, expected_was_not_checked_before_assigning_failure) {
+  auto action = []() {
+    auto expected = ExpectedSuccess<TestError>{Success()};
+    expected = ExpectedSuccess<TestError>{Success()};
+    expected.isValue();
+  };
+#ifndef NDEBUG
+  ASSERT_DEATH(action(), "Expected was not checked before assigning");
+#else
+  boost::ignore_unused(action);
+#endif
+}
+
+GTEST_TEST(ExpectedTest, expected_move_is_safe) {
+  auto expected = ExpectedSuccess<TestError>{Success()};
+  expected.isValue();
+  expected = ExpectedSuccess<TestError>{Success()};
+  expected.isValue();
 }
 
 GTEST_TEST(ExpectedTest, get_value_from_expected_with_error) {


### PR DESCRIPTION
Make error messages in Expected check different to know for sure which check is failed.