### PR TITLE
intel_me_info/Windows: Fix the buffer size for the GetFirmwareVersion command

### DIFF
--- a/osquery/tables/system/intel_me.hpp
+++ b/osquery/tables/system/intel_me.hpp
@@ -29,7 +29,7 @@ const std::vector<uint8_t> kMEIUpdateGUID{
 };
 
 struct mei_response {
-  uint32_t maxlen;
+  uint32_t response_size;
   uint8_t version;
 };
 

--- a/osquery/tables/system/intel_me.hpp
+++ b/osquery/tables/system/intel_me.hpp
@@ -29,7 +29,7 @@ const std::vector<uint8_t> kMEIUpdateGUID{
 };
 
 struct mei_response {
-  uint32_t response_size;
+  uint32_t maxlen;
   uint8_t version;
 };
 
@@ -44,9 +44,6 @@ struct mei_version {
   uint16_t r_hotfix;
   uint16_t r_build;
   uint16_t codes[6];
-#ifdef WIN32
-  uint16_t codes2[256];
-#endif
 };
 }
 }

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -138,11 +138,6 @@ void getHECIDriverVersion(QueryData& results) {
     return;
   }
 
-  if (response.version != 0x1) {
-    VLOG(1) << "Intel MEI version is unsupported: " << response.version;
-    return;
-  }
-
   if (response.maxlen < kMinResponseSize) {
     VLOG(1) << "Invalid maxlen size: " << response.maxlen;
     return;

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -125,7 +125,14 @@ void getHECIDriverVersion(QueryData& results) {
                         nullptr);
 
   if (ret == 0) {
-    VLOG(1) << "Device IOCTL call failed with " << GetLastError();
+    auto last_error = GetLastError();
+    if (last_error == ERROR_GEN_FAILURE) {
+      VLOG(1) << "The driver is already in use by another client and can't be "
+                 "queried at this time";
+    } else {
+      VLOG(1) << "Device IOCTL call failed with " << last_error;
+    }
+
     CloseHandle(driver);
     return;
   }

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -24,7 +24,6 @@
 
 namespace osquery {
 namespace {
-const size_t kMinResponseSize = 0x38U;
 const std::unordered_set<size_t> kExpectedMaxLenValues = {512U, 4096U};
 } // namespace
 
@@ -140,7 +139,7 @@ void getHECIDriverVersion(QueryData& results) {
     return;
   }
 
-  if (response.maxlen < kMinResponseSize) {
+  if (response.maxlen < sizeof(mei_version)) {
     LOG(WARNING) << "Invalid maxlen size: " << response.maxlen;
     return;
   } else if (kExpectedMaxLenValues.count(response.maxlen) == 0U) {
@@ -170,7 +169,7 @@ void getHECIDriverVersion(QueryData& results) {
   if (ret != TRUE) {
     std::fill(read_buffer.begin(), read_buffer.end(), 0U);
     LOG(WARNING) << "HECI driver read failed with " << GetLastError();
-  } else if (static_cast<size_t>(bytes_read) < kMinResponseSize) {
+  } else if (static_cast<size_t>(bytes_read) < sizeof(mei_version)) {
     // This is unlikely
     std::fill(read_buffer.begin(), read_buffer.end(), 0U);
     LOG(WARNING) << "The driver has not returned enough bytes";

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -26,7 +26,7 @@ namespace osquery {
 namespace {
 const size_t kMinResponseSize = 0x38U;
 const std::unordered_set<size_t> kExpectedMaxLenValues = {512U, 4096U};
-}
+} // namespace
 
 namespace tables {
 
@@ -190,5 +190,5 @@ QueryData getIntelMEInfo(QueryContext& context) {
   getHECIDriverVersion(results);
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -50,7 +50,7 @@ void getHECIDriverVersion(QueryData& results) {
       guid, nullptr, nullptr, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
 
   if (deviceInfo == INVALID_HANDLE_VALUE) {
-    VLOG(1) << "Failed to open MEI device with " << GetLastError();
+    LOG(WARNING) << "Failed to open MEI device with " << GetLastError();
     return;
   }
 
@@ -96,7 +96,7 @@ void getHECIDriverVersion(QueryData& results) {
 
   // HECI driver was not found
   if (devPath.empty()) {
-    VLOG(1) << "Could not locate HECI driver";
+    LOG(WARNING) << "Could not locate HECI driver";
     return;
   }
 
@@ -108,7 +108,8 @@ void getHECIDriverVersion(QueryData& results) {
                              0,
                              nullptr);
   if (driver == INVALID_HANDLE_VALUE) {
-    VLOG(1) << "Failed to open handle to device path with " << GetLastError();
+    LOG(WARNING) << "Failed to open handle to device path with "
+                 << GetLastError();
     return;
   }
 
@@ -128,10 +129,11 @@ void getHECIDriverVersion(QueryData& results) {
   if (ret == 0) {
     auto last_error = GetLastError();
     if (last_error == ERROR_GEN_FAILURE) {
-      VLOG(1) << "The driver is already in use by another client and can't be "
-                 "queried at this time";
+      LOG(WARNING)
+          << "The driver is already in use by another client and can't be "
+             "queried at this time";
     } else {
-      VLOG(1) << "Device IOCTL call failed with " << last_error;
+      LOG(WARNING) << "Device IOCTL call failed with " << last_error;
     }
 
     CloseHandle(driver);
@@ -139,18 +141,18 @@ void getHECIDriverVersion(QueryData& results) {
   }
 
   if (response.maxlen < kMinResponseSize) {
-    VLOG(1) << "Invalid maxlen size: " << response.maxlen;
+    LOG(WARNING) << "Invalid maxlen size: " << response.maxlen;
     return;
   } else if (kExpectedMaxLenValues.count(response.maxlen) == 0U) {
-    VLOG(1) << "The returned maxlen field value is unexpected: "
-            << response.maxlen;
+    LOG(WARNING) << "The returned maxlen field value is unexpected: "
+                 << response.maxlen;
   }
 
   unsigned char fw_cmd[4] = {0};
   ret = WriteFile(
       driver, static_cast<void*>(fw_cmd), sizeof(fw_cmd), nullptr, nullptr);
   if (ret != TRUE) {
-    VLOG(1) << "HECI driver write failed with " << GetLastError();
+    LOG(WARNING) << "HECI driver write failed with " << GetLastError();
   }
 
   // Response from FirmwareUpdate HECI GUID.
@@ -167,11 +169,11 @@ void getHECIDriverVersion(QueryData& results) {
 
   if (ret != TRUE) {
     std::fill(read_buffer.begin(), read_buffer.end(), 0U);
-    VLOG(1) << "HECI driver read failed with " << GetLastError();
+    LOG(WARNING) << "HECI driver read failed with " << GetLastError();
   } else if (static_cast<size_t>(bytes_read) < kMinResponseSize) {
     // This is unlikely
     std::fill(read_buffer.begin(), read_buffer.end(), 0U);
-    VLOG(1) << "The driver has not returned enough bytes";
+    LOG(WARNING) << "The driver has not returned enough bytes";
   }
 
   auto version = reinterpret_cast<const mei_version*>(read_buffer.data());

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -25,6 +25,7 @@
 namespace osquery {
 namespace {
 const size_t kMinResponseSize = 0x38U;
+const std::unordered_set<size_t> kExpectedMaxLenValues = {512U, 4096U};
 }
 
 namespace tables {
@@ -138,15 +139,16 @@ void getHECIDriverVersion(QueryData& results) {
   }
 
   if (response.version != 0x1) {
-    VLOG(1) << "Intel MEI version is unsupported";
+    VLOG(1) << "Intel MEI version is unsupported: " << response.version;
     return;
   }
 
   if (response.maxlen < kMinResponseSize) {
-    VLOG(1) << "Invalid maxlen size";
+    VLOG(1) << "Invalid maxlen size: " << response.maxlen;
     return;
-  } else if (response.maxlen != 0x1000) {
-    VLOG(1) << "The returned maxlen field value is unexpected";
+  } else if (kExpectedMaxLenValues.count(response.maxlen) == 0U) {
+    VLOG(1) << "The returned maxlen field value is unexpected: "
+            << response.maxlen;
   }
 
   unsigned char fw_cmd[4] = {0};


### PR DESCRIPTION
This is a small fix for the `intel_me_info` table. The size of the response buffer should always match the size field found in the ioctl response.

I've tested this on Windows 10 with a Skylake processor. ~~Additional testing is welcome, as I'm only able to run it on one machine.~~
EDIT: We managed to test on different processors!

This will fix issue #4765

Processors we managed to test:
1. [i5-3320M - Ivy Bridge](https://github.com/facebook/osquery/pull/5111#issuecomment-416724062)
2. i5-6600K - Skylake
3. [i5-7200U - Kaby Lake](https://github.com/facebook/osquery/pull/5111#issuecomment-417642587)
4. [i7-7600U - Kaby Lake](https://github.com/facebook/osquery/pull/5111#issuecomment-416728451)
5. [i7-8650U - Kaby Lake](https://github.com/facebook/osquery/pull/5111#issuecomment-416628064)