### PR TITLE
Adding WMI perf proc process table

### DIFF
--- a/osquery/tables/system/windows/wmi_perf_proc_process.cpp
+++ b/osquery/tables/system/windows/wmi_perf_proc_process.cpp
@@ -21,10 +21,10 @@ namespace tables {
 QueryData genPerfProcProcess(QueryContext& context) {
   QueryData results_data;
   const WmiRequest request(
-    "SELECT CreatingProcessID, ElapsedTime, HandleCount, Name, "
-    "PageFileBytes, PageFileBytesPeak, PercentPrivilegedTime, "
-    "PercentProcessorTime, PercentUserTime FROM "
-    "Win32_PerfFormattedData_PerfProc_Process");
+      "SELECT CreatingProcessID, ElapsedTime, HandleCount, Name, "
+      "PageFileBytes, PageFileBytesPeak, PercentPrivilegedTime, "
+      "PercentProcessorTime, PercentUserTime FROM "
+      "Win32_PerfFormattedData_PerfProc_Process");
 
   if (request.getStatus().ok()) {
     const auto& results = request.results();

--- a/osquery/tables/system/windows/wmi_perf_proc_process.cpp
+++ b/osquery/tables/system/windows/wmi_perf_proc_process.cpp
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <sstream>
+
+#include <osquery/logger.h>
+#include <osquery/tables.h>
+
+#include "osquery/core/windows/wmi.h"
+
+namespace osquery {
+namespace tables {
+
+QueryData genPerfProcProcess(QueryContext& context) {
+  QueryData results_data;
+  const WmiRequest request("SELECT CreatingProcessID, ElapsedTime, HandleCount, Name, PageFileBytes, PageFileBytesPeak, PercentPrivilegedTime, PercentProcessorTime, PercentUserTime FROM Win32_PerfFormattedData_PerfProc_Process");
+
+  if (request.getStatus().ok()) {
+    const auto& results = request.results();
+    for (const auto& result : results) {
+      Row r;
+	  long process_id = 0;
+	  long handle_count = 0;
+	  result.GetLong("CreatingProcessID", process_id);
+	  r["pid"] = INTEGER(process_id);
+	  result.GetString("ElapsedTime", r["elapsed_time"]);
+	  result.GetLong("HandleCount", handle_count);
+	  r["handle_count"] = INTEGER(handle_count);
+	  result.GetString("Name", r["name"]);
+	  result.GetString("PageFileBytes", r["page_file_bytes"]);
+	  result.GetString("PageFileBytesPeak", r["page_file_bytes_peak"]);
+	  result.GetString("PercentPrivilegedTime", r["percent_privileged_time"]);
+	  result.GetString("PercentProcessorTime", r["percent_processor_time"]);
+	  result.GetString("PercentUserTime", r["percent_user_time"]);
+	  results_data.push_back(r);
+    }
+  }
+
+  return results_data;
+}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wmi_perf_proc_process.cpp
+++ b/osquery/tables/system/windows/wmi_perf_proc_process.cpp
@@ -20,26 +20,30 @@ namespace tables {
 
 QueryData genPerfProcProcess(QueryContext& context) {
   QueryData results_data;
-  const WmiRequest request("SELECT CreatingProcessID, ElapsedTime, HandleCount, Name, PageFileBytes, PageFileBytesPeak, PercentPrivilegedTime, PercentProcessorTime, PercentUserTime FROM Win32_PerfFormattedData_PerfProc_Process");
+  const WmiRequest request(
+    "SELECT CreatingProcessID, ElapsedTime, HandleCount, Name, "
+    "PageFileBytes, PageFileBytesPeak, PercentPrivilegedTime, "
+    "PercentProcessorTime, PercentUserTime FROM "
+    "Win32_PerfFormattedData_PerfProc_Process");
 
   if (request.getStatus().ok()) {
     const auto& results = request.results();
     for (const auto& result : results) {
       Row r;
-	  long process_id = 0;
-	  long handle_count = 0;
-	  result.GetLong("CreatingProcessID", process_id);
-	  r["pid"] = INTEGER(process_id);
-	  result.GetString("ElapsedTime", r["elapsed_time"]);
-	  result.GetLong("HandleCount", handle_count);
-	  r["handle_count"] = INTEGER(handle_count);
-	  result.GetString("Name", r["name"]);
-	  result.GetString("PageFileBytes", r["page_file_bytes"]);
-	  result.GetString("PageFileBytesPeak", r["page_file_bytes_peak"]);
-	  result.GetString("PercentPrivilegedTime", r["percent_privileged_time"]);
-	  result.GetString("PercentProcessorTime", r["percent_processor_time"]);
-	  result.GetString("PercentUserTime", r["percent_user_time"]);
-	  results_data.push_back(r);
+      long process_id = 0;
+      long handle_count = 0;
+      result.GetLong("CreatingProcessID", process_id);
+      r["pid"] = INTEGER(process_id);
+      result.GetString("ElapsedTime", r["elapsed_time"]);
+      result.GetLong("HandleCount", handle_count);
+      r["handle_count"] = INTEGER(handle_count);
+      result.GetString("Name", r["name"]);
+      result.GetString("PageFileBytes", r["page_file_bytes"]);
+      result.GetString("PageFileBytesPeak", r["page_file_bytes_peak"]);
+      result.GetString("PercentPrivilegedTime", r["percent_privileged_time"]);
+      result.GetString("PercentProcessorTime", r["percent_processor_time"]);
+      result.GetString("PercentUserTime", r["percent_user_time"]);
+      results_data.push_back(r);
     }
   }
 

--- a/specs/windows/wmi_perf_proc_process.table
+++ b/specs/windows/wmi_perf_proc_process.table
@@ -1,0 +1,17 @@
+table_name("wmi_perf_proc_process")
+description("Lists some performance metrics from the Win32_PerfFormattedData_PerfProc_Process WMI class.")
+schema([
+    Column("pid", INTEGER, "Process ID"),
+    Column("elapsed_time", TEXT, "Elapsed time, in seconds, that this process has been running."),
+    Column("handle_count", INTEGER, "Total number of handles that the process has open. This number is the sum of the handles currently opened by each thread in the process."),
+    Column("name", TEXT, "Label by which the statistic or metric is known. When sub-classed, the property can be overridden to be a key property."),
+    Column("page_file_bytes", TEXT, "Value, in bytes, that this process has used in the paging file(s). Paging files store pages of memory used by the process that are not contained in other files. Paging files are shared by all processes and lack of space in paging files can prevent other processes from allocating memory."),
+    Column("page_file_bytes_peak", TEXT, "Maximum number, in bytes, that this process has used in the paging file(s). Paging files are used to store pages of memory used by the process that are not contained in other files. Paging files are shared by all processes, and lack of space in paging files can prevent other processes from allocating memory."),
+    Column("percent_privileged_time", TEXT, "Percentage of elapsed time that this thread has spent executing code in privileged mode."),
+    Column("percent_processor_time", TEXT, "Percentage of elapsed time that all of the threads of this process used the processor to execute instructions."),
+    Column("percent_user_time", TEXT, "Percentage of elapsed time that this process's threads have spent executing code in user mode."),
+])
+implementation("wmi_perf_proc_process@genPerfProcProcess")
+examples([
+  "select * from wmi_perf_proc_process",
+])


### PR DESCRIPTION
This adds a table that queries WMI for per process performance data. The most useful data is percent of CPU resources by process.