### PR TITLE
Add an event driven table for the new unified system log on darwin

### DIFF
--- a/osquery/events/CMakeLists.txt
+++ b/osquery/events/CMakeLists.txt
@@ -21,6 +21,8 @@ if(APPLE)
     "${CMAKE_CURRENT_LIST_DIR}/darwin/fsevents.h"
     "${CMAKE_CURRENT_LIST_DIR}/darwin/iokit.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/darwin/iokit.h"
+    "${CMAKE_CURRENT_LIST_DIR}/darwin/log_events.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/darwin/log_events.h"
     "${CMAKE_CURRENT_LIST_DIR}/darwin/openbsm.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/darwin/openbsm.h"
     "${CMAKE_CURRENT_LIST_DIR}/darwin/scnetwork.cpp"

--- a/osquery/events/darwin/log_events.cpp
+++ b/osquery/events/darwin/log_events.cpp
@@ -1,0 +1,111 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <signal.h>
+#include <thread>
+
+#include <boost/asio.hpp>
+#include <boost/process.hpp>
+
+#include <osquery/logger.h>
+#include <osquery/registry_factory.h>
+#include <osquery/tables.h>
+
+#include "osquery/events/darwin/log_events.h"
+
+namespace bp = boost::process;
+
+namespace osquery {
+
+REGISTER(LogEventsEventPublisher,
+         "event_publisher",
+         "darwin_unified_log_events");
+
+void process_log_stream(LogEventsEventPublisher* publisher) {
+  // the stream format is
+  //   [{
+  //     key: value,
+  //     ...
+  //   },{
+  //     key: value,
+  //     ...
+  //   },{
+  // and so on until the `log` process terminates.
+  // this thread just slices the stream into individual
+  // strings of entries and passes them to the callback
+
+  std::stringstream buffer;
+  std::string line;
+  while (std::getline(publisher->child_output, line)) {
+    if (line[0] == '[' || line[0] == '}') {
+      if (buffer.str().size()) {
+        buffer << "}";
+        publisher->callback(buffer.str());
+      }
+      buffer.clear();
+      buffer.str("");
+      buffer << "{";
+    } else {
+      buffer << line;
+    }
+  }
+}
+
+void LogEventsEventPublisher::callback(std::string json_string) {
+  auto ec = createEventContext();
+  ec->json_string = json_string;
+  fire(ec);
+}
+
+Status LogEventsEventPublisher::setUp() {
+  if (child.running()) {
+    stop();
+  }
+
+  try {
+    child = bp::child("/usr/bin/log",
+                      "stream",
+                      "--style",
+                      "json",
+                      bp::std_in.close(),
+                      bp::std_out > child_output,
+                      bp::std_err > bp::null);
+
+    reading_thread = std::thread(process_log_stream, this);
+
+    return Status(0, "OK");
+
+  } catch (std::exception& e) {
+    LOG(ERROR) << "Exception when setting up log monitoring process: "
+               << e.what();
+  }
+
+  return Status(1, "Error starting child process and monitoring thread");
+}
+
+Status LogEventsEventPublisher::run() {
+  return Status(0, "OK");
+}
+
+void LogEventsEventPublisher::stop() {
+  if (child.running()) {
+    kill(child.id(), SIGTERM);
+  }
+
+  if (reading_thread.joinable()) {
+    reading_thread.join();
+  }
+}
+
+void LogEventsEventPublisher::tearDown() {
+  stop();
+}
+
+} // namespace osquery

--- a/osquery/events/darwin/log_events.h
+++ b/osquery/events/darwin/log_events.h
@@ -1,0 +1,58 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <thread>
+
+#include <boost/process.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/events.h>
+
+namespace osquery {
+
+struct LogEventsSubscriptionContext : public SubscriptionContext {
+ public:
+ private:
+  friend class LogEventsEventPublisher;
+};
+
+struct LogEventsEventContext : public EventContext {
+ public:
+  std::string json_string;
+};
+
+using LogEventsEventContextRef = std::shared_ptr<LogEventsEventContext>;
+using LogEventsSubscriptionContextRef =
+    std::shared_ptr<LogEventsSubscriptionContext>;
+
+class LogEventsEventPublisher
+    : public EventPublisher<LogEventsSubscriptionContext,
+                            LogEventsEventContext> {
+  DECLARE_PUBLISHER("mac_unified_log_events");
+
+ public:
+  Status setUp() override;
+  void tearDown() override;
+  Status run() override;
+
+ private:
+  void callback(std::string json_string);
+  void stop() override;
+
+  boost::process::child child;
+  boost::process::ipstream child_output;
+  std::thread reading_thread;
+
+  friend void process_log_stream(LogEventsEventPublisher* publisher);
+};
+
+} // namespace osquery

--- a/osquery/tables/events/darwin/log_events.cpp
+++ b/osquery/tables/events/darwin/log_events.cpp
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <osquery/core.h>
+#include <osquery/logger.h>
+#include <osquery/registry_factory.h>
+#include <osquery/tables.h>
+
+#include "osquery/events/darwin/log_events.h"
+
+namespace pt = boost::property_tree;
+
+const std::string FIELD_NAMES[] = {"category",
+                                   "activityID",
+                                   "eventType",
+                                   "processImageUUID",
+                                   "processUniqueID",
+                                   "threadID",
+                                   "timestamp",
+                                   "traceID",
+                                   "messageType",
+                                   "senderProgramCounter",
+                                   "processID",
+                                   "machTimestamp",
+                                   "timezoneName",
+                                   "subsystem",
+                                   "eventMessage",
+                                   "senderImageUUID",
+                                   "processImagePath",
+                                   "senderImagePath"};
+
+namespace osquery {
+
+class LogEventSubscriber : public EventSubscriber<LogEventsEventPublisher> {
+ public:
+  Status init() override;
+
+  Status Callback(const LogEventsEventContextRef& ec,
+                  const LogEventsSubscriptionContextRef& sc);
+};
+
+REGISTER(LogEventSubscriber, "event_subscriber", "darwin_unified_log_events");
+
+Status LogEventSubscriber::init() {
+  auto subscription = createSubscriptionContext();
+  subscribe(&LogEventSubscriber::Callback, subscription);
+
+  return Status(0, "OK");
+}
+
+Status LogEventSubscriber::Callback(const LogEventsEventContextRef& ec,
+                                    const LogEventsSubscriptionContextRef& sc) {
+  Row r;
+
+  pt::ptree t;
+  std::stringstream str(ec->json_string);
+  try {
+    pt::read_json(str, t);
+    for (auto field : FIELD_NAMES) {
+      r[field] = t.get<std::string>(field, "");
+    }
+    add(r);
+  } catch (std::exception& e) {
+    LOG(ERROR) << "Exception while parsing log event: " << e.what();
+  }
+
+  return Status(0, "OK");
+}
+} // namespace osquery

--- a/specs/darwin/log_events.table
+++ b/specs/darwin/log_events.table
@@ -1,0 +1,25 @@
+table_name("darwin_unified_log_events")
+description("Entries from the MacOS unified system log.")
+schema([
+    Column("category", TEXT, "Category"),
+    Column("activityID", BIGINT, "Activity ID"),
+    Column("eventType", TEXT, "Log Event Type"),
+    Column("processImageUUID", TEXT, "UUID of the process image"),
+    Column("processUniqueID", BIGINT, "Unique ID of the process"),
+    Column("threadID", BIGINT, "Thread ID"),
+    Column("timestamp", TEXT, "Date and time"),
+    Column("traceID", BIGINT, "Trace ID"),
+    Column("messageType", TEXT, "Log Message Type"),
+    Column("senderProgramCounter", TEXT, "Sending process PC"),
+    Column("processID", BIGINT, "Process ID"),
+    Column("machTimestamp", BIGINT, "Log Event Timestamp"),
+    Column("timezoneName", TEXT, "Timezone"),
+    Column("subsystem", TEXT, "Subsystem"),
+    Column("eventMessage", TEXT, "Message"),
+    Column("senderImageUUID", TEXT, "Sending image UUID"),
+    Column("processImagePath", TEXT, "Path to process image"),
+    Column("senderImagePath", TEXT, "Path to sending image"),
+    Column("time", BIGINT, "Time"),
+])
+attributes(event_subscriber=True)
+implementation("events/darwin/darwin_unified_log_events@darwin_unified_log_events::genTable")


### PR DESCRIPTION
This implements an event driven table for the new unified system log on darwin. It creates a child process invocation of `/usr/bin/log` and spawns a thread that reads the output of that process and feeds it to the subscribing table.