### PR TITLE
osqueryi needs root to test auditing

### DIFF
--- a/docs/wiki/deployment/process-auditing.md
+++ b/docs/wiki/deployment/process-auditing.md
@@ -88,7 +88,7 @@ There are a few different methods to ensure you have configured auditing correct
 2. Verify auditd is not running if it is installed on the system.
 3. Run `auditctl -s` if the binary is present on your system and verify that `enable` is not set to zero and the `pid` corresponds to a process for osquery
 4. Verify that your osquery configuration has a query to `SELECT` from the process_events and/or socket_events tables
-5. You may also run auditing using osqueryi:
+5. You may also run auditing using osqueryi **as root**:
 ```
 $ osqueryi --audit_allow_config=true --audit_allow_sockets=true --audit_persist=true --disable_audit=false --events_expiry=1 --events_max=50000 --logger_plugin=filesystem  --disable_events=false
 ```


### PR DESCRIPTION
Specify that you need to run _osqueryi_ as root to test audit framework. Usually you do not need to run _osqueryi_ as root, but in this case you need to. It may be obvious, but it wasn't for me! 

