### PR TITLE
 numeric_monitoring recursive sync record

### DIFF
--- a/include/osquery/numeric_monitoring.h
+++ b/include/osquery/numeric_monitoring.h
@@ -53,7 +53,7 @@ enum class PreAggregationType {
  * path @see PreAggregationType. It allows some numeric monitoring plugins
  * pre-aggregate points before send it.
  * @param sync when true pushes record without any buffering. This value is also
- * propagated to the plugin, so call from the plugin only returns once record is
+ * propagated to the plugin, so call to the plugin only returns once record is
  * sent.
  * @param time_point A time of new point, in vast majority of cases it is just
  * a now time (default time).
@@ -68,7 +68,7 @@ enum class PreAggregationType {
 void record(const std::string& path,
             ValueType value,
             PreAggregationType pre_aggregation = PreAggregationType::None,
-            bool sync = false,
+            const bool sync = false,
             TimePoint time_point = Clock::now());
 
 /**

--- a/include/osquery/numeric_monitoring.h
+++ b/include/osquery/numeric_monitoring.h
@@ -52,6 +52,9 @@ enum class PreAggregationType {
  * @param pre_aggregation An preliminary aggregation type for this particular
  * path @see PreAggregationType. It allows some numeric monitoring plugins
  * pre-aggregate points before send it.
+ * @param sync when true pushes record without any buffering. This value is also
+ * propagated to the plugin, so call from the plugin only returns once record is
+ * sent.
  * @param time_point A time of new point, in vast majority of cases it is just
  * a now time (default time).
  *
@@ -65,6 +68,7 @@ enum class PreAggregationType {
 void record(const std::string& path,
             ValueType value,
             PreAggregationType pre_aggregation = PreAggregationType::None,
+            bool sync = false,
             TimePoint time_point = Clock::now());
 
 /**

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -130,9 +130,10 @@ class PreAggregationBuffer final {
   void record(const std::string& path,
               const ValueType& value,
               const PreAggregationType& pre_aggregation,
+              const bool sync,
               const TimePoint& time_point) {
-    if (0 == FLAGS_numeric_monitoring_pre_aggregation_time) {
-      dispatchOne(path, value, pre_aggregation, time_point);
+    if (0 == FLAGS_numeric_monitoring_pre_aggregation_time || sync) {
+      dispatchOne(path, value, pre_aggregation, sync, time_point);
     } else {
       std::lock_guard<std::mutex> lock(mutex_);
       cache_.addPoint(Point(path, value, pre_aggregation, time_point));
@@ -143,7 +144,7 @@ class PreAggregationBuffer final {
     auto points = takeCachedPoints();
     for (const auto& pt : points) {
       dispatchOne(
-          pt.path_, pt.value_, pt.pre_aggregation_type_, pt.time_point_);
+          pt.path_, pt.value_, pt.pre_aggregation_type_, false, pt.time_point_);
     }
   }
 
@@ -157,6 +158,7 @@ class PreAggregationBuffer final {
   void dispatchOne(const std::string& path,
                    const ValueType& value,
                    const PreAggregationType& pre_aggregation,
+                   const bool sync,
                    const TimePoint& time_point) {
     auto status = Registry::call(
         registryName(),
@@ -167,6 +169,7 @@ class PreAggregationBuffer final {
             {recordKeys().pre_aggregation, to<std::string>(pre_aggregation)},
             {recordKeys().timestamp,
              std::to_string(time_point.time_since_epoch().count())},
+            {recordKeys().sync, sync ? "true" : "false"},
         });
     if (!status.ok()) {
       LOG(ERROR) << "Data loss. Numeric monitoring point dispatch failed: "
@@ -208,12 +211,13 @@ void flush() {
 void record(const std::string& path,
             ValueType value,
             PreAggregationType pre_aggregation,
+            bool sync,
             TimePoint time_point) {
   if (!FLAGS_enable_numeric_monitoring) {
     return;
   }
   PreAggregationBuffer::get().record(
-      path, value, pre_aggregation, std::move(time_point));
+      path, value, pre_aggregation, sync, std::move(time_point));
 }
 
 } // namespace monitoring

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -211,7 +211,7 @@ void flush() {
 void record(const std::string& path,
             ValueType value,
             PreAggregationType pre_aggregation,
-            bool sync,
+            const bool sync,
             TimePoint time_point) {
   if (!FLAGS_enable_numeric_monitoring) {
     return;

--- a/osquery/numeric_monitoring/plugin_interface.cpp
+++ b/osquery/numeric_monitoring/plugin_interface.cpp
@@ -32,6 +32,7 @@ RecordKeys createRecordKeys() {
   keys.value = "value";
   keys.timestamp = "timestamp";
   keys.pre_aggregation = "pre_aggregation";
+  keys.sync = "sync";
   return keys;
 };
 

--- a/osquery/numeric_monitoring/plugin_interface.h
+++ b/osquery/numeric_monitoring/plugin_interface.h
@@ -29,6 +29,7 @@ struct RecordKeys {
   std::string value;
   std::string timestamp;
   std::string pre_aggregation;
+  std::string sync;
 };
 
 const RecordKeys& recordKeys();

--- a/osquery/numeric_monitoring/plugins/filesystem.cpp
+++ b/osquery/numeric_monitoring/plugins/filesystem.cpp
@@ -40,6 +40,7 @@ NumericMonitoringFilesystemPlugin::NumericMonitoringFilesystemPlugin(
       monitoring::recordKeys().path,
       monitoring::recordKeys().value,
       monitoring::recordKeys().timestamp,
+      monitoring::recordKeys().sync,
   }
   , separator_{'\t'}
   , log_file_path_(

--- a/osquery/numeric_monitoring/tests/numeric_monitoring_tests.cpp
+++ b/osquery/numeric_monitoring/tests/numeric_monitoring_tests.cpp
@@ -97,7 +97,12 @@ GTEST_TEST(NumericMonitoringTests, record_with_buffer) {
   const auto monitoring_path = "some.path.to.heaven";
   monitoring::record(monitoring_path,
                      monitoring::ValueType{83},
-                     monitoring::PreAggregationType::Sum);
+                     monitoring::PreAggregationType::Sum,
+                     false);
+  monitoring::record(monitoring_path,
+                     monitoring::ValueType{84},
+                     monitoring::PreAggregationType::Sum,
+                     true);
   monitoring::record(monitoring_path,
                      monitoring::ValueType{88},
                      monitoring::PreAggregationType::Sum);
@@ -106,7 +111,7 @@ GTEST_TEST(NumericMonitoringTests, record_with_buffer) {
                      monitoring::PreAggregationType::Sum);
   monitoring::flush();
 
-  EXPECT_EQ(1, NumericMonitoringInMemoryTestPlugin::points.size());
+  EXPECT_EQ(2, NumericMonitoringInMemoryTestPlugin::points.size());
   EXPECT_EQ(monitoring_path,
             NumericMonitoringInMemoryTestPlugin::points.back().at(
                 monitoring::recordKeys().path));


### PR DESCRIPTION
While program is terminating we need mechanism to make sure that plugin has really sent the data. sync monitor offers way to get rid of numeric_plugin buffer and also to let the plugin know that we need to send the record ASAP.