### PR TITLE
executing query monitor under killswitch

### DIFF
--- a/include/osquery/killswitch.h
+++ b/include/osquery/killswitch.h
@@ -1,13 +1,12 @@
-/**
- *  Copyright (c) 2014-present, Facebook, Inc.
- *  All rights reserved.
- *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
- */
-
+\/**
+  *  Copyright (c) 2014-present, Facebook, Inc.
+  *  All rights reserved.
+  *
+  *  This source code is licensed under both the Apache 2.0 license (found in
+  * the LICENSE file in the root directory of this source tree) and the GPLv2
+  * (found in the COPYING file in the root directory of this source tree). You
+  * may select, at your option, one of the above-listed licenses.
+  */
 #pragma once
 #include <string>
 
@@ -16,7 +15,7 @@
 #include <osquery/expected.h>
 #include <osquery/status.h>
 
-namespace osquery {
+    namespace osquery {
 
 class Killswitch : private boost::noncopyable {
  public:
@@ -31,6 +30,10 @@ class Killswitch : private boost::noncopyable {
 
  public:
   virtual ~Killswitch();
+
+  // Author: @guliashvili
+  // Creation Time: 3/09/2018
+  bool isExecutingQueryMonitorEnabled();
 
   // Author: @guliashvili
   // Creation Time: 24/08/2018

--- a/include/osquery/killswitch.h
+++ b/include/osquery/killswitch.h
@@ -1,12 +1,12 @@
-\/**
-  *  Copyright (c) 2014-present, Facebook, Inc.
-  *  All rights reserved.
-  *
-  *  This source code is licensed under both the Apache 2.0 license (found in
-  * the LICENSE file in the root directory of this source tree) and the GPLv2
-  * (found in the COPYING file in the root directory of this source tree). You
-  * may select, at your option, one of the above-listed licenses.
-  */
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in
+ * the LICENSE file in the root directory of this source tree) and the GPLv2
+ * (found in the COPYING file in the root directory of this source tree). You
+ * may select, at your option, one of the above-listed licenses.
+ */
 #pragma once
 #include <string>
 
@@ -15,7 +15,7 @@
 #include <osquery/expected.h>
 #include <osquery/status.h>
 
-    namespace osquery {
+namespace osquery {
 
 class Killswitch : private boost::noncopyable {
  public:

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -179,7 +179,7 @@ inline void launchQueryWithProfiling(const std::string& name,
   auto status = launchQuery(name, query);
   auto query_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start_time_point);
-  if (isExecutingQueryMonitorEnabled()) {
+  if (Killswitch::get().isExecutingQueryMonitorEnabled()) {
     auto monitoring_path = boost::format("scheduler.executing_query.%s.%s") %
                            name % (status.ok() ? "success" : "failure");
 

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -16,6 +16,7 @@
 #include <osquery/core.h>
 #include <osquery/database.h>
 #include <osquery/flags.h>
+#include <osquery/killswitch.h>
 #include <osquery/logger.h>
 #include <osquery/numeric_monitoring.h>
 #include <osquery/query.h>
@@ -178,11 +179,14 @@ inline void launchQueryWithProfiling(const std::string& name,
   auto status = launchQuery(name, query);
   auto query_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start_time_point);
-  auto monitoring_path = boost::format("scheduler.executing_query.%s.%s") %
-                         name % (status.ok() ? "success" : "failure");
-  monitoring::record(monitoring_path.str(),
-                     query_duration.count(),
-                     monitoring::PreAggregationType::Min);
+  if (isExecutingQueryMonitorEnabled()) {
+    auto monitoring_path = boost::format("scheduler.executing_query.%s.%s") %
+                           name % (status.ok() ? "success" : "failure");
+
+    monitoring::record(monitoring_path.str(),
+                       query_duration.count(),
+                       monitoring::PreAggregationType::Min);
+  }
 }
 
 void SchedulerRunner::start() {

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -40,10 +40,6 @@ bool Killswitch::isConfigBackupEnabled() {
   return isNewCodeEnabled("configBackupSwitch");
 }
 
-bool Killswitch::isConfigBackupEnabled() {
-  return isNewCodeEnabled("configBackupSwitch");
-}
-
 bool Killswitch::isNewCodeEnabled(const std::string& key) {
   auto result = isEnabled(key);
   if (result) {

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -32,6 +32,14 @@ FLAG(string,
 Killswitch::Killswitch() {}
 Killswitch::~Killswitch() = default;
 
+bool isExecutingQueryMonitorEnabled() {
+  return isNewCodeEnabled("executingQueryMonitorSwitch");
+}
+
+bool Killswitch::isConfigBackupEnabled() {
+  return isNewCodeEnabled("configBackupSwitch");
+}
+
 bool Killswitch::isConfigBackupEnabled() {
   return isNewCodeEnabled("configBackupSwitch");
 }

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -32,7 +32,7 @@ FLAG(string,
 Killswitch::Killswitch() {}
 Killswitch::~Killswitch() = default;
 
-bool isExecutingQueryMonitorEnabled() {
+bool Killswitch::isExecutingQueryMonitorEnabled() {
   return isNewCodeEnabled("executingQueryMonitorSwitch");
 }
 


### PR DESCRIPTION
Protect numeric_monitoring executing monitor with killswitch as it might misbehave and generate to much data for backend to handle.