### PR TITLE
Create helper functions to get CPU cores info on linux

### DIFF
--- a/osquery/core/CMakeLists.txt
+++ b/osquery/core/CMakeLists.txt
@@ -49,6 +49,14 @@ if(APPLE)
   )
 endif()
 
+if(LINUX)
+  target_sources(libosquery
+    PRIVATE
+    "${CMAKE_CURRENT_LIST_DIR}/linux/cpu.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/linux/cpu.h"
+  )
+endif()
+
 if(POSIX)
   target_sources(libosquery
     PRIVATE
@@ -96,4 +104,10 @@ if(POSIX)
   ADD_OSQUERY_TEST_CORE(
     "${CMAKE_CURRENT_LIST_DIR}/tests/posix/permissions_tests.cpp"
   )   
+endif()
+
+if(LINUX)
+  ADD_OSQUERY_TEST_CORE(
+    "${CMAKE_CURRENT_LIST_DIR}/linux/tests/cpu_test.cpp"
+  )
 endif()

--- a/osquery/core/linux/cpu.cpp
+++ b/osquery/core/linux/cpu.cpp
@@ -1,0 +1,145 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#include "osquery/core/linux/cpu.h"
+
+#include <osquery/core/conversions.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <fstream>
+#include <functional>
+
+namespace osquery {
+namespace cpu {
+
+namespace {
+
+Expected<std::string, Error> readSysCpuFile(char const* path) {
+  auto fin = std::ifstream(path, std::ios_base::in | std::ios_base::binary);
+  if (fin.fail() || fin.bad()) {
+    return createError(Error::IOError, "No access to the system file ") << path;
+  }
+  auto data = std::string{};
+  fin >> data;
+  return data;
+}
+
+Expected<std::size_t, Error> decodeCpuNumber(const std::string& str) {
+  auto exp = tryTo<std::size_t>(str);
+  if (exp.isError()) {
+    return createError(Error::IncorrectRange, "", exp.takeError())
+           << "Incorrect CPU number representation " << boost::io::quoted(str);
+  }
+  return exp.take();
+}
+
+} // namespace
+
+Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str) {
+  auto mask = Mask{};
+  if (encoded_str.empty()) {
+    return mask;
+  }
+  using It = boost::split_iterator<std::string::const_iterator>;
+  for (auto it = boost::make_split_iterator(
+           encoded_str, boost::first_finder(",", boost::is_equal()));
+       it != It{};
+       ++it) {
+    auto const interval = boost::copy_range<std::string>(*it);
+    auto dash_pos = interval.find("-");
+    if (dash_pos == std::string::npos) {
+      auto num_exp = decodeCpuNumber(interval);
+      if (num_exp.isError()) {
+        return num_exp.takeError();
+      }
+      if (num_exp.get() < mask.size()) {
+        mask.set(num_exp.get());
+      } else {
+        return createError(Error::IncorrectRange, "")
+               << "CPU number " << num_exp.get() << " out of bound [0,"
+               << mask.size() << ")";
+      }
+    } else {
+      auto from_exp = decodeCpuNumber(interval.substr(0, dash_pos));
+      if (from_exp.isError()) {
+        return from_exp.takeError();
+      }
+      auto to_exp = decodeCpuNumber(interval.substr(dash_pos + 1));
+      if (to_exp.isError()) {
+        return to_exp.takeError();
+      }
+      if (to_exp.get() < from_exp.get()) {
+        return createError(Error::IncorrectRange,
+                           "Incorrect CPU number interval ")
+               << boost::io::quoted(interval);
+      }
+      if (to_exp.get() >= mask.size()) {
+        return createError(Error::IncorrectRange, "")
+               << "CPU number " << to_exp.get() << " out of bound [0,"
+               << mask.size() << ")";
+      }
+      for (auto pos = from_exp.get(); pos <= to_exp.get(); ++pos) {
+        mask.set(pos);
+      }
+    }
+  }
+  return mask;
+}
+
+Expected<std::string, Error> getOfflineRaw() {
+  return readSysCpuFile("/sys/devices/system/cpu/offline");
+}
+
+Expected<Mask, Error> getOffline() {
+  auto exp = getOfflineRaw();
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return decodeMaskFromString(exp.get());
+}
+
+Expected<std::string, Error> getOnlineRaw() {
+  return readSysCpuFile("/sys/devices/system/cpu/online");
+}
+
+Expected<Mask, Error> getOnline() {
+  auto exp = getOnlineRaw();
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return decodeMaskFromString(exp.get());
+}
+
+Expected<std::string, Error> getPossibleRaw() {
+  return readSysCpuFile("/sys/devices/system/cpu/possible");
+}
+
+Expected<Mask, Error> getPossible() {
+  auto exp = getPossibleRaw();
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return decodeMaskFromString(exp.get());
+}
+
+Expected<std::string, Error> getPresentRaw() {
+  return readSysCpuFile("/sys/devices/system/cpu/present");
+}
+
+Expected<Mask, Error> getPresent() {
+  auto exp = getPresentRaw();
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return decodeMaskFromString(exp.get());
+}
+
+} // namespace cpu
+} // namespace osquery

--- a/osquery/core/linux/cpu.cpp
+++ b/osquery/core/linux/cpu.cpp
@@ -14,7 +14,6 @@
 #include <boost/io/detail/quoted_manip.hpp>
 
 #include <fstream>
-#include <functional>
 
 namespace osquery {
 namespace cpu {
@@ -53,7 +52,7 @@ Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str) {
        it != It{};
        ++it) {
     auto const interval = boost::copy_range<std::string>(*it);
-    auto dash_pos = interval.find("-");
+    auto const dash_pos = interval.find("-");
     if (dash_pos == std::string::npos) {
       auto num_exp = decodeCpuNumber(interval);
       if (num_exp.isError()) {

--- a/osquery/core/linux/cpu.h
+++ b/osquery/core/linux/cpu.h
@@ -1,0 +1,68 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/expected.h>
+
+#include <string>
+#include <vector>
+
+namespace osquery {
+
+namespace cpu {
+
+/**
+ * CPU topology info exported via sysfs in linux
+ * @see Documentation/cputopology.txt in linux kernel code
+ */
+
+enum class Error {
+  IOError = 1,
+  IncorrectRange = 2,
+};
+
+constexpr std::size_t kMaskSize = 128; // see NR_CPUS from linux/cpumask.h
+using Mask = std::bitset<kMaskSize>;
+
+/**
+ * @brief Decode string representation of CPU mask to Mask (aka std::bitset)
+ */
+Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str);
+
+/**
+ * @brief Return the CPUs that are not online because they have been HOTPLUGGED
+ * off or exceed the limit of CPUs allowed by the kernel configuration
+ * (kernel_max above).
+ */
+Expected<std::string, Error> getOfflineRaw();
+Expected<Mask, Error> getOffline();
+
+/**
+ * @brief Return the CPUs that are online and being scheduled
+ */
+Expected<std::string, Error> getOnlineRaw();
+Expected<Mask, Error> getOnline();
+
+/**
+ * @brief Return the CPUs that have been allocated resources and can be brought
+ * online if they are present.
+ */
+Expected<std::string, Error> getPossibleRaw();
+Expected<Mask, Error> getPossible();
+
+/**
+ * @brief Return the CPUs that have been identified as being present in the
+ * system
+ */
+Expected<std::string, Error> getPresentRaw();
+Expected<Mask, Error> getPresent();
+
+} // namespace cpu
+
+} // namespace osquery

--- a/osquery/core/linux/cpu.h
+++ b/osquery/core/linux/cpu.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 namespace osquery {
-
 namespace cpu {
 
 /**
@@ -64,5 +63,4 @@ Expected<std::string, Error> getPresentRaw();
 Expected<Mask, Error> getPresent();
 
 } // namespace cpu
-
 } // namespace osquery

--- a/osquery/core/linux/cpu.h
+++ b/osquery/core/linux/cpu.h
@@ -10,8 +10,8 @@
 
 #include <osquery/expected.h>
 
+#include <bitset>
 #include <string>
-#include <vector>
 
 namespace osquery {
 namespace cpu {

--- a/osquery/core/linux/tests/cpu_test.cpp
+++ b/osquery/core/linux/tests/cpu_test.cpp
@@ -10,12 +10,9 @@
 
 #include <gtest/gtest.h>
 
-#include <osquery/logger.h>
 #include <osquery/tests/test_util.h>
 
 #include "osquery/core/linux/cpu.h"
-
-namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace {

--- a/osquery/core/linux/tests/cpu_test.cpp
+++ b/osquery/core/linux/tests/cpu_test.cpp
@@ -1,0 +1,148 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include <osquery/logger.h>
+#include <osquery/tests/test_util.h>
+
+#include "osquery/core/linux/cpu.h"
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace {
+
+class SystemCpuTests : public testing::Test {};
+
+TEST_F(SystemCpuTests, decodeMaskFromString_empty_string) {
+  auto exp = cpu::decodeMaskFromString("");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask(0));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_0) {
+  auto exp = cpu::decodeMaskFromString("0");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask(1));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_7) {
+  auto exp = cpu::decodeMaskFromString("7");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask("10000000"));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_from_2_to_4) {
+  auto exp = cpu::decodeMaskFromString("2-4");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask("11100"));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_0_from_2_to_5) {
+  auto exp = cpu::decodeMaskFromString("0,2-5");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask("111101"));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_from_1_to_3_from_6_to_7) {
+  auto exp = cpu::decodeMaskFromString("1-3,6-7");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask("11001110"));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_from_1_to_3_from_5_to_7_and_11) {
+  auto exp = cpu::decodeMaskFromString("1-3,5-7,11");
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_EQ(exp.get(), cpu::Mask("100011101110"));
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_0) {
+  auto exp = cpu::decodeMaskFromString("1-0");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_1) {
+  auto exp = cpu::decodeMaskFromString("1-");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_2) {
+  auto exp = cpu::decodeMaskFromString("1,-2");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_3) {
+  auto exp = cpu::decodeMaskFromString(",2");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_4) {
+  auto exp = cpu::decodeMaskFromString("0,9-a");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, decodeMaskFromString_fail_5) {
+  auto exp = cpu::decodeMaskFromString("b");
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), cpu::Error::IncorrectRange);
+}
+
+TEST_F(SystemCpuTests, getOfflineRaw) {
+  auto exp = cpu::getOfflineRaw();
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_TRUE(cpu::decodeMaskFromString(exp.get()));
+}
+
+TEST_F(SystemCpuTests, getOffline) {
+  auto exp = cpu::getOffline();
+  ASSERT_TRUE(exp.isValue());
+}
+
+TEST_F(SystemCpuTests, getOnlineRaw) {
+  auto exp = cpu::getOnlineRaw();
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_TRUE(cpu::decodeMaskFromString(exp.get()));
+}
+
+TEST_F(SystemCpuTests, getOnline) {
+  auto exp = cpu::getOnline();
+  ASSERT_TRUE(exp.isValue());
+}
+
+TEST_F(SystemCpuTests, getPossibleRaw) {
+  auto exp = cpu::getPossibleRaw();
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_TRUE(cpu::decodeMaskFromString(exp.get()));
+}
+
+TEST_F(SystemCpuTests, getPossible) {
+  auto exp = cpu::getPossible();
+  ASSERT_TRUE(exp.isValue());
+}
+
+TEST_F(SystemCpuTests, getPresentRaw) {
+  auto exp = cpu::getPresentRaw();
+  ASSERT_TRUE(exp.isValue());
+  ASSERT_TRUE(cpu::decodeMaskFromString(exp.get()));
+}
+
+TEST_F(SystemCpuTests, getPresent) {
+  auto exp = cpu::getPresent();
+  ASSERT_TRUE(exp.isValue());
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Helper functions to get CPU cores info exposed via sysfs on linux.
I need this information to use `kprobes` in osquery on linux.
