### PR TITLE
Trim whitespace from Darwin system_info fields

### DIFF
--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -70,6 +70,12 @@ static inline void genHardwareInfo(Row& r) {
   r["hardware_vendor"] = getIOKitProperty(properties, "manufacturer");
   r["hardware_model"] = getIOKitProperty(properties, "product-name");
   r["hardware_serial"] = getIOKitProperty(properties, "IOPlatformSerialNumber");
+
+  // version, manufacturer, and product-name have a trailing space
+  boost::trim(r["hardware_version"]);
+  boost::trim(r["hardware_vendor"]);
+  boost::trim(r["hardware_model"]);
+
   CFRelease(properties);
 }
 


### PR DESCRIPTION
This PR fixes #5106 by trimming the whitespace we get from the data returned from the macOS API. At first I thought this was an osquery regression, but going as far back as 2.x this looks like it has always been a problem.

Before the fix...

```
echo "select hardware_model, hardware_vendor, hardware_version from system_info;" | osqueryi --json | jq
[
  {
    "hardware_model": "MacBookPro13,3 ",
    "hardware_vendor": "Apple Inc. ",
    "hardware_version": "1.0 "
  }
]
```

After the fix... (note the lack of trailing spaces)

```
echo "select hardware_version, hardware_vendor, hardware_model from system_info;" | /Users/jmeller/source/osquery/build/darwin10.13/osquery/osqueryi --json | jq
[
  {
    "hardware_model": "MacBookPro13,3",
    "hardware_vendor": "Apple Inc.",
    "hardware_version": "1.0"
  }
]
```