### PR TITLE
tables: augment pci_devices table on linux with pci_subclass

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -28,6 +28,7 @@ namespace tables {
 
 const std::string kPCIKeySlot = "PCI_SLOT_NAME";
 const std::string kPCIKeyClass = "ID_PCI_CLASS_FROM_DATABASE";
+const std::string kPCIKeySubclass = "ID_PCI_SUBCLASS_FROM_DATABASE";
 const std::string kPCIKeyVendor = "ID_VENDOR_FROM_DATABASE";
 const std::string kPCIKeyModel = "ID_MODEL_FROM_DATABASE";
 const std::string kPCIKeyID = "PCI_ID";
@@ -286,6 +287,8 @@ QueryData genPCIDevices(QueryContext& context) {
     Row r;
     r["pci_slot"] = UdevEventPublisher::getValue(device.get(), kPCIKeySlot);
     r["pci_class"] = UdevEventPublisher::getValue(device.get(), kPCIKeyClass);
+    r["pci_subclass"] =
+        UdevEventPublisher::getValue(device.get(), kPCIKeySubclass);
     r["driver"] = UdevEventPublisher::getValue(device.get(), kPCIKeyDriver);
     r["vendor"] = UdevEventPublisher::getValue(device.get(), kPCIKeyVendor);
     r["model"] = UdevEventPublisher::getValue(device.get(), kPCIKeyModel);

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -17,9 +17,11 @@ schema([
 ])
 
 extended_schema(LINUX, [
+    Column("pci_subclass", TEXT, "PCI Device subclass"),
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),
     Column("subsystem_model_id", TEXT, "Model ID of PCI device subsystem"),
     Column("subsystem_model", TEXT, "Device description of PCI device subsystem"),
 ])
+
 implementation("pci_devices@genPCIDevices")


### PR DESCRIPTION
This PR is the first portion of the plan discussed [here](https://github.com/facebook/osquery/pull/5160).  This PR augments the `pci_devices` table on `Linux` with pci_subclass description.
