### PR TITLE
bug: explicitly set safe permissions on osquery dbs

### DIFF
--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -164,7 +164,7 @@ Status RocksDBDatabasePlugin::setUp() {
   }
 
   // RocksDB may not create/append a directory with acceptable permissions.
-  if (!read_only_ && platformChmod(path_, S_IRWXU) == false) {
+  if (!read_only_ && platformSetSafeDbPerms(path_) == false) {
     return Status(1, "Cannot set permissions on RocksDB path: " + path_);
   }
   return Status(0);

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -92,7 +92,7 @@ Status SQLiteDatabasePlugin::setUp() {
   }
 
   // RocksDB may not create/append a directory with acceptable permissions.
-  if (!read_only_ && platformChmod(path_, S_IRWXU) == false) {
+  if (!read_only_ && platformSetSafeDbPerms(path_) == false) {
     close();
     return Status(1, "Cannot set permissions on database path: " + path_);
   }

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -142,8 +142,8 @@ Status launchQuery(const std::string& name, const ScheduledQuery& query) {
     status = dbQuery.addNewResults(
         std::move(sql.rows()), item.epoch, item.counter, diff_results);
     if (!status.ok()) {
-      std::string line =
-          "Error adding new results to database: " + status.what();
+      std::string line = "Error adding new results to database for query " +
+                         name + ": " + status.what();
       LOG(ERROR) << line;
 
       // If the database is not available then the daemon cannot continue.

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -337,6 +337,15 @@ boost::optional<std::string> getHomeDirectory();
 bool platformChmod(const std::string& path, mode_t perms);
 
 /**
+ * @brief Sets 'safe' permissions for the database backing osquery
+ *
+ * @note Safe DB perms are equivalent to a chmod 0700 for root on posix
+ * so we emulate this by granting Full perms to SYSTEM and Administrators
+ * only.
+ */
+bool platformSetSafeDbPerms(const std::string& path);
+
+/**
  * @brief Multi-platform implementation of glob.
  * @note glob support is not 100% congruent with Linux glob. There are slight
  *       differences in how GLOB_TILDE and GLOB_BRACE are implemented.

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -281,6 +281,10 @@ boost::optional<std::string> getHomeDirectory() {
   }
 }
 
+bool platformSetSafeDbPerms(const std::string& path) {
+  return platformChmod(path, S_IRWXU);
+}
+
 bool platformChmod(const std::string& path, mode_t perms) {
   return (::chmod(path.c_str(), perms) == 0);
 }


### PR DESCRIPTION
The `paltformChmod` abstraction on Windows specifically leverages Deny ACE entries to attempt to prevent access to lower privileged users. The usage of Deny ACEs is pretty risky at best, and isn't something that's encouraged typically considering Windows DACLs will deny anyone who isn't explicitly granted an Allow ACE. This PR changes the permission management function we are using to manage our database permissions to simply set explicit allow entries for the Administrators and SYSTEM user accounts, our "equivalent" of root on Windows, as these are the only users that should have access to the osquery database. This addresses #5227, however this does not fix in entirety the issue that platformChmod shouldn't be leveraging Deny ACEs. That being said there are exceptionally few places in our codebase that are making use of the `platformChmod` abstraction, so it might be a good candidate for removal.

I have another [branch up](https://github.com/facebook/osquery/compare/master...muffins:win-large-db-fix) that had attempted to change the `platformChmod` abstraction to not leverage Deny ACEs, and I believe that I got pretty close, however there are numerous unit tests relying on the Deny behavior of the chmod abstraction that fail with this branch, and I don't currently have time to dig into this. If someone else would like to pick up fixing this abstraction I think I have a good head start on it, but considering this is a relatively unused feature of the code base, as I mentioned, we might just want to remove it. Happy to start the discussion here around whether folks think there's another approach that might be valid however this is a pretty serious bug and I think this is a relatively good solution.
