### PR TITLE
Fix plist.table description

### DIFF
--- a/specs/darwin/plist.table
+++ b/specs/darwin/plist.table
@@ -4,7 +4,7 @@ schema([
     Column("key", TEXT, "Preference top-level key"),
     Column("subkey", TEXT, "Intemediate key path, includes lists/dicts"),
     Column("value", TEXT, "String value of most CF types"),
-    Column("path", TEXT, "(optional) read preferences from a plist",
+    Column("path", TEXT, "(required) read preferences from a plist",
       required=True),
 ])
 implementation("system/darwin/preferences@genOSXPlist")


### PR DESCRIPTION
The column "path" is a required column.  Fixed description.


