### PR TITLE
treat warnings as error only in the osquery core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,6 @@ if(NOT WIN32)
 endif()
 
 if(POSIX)
-  add_compile_options(
-    -Werror
-  )
   if(CLANG)
     add_compile_options(
       -Qunused-arguments

--- a/osquery/CMakeLists.txt
+++ b/osquery/CMakeLists.txt
@@ -34,6 +34,9 @@ set(OSQUERY_ADDITIONAL_TESTS "")
 set(OSQUERY_TABLES_TESTS "")
 
 # Add all and extra for osquery code.
+add_compile_options(
+  -Werror
+)
 if(CLANG AND POSIX)
   add_compile_options(
     -Wall


### PR DESCRIPTION
We should treat warnings as errors only in osquery core. It's harder to fix warnings for dependencies.