### PR TITLE
Typo on Ubuntu 17.04 bento box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,7 +36,7 @@ targets = {
     "box" => "bento/ubuntu-16.10"
   },
   "ubuntu17.04" => {
-    "box" => "bento/ubuntu17.04"
+    "box" => "bento/ubuntu-17.04"
   },
   "ubuntu18.04" => {
     "box" => "ubuntu/bionic64"


### PR DESCRIPTION
The Vagrantfile is missing a "-" in the name of the vagrant box for Ubuntu 17.04.

Typo'd vagrant box name causes vagrant up to fail.
```
osquery vagrant up ubuntu17.04
Bringing machine 'ubuntu17.04' up with 'virtualbox' provider...
==> ubuntu17.04: Box 'bento/ubuntu17.04' could not be found. Attempting to find and install...
    ubuntu17.04: Box Provider: virtualbox
    ubuntu17.04: Box Version: >= 0
The box 'bento/ubuntu17.04' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Vagrant Cloud, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://vagrantcloud.com/bento/ubuntu17.04"]
Error: The requested URL returned error: 404 Not Found
```
Corrected name output:
```
==> ubuntu17.04: Box 'bento/ubuntu-17.04' could not be found. Attempting to find and install...
    ubuntu17.04: Box Provider: virtualbox
    ubuntu17.04: Box Version: >= 0
==> ubuntu17.04: Loading metadata for box 'bento/ubuntu-17.04'
    ubuntu17.04: URL: https://vagrantcloud.com/bento/ubuntu-17.04
==> ubuntu17.04: Adding box 'bento/ubuntu-17.04' (v201801.02.0) for provider: virtualbox
    ubuntu17.04: Downloading: https://vagrantcloud.com/bento/boxes/ubuntu-17.04/versions/201801.02.0/providers/virtualbox.box
==> ubuntu17.04: Successfully added box 'bento/ubuntu-17.04' (v201801.02.0) for 'virtualbox'!
```