### PR TITLE
chrome_extensions: Use the translation dictionary with case insensitive keys

### DIFF
--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -55,7 +55,7 @@ void genExtension(const std::string& uid,
     return;
   }
 
-  pt::ptree messagetree;
+  pt::iptree messagetree;
   // Find out if there are localized values for fields
   if (!tree.get<std::string>("default_locale", "").empty()) {
     // Read the localized variables into a second ptree


### PR DESCRIPTION
This PR fixes a translation issue in the `chrome_extensions` table, caused by how key names are handled in the translation dictionary.

The case of the string anchor (i.e.: `__MSG_APP_NAME__`, or `__MSG_appName__`) in the extension manifest does not always match the case used in the translation dictionary (`_locales/<locale_name>/messages.json`). This patch ensures that the translation dictionary is used with case insensitive keys. This fixes how the default `Chrome Web Store Payments` extension is shown to the user.