### PR TITLE
Implement setThreadName() for FreeBSD

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -29,6 +29,10 @@
 #include <WinSock2.h>
 #endif
 
+#if defined(__FreeBSD__)
+#include <pthread_np.h>
+#endif
+
 #include <ctime>
 #include <sstream>
 
@@ -579,6 +583,10 @@ Status setThreadName(const std::string& name) {
              ? Status::success()
              : Status::failure("pthread_setname_np failed with error " +
                                std::to_string(return_code));
+#elif defined(__FreeBSD__)
+  // FreeBSD silently ignores errors and does not return an error code
+  pthread_set_name_np(pthread_self(), name.c_str());
+  return Status::success();
 #elif defined(WIN32)
   // SetThreadDescription is available in builds newer than 1607 of windows 10
   // and works even if there is no debugger.


### PR DESCRIPTION
FreeBSD supports renaming threads with `pthread_np`.

The difference with Linux or Darwin is that there's no error code:

>   Because of the debugging nature of this function, all errors that may
>    appear inside are silently ignored

This isn't really a problem because thread names are meant for debugging
and osquery does not check the retun value of `setThreadName()` anyway.

Test plan:
```
  adrs@freebsd: procstat -t `pidof old_osqueryi`
    PID    TID COMM                TDNAME              CPU  PRI STATE   WCHAN
   7612 100059 osqueryi            -                    -1  152 sleep   ttyin
   7612 100162 osqueryi            -                    -1  152 sleep   uwait
   7612 100163 osqueryi            -                    -1  152 sleep   select
  adrs@freebsd: procstat -t `pidof osqueryi`
    PID    TID COMM                TDNAME              CPU  PRI STATE   WCHAN
   7278 100151 osqueryi            -                    -1  120 sleep   ttyin
   7278 100160 osqueryi            ExtensionWatcher     -1  120 sleep   uwait
   7278 100161 osqueryi            ExtensionRunnerCore  -1  131 sleep   select
```