### PR TITLE
Darwin provisioning script to use /usr/local/bin to avoid SIP violation

### DIFF
--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -25,7 +25,7 @@ function vagrant_setup() {
 
 function distro_main() {
   GEM=`which gem`
-  do_sudo $GEM install --no-ri --no-rdoc fpm
+  do_sudo $GEM install --no-ri --no-rdoc -n /usr/local/bin fpm
 }
 
 [ "$0" = "$BASH_SOURCE" ] && vagrant_setup || true


### PR DESCRIPTION
When running `make sysprep` on High Sierra with SIP enabled, this step will fail with the following due to SIP:
```
$ make sysprep
-- Warning! The only Apple OS supported for building is 10.12
-- Note: Installing and running osquery is supported on versions 10.9+
[+] found darwin provision script: ~/osquery/tools/provision/darwin.sh
[+] requesting sudo: /usr/bin/gem install --no-ri --no-rdoc fpm
Password:
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /usr/bin directory.
make: *** [sysprep] Error 1
```

This can be avoided by installing the fpm gem to `/usr/local/bin`. This issue is documented in #5116 