### PR TITLE
allow numeric_monitoring flush for non testing purposes

### DIFF
--- a/include/osquery/numeric_monitoring.h
+++ b/include/osquery/numeric_monitoring.h
@@ -63,9 +63,9 @@ void record(const std::string& path,
 
 /**
  * Force flush the pre-aggregation buffer.
- * Only for tests, please do not use it anywhere.
+ * Please use it, only when it's totally necessary.
  */
-void flushForTests();
+void flush();
 
 }; // namespace monitoring
 

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -196,7 +196,7 @@ FlusherIsScheduled schedule() {
 
 } // namespace
 
-void flushForTests() {
+void flush() {
   PreAggregationBuffer::get().flush();
 }
 

--- a/osquery/numeric_monitoring/tests/numeric_monitoring_tests.cpp
+++ b/osquery/numeric_monitoring/tests/numeric_monitoring_tests.cpp
@@ -91,7 +91,7 @@ GTEST_TEST(NumericMonitoringTests, record_with_buffer) {
       monitoring::registryName(), FLAGS_numeric_monitoring_plugins);
   ASSERT_TRUE(status.ok());
 
-  monitoring::flushForTests();
+  monitoring::flush();
   NumericMonitoringInMemoryTestPlugin::points.clear();
 
   const auto monitoring_path = "some.path.to.heaven";
@@ -104,7 +104,7 @@ GTEST_TEST(NumericMonitoringTests, record_with_buffer) {
   monitoring::record(monitoring_path,
                      monitoring::ValueType{93},
                      monitoring::PreAggregationType::Sum);
-  monitoring::flushForTests();
+  monitoring::flush();
 
   EXPECT_EQ(1, NumericMonitoringInMemoryTestPlugin::points.size());
   EXPECT_EQ(monitoring_path,
@@ -132,7 +132,7 @@ GTEST_TEST(NumericMonitoringTests, record_without_buffer) {
   FLAGS_numeric_monitoring_plugins = kNameForTestPlugin;
   FLAGS_numeric_monitoring_pre_aggregation_time = 0;
 
-  monitoring::flushForTests();
+  monitoring::flush();
   NumericMonitoringInMemoryTestPlugin::points.clear();
 
   auto status = RegistryFactory::get().setActive(


### PR DESCRIPTION
There was found non testing use case for numeric_monitoring flush. 
For example, when osquery receives termination signal and wants to store it, it needs to be flushed ASAP. 
Using flush is still not recommended when it's not necessary, as it might degrade performance or DDoS server.