### PR TITLE
Add ReleaseDate to table for platform_info queries on Windows

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -87,6 +87,59 @@ Status WmiResultItem::GetBool(const std::string& name, bool& ret) const {
   return Status(0);
 }
 
+Status WmiResultItem::GetDateTime(const std::string& name, 
+                                  bool is_local, 
+                                  FILETIME& ft) const {
+  std::wstring property_name = stringToWstring(name);
+  
+  VARIANT value;
+  HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
+  if (hr != S_OK) {
+    return Status(-1, "Error retrieving datetime from WMI query result.");
+  }
+
+  if (value.vt != VT_BSTR) {
+    VariantClear(&value);
+    return Status(-1, "Expected VT_BSTR, got something else.");
+  }
+
+  ISWbemDateTime *dt = nullptr;
+  hr = CoCreateInstance(CLSID_SWbemDateTime, 
+                        nullptr, 
+                        CLSCTX_INPROC_SERVER, 
+                        IID_PPV_ARGS(&dt));
+  if (!SUCCEEDED(hr)) {
+    VariantClear(&value);
+    return Status(-1, "Failed to create SWbemDateTime object.");
+  }
+
+  hr = dt->put_Value(value.bstrVal);
+  VariantClear(&value);
+
+  if (!SUCCEEDED(hr)) {
+    dt->Release();
+    return Status(-1, "Failed to set SWbemDateTime value.");
+  }
+
+  BSTR filetime_str = {0};
+  hr = dt->GetFileTime(is_local ? VARIANT_TRUE : VARIANT_FALSE, &filetime_str);
+  if (!SUCCEEDED(hr)) {
+    dt->Release();
+    return Status(-1, "GetFileTime failed.");
+  }
+
+  ULARGE_INTEGER ui = {};
+
+  ui.QuadPart = _wtoi64(filetime_str);
+  ft.dwLowDateTime = ui.LowPart;
+  ft.dwHighDateTime = ui.HighPart;
+
+  SysFreeString(filetime_str);
+  dt->Release();
+
+  return Status(0);
+}
+
 Status WmiResultItem::GetUChar(const std::string& name,
                                unsigned char& ret) const {
   std::wstring property_name = stringToWstring(name);

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -87,11 +87,11 @@ Status WmiResultItem::GetBool(const std::string& name, bool& ret) const {
   return Status(0);
 }
 
-Status WmiResultItem::GetDateTime(const std::string& name, 
-                                  bool is_local, 
+Status WmiResultItem::GetDateTime(const std::string& name,
+                                  bool is_local,
                                   FILETIME& ft) const {
   std::wstring property_name = stringToWstring(name);
-  
+
   VARIANT value;
   HRESULT hr = result_->Get(property_name.c_str(), 0, &value, nullptr, nullptr);
   if (hr != S_OK) {
@@ -103,11 +103,9 @@ Status WmiResultItem::GetDateTime(const std::string& name,
     return Status(-1, "Expected VT_BSTR, got something else.");
   }
 
-  ISWbemDateTime *dt = nullptr;
-  hr = CoCreateInstance(CLSID_SWbemDateTime, 
-                        nullptr, 
-                        CLSCTX_INPROC_SERVER, 
-                        IID_PPV_ARGS(&dt));
+  ISWbemDateTime* dt = nullptr;
+  hr = CoCreateInstance(
+      CLSID_SWbemDateTime, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dt));
   if (!SUCCEEDED(hr)) {
     VariantClear(&value);
     return Status(-1, "Failed to create SWbemDateTime object.");

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -94,6 +94,16 @@ class WmiResultItem {
   Status GetBool(const std::string& name, bool& ret) const;
 
   /**
+  * @brief Windows WMI Helper function to retrieve a local/non-local FILETIME 
+  * from WMI query.
+  *
+  * @returns Status indiciating the success of the query
+  */
+  Status GetDateTime(const std::string& name, 
+                     bool is_local, 
+                     FILETIME& ft) const;
+
+  /**
   * @brief Windows WMI Helper function to retrieve an unsigned Char from WMI
   * query
   *

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -94,11 +94,11 @@ class WmiResultItem {
   Status GetBool(const std::string& name, bool& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a local/non-local FILETIME
-  * from WMI query.
-  *
-  * @returns Status indiciating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve a local/non-local FILETIME
+   * from WMI query.
+   *
+   * @returns Status indiciating the success of the query
+   */
   Status GetDateTime(const std::string& name,
                      bool is_local,
                      FILETIME& ft) const;

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -104,11 +104,11 @@ class WmiResultItem {
                      FILETIME& ft) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve an unsigned Char from WMI
-  * query
-  *
-  * @returns Status indiciating the success of the query
-  */
+   * @brief Windows WMI Helper function to retrieve an unsigned Char from WMI
+   * query
+   *
+   * @returns Status indiciating the success of the query
+   */
   Status GetUChar(const std::string& name, unsigned char& ret) const;
 
   /**

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -94,13 +94,13 @@ class WmiResultItem {
   Status GetBool(const std::string& name, bool& ret) const;
 
   /**
-  * @brief Windows WMI Helper function to retrieve a local/non-local FILETIME 
+  * @brief Windows WMI Helper function to retrieve a local/non-local FILETIME
   * from WMI query.
   *
   * @returns Status indiciating the success of the query
   */
-  Status GetDateTime(const std::string& name, 
-                     bool is_local, 
+  Status GetDateTime(const std::string& name,
+                     bool is_local,
                      FILETIME& ft) const;
 
   /**

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -23,7 +23,6 @@ std::string to_iso8601_date(const FILETIME& ft) {
   SYSTEMTIME date = {0};
 
   if (FileTimeToSystemTime(&ft, &date) == FALSE) {
-    // NOTE(andy): Failure to convert to SYSTEMTIME yields empty response
     return "";
   }
 
@@ -63,7 +62,8 @@ QueryData genPlatformInfo(QueryContext& context) {
   FILETIME release_date = {0};
   wmiResults[0].GetDateTime("ReleaseDate", false, release_date);
 
-  r["date"] = to_iso8601_date(release_date);
+  auto s = to_iso8601_date(release_date);
+  r["date"] = s.empty() ? "-1" : s;
 
   results.push_back(r);
   return results;

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -19,7 +19,7 @@
 namespace osquery {
 namespace tables {
 
-std::string to_iso8601_datetime(const FILETIME& ft) {
+std::string to_iso8601_date(const FILETIME& ft) {
   SYSTEMTIME date = {0};
 
   if (FileTimeToSystemTime(&ft, &date) == FALSE) {
@@ -30,25 +30,8 @@ std::string to_iso8601_datetime(const FILETIME& ft) {
   std::ostringstream iso_date;
   iso_date << std::setfill('0');
   iso_date << std::setw(4) << date.wYear << "-" << std::setw(2) << date.wMonth
-           << "-" << std::setw(2) << date.wDay << "T" << std::setw(2)
-           << date.wHour << ":" << std::setw(2) << date.wMinute << ":"
-           << std::setw(2) << date.wSecond << "." << std::setw(3)
-           << date.wMilliseconds;
+           << "-" << std::setw(2) << date.wDay;
 
-  TIME_ZONE_INFORMATION tz = {0};
-  if (GetTimeZoneInformationForYear(date.wYear, nullptr, &tz) == FALSE) {
-    // NOTE(andy): On error getting timezone information, return an empty
-    //             string
-    return "";
-  }
-
-  // NOTE(andy): Calculate time zone portion of date time
-  LONG tMin = std::abs(tz.Bias);
-  LONG wHours = tMin / 60;
-  LONG wMinute = tMin - (wHours * 60);
-
-  iso_date << ((tz.Bias > 0) ? "-" : "+") << std::setw(2) << wHours << ":"
-           << std::setw(2) << wMinute;
   return iso_date.str();
 }
 
@@ -80,7 +63,7 @@ QueryData genPlatformInfo(QueryContext& context) {
   FILETIME release_date = {0};
   wmiResults[0].GetDateTime("ReleaseDate", false, release_date);
 
-  r["date"] = to_iso8601_datetime(release_date);
+  r["date"] = to_iso8601_date(release_date);
 
   results.push_back(r);
   return results;

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -29,14 +29,15 @@ std::string to_iso8601_datetime(const FILETIME& ft) {
 
   std::ostringstream iso_date;
   iso_date << std::setfill('0');
-  iso_date << std::setw(4) << date.wYear << "-" << std::setw(2) << 
-    date.wMonth << "-" << std::setw(2) << date.wDay << "T" << std::setw(2) << 
-    date.wHour << ":" << std::setw(2) << date.wMinute << ":" << std::setw(2) << 
-    date.wSecond << "." << std::setw(3) << date.wMilliseconds;
+  iso_date << std::setw(4) << date.wYear << "-" << std::setw(2) << date.wMonth
+           << "-" << std::setw(2) << date.wDay << "T" << std::setw(2)
+           << date.wHour << ":" << std::setw(2) << date.wMinute << ":"
+           << std::setw(2) << date.wSecond << "." << std::setw(3)
+           << date.wMilliseconds;
 
   TIME_ZONE_INFORMATION tz = {0};
   if (GetTimeZoneInformationForYear(date.wYear, nullptr, &tz) == FALSE) {
-    // NOTE(andy): On error getting timezone information, return an empty 
+    // NOTE(andy): On error getting timezone information, return an empty
     //             string
     return "";
   }
@@ -46,8 +47,8 @@ std::string to_iso8601_datetime(const FILETIME& ft) {
   LONG wHours = tMin / 60;
   LONG wMinute = tMin - (wHours * 60);
 
-  iso_date << ((tz.Bias > 0) ? "-" : "+") << std::setw(2) << wHours << ":" <<
-    std::setw(2) << wMinute;
+  iso_date << ((tz.Bias > 0) ? "-" : "+") << std::setw(2) << wHours << ":"
+           << std::setw(2) << wMinute;
   return iso_date.str();
 }
 


### PR DESCRIPTION
Previously, the `platform_info` table on Windows did not include the `ReleaseDate` field. This fix fills in the `date` column with an ISO8601 version of the `ReleaseDate`.

Closes #4771 