### PR TITLE
chrome_extensions: Add the profile name to the table

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -34,10 +34,45 @@ const std::map<std::string, std::string> kExtensionKeys = {
     {"background.persistent", "persistent"}};
 
 const std::string kExtensionPermissionKey = "permissions";
+const std::string kProfilePreferencesFile = "Preferences";
+const std::string kProfilePreferenceKey = "profile";
+
+Status getChromeProfileName(std::string& name, const fs::path& path) {
+  name.clear();
+
+  std::string json_data;
+  if (!forensicReadFile(path / kProfilePreferencesFile, json_data).ok()) {
+    return Status(
+        1, "Failed to read the Preferences file for profile " + path.string());
+  }
+
+  pt::ptree tree;
+  try {
+    std::stringstream json_stream;
+    json_stream << json_data;
+    pt::read_json(json_stream, tree);
+  } catch (const pt::json_parser::json_parser_error&) {
+    return Status(
+        1, "Failed to parse the Preferences file for profile " + path.string());
+  }
+
+  const auto& profile_obj = tree.get_child_optional(kProfilePreferenceKey);
+  if (!profile_obj) {
+    return Status(1, "The following profile is malformed: " + path.string());
+  }
+
+  name = profile_obj.get().get<std::string>("name", "");
+  if (name.empty()) {
+    return Status(1, "The following profile has no name: " + path.string());
+  }
+
+  return Status(0);
+}
 } // namespace
 
 void genExtension(const std::string& uid,
                   const std::string& path,
+                  const std::string& profile_name,
                   QueryData& results) {
   std::string json_data;
   if (!forensicReadFile(path + kManifestFile, json_data).ok()) {
@@ -106,6 +141,7 @@ void genExtension(const std::string& uid,
   Row r;
   r["uid"] = uid;
   r[kExtensionPermissionKey] = permission_list;
+  r["profile"] = profile_name;
   // Most of the keys are in the top-level JSON dictionary.
   for (const auto& it : kExtensionKeys) {
     std::string key = tree.get<std::string>(it.first, "");
@@ -150,20 +186,32 @@ QueryData genChromeBasedExtensions(QueryContext& context,
       }
 
       // For each profile list each extension in the Extensions directory.
-      std::vector<std::string> extensions;
       for (const auto& profile : profiles) {
+        std::vector<std::string> extensions = {};
         listDirectoriesInDirectory(profile, extensions);
-      }
 
-      // Generate an addons list from their extensions JSON.
-      std::vector<std::string> versions;
-      for (const auto& extension : extensions) {
-        listDirectoriesInDirectory(extension, versions);
-      }
+        if (extensions.empty()) {
+          continue;
+        }
 
-      // Extensions use /<EXTENSION>/<VERSION>/manifest.json.
-      for (const auto& version : versions) {
-        genExtension(row.at("uid"), version, results);
+        auto profile_path = fs::path(profile).parent_path().parent_path();
+
+        std::string profile_name;
+        auto status = getChromeProfileName(profile_name, profile_path);
+        if (!status.ok()) {
+          LOG(WARNING) << status.getMessage();
+        }
+
+        // Generate an addons list from their extensions JSON.
+        std::vector<std::string> versions;
+        for (const auto& extension : extensions) {
+          listDirectoriesInDirectory(extension, versions);
+        }
+
+        // Extensions use /<EXTENSION>/<VERSION>/manifest.json.
+        for (const auto& version : versions) {
+          genExtension(row.at("uid"), version, profile_name, results);
+        }
       }
     }
   }

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -4,6 +4,7 @@ schema([
     Column("uid", BIGINT, "The local user that owns the extension",
         additional=True),
     Column("name", TEXT, "Extension display name"),
+    Column("profile", TEXT, "The Chrome profile that contains this extension"),
     Column("identifier", TEXT, "Extension identifier", index=True),
     Column("version", TEXT, "Extension-supplied version"),
     Column("description", TEXT, "Extension-optional description"),


### PR DESCRIPTION
This PR adds a new column to the `chrome_extensions` table named `profile`, used to show the name of the Chrome profile that owns each extension.

```
osqueryi --verbose 'SELECT profile, name, version FROM chrome_extensions;'
```
```
+---------------+---------------------+--------------+
| profile       | name                | version      |
+---------------+---------------------+--------------+
| trail_of_bits | Slides              | 0.10         |
| trail_of_bits | Docs                | 0.10         |
| trail_of_bits | Google Drive        | 14.1         |
| trail_of_bits | YouTube             | 4.2.8        |
| trail_of_bits | Sheets              | 1.2          |
| trail_of_bits | HTTPS Everywhere    | 2018.8.22    |
| trail_of_bits | Google Docs Offline | 1.7          |
| trail_of_bits | __MSG_APP_NAME__    | 1.0.0.4      |
| trail_of_bits | Gmail               | 8.1          |
| trail_of_bits | Chrome Media Router | 6818.528.0.0 |
| Person 1      | Slides              | 0.10         |
| Person 1      | Docs                | 0.10         |
| Person 1      | Google Drive        | 14.1         |
| Person 1      | YouTube             | 4.2.8        |
| Person 1      | Sheets              | 1.2          |
| Person 1      | Google Docs Offline | 1.7          |
| Person 1      | __MSG_APP_NAME__    | 1.0.0.4      |
| Person 1      | Gmail               | 8.1          |
| Person 1      | Chrome Media Router | 6818.528.0.0 |
+---------------+---------------------+--------------+
```