### PR TITLE
added integration tests target and helper functions to tests table sanity

### DIFF
--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -472,6 +472,16 @@ if(NOT SKIP_TESTS)
     target_link_libraries(osquery_tables_tests gtest gmock libosquery_testing)
     SET_OSQUERY_COMPILE(osquery_tables_tests "${GTEST_FLAGS}")
     add_test(osquery_tables_tests osquery_tables_tests ${TEST_ARGS})
+
+    include(tests/integration/CMakeLists.txt)
+    add_executable(osquery_integration_tests main/tests.cpp $<TARGET_OBJECTS:osquery_tables_integration_tests>)
+    ADD_DEFAULT_LINKS(osquery_integration_tests TRUE)
+    target_link_libraries(osquery_integration_tests gtest gmock libosquery_testing)
+    SET_OSQUERY_COMPILE(osquery_integration_tests "${GTEST_FLAGS}")
+    add_test(NAME
+              osquery_integration_tests
+            COMMAND
+              osquery_tables_tests ${TEST_ARGS})
   endif()
 
   # Build the example extension with the SDK.

--- a/osquery/tests/integration/CMakeLists.txt
+++ b/osquery/tests/integration/CMakeLists.txt
@@ -1,0 +1,19 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+# All libraries from this file will be used in main integration tests binary
+
+# Object library for all tables integration tests
+add_library(osquery_tables_integration_tests OBJECT)
+
+#small hack for now
+SET_OSQUERY_COMPILE(osquery_tables_integration_tests "${GTEST_FLAGS}")
+
+include(${CMAKE_CURRENT_LIST_DIR}/tables/CMakeLists.txt)
+
+target_group_sources(osquery_tables_integration_tests "${CMAKE_CURRENT_LIST_DIR}")

--- a/osquery/tests/integration/tables/CMakeLists.txt
+++ b/osquery/tests/integration/tables/CMakeLists.txt
@@ -1,0 +1,13 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+target_sources(osquery_tables_integration_tests 
+  PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/helper.h"
+    "${CMAKE_CURRENT_LIST_DIR}/helper.cpp"
+)

--- a/osquery/tests/integration/tables/helper.cpp
+++ b/osquery/tests/integration/tables/helper.cpp
@@ -1,0 +1,175 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+#include <boost/filesystem.hpp>
+#include <boost/uuid/string_generator.hpp>
+
+#include <osquery/core/conversions.h>
+#include <osquery/tests/integration/tables/helper.h>
+
+namespace osquery {
+
+namespace fs = boost::filesystem;
+
+bool IntMinMaxCheck::validate(std::string string) {
+  auto cast_result = tryTo<int>(string);
+  if (!cast_result) {
+    return false;
+  }
+  int value = cast_result.get();
+  return value >= min_ && value <= max_;
+}
+
+bool SpecificValuesCheck::validate(std::string string) {
+  return set_.find(string) != set_.end();
+}
+
+QueryData IntegrationTableTest::execute_query(std::string query) {
+  SQLInternal sql(query, false);
+  return sql.rows();
+}
+
+bool IntegrationTableTest::validate_rows(const std::vector<Row>& rows,
+                                         const ValidatatioMap& validation_map) {
+  for (auto row : rows) {
+    if (!validate_row(row, validation_map)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IntegrationTableTest::is_valid_hex(const std::string& value) {
+  for (auto ch : value) {
+    if (!std::isxdigit(ch)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IntegrationTableTest::validate_value_using_flags(const std::string& value,
+                                                      int flags) {
+  if ((flags & NonEmpty) > 0) {
+    if (value.length() == 0) {
+      return false;
+    }
+  }
+
+  if ((flags & NonNull)) {
+    if (value == "null") {
+      return false;
+    }
+  }
+
+  if ((flags & NonZero)) {
+    if (value == "0") {
+      return false;
+    }
+  }
+
+  if ((flags & IntType) > 0) {
+    auto cast_result = tryTo<int>(value);
+    if (!cast_result) {
+      return false;
+    }
+    int intValue = cast_result.get();
+    if ((flags & NonNegative) > 0) {
+      if (intValue < 0) {
+        return false;
+      }
+    }
+  }
+
+  if ((flags & FileOnDisk) > 0) {
+    auto path = fs::path(value);
+    auto status = fs::status(path);
+    if (!fs::exists(status) || !fs::is_regular_file(status)) {
+      return false;
+    }
+  }
+
+  if ((flags & DirectoryOnDisk) > 0) {
+    auto path = fs::path(value);
+    auto status = fs::status(path);
+    if (!fs::exists(status) || !fs::is_directory(status)) {
+      return false;
+    }
+  }
+
+  if ((flags & MD5) > 0) {
+    if (!is_valid_hex(value) || value.size() != 32) {
+      return false;
+    }
+  }
+
+  if ((flags & SHA1) > 0) {
+    if (!is_valid_hex(value) || value.size() != 40) {
+      return false;
+    }
+  }
+
+  if ((flags & SHA256) > 0) {
+    if (!is_valid_hex(value) || value.size() != 64) {
+      return false;
+    }
+  }
+
+  if ((flags & Bool) > 0) {
+    if (value.length() != 1 || (value != "1" && value != "0")) {
+      return false;
+    }
+  }
+
+  if ((flags & ValidUUID) > 0) {
+    try {
+      boost::uuids::string_generator()(value);
+    } catch (...) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool IntegrationTableTest::validate_row(const Row& row,
+                                        const ValidatatioMap& validation_map) {
+  if (row.size() != validation_map.size()) {
+    return false;
+  }
+
+  for (auto iter : validation_map) {
+    std::string key = iter.first;
+    auto row_data_iter = row.find(key);
+    if (row_data_iter == row.end()) {
+      return false;
+    }
+
+    std::string value = row_data_iter->second;
+
+    ValidatatioDataType validator = iter.second;
+    if (validator.type() == typeid(int)) {
+      int flags = boost::get<int>(validator);
+      if (!validate_value_using_flags(value, flags)) {
+        return false;
+      }
+    } else {
+      if (!boost::get<std::shared_ptr<DataCheck>>(validator)->validate(value)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace osquery

--- a/osquery/tests/integration/tables/helper.h
+++ b/osquery/tests/integration/tables/helper.h
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <unordered_set>
+
+#include <boost/variant.hpp>
+#include <gtest/gtest.h>
+
+#include <osquery/sql/sqlite_util.h>
+
+namespace osquery {
+
+class DataCheck {
+ public:
+  virtual ~DataCheck() = default;
+  virtual bool validate(std::string string) = 0;
+};
+
+class IntMinMaxCheck : public DataCheck {
+ public:
+  explicit IntMinMaxCheck(int min, int max) : min_(min), max_(max){};
+  virtual ~IntMinMaxCheck() = default;
+  virtual bool validate(std::string string) override;
+
+ private:
+  const int min_;
+  const int max_;
+};
+
+class SpecificValuesCheck : public DataCheck {
+ public:
+  explicit SpecificValuesCheck(std::initializer_list<std::string> list)
+      : set_(list) {}
+  virtual ~SpecificValuesCheck() = default;
+  virtual bool validate(std::string string) override;
+
+ private:
+  const std::unordered_set<std::string> set_;
+};
+
+class IntegrationTableTest : public ::testing::Test {
+ protected:
+  enum {
+    NormalType = 0 << 0,
+    IntType = 1 << 0,
+
+    NonEmpty = 1 << 1,
+    NonNull = 1 << 2,
+    NonNegative = 1 << 3,
+    NonZero = 1 << 4,
+    FileOnDisk = 1 << 5,
+    DirectoryOnDisk = 1 << 6,
+    ValidUUID = 1 << 7,
+    MD5 = 1 << 8,
+    SHA256 = 1 << 9,
+    SHA1 = 1 << 10,
+    Bool = 1 << 11,
+
+    NonNegativeInt = IntType | NonEmpty | NonNull | NonNegative,
+    NonEmptyString = NonEmpty | NormalType | NonNull,
+  };
+
+  using ValidatatioDataType = boost::variant<int, std::shared_ptr<DataCheck>>;
+  using ValidatatioMap = std::unordered_map<std::string, ValidatatioDataType>;
+
+  virtual void SetUp() {}
+
+  virtual void TearDown() {}
+
+  QueryData execute_query(std::string query);
+  static bool validate_row(const Row& row,
+                           const ValidatatioMap& validation_map);
+  static bool validate_rows(const std::vector<Row>& rows,
+                            const ValidatatioMap& validation_map);
+  static bool validate_value_using_flags(const std::string& value, int flags);
+  static bool is_valid_hex(const std::string& value);
+};
+
+} // namespace osquery


### PR DESCRIPTION
As preparation for adding sanity tests for table this PR adds:
- new test target for all non-unit tests (aka integration tests)
- set of helper functions that can help to do very simple sanity checks for query results

*Table sanity check problem*
I right now we have plenty of unit tests, but unfortunately we don't have enough integration tests for our tables and its very easy to break things without breaking unit test. 
Goal here is to add basic sanity check for every table that will clearly show what end user should expect from table output, thinks like:
- types
- data format for strings
- specific values 
- number or rows
In case of success some of this tests may be migrated to table usage examples and be part of spec and documentation. 