### PR TITLE
Fix config_name typo on documentation

### DIFF
--- a/docs/wiki/installation/cli-flags.md
+++ b/docs/wiki/installation/cli-flags.md
@@ -30,7 +30,7 @@ Include line-delimited switches to be interpreted and used as CLI-flags:
 --config_plugin=custom_plugin
 --logger_plugin=custom_plugin
 --distributed_plugin=custom_plugin
---watchlog_level=2
+--watchdog_level=0
 ```
 
 If no `--flagfile` is provided, osquery will try to find and use a "default" flagfile at `/etc/osquery/osquery.flags.default`. Both the shell and daemon will discover and use the defaults.


### PR DESCRIPTION
* I think watchlog is a typo for watchdog.
* watchlog_level=2 is legacy configuration.
    * https://github.com/facebook/osquery/pull/2173