### PR TITLE
boost throwing is_directory bug

### DIFF
--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1572,7 +1572,7 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
                               FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM |
                               FILE_ATTRIBUTE_TEMPORARY;
   boost::system::error_code ec;
-  if (fs::is_directory(result, ec) && ec.value() == errc::success) {
+  if (fs::is_directory(path, ec) && ec.value() == errc::success) {
     FLAGS_AND_ATTRIBUTES |= FILE_FLAG_BACKUP_SEMANTICS;
   }
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1571,8 +1571,8 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
                               FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_OFFLINE |
                               FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_SYSTEM |
                               FILE_ATTRIBUTE_TEMPORARY;
-
-  if (fs::is_directory(path)) {
+  boost::system::error_code ec;
+  if (fs::is_directory(result, ec) && ec.value() == errc::success) {
     FLAGS_AND_ATTRIBUTES |= FILE_FLAG_BACKUP_SEMANTICS;
   }
 


### PR DESCRIPTION
fixes #5194. osquery should not crash because of boost throwing. Reverting to non throwing api, as all other call to the is_directory in the fileops file