### PR TITLE
Remove unused and most likely broken operator== overload from error

### DIFF
--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -135,12 +135,6 @@ inline bool operator==(const ErrorBase& lhs, const T rhs) {
   }
 }
 
-template <class T>
-inline bool operator==(const ErrorBase* lhs, const T rhs) {
-  auto casted_lhs = dynamic_cast<const Error<T>*>(lhs);
-  return casted_lhs != nullptr && casted_lhs == rhs;
-}
-
 inline std::ostream& operator<<(std::ostream& out, const ErrorBase& error) {
   out << error.getFullMessageRecursive();
   return out;


### PR DESCRIPTION
Summary: This is most likely broken and is causing problems with some toolchains (e.g. clang on Ubuntu xenial).

Differential Revision: D13415457
