### PR TITLE
Use just std::function for custom validator in table integration tests

### DIFF
--- a/osquery/tests/integration/tables/crontab.cpp
+++ b/osquery/tests/integration/tables/crontab.cpp
@@ -34,15 +34,14 @@ TEST_F(Crontab, test_sanity) {
                                                 "dec"};
   std::unordered_set<std::string> days_list = {
       "mon", "tue", "wed", "thu", "fri", "sat", "sun"};
-  ValidatatioMap row_map = {
-      {"event", NormalType},
-      {"minute", std::make_shared<CronValuesCheck>(0, 59)},
-      {"hour", std::make_shared<CronValuesCheck>(0, 23)},
-      {"day_of_month", std::make_shared<CronValuesCheck>(1, 31)},
-      {"month", std::make_shared<CronValuesCheck>(1, 31, month_list)},
-      {"day_of_week", std::make_shared<CronValuesCheck>(0, 6, days_list)},
-      {"command", NonEmptyString},
-      {"path", FileOnDisk}};
+  ValidatatioMap row_map = {{"event", NormalType},
+                            {"minute", CronValuesCheck(0, 59)},
+                            {"hour", CronValuesCheck(0, 23)},
+                            {"day_of_month", CronValuesCheck(1, 31)},
+                            {"month", CronValuesCheck(1, 31, month_list)},
+                            {"day_of_week", CronValuesCheck(0, 6, days_list)},
+                            {"command", NonEmptyString},
+                            {"path", FileOnDisk}};
   EXPECT_TRUE(validate_rows(data, row_map));
 }
 

--- a/osquery/tests/integration/tables/helper.cpp
+++ b/osquery/tests/integration/tables/helper.cpp
@@ -68,7 +68,7 @@ bool CronValuesCheck::validate(std::string string) {
   return true;
 }
 
-bool IntMinMaxCheck::validate(std::string string) {
+bool IntMinMaxCheck::operator()(const std::string& string) const {
   auto cast_result = tryTo<int>(string);
   if (!cast_result) {
     return false;
@@ -77,7 +77,7 @@ bool IntMinMaxCheck::validate(std::string string) {
   return value >= min_ && value <= max_;
 }
 
-bool SpecificValuesCheck::validate(std::string string) {
+bool SpecificValuesCheck::operator()(const std::string& string) const {
   return set_.find(string) != set_.end();
 }
 
@@ -211,7 +211,7 @@ bool IntegrationTableTest::validate_row(const Row& row,
         return false;
       }
     } else {
-      if (!boost::get<std::shared_ptr<DataCheck>>(validator)->validate(value)) {
+      if (!boost::get<CustomCheckerType>(validator)(value)) {
         return false;
       }
     }

--- a/osquery/tests/integration/tables/helper.cpp
+++ b/osquery/tests/integration/tables/helper.cpp
@@ -21,7 +21,7 @@ namespace osquery {
 
 namespace fs = boost::filesystem;
 
-bool CronValuesCheck::validate(std::string string) {
+bool CronValuesCheck::operator()(const std::string& string) const {
   // Fast asterisk check, its most common
   if (string == "*") {
     return true;

--- a/osquery/tests/integration/tables/helper.h
+++ b/osquery/tests/integration/tables/helper.h
@@ -17,29 +17,22 @@
 
 namespace osquery {
 
-class DataCheck {
- public:
-  virtual ~DataCheck() = default;
-  virtual bool validate(std::string string) = 0;
-};
-
-class IntMinMaxCheck : public DataCheck {
+class IntMinMaxCheck {
  public:
   explicit IntMinMaxCheck(int min, int max) : min_(min), max_(max){};
-  virtual ~IntMinMaxCheck() = default;
-  virtual bool validate(std::string string) override;
+
+  bool operator()(const std::string& string) const;
 
  private:
   const int min_;
   const int max_;
 };
 
-class SpecificValuesCheck : public DataCheck {
+class SpecificValuesCheck {
  public:
   explicit SpecificValuesCheck(std::initializer_list<std::string> list)
       : set_(list) {}
-  virtual ~SpecificValuesCheck() = default;
-  virtual bool validate(std::string string) override;
+  bool operator()(const std::string& string) const;
 
  private:
   const std::unordered_set<std::string> set_;
@@ -82,7 +75,8 @@ class IntegrationTableTest : public ::testing::Test {
     NonEmptyString = NonEmpty | NormalType | NonNull,
   };
 
-  using ValidatatioDataType = boost::variant<int, std::shared_ptr<DataCheck>>;
+  using CustomCheckerType = std::function<bool(const std::string&)>;
+  using ValidatatioDataType = boost::variant<int, CustomCheckerType>;
   using ValidatatioMap = std::unordered_map<std::string, ValidatatioDataType>;
 
   virtual void SetUp() {}

--- a/osquery/tests/integration/tables/helper.h
+++ b/osquery/tests/integration/tables/helper.h
@@ -17,7 +17,7 @@
 
 namespace osquery {
 
-class IntMinMaxCheck {
+class IntMinMaxCheck final {
  public:
   explicit IntMinMaxCheck(int min, int max) : min_(min), max_(max){};
 
@@ -28,7 +28,7 @@ class IntMinMaxCheck {
   const int max_;
 };
 
-class SpecificValuesCheck {
+class SpecificValuesCheck final {
  public:
   explicit SpecificValuesCheck(std::initializer_list<std::string> list)
       : set_(list) {}

--- a/osquery/tests/integration/tables/helper.h
+++ b/osquery/tests/integration/tables/helper.h
@@ -38,14 +38,13 @@ class SpecificValuesCheck final {
   const std::unordered_set<std::string> set_;
 };
 
-class CronValuesCheck : public DataCheck {
+class CronValuesCheck final {
  public:
   explicit CronValuesCheck(int min,
                            int max,
                            std::unordered_set<std::string> values = {})
       : min_(min), max_(max), values_(std::move(values)){};
-  virtual ~CronValuesCheck() = default;
-  virtual bool validate(std::string string) override;
+  bool operator()(const std::string& string) const;
 
  private:
   const int min_;

--- a/osquery/tests/integration/tables/uptime.cpp
+++ b/osquery/tests/integration/tables/uptime.cpp
@@ -20,9 +20,9 @@ TEST_F(UptimeTests, test_sanity) {
 
   ValidatatioMap row_map = {
       {"days", NonNegativeInt},
-      {"hours", std::make_shared<IntMinMaxCheck>(0, 24)},
-      {"minutes", std::make_shared<IntMinMaxCheck>(0, 60)},
-      {"seconds", std::make_shared<IntMinMaxCheck>(0, 60)},
+      {"hours", IntMinMaxCheck(0, 24)},
+      {"minutes", IntMinMaxCheck(0, 60)},
+      {"seconds", IntMinMaxCheck(0, 60)},
       {"total_seconds", NonNegativeInt}};
 
   EXPECT_TRUE(validate_rows(data, row_map));

--- a/osquery/tests/integration/tables/uptime.cpp
+++ b/osquery/tests/integration/tables/uptime.cpp
@@ -18,12 +18,11 @@ TEST_F(UptimeTests, test_sanity) {
   QueryData data = execute_query("select * from uptime");
   ASSERT_EQ(data.size(), 1ul);
 
-  ValidatatioMap row_map = {
-      {"days", NonNegativeInt},
-      {"hours", IntMinMaxCheck(0, 24)},
-      {"minutes", IntMinMaxCheck(0, 60)},
-      {"seconds", IntMinMaxCheck(0, 60)},
-      {"total_seconds", NonNegativeInt}};
+  ValidatatioMap row_map = {{"days", NonNegativeInt},
+                            {"hours", IntMinMaxCheck(0, 24)},
+                            {"minutes", IntMinMaxCheck(0, 60)},
+                            {"seconds", IntMinMaxCheck(0, 60)},
+                            {"total_seconds", NonNegativeInt}};
 
   EXPECT_TRUE(validate_rows(data, row_map));
 }


### PR DESCRIPTION
It is a bit more clear to use just a functions without smartpointers
