### PR TITLE
Fix OsqueryHttpClient failing to make requests

### DIFF
--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -121,7 +121,7 @@ OsqueryHttpClientFactory::CreateHttpRequest(
   return request;
 }
 
-std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::InternalRequest(
+std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
     Aws::Http::HttpRequest& request,
     Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
     Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
@@ -200,6 +200,13 @@ std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::InternalRequest(
   }
 
   return response;
+}
+
+std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
+    const std::shared_ptr<Aws::Http::HttpRequest>& request,
+    Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+    Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {
+  return MakeRequest(*request, readLimiter, writeLimiter);
 }
 
 Aws::Auth::AWSCredentials

--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -121,7 +121,7 @@ OsqueryHttpClientFactory::CreateHttpRequest(
   return request;
 }
 
-std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::MakeRequest(
+std::shared_ptr<Aws::Http::HttpResponse> OsqueryHttpClient::InternalRequest(
     Aws::Http::HttpRequest& request,
     Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
     Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter) const {

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -66,28 +66,17 @@ class OsqueryHttpClient : public Aws::Http::HttpClient {
  public:
   OsqueryHttpClient() : HttpClient() {}
 
-  std::shared_ptr<Aws::Http::HttpResponse> InternalRequest(
-      Aws::Http::HttpRequest& request,
-      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
-      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
-          nullptr) const;
-
-  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
-      // This override method has been deprecated within AWS HttpClient.
-      Aws::Http::HttpRequest& request,
-      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
-      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
-          nullptr) const override {
-    return InternalRequest(request, readLimiter, writeLimiter);
-  }
-
   std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
       const std::shared_ptr<Aws::Http::HttpRequest>& request,
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
       Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
-          nullptr) const override {
-    return InternalRequest(*request, readLimiter, writeLimiter);
-  }
+          nullptr) const override;
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      Aws::Http::HttpRequest& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
+          nullptr) const override;
 };
 
 /**

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -66,11 +66,28 @@ class OsqueryHttpClient : public Aws::Http::HttpClient {
  public:
   OsqueryHttpClient() : HttpClient() {}
 
-  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+  std::shared_ptr<Aws::Http::HttpResponse> InternalRequest(
       Aws::Http::HttpRequest& request,
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
       Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
-          nullptr) const override;
+          nullptr) const;
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      // This override method has been deprecated within AWS HttpClient.
+      Aws::Http::HttpRequest& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
+          nullptr) const override {
+    return InternalRequest(request, readLimiter, writeLimiter);
+  }
+
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
+          nullptr) const override {
+    return InternalRequest(*request, readLimiter, writeLimiter);
+  }
 };
 
 /**


### PR DESCRIPTION
This request provides a fix implementation for https://github.com/facebook/osquery/issues/4735

* New method `InternalRequest` replaces `MakeRequest(HttpRequest& request, ...)`
* `MakeRequest(HttpRequest& request, ...)` wraps `InternalRequest(HttpRequest& request, ...)` [passthrough]
* Added missing override method for `MakeRequest(const std::shared_ptr<HttpRequest>& request, ...)`
  - wraps `InternalRequest(HttpRequest& request, ...)` [dereferencing passthrough]

Although `MakeRequest(HttpRequest& request, ...)` has been deprecated in AWS HttpClient, I have left this in place as it may still be in use by applications linked against OSQuerys SDK? Instead I have made this a passthrough method to an InternalRequest function so the team can deprecate / remove it in the future without breaking existing functionality. If the team wish to maintain this as an entrypoint to the client, it will need the override flag removing in future should the AWS team remove the method entirely.