### PR TITLE
Add a 'permission' field to the chrome_extensions table

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -19,6 +19,7 @@ namespace pt = boost::property_tree;
 
 namespace osquery {
 namespace tables {
+namespace {
 
 #define kManifestFile "/manifest.json"
 
@@ -32,6 +33,7 @@ const std::map<std::string, std::string> kExtensionKeys = {
     {"background.persistent", "persistent"}};
 
 const std::string kExtensionPermissionKey = "permissions";
+} // namespace
 
 void genExtension(const std::string& uid,
                   const std::string& path,
@@ -81,7 +83,10 @@ void genExtension(const std::string& uid,
 
   const auto& perm_array_obj = tree.get_child_optional(kExtensionPermissionKey);
   if (perm_array_obj) {
-    for (const auto& perm_obj : perm_array_obj.get()) {
+    const auto& perm_array_contents = perm_array_obj.get();
+    permission_list.reserve(perm_array_contents.size());
+
+    for (const auto& perm_obj : perm_array_contents) {
       const auto& permission = perm_obj.second.get_value<std::string>();
       permission_list.push_back(permission);
     }

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -84,16 +84,21 @@ void genExtension(const std::string& uid,
   const auto& perm_array_obj = tree.get_child_optional(kExtensionPermissionKey);
   if (perm_array_obj) {
     const auto& perm_array_contents = perm_array_obj.get();
+
+    std::vector<std::string> perm_vector;
+    perm_vector.reserve(perm_array_contents.size());
+
     for (auto it = perm_array_contents.begin(); it != perm_array_contents.end();
          ++it) {
       const auto& perm_obj = *it;
-      const auto& permission = perm_obj.second.get_value<std::string>();
-      permission_list.append(permission);
-
-      if (std::next(it, 1) != perm_array_contents.end()) {
-        permission_list.append(", ");
+      const auto& permission =
+          perm_obj.second.get_value_optional<std::string>();
+      if (permission) {
+        perm_vector.emplace_back(*permission);
       }
     }
+
+    permission_list = boost::algorithm::join(perm_vector, ", ");
   }
 
   std::string localized_prefix = "__MSG_";

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -83,23 +83,17 @@ void genExtension(const std::string& uid,
 
   const auto& perm_array_obj = tree.get_child_optional(kExtensionPermissionKey);
   if (perm_array_obj) {
-    std::stringstream temp_stream;
-
     const auto& perm_array_contents = perm_array_obj.get();
     for (auto it = perm_array_contents.begin(); it != perm_array_contents.end();
          ++it) {
       const auto& perm_obj = *it;
       const auto& permission = perm_obj.second.get_value<std::string>();
-      temp_stream << permission;
+      permission_list.append(permission);
 
       if (std::next(it, 1) != perm_array_contents.end()) {
-        temp_stream << ", ";
+        permission_list.append(", ");
       }
     }
-
-    permission_list = temp_stream.str();
-  } else {
-    permission_list = "";
   }
 
   std::string localized_prefix = "__MSG_";

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -13,7 +13,7 @@ schema([
     Column("persistent", INTEGER,
         "1 If extension is persistent across all tabs else 0"),
     Column("path", TEXT, "Path to extension folder"),
-    Column("permission", TEXT, "A single permission granted to the extension"),
+    Column("permissions", TEXT, "The permissions required by the extension"),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -13,6 +13,7 @@ schema([
     Column("persistent", INTEGER,
         "1 If extension is persistent across all tabs else 0"),
     Column("path", TEXT, "Path to extension folder"),
+    Column("permission", TEXT, "A single permission granted to the extension"),
     ForeignKey(column="uid", table="users"),
 ])
 attributes(user_data=True)


### PR DESCRIPTION
This PR adds support for reading the permissions from the extension manifest file.

Here's a couple of examples:

```
osquery> SELECT uid, name, identifier, version, permission
    ...> FROM chrome_extensions
    ...> WHERE permission = "desktopCapture" OR
    ...>       permission = "clipboardRead";
+------+---------------------+----------------------------------+--------------+----------------+
| uid  | name                | identifier                       | version      | permission     |
+------+---------------------+----------------------------------+--------------+----------------+
| 1000 | Google Drive        | apdfllckaahabafndbhieahigkjlhalf | 14.1         | clipboardRead  |
| 1000 | Google Docs Offline | ghbmnnjooekpmoecnnnilnnbdlolhkhi | 1.4          | clipboardRead  |
| 1000 | Google Docs Offline | ghbmnnjooekpmoecnnnilnnbdlolhkhi | 1.7          | clipboardRead  |
| 1000 | Chrome Media Router | pkedcjkdefgpdelpbcmbmeomcjbeemfm | 6718.423.0.0 | desktopCapture |
| 1000 | Chrome Media Router | pkedcjkdefgpdelpbcmbmeomcjbeemfm | 6818.528.0.0 | desktopCapture |
+------+---------------------+----------------------------------+--------------+----------------+
```
```
osquery> SELECT uid, name, identifier, version, permission
    ...> FROM chrome_extensions
    ...> WHERE permission LIKE '%ftp%';
+------+------------------+----------------------------------+-----------+------------+
| uid  | name             | identifier                       | version   | permission |
+------+------------------+----------------------------------+-----------+------------+
| 1000 | HTTPS Everywhere | gcbommkclmclpchllfjekcdonpmejbdp | 2018.8.22 | ftp://*/*  |
+------+------------------+----------------------------------+-----------+------------+
```