### PR TITLE
pci_devices table: augment with `pci_class_id`, `pci_subclass_id`, `pci_subclass` columns for linux

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -28,6 +28,7 @@ namespace tables {
 
 const std::string kPCIKeySlot = "PCI_SLOT_NAME";
 const std::string kPCIKeyClass = "ID_PCI_CLASS_FROM_DATABASE";
+const std::string kPCIKeySubclass = "ID_PCI_SUBCLASS_FROM_DATABASE";
 const std::string kPCIKeyVendor = "ID_VENDOR_FROM_DATABASE";
 const std::string kPCIKeyModel = "ID_MODEL_FROM_DATABASE";
 const std::string kPCIKeyID = "PCI_ID";
@@ -286,6 +287,8 @@ QueryData genPCIDevices(QueryContext& context) {
     Row r;
     r["pci_slot"] = UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
     r["pci_class"] = UdevEventPublisher::getValue(device.get(), kPCIKeyClass);
+    r["pci_subclass"] =
+        UdevEventPublisher::getValue(device.get(), kPCIKeySubclass);
     r["driver"] = UdevEventPublisher::getValue(device.get(), kPCIKeyDriver);
     r["vendor"] = UdevEventPublisher::getValue(device.get(), kPCIKeyVendor);
     r["model"] = UdevEventPublisher::getValue(device.get(), kPCIKeyModel);

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -32,6 +32,7 @@ const std::string kPCIKeySubclass = "ID_PCI_SUBCLASS_FROM_DATABASE";
 const std::string kPCIKeyVendor = "ID_VENDOR_FROM_DATABASE";
 const std::string kPCIKeyModel = "ID_MODEL_FROM_DATABASE";
 const std::string kPCIKeyID = "PCI_ID";
+const std::string kPCIClassID = "PCI_CLASS";
 const std::string kPCIKeyDriver = "DRIVER";
 const std::string kPCISubsysID = "PCI_SUBSYS_ID";
 
@@ -293,6 +294,7 @@ QueryData genPCIDevices(QueryContext& context) {
     r["vendor"] = UdevEventPublisher::getValue(device.get(), kPCIKeyVendor);
     r["model"] = UdevEventPublisher::getValue(device.get(), kPCIKeyModel);
 
+    // TODO: extract to separate function
     // VENDOR:MODEL ID is in the form of HHHH:HHHH.
     std::vector<std::string> ids;
     auto device_id = UdevEventPublisher::getValue(device.get(), kPCIKeyID);
@@ -350,6 +352,25 @@ QueryData genPCIDevices(QueryContext& context) {
 
     if (r["model_id"].size() == 0) {
       r["model_id"] = "0";
+    }
+
+    // TODO: extract to seperate function
+    auto pci_class_id = UdevEventPublisher::getValue(device.get(), kPCIClassID);
+    auto id_len = pci_class_id.length();
+    switch (id_len) {
+    case 5:
+      r["pci_class_id"] = "0x0" + pci_class_id.substr(0, 1);
+      r["pci_subclass_id"] = "0x" + pci_class_id.substr(1, 2);
+      break;
+
+    case 6:
+      r["pci_class_id"] = "0x" + pci_class_id.substr(0, 2);
+      r["pci_subclass_id"] = "0x" + pci_class_id.substr(2, 2);
+      break;
+
+    default:
+      VLOG(1) << "Expected PCI Class ID to be 6 or 7 characters long, but got "
+              << id_len;
     }
 
     results.push_back(r);

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -50,7 +50,7 @@ class PciDB {
    *
    * @return an instance of Status, indicating success or failure.
    */
-  Status getVendorName(const std::string& vendor_id, std::string& vendor);
+  Status getVendorName(const std::string& vendor_id, std::string& vendor) const;
 
   /**
    * @brief retrieves PCI device model description from pci.ids database.
@@ -64,7 +64,7 @@ class PciDB {
    */
   Status getModel(const std::string& vendor_id,
                   const std::string& model_id,
-                  std::string& model);
+                  std::string& model) const;
 
   /**
    * @brief retrieves PCI device subsystem description from pci.ids database.
@@ -82,7 +82,7 @@ class PciDB {
                           const std::string& model_id,
                           const std::string& subsystem_vendor_id,
                           const std::string& subsystem_device_id,
-                          std::string& subsystem);
+                          std::string& subsystem) const;
 
  public:
   PciDB(std::istream& db_filestream);
@@ -115,5 +115,16 @@ class PciDB {
  private:
   std::unordered_map<std::string, PciVendor> db_;
 };
+
+/// Extracts PCI device information into row for provided sysFS attributes.
+Status extractPCIDeviceInfo(Row& row,
+                            std::string&& device_attr,
+                            std::string&& subsystem_attr,
+                            const PciDB& pcidb);
+
+///  Extracts PCI class identifier information into row for provided sysFs
+///  attribute.
+Status extractPCIClassIDAttrs(Row& row, std::string&& pci_class_attr);
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/linux/tests/pci_devices_test.cpp
+++ b/osquery/tables/system/linux/tests/pci_devices_test.cpp
@@ -18,102 +18,130 @@ using namespace testing;
 namespace osquery {
 namespace tables {
 
-class PciDBTest : public ::testing::Test {};
+class PciDevicesTest : public ::testing::Test {
+ protected:
+  PciDevicesTest() {}
 
-TEST_F(PciDBTest, basic_db_format) {
-  std::istringstream raw_db(
-      "# Some Test Comment\n"
-      "8002  Fake Vendor, Inc.\n"
-      "\t1312  Foobar\n"
-      "\t1313  Foobar [Some R7 Rapidfire]\n"
-      "\t1314  Wrestler HDMI Audio\n"
-      "\t\t174b 1001  90K Diffusion Mini\n"
-      "\t1315  Foobar [Some R5 Rapidfire]\n"
-      "\t1316  Foobar [Some R5 Rapidfire]\n"
-      "\t1317  Foobar\n"
-      "\t1318  Foobar [Some R5 Rapidfire]\n"
-      "\t131b  Foobar [Some R4 Rapidfire]\n"
-      "\t131c  Foobar [Some R7 Rapidfire]\n"
-      "\t131d  Foobar [Some R6 Rapidfire]\n"
-      "\t1714  BeaverCreek HDMI Audio [Some HD 6500D and 6400G-6600G series]\n"
-      "\t\t103c 168b  ProBook 4535s\n"
-      "\t3150  RV380/M24 [Loops Some X600]\n"
-      "\t\t103c 0934  nx8220\n"
-      "\t3151  RV380 GL [IcyhotMV 2400]\n"
-      "\t3152  RV370/M22 [Loops Some X300]\n"
-      "\t3154  RV380/M24 GL [Loops IcyhotGL V3200]\n"
-      "\t3155  RV380 GL [IcyhotMV 2400]\n"
-      "\t3171  RV380 GL [IcyhotMV 2400] (Secondary)\n"
-      "\t3e50  RV380 [Some X600]\n"
-      "\t3e54  RV380 GL [IcyhotGL V3200]\n"
-      "\t3e70  RV380 [Some X600] (Secondary)\n"
-      "\t4136  RS100 [Loops ABC 320M]\n"
-      "ffff  Illegal Vendor ID\n" // Device class information below.
-      "\n\n"
-      "# List of known device classes, subclasses and programming interfaces\n"
-      "\n"
-      "# Syntax:\n"
-      "# C class	class_name\n"
-      "#	subclass	subclass_name  		<-- single tab\n"
-      "#		prog-if  prog-if_name  	<-- two tabs\n"
-      "\n"
-      "C 00  Unclassified device\n"
-      "\t00  Non-VGA unclassified device\n"
-      "\t01  VGA compatible unclassified device\n"
-      "C 01  Mass storage controller\n"
-      "\t00  SCSI storage controller\n"
-      "\t01  IDE interface\n");
+  static void SetUpTestCase() {
+    std::istringstream test_db_stream(
+        "# Some Test Comment\n"
+        "8002  Fake Vendor, Inc.\n"
+        "\t1312  Foobar\n"
+        "\t1313  Foobar [Some R7 Rapidfire]\n"
+        "\t131b  Wrestler HDMI Audio\n"
+        "\t\t174b 1001  90K Diffusion Mini\n"
+        "174b  Fake Vendor, LLC.\n"
+        "ffff  Illegal Vendor ID\n" // Device class information below.
 
-  PciDB parsed_db(raw_db);
+    );
 
-  std::string got;
+    pcidb_ = new PciDB(test_db_stream);
+  }
 
-  // Happy Path Tests
-  parsed_db.getVendorName("8002", got);
-  EXPECT_EQ("Fake Vendor, Inc.", got);
+  static void TearDownTestCase() {
+    delete pcidb_;
+    pcidb_ = nullptr;
+  }
 
-  parsed_db.getModel("8002", "1313", got);
-  EXPECT_EQ("Foobar [Some R7 Rapidfire]", got);
+  static PciDB* pcidb_;
+};
 
-  parsed_db.getModel("8002", "1314", got);
-  EXPECT_EQ("Wrestler HDMI Audio", got);
+PciDB* PciDevicesTest::pcidb_ = nullptr;
 
-  parsed_db.getModel("8002", "4136", got);
-  EXPECT_EQ("RS100 [Loops ABC 320M]", got);
+TEST_F(PciDevicesTest, extract_pci_device_info_all_fields_exists) {
+  Row expected = {
+      {"vendor_id", "0x8002"},
+      {"model_id", "0x131b"},
+      {"vendor", "Fake Vendor, Inc."},
+      {"model", "Wrestler HDMI Audio"},
+      {"subsystem_vendor_id", "0x174b"},
+      {"subsystem_model_id", "0x1001"},
+      {"subsystem_vendor", "Fake Vendor, LLC."},
+      {"subsystem_model", "90K Diffusion Mini"},
+  };
 
-  parsed_db.getSubsystemInfo("8002", "1314", "174b", "1001", got);
-  EXPECT_EQ("90K Diffusion Mini", got);
-
-  parsed_db.getSubsystemInfo("8002", "3150", "103c", "0934", got);
-  EXPECT_EQ("nx8220", got);
-
-  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168b", got);
-  EXPECT_EQ("ProBook 4535s", got);
-
-  // Negative Tests
-  got = "";
-
-  parsed_db.getVendorName("8086", got);
-  EXPECT_EQ("", got);
-
-  parsed_db.getModel("8002", "1388", got);
-  EXPECT_EQ("", got);
-
-  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168c", got);
-  EXPECT_EQ("", got);
-
-  // Things below 'ffff' should not be retrievable.
-  parsed_db.getVendorName("ffff", got);
-  EXPECT_EQ("", got);
-
-  parsed_db.getVendorName("C 00", got);
-  EXPECT_EQ("", got);
-
-  parsed_db.getVendorName("C 01", got);
-  EXPECT_EQ("", got);
-
-  parsed_db.getModel("C 00", "00", got);
-  EXPECT_EQ("", got);
+  Row got;
+  auto status = extractPCIDeviceInfo(
+      got, "8002:131B", "174B:1001", *PciDevicesTest::pcidb_);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(expected, got);
 }
+
+TEST_F(PciDevicesTest, extract_pci_device_info_missing_subsystem_info) {
+  Row expected = {
+      {"vendor_id", "0x8002"},
+      {"model_id", "0x131b"},
+      {"vendor", "Fake Vendor, Inc."},
+      {"model", "Wrestler HDMI Audio"},
+      {"subsystem_vendor_id", "0x174c"},
+      {"subsystem_model_id", "0x1003"},
+  };
+
+  Row got;
+  auto status = extractPCIDeviceInfo(
+      got, "8002:131B", "174C:1003", *PciDevicesTest::pcidb_);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(expected, got);
+}
+
+TEST_F(PciDevicesTest, extract_pci_device_info_missing_all_info) {
+  Row expected = {
+      {"vendor_id", "0x8005"},
+      {"model_id", "0x1311"},
+      {"subsystem_vendor_id", "0x174c"},
+      {"subsystem_model_id", "0x1003"},
+  };
+
+  Row got;
+  auto status = extractPCIDeviceInfo(
+      got, "8005:1311", "174C:1003", *PciDevicesTest::pcidb_);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(expected, got);
+}
+
+TEST_F(PciDevicesTest, extract_pci_device_info_negative_bad_pci_id) {
+  Row got;
+  auto status = extractPCIDeviceInfo(
+      got, "blahblah", "174C:1003", *PciDevicesTest::pcidb_);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST_F(PciDevicesTest, extract_pci_device_info_negative_bad_subsys_id) {
+  Row got;
+  auto status = extractPCIDeviceInfo(
+      got, "8005:1311", "blahblah", *PciDevicesTest::pcidb_);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST_F(PciDevicesTest, extract_pci_class_ids_single_digit_class_id) {
+  Row expected = {
+      {"pci_class_id", "0x08"},
+      {"pci_subclass_id", "0x1c"},
+  };
+
+  Row got;
+  auto status = extractPCIClassIDAttrs(got, "81C00");
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(expected, got);
+}
+
+TEST_F(PciDevicesTest, extract_pci_class_ids_double_digit_class_id) {
+  Row expected = {
+      {"pci_class_id", "0x1d"},
+      {"pci_subclass_id", "0x1c"},
+  };
+
+  Row got;
+  auto status = extractPCIClassIDAttrs(got, "1D1C00");
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(expected, got);
+}
+
+TEST_F(PciDevicesTest, extract_pci_class_ids_negative_bad_length) {
+  Row got;
+  auto status = extractPCIClassIDAttrs(got, "FDD1D1C00");
+  EXPECT_FALSE(status.ok());
+}
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/linux/tests/pcidb_test.cpp
+++ b/osquery/tables/system/linux/tests/pcidb_test.cpp
@@ -1,0 +1,119 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "osquery/tables/system/linux/pci_devices.h"
+
+using namespace testing;
+
+namespace osquery {
+namespace tables {
+
+class PciDBTest : public ::testing::Test {};
+
+TEST_F(PciDBTest, basic_db_format) {
+  std::istringstream raw_db(
+      "# Some Test Comment\n"
+      "8002  Fake Vendor, Inc.\n"
+      "\t1312  Foobar\n"
+      "\t1313  Foobar [Some R7 Rapidfire]\n"
+      "\t1314  Wrestler HDMI Audio\n"
+      "\t\t174b 1001  90K Diffusion Mini\n"
+      "\t1315  Foobar [Some R5 Rapidfire]\n"
+      "\t1316  Foobar [Some R5 Rapidfire]\n"
+      "\t1317  Foobar\n"
+      "\t1318  Foobar [Some R5 Rapidfire]\n"
+      "\t131b  Foobar [Some R4 Rapidfire]\n"
+      "\t131c  Foobar [Some R7 Rapidfire]\n"
+      "\t131d  Foobar [Some R6 Rapidfire]\n"
+      "\t1714  BeaverCreek HDMI Audio [Some HD 6500D and 6400G-6600G series]\n"
+      "\t\t103c 168b  ProBook 4535s\n"
+      "\t3150  RV380/M24 [Loops Some X600]\n"
+      "\t\t103c 0934  nx8220\n"
+      "\t3151  RV380 GL [IcyhotMV 2400]\n"
+      "\t3152  RV370/M22 [Loops Some X300]\n"
+      "\t3154  RV380/M24 GL [Loops IcyhotGL V3200]\n"
+      "\t3155  RV380 GL [IcyhotMV 2400]\n"
+      "\t3171  RV380 GL [IcyhotMV 2400] (Secondary)\n"
+      "\t3e50  RV380 [Some X600]\n"
+      "\t3e54  RV380 GL [IcyhotGL V3200]\n"
+      "\t3e70  RV380 [Some X600] (Secondary)\n"
+      "\t4136  RS100 [Loops ABC 320M]\n"
+      "ffff  Illegal Vendor ID\n" // Device class information below.
+      "\n\n"
+      "# List of known device classes, subclasses and programming interfaces\n"
+      "\n"
+      "# Syntax:\n"
+      "# C class	class_name\n"
+      "#	subclass	subclass_name  		<-- single tab\n"
+      "#		prog-if  prog-if_name  	<-- two tabs\n"
+      "\n"
+      "C 00  Unclassified device\n"
+      "\t00  Non-VGA unclassified device\n"
+      "\t01  VGA compatible unclassified device\n"
+      "C 01  Mass storage controller\n"
+      "\t00  SCSI storage controller\n"
+      "\t01  IDE interface\n");
+
+  PciDB parsed_db(raw_db);
+
+  std::string got;
+
+  // Happy Path Tests
+  parsed_db.getVendorName("8002", got);
+  EXPECT_EQ("Fake Vendor, Inc.", got);
+
+  parsed_db.getModel("8002", "1313", got);
+  EXPECT_EQ("Foobar [Some R7 Rapidfire]", got);
+
+  parsed_db.getModel("8002", "1314", got);
+  EXPECT_EQ("Wrestler HDMI Audio", got);
+
+  parsed_db.getModel("8002", "4136", got);
+  EXPECT_EQ("RS100 [Loops ABC 320M]", got);
+
+  parsed_db.getSubsystemInfo("8002", "1314", "174b", "1001", got);
+  EXPECT_EQ("90K Diffusion Mini", got);
+
+  parsed_db.getSubsystemInfo("8002", "3150", "103c", "0934", got);
+  EXPECT_EQ("nx8220", got);
+
+  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168b", got);
+  EXPECT_EQ("ProBook 4535s", got);
+
+  // Negative Tests
+  got = "";
+
+  parsed_db.getVendorName("8086", got);
+  EXPECT_EQ("", got);
+
+  parsed_db.getModel("8002", "1388", got);
+  EXPECT_EQ("", got);
+
+  parsed_db.getSubsystemInfo("8002", "1714", "103c", "168c", got);
+  EXPECT_EQ("", got);
+
+  // Things below 'ffff' should not be retrievable.
+  parsed_db.getVendorName("ffff", got);
+  EXPECT_EQ("", got);
+
+  parsed_db.getVendorName("C 00", got);
+  EXPECT_EQ("", got);
+
+  parsed_db.getVendorName("C 01", got);
+  EXPECT_EQ("", got);
+
+  parsed_db.getModel("C 00", "00", got);
+  EXPECT_EQ("", got);
+}
+} // namespace tables
+} // namespace osquery

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -17,6 +17,8 @@ schema([
 ])
 
 extended_schema(LINUX, [
+    Column("pci_class_id", TEXT, "PCI Device class ID in hex format"),
+    Column("pci_subclass_id", TEXT, "PCI Device  subclass in hex format"),
     Column("pci_subclass", TEXT, "PCI Device subclass"),
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -17,9 +17,12 @@ schema([
 ])
 
 extended_schema(LINUX, [
+    Column("pci_subclass", TEXT, "PCI Device subclass"),
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),
     Column("subsystem_model_id", TEXT, "Model ID of PCI device subsystem"),
     Column("subsystem_model", TEXT, "Device description of PCI device subsystem"),
 ])
+
+>>>>>>> tables: augment pci_devices table on linux with pci_subclass
 implementation("pci_devices@genPCIDevices")

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -17,14 +17,13 @@ schema([
 ])
 
 extended_schema(LINUX, [
-    Column("pci_class_id", TEXT, "PCI Device class ID in hex format"),
-    Column("pci_subclass_id", TEXT, "PCI Device  subclass in hex format"),
-    Column("pci_subclass", TEXT, "PCI Device subclass"),
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),
     Column("subsystem_model_id", TEXT, "Model ID of PCI device subsystem"),
     Column("subsystem_model", TEXT, "Device description of PCI device subsystem"),
+    Column("pci_class_id", TEXT, "PCI Device class ID in hex format"),
+    Column("pci_subclass_id", TEXT, "PCI Device  subclass in hex format"),
+    Column("pci_subclass", TEXT, "PCI Device subclass"),
 ])
 
->>>>>>> tables: augment pci_devices table on linux with pci_subclass
 implementation("pci_devices@genPCIDevices")


### PR DESCRIPTION
Currently PCI subclass information is unavailable for Linux.   The actual PCI class and subclass ID's were also missing from the table.  Providing these columns brings value in that a user can now ask for information about PCI devices by their class and subclass attributes, and the queries will be less error prone because we can now select by their respective ID's rather than a textual description.

Also, I noticed that the `getPCIDevices` function was getting quite long and harder to read.  So I added some extra abstractions to help alleviate this, which lead to this PR's scope of change to creep up.   I was hoping  the fact that it was this change that triggered (or perhaps emphasized is the better word?), that it would make more sense to put this refactor as part of this PR.    Please let me know that's not the case, I can put the refactor into a subsequent PR.