### PR TITLE
Adding OSX Malware SearchAwesome to osx-attacks pack

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -595,6 +595,25 @@
       "version": "1.4.5",
       "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
       "value": "Artifacts created by this malware"
+    },
+    "OSX_SearchAwesome_files": {
+      "query" : "SELECT * FROM file \
+         WHERE path = '/Applications/spi.app' OR \
+           path = '/Users/%/Library/LaunchAgents/spid-uninstall.plist' OR \
+           path = '/Users/%/Library/LaunchAgents/spid.plist' OR \
+           path = '/Users/%/Library/SPI' OR \
+           path = '/Users/%/.mitmproxy';",
+      "interval" : "3600",
+      "version": "1.4.5",
+      "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",
+      "value": "Artifacts created by this malware"
+    },
+    "OSX_SearchAwesome_certificate": {
+      "query" : "SELECT * FROM certificates WHERE common_name = 'mitmproxy';",
+      "interval" : "3600",
+      "version" : "2.8.0",
+      "description": "OSX SearchAwesome Malware (https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/)",
+      "value" : "bogus certificate added to key store by this malware"
     }
   }
 }


### PR DESCRIPTION
## Overview

New OSX malware can be easily detected with osquery and it is consistent with other entries in the `osx-attacks` pack. More details can be found [here](https://blog.malwarebytes.com/threat-analysis/2018/10/mac-malware-intercepts-encrypted-web-traffic-for-ad-injection/).

File artifacts are:
* `/Applications/spi.app`
* `~/Library/LaunchAgents/spid-uninstall.plist`
* `~/Library/LaunchAgents/spid.plist`
* `~/Library/SPI`
* `~/.mitmproxy`

And a certificate with the name `mitmproxy`.