### PR TITLE
added database migration class

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(libosquery
     "${CMAKE_CURRENT_LIST_DIR}/database/in_memory_database.h"
     "${CMAKE_CURRENT_LIST_DIR}/database/rocksdb_database.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/database/rocksdb_database.h"
+    "${CMAKE_CURRENT_LIST_DIR}/database/rocksdb_migration.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/database/rocksdb_migration.h"
     "${CMAKE_CURRENT_LIST_DIR}/flags.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/map_take.h"
     "${CMAKE_CURRENT_LIST_DIR}/hashing.cpp"

--- a/osquery/core/database/rocksdb_migration.cpp
+++ b/osquery/core/database/rocksdb_migration.cpp
@@ -1,0 +1,228 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/core/conversions.h>
+#include <osquery/core/database/rocksdb_migration.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+namespace osquery {
+
+namespace fs = boost::filesystem;
+
+ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::migrateDatabase(
+    const std::string& path) {
+  auto migration = std::make_unique<RocksdbMigration>(path);
+  return migration->migrateIfNeeded();
+}
+
+RocksdbMigration::RocksdbMigration(const std::string& path) {
+  auto boost_path = fs::path(path).make_preferred();
+  source_path_ = boost_path.string();
+}
+
+ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::migrateIfNeeded() {
+  auto open_result = openDatabase(source_path_, false, false);
+  if (open_result) {
+    auto db_handle = open_result.take();
+    auto version_result = getVersion(db_handle);
+    if (version_result) {
+      int version = version_result.take();
+      if (version != kDatabaseSchemaVersionCurrent) {
+        migrateFromVersion(version);
+      } else {
+        return Success();
+      }
+    } else {
+      return version_result.takeError();
+    }
+  } else {
+    // InvalidArgument means that db does not exists
+    if (open_result.getErrorCode() == RocksdbMigrationError::InvalidArgument) {
+      return Success();
+    } else {
+      return open_result.takeError();
+    }
+  }
+  return Success();
+}
+
+ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::dropDbMigration(
+    const std::string& src_path, const std::string& dst_path) {
+  auto dst_db = openDatabase(dst_path, true, true);
+  if (dst_db) {
+    return Success();
+  }
+  return dst_db.takeError();
+}
+
+void RocksdbMigration::buildMigrationMap() {
+  // No migration map at this stage, will be added as separate commit
+}
+
+ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::migrateFromVersion(
+    int original_version) {
+  buildMigrationMap();
+  std::string src_path = source_path_;
+  std::string dst_path = randomOutputPath();
+  bool drop_src_data = false;
+  for (int version = original_version;
+       version < kDatabaseSchemaVersionCurrent;) {
+    auto iter = migration_map_.find(version);
+    if (iter == migration_map_.end()) {
+      return createError(RocksdbMigrationError::NoMigrationFromCurrentVersion,
+                         "No migration logic from version: ")
+             << version;
+    }
+    VLOG(1) << "Migrating from version: " << version
+            << ". Src path: " << src_path << ". Dst path: " << dst_path;
+    auto migration_result = iter->second(src_path, dst_path);
+    if (migration_result) {
+      int new_version = migration_result.take();
+      if (new_version <= version) {
+        return createError(RocksdbMigrationError::MigrationLogicError,
+                           "New version(")
+               << version << ") is lower or same as old(" << new_version << ")";
+      }
+      version = new_version;
+    } else {
+      return migration_result.takeError();
+    }
+    if (drop_src_data) {
+      VLOG(1) << "Destroying db at path: " << src_path;
+      rocksdb::DestroyDB(src_path, rocksdb::Options());
+    }
+    drop_src_data = true;
+    src_path = dst_path;
+    dst_path = randomOutputPath();
+  }
+
+  std::string temp_store = randomOutputPath();
+  auto original_src = source_path_;
+  auto new_src = src_path;
+
+  auto move1 = moveDb(original_src, temp_store);
+  if (move1) {
+    auto move2 = moveDb(new_src, original_src);
+    if (move2) {
+      rocksdb::DestroyDB(temp_store, rocksdb::Options());
+      return Success();
+    }
+    return move2.takeError();
+  }
+  return move1.takeError();
+}
+
+ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::moveDb(
+    const std::string& src_path, const std::string& dst_path) {
+  if (BOOST_UNLIKELY(fs::exists(fs::path(dst_path)))) {
+    return createError(RocksdbMigrationError::FailMoveDatabase,
+                       "Database at dst path already exists: ")
+           << dst_path;
+  }
+  boost::system::error_code ec;
+  fs::rename(src_path, dst_path, ec);
+  if (ec.value() == boost::system::errc::success) {
+    return Success();
+  } else {
+    return createError(RocksdbMigrationError::FailMoveDatabase, "Move failed: ")
+           << ec.value() << " " << ec.message();
+  }
+}
+
+Expected<RocksdbMigration::DatabaseHandle, RocksdbMigrationError>
+RocksdbMigration::openDatabase(const std::string& path,
+                               bool create_if_missing,
+                               bool error_if_exists) {
+  DatabaseHandle handle;
+  handle.options.OptimizeForSmallDb();
+  handle.options.create_if_missing = create_if_missing;
+  handle.options.error_if_exists = error_if_exists;
+  handle.path = path;
+  std::vector<std::string> column_families;
+  rocksdb::DB::ListColumnFamilies(handle.options, path, &column_families);
+
+  std::vector<rocksdb::ColumnFamilyDescriptor> descriptors;
+  for (const auto& column : column_families) {
+    descriptors.push_back(
+        rocksdb::ColumnFamilyDescriptor(column, handle.options));
+  }
+  std::vector<rocksdb::ColumnFamilyHandle*> column_family_handles;
+  rocksdb::DB* db = nullptr;
+  auto status = rocksdb::DB::Open(
+      handle.options, path, descriptors, &column_family_handles, &db);
+  if (status.IsInvalidArgument()) {
+    return createError(RocksdbMigrationError::InvalidArgument,
+                       status.ToString());
+  }
+  if (!status.ok()) {
+    return createError(RocksdbMigrationError::FailToOpen, status.ToString());
+  }
+  handle.db_handle = std::unique_ptr<rocksdb::DB>(db);
+  for (const auto& ptr : column_family_handles) {
+    handle.handles[ptr->GetName()] =
+        std::unique_ptr<rocksdb::ColumnFamilyHandle>(ptr);
+  }
+  return std::move(handle);
+}
+
+Expected<int, RocksdbMigrationError> RocksdbMigration::getVersion(
+    const DatabaseHandle& db) {
+  rocksdb::ReadOptions options;
+  options.verify_checksums = true;
+  auto handle_iter = db.handles.find("configurations");
+  if (handle_iter != db.handles.end()) {
+    // Try to get new version first
+    // Version stored as string value to help analyze db by tools
+    std::string version_str;
+
+    rocksdb::ColumnFamilyHandle* raw_handle = handle_iter->second.get();
+
+    auto status = db.db_handle->Get(options,
+                                    raw_handle,
+                                    std::string("database_schema_version"),
+                                    &version_str);
+    if (status.IsNotFound()) {
+      // Fallback to old version storage
+      auto default_family_handle_iter = db.handles.find("default");
+      if (default_family_handle_iter != db.handles.end()) {
+        status = db.db_handle->Get(options,
+                                   default_family_handle_iter->second.get(),
+                                   std::string("results_version"),
+                                   &version_str);
+      }
+    }
+    if (!status.ok()) {
+      return createError(RocksdbMigrationError::FailToGetVersion,
+                         status.ToString());
+    }
+    auto result = tryTo<int>(version_str);
+    if (result) {
+      return *result;
+    }
+    return createError(
+        RocksdbMigrationError::FailToGetVersion, "", result.takeError());
+  }
+  return createError(RocksdbMigrationError::FailToGetVersion,
+                     "Verion data is not found");
+}
+
+std::string RocksdbMigration::randomOutputPath() {
+  auto path = fs::path(OSQUERY_HOME);
+  boost::uuids::uuid uuid = boost::uuids::random_generator()();
+  path.append("migration");
+  path.append(boost::uuids::to_string(uuid));
+  return path.string();
+}
+
+} // namespace osquery

--- a/osquery/core/database/rocksdb_migration.cpp
+++ b/osquery/core/database/rocksdb_migration.cpp
@@ -40,7 +40,7 @@ class RocksdbMigration final {
 
  private:
   struct DatabaseHandle {
-    std::unique_ptr<rocksdb::DB> db_handle = nullptr;
+    std::unique_ptr<rocksdb::DB> db_handle;
     rocksdb::Options options;
     std::string path;
     std::unordered_map<std::string,

--- a/osquery/core/database/rocksdb_migration.h
+++ b/osquery/core/database/rocksdb_migration.h
@@ -17,13 +17,6 @@
 
 namespace osquery {
 
-enum DatabaseSchemaVersion {
-  kDatabaseSchemaV1 = 1,
-  kDatabaseSchemaV2 = 2,
-  kDatabaseSchemaV3 = 3,
-  kDatabaseSchemaVersionCurrent = kDatabaseSchemaV3,
-};
-
 enum class RocksdbMigrationError {
   InvalidArgument = 1,
   FailToOpen = 2,
@@ -34,46 +27,7 @@ enum class RocksdbMigrationError {
   FailMoveDatabase = 8,
 };
 
-class RocksdbMigration final {
- public:
-  static ExpectedSuccess<RocksdbMigrationError> migrateDatabase(
-      const std::string& path);
-  RocksdbMigration(const std::string& path);
-
- private:
-  struct DatabaseHandle {
-    std::unique_ptr<rocksdb::DB> db_handle = nullptr;
-    rocksdb::Options options;
-    std::string path;
-    std::unordered_map<std::string,
-                       std::unique_ptr<rocksdb::ColumnFamilyHandle>>
-        handles;
-  };
-  DatabaseHandle input_db_;
-  DatabaseHandle output_db_;
-
-  std::string source_path_;
-  std::unordered_map<int,
-                     std::function<Expected<int, RocksdbMigrationError>(
-                         const std::string& src, const std::string& dst)>>
-      migration_map_;
-
- private:
-  static Expected<DatabaseHandle, RocksdbMigrationError> openDatabase(
-      const std::string& path, bool create_if_missing, bool error_if_exists);
-  static ExpectedSuccess<RocksdbMigrationError> dropDbMigration(
-      const std::string& src_path, const std::string& dst_path);
-  static ExpectedSuccess<RocksdbMigrationError> moveDb(
-      const std::string& src_path, const std::string& dst_path);
-
-  Expected<int, RocksdbMigrationError> getVersion(const DatabaseHandle& db);
-  ExpectedSuccess<RocksdbMigrationError> migrateFromVersion(int version);
-
-  void buildMigrationMap();
-
-  std::string randomOutputPath();
-
-  ExpectedSuccess<RocksdbMigrationError> migrateIfNeeded();
-};
+static ExpectedSuccess<RocksdbMigrationError> migrateDatabase(
+    const std::string& path);
 
 } // namespace osquery

--- a/osquery/core/database/rocksdb_migration.h
+++ b/osquery/core/database/rocksdb_migration.h
@@ -11,9 +11,6 @@
 #pragma once
 
 #include <osquery/expected.h>
-#include <rocksdb/db.h>
-
-#include <unordered_map>
 
 namespace osquery {
 
@@ -27,7 +24,7 @@ enum class RocksdbMigrationError {
   FailMoveDatabase = 8,
 };
 
-static ExpectedSuccess<RocksdbMigrationError> migrateDatabase(
+ExpectedSuccess<RocksdbMigrationError> migrateRocksDBDatabase(
     const std::string& path);
 
 } // namespace osquery

--- a/osquery/core/database/rocksdb_migration.h
+++ b/osquery/core/database/rocksdb_migration.h
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/expected.h>
+#include <rocksdb/db.h>
+
+#include <unordered_map>
+
+namespace osquery {
+
+enum DatabaseSchemaVersion {
+  kDatabaseSchemaV1 = 1,
+  kDatabaseSchemaV2 = 2,
+  kDatabaseSchemaV3 = 3,
+  kDatabaseSchemaVersionCurrent = kDatabaseSchemaV3,
+};
+
+enum class RocksdbMigrationError {
+  InvalidArgument = 1,
+  FailToOpen = 2,
+  FailToGetVersion = 3,
+  NoMigrationFromCurrentVersion = 5,
+  MigrationLogicError = 6,
+  FailToOpenSrcDatabase = 7,
+  FailMoveDatabase = 8,
+};
+
+class RocksdbMigration final {
+ public:
+  static ExpectedSuccess<RocksdbMigrationError> migrateDatabase(
+      const std::string& path);
+  RocksdbMigration(const std::string& path);
+
+ private:
+  struct DatabaseHandle {
+    std::unique_ptr<rocksdb::DB> db_handle = nullptr;
+    rocksdb::Options options;
+    std::string path;
+    std::unordered_map<std::string,
+                       std::unique_ptr<rocksdb::ColumnFamilyHandle>>
+        handles;
+  };
+  DatabaseHandle input_db_;
+  DatabaseHandle output_db_;
+
+  std::string source_path_;
+  std::unordered_map<int,
+                     std::function<Expected<int, RocksdbMigrationError>(
+                         const std::string& src, const std::string& dst)>>
+      migration_map_;
+
+ private:
+  static Expected<DatabaseHandle, RocksdbMigrationError> openDatabase(
+      const std::string& path, bool create_if_missing, bool error_if_exists);
+  static ExpectedSuccess<RocksdbMigrationError> dropDbMigration(
+      const std::string& src_path, const std::string& dst_path);
+  static ExpectedSuccess<RocksdbMigrationError> moveDb(
+      const std::string& src_path, const std::string& dst_path);
+
+  Expected<int, RocksdbMigrationError> getVersion(const DatabaseHandle& db);
+  ExpectedSuccess<RocksdbMigrationError> migrateFromVersion(int version);
+
+  void buildMigrationMap();
+
+  std::string randomOutputPath();
+
+  ExpectedSuccess<RocksdbMigrationError> migrateIfNeeded();
+};
+
+} // namespace osquery


### PR DESCRIPTION
This PR adds new class that will handle all step by step db migrations in future. 
Implementation intentionally does not depends on actual rocksdb implementation, as well as on all existing constants to make each migration independent as much as possible.


#### Migration problem
Right now db migration is located in few places or non existent. It forces users to write logic that support old and new schema and provides no guarantees that other parts of the application will not access new data till it was actually migrated. Goal is to move all migration to single place and ensure that migration was performed before other parts of the app are inited.