### PR TITLE
Include weekends on the kernel_panics table

### DIFF
--- a/osquery/tables/system/darwin/kernel_panics.cpp
+++ b/osquery/tables/system/darwin/kernel_panics.cpp
@@ -39,7 +39,8 @@ const std::set<std::string> kKernelRegisters = {
 };
 
 /// List of the days of the Week, used to grab our timestamp.
-const std::set<std::string> kDays = {"Mon", "Tue", "Wed", "Thu", "Fri"};
+const std::set<std::string> kDays = {
+    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
 /// Map of the values we currently parse out of the log file
 const std::map<std::string, std::string> kKernelPanicKeys = {


### PR DESCRIPTION
The set accidentally missed Saturday and Sunday days of the week. This just adds them in.

Fixes #5297.