### PR TITLE
Fix of issue #4674:  Updated Documentation

### DIFF
--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -406,7 +406,7 @@ if __name__ == '__main__':
         "--persist",
         default=HTTP_SERVER_PERSIST,
         action="store_true",
-        help="Wrap the HTTP server socket in TLS.")
+        help="Create a persistent HTTP connection.")
     parser.add_argument(
         "--timeout",
         default=HTTP_SERVER_TIMEOUT,


### PR DESCRIPTION
Issue #4674 (https://github.com/facebook/osquery/issues/4674) details incorrect documentation for the persist argument in osquery/tools/tests/test_http_server.py

Updated description more accurately describes the persist argument.
