### PR TITLE
bug: actually remove additional newline from event data

### DIFF
--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -132,7 +132,7 @@ Status WindowsEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   auto s = ss.str();
   if (s.at(s.size() - 1) == '\n') {
-    s.erase(s.end());
+    s.erase(s.end() - 1);
   }
   r["data"] = s;
 


### PR DESCRIPTION
I had previously attempted to land a fix to the extra newline that was trailing on Windows Event Logs, but had failed. This actually fixes the extra newline, which I verified. I'd love to have unit tests for this, however we don't currently have any unit tests setup for Windows Event Logging.