### PR TITLE
tables: add pci_class_id and pci_subclass_id to pci_devices

### DIFF
--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -32,6 +32,7 @@ const std::string kPCIKeySubclass = "ID_PCI_SUBCLASS_FROM_DATABASE";
 const std::string kPCIKeyVendor = "ID_VENDOR_FROM_DATABASE";
 const std::string kPCIKeyModel = "ID_MODEL_FROM_DATABASE";
 const std::string kPCIKeyID = "PCI_ID";
+const std::string kPCIClassID = "PCI_CLASS";
 const std::string kPCIKeyDriver = "DRIVER";
 const std::string kPCISubsysID = "PCI_SUBSYS_ID";
 
@@ -293,6 +294,7 @@ QueryData genPCIDevices(QueryContext& context) {
     r["vendor"] = UdevEventPublisher::getValue(device.get(), kPCIKeyVendor);
     r["model"] = UdevEventPublisher::getValue(device.get(), kPCIKeyModel);
 
+    // TODO: extract to separate function
     // VENDOR:MODEL ID is in the form of HHHH:HHHH.
     std::vector<std::string> ids;
     auto device_id = UdevEventPublisher::getValue(device.get(), kPCIKeyID);
@@ -350,6 +352,25 @@ QueryData genPCIDevices(QueryContext& context) {
 
     if (r["model_id"].size() == 0) {
       r["model_id"] = "0";
+    }
+
+    // TODO: extract to seperate function
+    auto pci_class_id = UdevEventPublisher::getValue(device.get(), kPCIClassID);
+    auto id_len = pci_class_id.length();
+    switch (id_len) {
+    case 5:
+      r["pci_class_id"] = "0x0" + pci_class_id.substr(0, 1);
+      r["pci_subclass_id"] = "0x" + pci_class_id.substr(1, 2);
+      break;
+
+    case 6:
+      r["pci_class_id"] = "0x" + pci_class_id.substr(0, 2);
+      r["pci_subclass_id"] = "0x" + pci_class_id.substr(2, 2);
+      break;
+
+    default:
+      VLOG(1) << "Expected PCI Class ID to be 6 or 7 characters long, but got "
+              << id_len;
     }
 
     results.push_back(r);

--- a/specs/posix/pci_devices.table
+++ b/specs/posix/pci_devices.table
@@ -17,6 +17,8 @@ schema([
 ])
 
 extended_schema(LINUX, [
+    Column("pci_class_id", TEXT, "PCI Device class ID in hex format"),
+    Column("pci_subclass_id", TEXT, "PCI Device  subclass in hex format"),
     Column("pci_subclass", TEXT, "PCI Device subclass"),
     Column("subsystem_vendor_id", TEXT, "Vendor ID of PCI device subsystem"),
     Column("subsystem_vendor", TEXT, "Vendor of PCI device subsystem"),


### PR DESCRIPTION
2nd PR of 3 described from [here](https://github.com/facebook/osquery/pull/5160).

The actual PCI class and subclass ID's were also missing from the table. Providing these columns brings value in that a user can now ask for information about PCI devices by their class and subclass attributes, and the queries will be less error prone because we can now select by their respective ID's rather than a textual description.

The next PR will contain a refactor for readability and easier unit testing of some of the subcomponents of `genPCIDevices` function, as well as some added unit tests.

@guliashvili let me know if there are updates to the integration tests.  I can add a test if it's ready to go.