### PR TITLE
Run `make test_debug` in order to run the tests for debug build

### DIFF
--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -117,6 +117,14 @@ function build_target() {
   fi
 }
 
+function test_target() {
+  if [[ "$RUN_TARGET" = "debug" ]]; then
+    $MAKE test_debug
+  else
+    $MAKE test
+  fi
+}
+
 function check_deterministic() {
   # Expect the project to have been built.
   ALIAS=$DISTRO
@@ -180,6 +188,6 @@ function build() {
 
   if [[ $RUN_TESTS = true ]]; then
     # Run code unit and integration tests.
-    $MAKE test
+    test_target
   fi
 }


### PR DESCRIPTION
Run `make test_debug` in order to run the tests for the debug build. Because currently build.sh tries to run `make test` instead, which is wrong. Because it looks for the tests binary in wrong directory (e.g. in `build/darwin/` instead of `build/debug_darwin/` on masos).

That is only for posix builds, I'll do the same for windows later.