### PR TITLE
numeric monitoring aggregation types

### DIFF
--- a/include/osquery/numeric_monitoring.h
+++ b/include/osquery/numeric_monitoring.h
@@ -35,10 +35,10 @@ enum class PreAggregationType {
   Max,
   Avg,
   Stddev,
-  P10,
-  P50,
-  P95,
-  P99,
+  P10, // Estimates 10th percentile
+  P50, // Estimates 50th percentile
+  P95, // Estimates 95th percentile
+  P99, // Estimates 99th percentile
   // not existing PreAggregationType, upper limit definition
   InvalidTypeUpperLimit,
 };

--- a/include/osquery/numeric_monitoring.h
+++ b/include/osquery/numeric_monitoring.h
@@ -33,6 +33,12 @@ enum class PreAggregationType {
   Sum,
   Min,
   Max,
+  Avg,
+  Stddev,
+  P10,
+  P50,
+  P95,
+  P99,
   // not existing PreAggregationType, upper limit definition
   InvalidTypeUpperLimit,
 };

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -67,7 +67,12 @@ const auto& getAggregationTypeToStringTable() {
           {PreAggregationType::Sum, "sum"},
           {PreAggregationType::Min, "min"},
           {PreAggregationType::Max, "max"},
-      };
+          {PreAggregationType::Avg, "avg"},
+          {PreAggregationType::Stddev, "stddev"},
+          {PreAggregationType::P10, "p10"},
+          {PreAggregationType::P50, "p50"},
+          {PreAggregationType::P95, "p95"},
+          {PreAggregationType::P99, "p99"}};
   return table;
 }
 

--- a/osquery/numeric_monitoring/pre_aggregation_cache.cpp
+++ b/osquery/numeric_monitoring/pre_aggregation_cache.cpp
@@ -46,6 +46,12 @@ bool Point::tryToAggregate(const Point& new_point) {
   time_point_ = std::max(time_point_, new_point.time_point_);
   switch (pre_aggregation_type_) {
   case PreAggregationType::None:
+  case PreAggregationType::Avg:
+  case PreAggregationType::Stddev:
+  case PreAggregationType::P10:
+  case PreAggregationType::P50:
+  case PreAggregationType::P95:
+  case PreAggregationType::P99:
     return false;
   case PreAggregationType::Sum:
     value_ = value_ + new_point.value_;

--- a/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
+++ b/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include <limits>
+#include <set>
 
 #include <gtest/gtest.h>
 
@@ -27,6 +28,36 @@ GTEST_TEST(PreAggregationPoint, tryToUpdate_same_path_none) {
   auto new_pt =
       monitoring::Point(path, 1, monitoring::PreAggregationType::None, now);
   ASSERT_FALSE(prev_pt.tryToAggregate(new_pt));
+}
+
+GTEST_TEST(PreAggregationPoint, tryToUpdate_same_path_different_types) {
+  const std::set<monitoring::PreAggregationType> nonaggregatable = {
+      monitoring::PreAggregationType::None,
+      monitoring::PreAggregationType::Avg,
+      monitoring::PreAggregationType::Stddev,
+      monitoring::PreAggregationType::P10,
+      monitoring::PreAggregationType::P50,
+      monitoring::PreAggregationType::P95,
+      monitoring::PreAggregationType::P99};
+  const auto now = monitoring::Clock::now();
+  const auto path = "test.path.to.nowhere/paranoid";
+  using UnderType = std::underlying_type<monitoring::PreAggregationType>::type;
+  const auto upper_limit = static_cast<UnderType>(
+      monitoring::PreAggregationType::InvalidTypeUpperLimit);
+  for (auto prev_ind = UnderType{}; prev_ind < upper_limit; ++prev_ind) {
+    for (auto new_ind = UnderType{}; new_ind < upper_limit; ++new_ind) {
+      auto prev_aggr = static_cast<monitoring::PreAggregationType>(prev_ind);
+      auto prev_pt = monitoring::Point(path, 1, prev_aggr, now);
+      auto new_aggr = static_cast<monitoring::PreAggregationType>(new_ind);
+      auto new_pt = monitoring::Point(path, 1, new_aggr, now);
+      if (new_aggr == prev_aggr &&
+          nonaggregatable.find(new_aggr) != nonaggregatable.end()) {
+        ASSERT_TRUE(prev_pt.tryToAggregate(new_pt));
+      } else {
+        ASSERT_FALSE(prev_pt.tryToAggregate(new_pt));
+      }
+    }
+  }
 }
 
 GTEST_TEST(PreAggregationPoint, tryToUpdate_different_path_sum) {

--- a/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
+++ b/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
@@ -29,32 +29,6 @@ GTEST_TEST(PreAggregationPoint, tryToUpdate_same_path_none) {
   ASSERT_FALSE(prev_pt.tryToAggregate(new_pt));
 }
 
-GTEST_TEST(PreAggregationPoint, tryToUpdate_same_path_different_types) {
-  const auto now = monitoring::Clock::now();
-  const auto path = "test.path.to.nowhere/paranoid";
-
-  using UnderType = std::underlying_type<monitoring::PreAggregationType>::type;
-  const auto upper_limit = static_cast<UnderType>(
-      monitoring::PreAggregationType::InvalidTypeUpperLimit);
-
-  for (auto prev_ind = UnderType{}; prev_ind < upper_limit; ++prev_ind) {
-    for (auto new_ind = UnderType{}; new_ind < upper_limit; ++new_ind) {
-      auto prev_aggr = static_cast<monitoring::PreAggregationType>(prev_ind);
-      auto prev_pt = monitoring::Point(path, 1, prev_aggr, now);
-
-      auto new_aggr = static_cast<monitoring::PreAggregationType>(new_ind);
-      auto new_pt = monitoring::Point(path, 1, new_aggr, now);
-
-      if (new_aggr == prev_aggr &&
-          new_aggr != monitoring::PreAggregationType::None) {
-        ASSERT_TRUE(prev_pt.tryToAggregate(new_pt));
-      } else {
-        ASSERT_FALSE(prev_pt.tryToAggregate(new_pt));
-      }
-    }
-  }
-}
-
 GTEST_TEST(PreAggregationPoint, tryToUpdate_different_path_sum) {
   const auto now = monitoring::Clock::now();
   const auto prev_path = "test.path.to.nowhere/something";

--- a/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
+++ b/osquery/numeric_monitoring/tests/pre_aggregation_cache_tests.cpp
@@ -51,7 +51,7 @@ GTEST_TEST(PreAggregationPoint, tryToUpdate_same_path_different_types) {
       auto new_aggr = static_cast<monitoring::PreAggregationType>(new_ind);
       auto new_pt = monitoring::Point(path, 1, new_aggr, now);
       if (new_aggr == prev_aggr &&
-          nonaggregatable.find(new_aggr) != nonaggregatable.end()) {
+          nonaggregatable.find(new_aggr) == nonaggregatable.end()) {
         ASSERT_TRUE(prev_pt.tryToAggregate(new_pt));
       } else {
         ASSERT_FALSE(prev_pt.tryToAggregate(new_pt));


### PR DESCRIPTION
Additional aggregation types for numeric monitoring. Those aggregations can not be aggregated in buffer easily so pushing the logic to the backend.