### PR TITLE
update aws-sdk-cpp 1.4.55 on windows

### DIFF
--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -12,6 +12,12 @@
 
 #include <boost/algorithm/string/join.hpp>
 
+#ifdef WIN32
+// AWS SDK provides deprecation warnings at compile-time, and osquery
+// build treats warnings as errors, so have to turn these off.
+#define AWS_DISABLE_DEPRECATION
+#endif
+
 #include <aws/core/client/AWSError.h>
 #include <aws/core/utils/Outcome.h>
 #include <aws/firehose/model/PutRecordBatchRequest.h>

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -13,6 +13,12 @@
 #include <iterator>
 #include <thread>
 
+#ifdef WIN32
+// AWS SDK provides deprecation warnings at compile-time, and osquery
+// build treats warnings as errors, so have to turn these off.
+#define AWS_DISABLE_DEPRECATION
+#endif
+
 #include <aws/core/client/AWSError.h>
 #include <aws/core/utils/Outcome.h>
 #include <aws/kinesis/model/PutRecordsRequest.h>

--- a/osquery/logger/plugins/tests/aws_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_logger_tests.cpp
@@ -13,6 +13,12 @@
 #include <memory>
 #include <vector>
 
+#ifdef WIN32
+// AWS SDK provides deprecation warnings at compile-time, and osquery
+// build treats warnings as errors, so have to turn these off.
+#define AWS_DISABLE_DEPRECATION
+#endif
+
 #include <aws/kinesis/KinesisClient.h>
 #include <aws/kinesis/model/PutRecordsRequestEntry.h>
 #include <gtest/gtest.h>

--- a/osquery/utils/aws_util.cpp
+++ b/osquery/utils/aws_util.cpp
@@ -17,6 +17,12 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#ifdef WIN32
+// AWS SDK provides deprecation warnings at compile-time, and osquery
+// build treats warnings as errors, so have to turn these off.
+#define AWS_DISABLE_DEPRECATION
+#endif
+
 #include <aws/core/Aws.h>
 #include <aws/core/Region.h>
 #include <aws/core/client/AWSClient.h>

--- a/osquery/utils/aws_util.h
+++ b/osquery/utils/aws_util.h
@@ -12,6 +12,12 @@
 
 #include <memory>
 
+#ifdef WIN32
+// AWS SDK provides deprecation warnings at compile-time, and osquery
+// build treats warnings as errors, so have to turn these off.
+#define AWS_DISABLE_DEPRECATION
+#endif
+
 #include <aws/core/Region.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
@@ -71,6 +77,14 @@ class OsqueryHttpClient : public Aws::Http::HttpClient {
       Aws::Utils::RateLimits::RateLimiterInterface* readLimiter = nullptr,
       Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter =
           nullptr) const override;
+  std::shared_ptr<Aws::Http::HttpResponse> MakeRequest(
+      const std::shared_ptr<Aws::Http::HttpRequest>& request,
+      Aws::Utils::RateLimits::RateLimiterInterface* readLimiter,
+      Aws::Utils::RateLimits::RateLimiterInterface* writeLimiter)
+      const override {
+    return MakeRequest(*request, readLimiter, writeLimiter);
+  }
+
 };
 
 /**

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -345,7 +345,7 @@ function Install-ThirdParty {
 
   # List of our third party packages, hosted in our AWS S3 bucket
   $packages = @(
-    "aws-sdk-cpp.1.2.7",
+    "aws-sdk-cpp.1.4.55",
     "boost-msvc14.1.66.0-r1",
     "bzip2.1.0.6",
     "doxygen.1.8.11",

--- a/tools/provision/chocolatey/aws-sdk-cpp.ps1
+++ b/tools/provision/chocolatey/aws-sdk-cpp.ps1
@@ -7,8 +7,8 @@
 #  You may select, at your option, one of the above-listed licenses.
 
 # Update-able metadata
-$version = '1.2.7'
-$chocoVersion = '1.2.7'
+$version = '1.4.55'
+$chocoVersion = '1.4.55'
 $packageName = 'aws-sdk-cpp'
 $projectSource = 'https://github.com/aws/aws-sdk-cpp'
 $packageSourceUrl = "https://github.com/aws/aws-sdk-cpp/archive/$version.zip"


### PR DESCRIPTION
Update windows build to use same aws-sdk-cpp version as other platforms.

NOTE:
  For this to work with tools/make-win64-dev-env.bat, the binary aws-sdk-cpp build must
  be made   available at https://github.com/aws/aws-sdk-cpp/archive/
  Here's my build (70MB):
    https://github.com/packetzero/osquery_dep_binaries/blob/master/win/aws-sdk-cpp.1.4.55.nupkg

Related PR issues:
https://github.com/facebook/osquery/issues/4158
https://github.com/facebook/osquery/pull/4437
