### PR TITLE
provision libsmartctl only for linux/darwin

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -90,6 +90,7 @@ function platform_linux_main() {
   brew_dependency osquery/osquery-local/libaudit
   brew_dependency osquery/osquery-local/libdpkg
   brew_dependency osquery/osquery-local/libelfin
+  brew_dependency osquery/osquery-local/libsmartctl
 }
 
 function platform_darwin_main() {
@@ -109,6 +110,7 @@ function platform_darwin_main() {
 
   brew_dependency osquery/osquery-local/python
   brew_dependency osquery/osquery-local/bison
+  brew_dependency osquery/osquery-local/libsmartctl
 
   platform_posix_main
 }
@@ -140,7 +142,6 @@ function platform_darwin_main() {
   brew_dependency osquery/osquery-local/lldpd
   brew_dependency osquery/osquery-local/librdkafka
   brew_dependency osquery/osquery-local/librpm
-  brew_dependency osquery/osquery-local/libsmartctl
 
   # POSIX-shared locally-managed tools.
   brew_dependency osquery/osquery-local/zzuf


### PR DESCRIPTION
smart_drives table is only for linux and darwin https://github.com/digitalocean/osquery/blob/a302f060965a1c3e489554969e3defe520d4f763/tools/codegen/genwebsitejson.py#L39

Provision should not require it to freebsd