### PR TITLE
Three new "add" wrapper JSON methods.

### DIFF
--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -212,6 +212,33 @@ void JSON::add(const std::string& key, bool value) {
   add(key, value, doc());
 }
 
+void JSON::add(const std::string& key, int64_t value, rj::Value& obj) {
+  assert(obj.IsObject());
+  auto itr = obj.FindMember(key);
+  if (itr != obj.MemberEnd()) {
+    obj.RemoveMember(itr);
+  }
+  obj.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                rj::Value(value).Move(),
+                doc_.GetAllocator());
+}
+void JSON::add(const std::string& key, int64_t value) {
+  add(key, value, doc());
+}
+void JSON::add(const std::string& key, double value, rj::Value& obj) {
+  assert(obj.IsObject());
+  auto itr = obj.FindMember(key);
+  if (itr != obj.MemberEnd()) {
+    obj.RemoveMember(itr);
+  }
+  obj.AddMember(rj::Value(rj::StringRef(key), doc_.GetAllocator()).Move(),
+                rj::Value(value).Move(),
+                doc_.GetAllocator());
+}
+void JSON::add(const std::string& key, double value) {
+  add(key, value, doc());
+}
+
 Status JSON::toString(std::string& str) const {
   rj::StringBuffer sb;
   rj::Writer<rj::StringBuffer> writer(sb);

--- a/osquery/core/json.h
+++ b/osquery/core/json.h
@@ -223,6 +223,41 @@ class JSON : private only_movable {
    */
   void add(const std::string& key, bool value);
 
+  /**
+   * @brief Add an unsigned int64_t to a JSON object by copying the
+   * contents.
+   *
+   * This will add the key and value to an input document. If the key exists
+   * the value will be replaced.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, int64_t value, rapidjson::Value& obj);
+  /**
+   * @brief Add an unsigned int64_t to a JSON object by copying the
+   * contents.
+   *
+   * This will add the key and value to the JSON document. If the key exists
+   * the value will be replaced.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, int64_t value);
+  /**
+   * @brief Add a double value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to an input document. If the key exists
+   * the value will be replaced.
+   * The input document must be an object type.
+   */
+  void add(const std::string& key, double value, rapidjson::Value& obj);
+  /**
+   * @brief Add an double value to a JSON object by copying the contents.
+   *
+   * This will add the key and value to the JSON document. If the key exists
+   * the value will be replaced.
+   * The document must be an object type.
+   */
+  void add(const std::string& key, double value);
+
   /// Add a JSON document as a member.
   void add(const std::string& key, const rapidjson::Value& value);
 

--- a/osquery/core/tests/conversions_tests.cpp
+++ b/osquery/core/tests/conversions_tests.cpp
@@ -84,6 +84,10 @@ TEST_F(ConversionsTests, test_json_array) {
     doc.add("key", value, obj);
     int value2 = -10;
     doc.add("key2", value2, obj);
+    int64_t value3 = (uint64_t(1)) << 48;
+    doc.add("key3", value3, obj);
+    double value4 = 3.14159265359;
+    doc.add("key4", value4, obj);
     doc.push(obj);
   }
 
@@ -93,7 +97,9 @@ TEST_F(ConversionsTests, test_json_array) {
   std::string result;
   EXPECT_TRUE(doc.toString(result));
 
-  std::string expected = "[{\"key\":10,\"key2\":-10},11]";
+  std::string expected =
+      "[{\"key\":10,\"key2\":-10,\"key3\":281474976710656,\"key4\":3."
+      "14159265359},11]";
   EXPECT_EQ(expected, result);
 }
 


### PR DESCRIPTION
New methods to allow adding numeric and arbitrary rapidjson::Value types.

See [tracking issue](https://github.com/facebook/osquery/issues/4799) for details.