### PR TITLE
Removing potentially risky method `getOr(T const&)` from `Expected`

### DIFF
--- a/include/osquery/expected.h
+++ b/include/osquery/expected.h
@@ -179,13 +179,6 @@ class Expected final {
     return boost::get<ValueType>(object_);
   }
 
-  const ValueType& getOr(const ValueType& defaultValue) const {
-    if (isError()) {
-      return defaultValue;
-    }
-    return boost::get<ValueType>(object_);
-  }
-
   ValueType take() && = delete;
   ValueType take() & {
     return std::move(get());

--- a/osquery/core/conversions.cpp
+++ b/osquery/core/conversions.cpp
@@ -281,7 +281,7 @@ const rj::Document& JSON::doc() const {
 
 size_t JSON::valueToSize(const rj::Value& value) {
   if (value.IsString()) {
-    return tryTo<std::size_t>(std::string{value.GetString()}).getOr(0_sz);
+    return tryTo<std::size_t>(std::string{value.GetString()}).takeOr(0_sz);
   } else if (value.IsNumber()) {
     return static_cast<size_t>(value.GetUint64());
   }

--- a/osquery/core/tests/exptected_tests.cpp
+++ b/osquery/core/tests/exptected_tests.cpp
@@ -268,18 +268,6 @@ GTEST_TEST(ExpectedTest, take_error_from_expected_with_value) {
 #endif
 }
 
-GTEST_TEST(ExpectedTest, value__getOr) {
-  const auto expectedValue = Expected<int, TestError>(225);
-  EXPECT_EQ(expectedValue.getOr(29), 225);
-  EXPECT_EQ(expectedValue.getOr(-29), 225);
-}
-
-GTEST_TEST(ExpectedTest, error__getOr) {
-  const auto err = Expected<int, TestError>(TestError::Semantic, "message");
-  EXPECT_EQ(err.getOr(37), 37);
-  EXPECT_EQ(err.getOr(-59), -59);
-}
-
 GTEST_TEST(ExpectedTest, value__takeOr) {
   const auto text = std::string{"some text"};
   auto callable = [&text]() -> Expected<std::string, TestError> {

--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -1065,7 +1065,7 @@ static int booleanValue(char* zArg) {
     fprintf(
         stderr, "ERROR: Not a boolean value: \"%s\". Assuming \"no\".\n", zArg);
   }
-  return expected.getOr(false) ? 1 : 0;
+  return expected.takeOr(false) ? 1 : 0;
 }
 
 inline void meta_tables(int nArg, char** azArg) {

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -84,7 +84,7 @@ static inline void getOptimizeData(EventTime& o_time,
   {
     std::string content;
     getDatabaseValue(kEvents, "optimize_eid." + query_name, content);
-    o_eid = tryTo<std::size_t>(content).getOr(std::size_t{0});
+    o_eid = tryTo<std::size_t>(content).takeOr(std::size_t{0});
   }
 }
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -341,7 +341,7 @@ bool GetIntegerFieldFromMap(std::uint64_t& value,
     return false;
   }
   auto exp = tryTo<std::uint64_t>(string_value, base);
-  value = exp.takeOr(default_value);
+  value = exp.takeOr(std::move(default_value));
   return exp.isValue();
 }
 

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -341,7 +341,7 @@ bool GetIntegerFieldFromMap(std::uint64_t& value,
     return false;
   }
   auto exp = tryTo<std::uint64_t>(string_value, base);
-  value = exp.getOr(default_value);
+  value = exp.takeOr(default_value);
   return exp.isValue();
 }
 

--- a/osquery/tables/networking/windows/arp_cache.cpp
+++ b/osquery/tables/networking/windows/arp_cache.cpp
@@ -51,7 +51,7 @@ QueryData genIPv4ArpCache(QueryContext& context) {
   for (const auto& iface : interfaces) {
 
     if (iface.count("interface") > 0) {
-      long interface_index = tryTo<long>(iface.at("interface"), 10).getOr(0l);
+      long interface_index = tryTo<long>(iface.at("interface"), 10).takeOr(0l);
       mapOfInterfaces[interface_index] =
           iface.count("mac") > 0 ? iface.at("mac") : "";
     }

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -69,24 +69,32 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       std::string sPlaceHolder;
 
       results[0].GetString("PacketsReceivedPerSec", sPlaceHolder);
-      r["ipackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["ipackets"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsSentPerSec", sPlaceHolder);
-      r["opackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["opackets"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("BytesReceivedPerSec", sPlaceHolder);
-      r["ibytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["ibytes"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("BytesSentPerSec", sPlaceHolder);
-      r["obytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["obytes"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("PacketsReceivedErrors", sPlaceHolder);
-      r["ierrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["ierrors"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsOutboundErrors", sPlaceHolder);
-      r["oerrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["oerrors"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("PacketsReceivedDiscarded", sPlaceHolder);
-      r["idrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["idrops"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsOutboundDiscarded", sPlaceHolder);
-      r["odrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
+      r["odrops"] =
+          BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     } else {
       LOG(INFO) << "Failed to retrieve network statistics for interface "
                 << r["interface"];

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -69,24 +69,24 @@ void genInterfaceDetail(const IP_ADAPTER_ADDRESSES* adapter, Row& r) {
       std::string sPlaceHolder;
 
       results[0].GetString("PacketsReceivedPerSec", sPlaceHolder);
-      r["ipackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["ipackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsSentPerSec", sPlaceHolder);
-      r["opackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["opackets"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("BytesReceivedPerSec", sPlaceHolder);
-      r["ibytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["ibytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("BytesSentPerSec", sPlaceHolder);
-      r["obytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["obytes"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("PacketsReceivedErrors", sPlaceHolder);
-      r["ierrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["ierrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsOutboundErrors", sPlaceHolder);
-      r["oerrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["oerrors"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
       results[0].GetString("PacketsReceivedDiscarded", sPlaceHolder);
-      r["idrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["idrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
       results[0].GetString("PacketsOutboundDiscarded", sPlaceHolder);
-      r["odrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+      r["odrops"] = BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     } else {
       LOG(INFO) << "Failed to retrieve network statistics for interface "
                 << r["interface"];

--- a/osquery/tables/system/windows/physical_disk_performance.cpp
+++ b/osquery/tables/system/windows/physical_disk_performance.cpp
@@ -33,43 +33,43 @@ QueryData genPhysicalDiskPerformance(QueryContext& context) {
 
     disk.GetString("AvgDiskBytesPerRead", sPlaceHolder);
     r["avg_disk_bytes_per_read"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     disk.GetString("AvgDiskBytesPerWrite", sPlaceHolder);
     r["avg_disk_bytes_per_write"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("AvgDiskReadQueueLength", sPlaceHolder);
     r["avg_disk_read_queue_length"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     disk.GetString("AvgDiskWriteQueueLength", sPlaceHolder);
     r["avg_disk_write_queue_length"] =
-        BIGINT(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        BIGINT(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("AvgDiskSecPerRead", sPlaceHolder);
     r["avg_disk_sec_per_read"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     disk.GetString("AvgDiskSecPerWrite", sPlaceHolder);
     r["avg_disk_sec_per_write"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("PercentDiskReadTime", sPlaceHolder);
     r["percent_disk_read_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
     disk.GetString("PercentDiskWriteTime", sPlaceHolder);
     r["percent_disk_write_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("CurrentDiskQueueLength", sPlaceHolder);
     r["current_disk_queue_length"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("PercentDiskTime", sPlaceHolder);
     r["percent_disk_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     disk.GetString("PercentIdleTime", sPlaceHolder);
     r["percent_idle_time"] =
-        INTEGER(tryTo<unsigned long long>(sPlaceHolder).getOr(0));
+        INTEGER(tryTo<unsigned long long>(sPlaceHolder).takeOr(0ull));
 
     results.push_back(r);
   }


### PR DESCRIPTION
Too dangerous, because it is so easy to create a dangling reference (to local object for instance) with it.

It was discussed in terms of PR #4833
Explanation [ref](https://www.youtube.com/watch?v=lkgszkPnV8g&feature=youtu.be&t=769).