### PR TITLE
Changing the active code page to United States code

### DIFF
--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -1,4 +1,21 @@
-@echo off
+@echo off & setlocal
+REM command chcp returns string: "Active code page: ..."
+for /F "tokens=*"  %%i in ('chcp') do SET t=%%i
+
+REM Get the last substring (codepage) from "t" and assign it to "CodePage" 
+:loop
+for /f "tokens=1*" %%a in ("%t%") do (
+    set CodePage=%%a
+    set t=%%b
+   )
+if defined t goto :loop
+
+REM Changing the active code page to US code
+chcp 437>nul
+
 %SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass .\tools\build.ps1
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 %ALLUSERSPROFILE%\chocolatey\bin\refreshenv.cmd
+
+REM Restore the original code page
+chcp %CodePage%>nul


### PR DESCRIPTION
# Bug report
### What operating system and version are you using?
Windows 10 x64 Russian edition

### What version of osquery are you using?
Latest source code (bf95191)

### What steps did you take to reproduce the issue?
Followed Windows 10 Development Environment Provisioning up to running `make-win64-binaries.bat`

### What did you expect to see?
Successful execution without errors

### What did you see instead?
```
6/6 Test #6: python_test_windows_service ......***Failed    1.57 sec
test_1_install_run_stop_uninstall_windows_service (__main__.OsquerydTest) ... ERROR
test_2_thrash_windows_service (__main__.OsquerydTest) ... ERROR

======================================================================
ERROR: test_1_install_run_stop_uninstall_windows_service (__main__.OsquerydTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 235, in setUp
    cleanOsqueryServices()
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 221, in cleanOsqueryServices
    stopService(service)
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 192, in stopService
    stop_ = sc('stop', name)
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 117, in sc
    out = [x.strip() for x in out.split('\r\n') if x.strip() is not '']
UnicodeDecodeError: 'ascii' codec can't decode byte 0xae in position 21: ordinal not in range(128)

======================================================================
ERROR: test_2_thrash_windows_service (__main__.OsquerydTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 235, in setUp
    cleanOsqueryServices()
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 221, in cleanOsqueryServices
    stopService(service)
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 192, in stopService
    stop_ = sc('stop', name)
  File "C:/Users/dimas/Documents/Projects/osquery/osquery/tools/tests/test_windows_service.py", line 117, in sc
    out = [x.strip() for x in out.split('\r\n') if x.strip() is not '']
UnicodeDecodeError: 'ascii' codec can't decode byte 0xae in position 21: ordinal not in range(128)

----------------------------------------------------------------------
```
## Problem

`Test # 6: python_test_windows_service` expects `sc.exe` output to be ASCII an in english. It fails on the localized version of Windows on the first non-ASCII char but if that's fixed it will fail on parsing non-english output.,

## Solution
We can switch the active code page to the US code, while the make-win64-binaries.bat is executing and switch back at the end. That way `sc.exe` outputs exactly in the format the test is expecting.

