### PR TITLE
improved blacklisting mechanism

### DIFF
--- a/include/osquery/killswitch.h
+++ b/include/osquery/killswitch.h
@@ -32,6 +32,10 @@ class Killswitch : private boost::noncopyable {
   virtual ~Killswitch();
 
   // Author: @guliashvili
+  // Creation Time: 14/09/2018
+  bool isFileBlacklistingEnabled();
+
+  // Author: @guliashvili
   // Creation Time: 4/09/2018
   bool isTotalQueryCounterMonitorEnabled();
 

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -32,6 +32,10 @@ FLAG(string,
 Killswitch::Killswitch() {}
 Killswitch::~Killswitch() = default;
 
+bool Killswitch::isFileBlacklistingEnabled() {
+  return isNewCodeEnabled("fileBlacklistingSwitch");
+}
+
 bool Killswitch::isTotalQueryCounterMonitorEnabled() {
   return isNewCodeEnabled("totalQueryCounterMonitorSwitch");
 }


### PR DESCRIPTION
Current blacklisting mechanism relies on the rocksdb. In order to reduce noise from the blacklisting, moving it to the simpler filesystem 'DB', where we can avoid buffering and some the strange behaviors while osquery is crashing.