### PR TITLE
Required Dependencies updated: 'curl' added

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -8,6 +8,7 @@ We include a `make deps` command to make it easier for developers to get started
 - `ruby`
 - `git`
 - `bash`
+- `curl`
 
 > NOTICE: This will install or build various dependencies on the build host that are not required to "use" osquery, only build osquery binaries and packages.
 


### PR DESCRIPTION
'Curl' added as a required dependency. Curl is required for linux builds for "make deps" to succeed. I added curl in the required dependencies of building osquery documentation.
fixes Issue: #4580 