### PR TITLE
virtual tables: Handle SQLite3 BLOB_TYPE

### DIFF
--- a/osquery/sql/sqlite_encoding.cpp
+++ b/osquery/sql/sqlite_encoding.cpp
@@ -35,7 +35,11 @@ static void b64SqliteValue(sqlite3_context* ctx,
     sqlite3_result_null(ctx);
     return;
   }
-  std::string input((char*)sqlite3_value_text(argv[0]));
+
+  const auto* value = sqlite3_value_text(argv[0]);
+  auto size = static_cast<size_t>(sqlite3_value_bytes(argv[0]));
+
+  std::string input(reinterpret_cast<const char*>(value), size);
   std::string result;
   switch (encode) {
   case B64Type::B64_ENCODE_CONDITIONAL:

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -711,7 +711,7 @@ int xColumn(sqlite3_vtab_cursor* cur, sqlite3_context* ctx, int col) {
     // Missing content.
     VLOG(1) << "Error " << column_name << " is empty";
     sqlite3_result_null(ctx);
-  } else if (type == TEXT_TYPE) {
+  } else if (type == TEXT_TYPE || type == BLOB_TYPE) {
     sqlite3_result_text(
         ctx, value.c_str(), static_cast<int>(value.size()), SQLITE_STATIC);
   } else if (type == INTEGER_TYPE) {


### PR DESCRIPTION
Previously:
```
~/git/osquery(branch:blob*)0 » osqueryi                      
Using a virtual database. Need help, type '.help'
osquery> .mode line
osquery> create table blobs (uid blob); insert into blobs values (x'0023456789abcdef0123456789abcdef42'); select length(uid), hex(uid), to_base64(uid), uid from blobs;
   length(uid) = 17
      hex(uid) = 0023456789ABCDEF0123456789ABCDEF42
to_base64(uid) = 
           uid = 
```

With this change:
```
~/git/osquery(branch:blob*)0 » ./build/linux/osquery/osqueryi                               
Using a virtual database. Need help, type '.help'
osquery> .mode line
osquery> create table blobs (uid blob); insert into blobs values (x'0023456789abcdef0123456789abcdef42'); select length(uid), hex(uid), to_base64(uid), uid from blobs;
   length(uid) = 17
      hex(uid) = 0023456789ABCDEF0123456789ABCDEF42
to_base64(uid) = ACNFZ4mrze8BI0VniavN70I=
           uid = 
```