### PR TITLE
fix xcode duplicate target names

### DIFF
--- a/osquery/filesystem/BUCK
+++ b/osquery/filesystem/BUCK
@@ -61,7 +61,7 @@ osquery_cxx_library(
         ),
     ],
     tests = [
-        ":tests",
+        ":filesystem_tests",
     ],
     visibility = ["PUBLIC"],
     deps = [
@@ -93,7 +93,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "filesystem_tests",
     srcs = [
         "tests/fileops.cpp",
         "tests/filesystem.cpp",

--- a/osquery/killswitch/BUCK
+++ b/osquery/killswitch/BUCK
@@ -23,6 +23,7 @@ osquery_cxx_library(
         "killswitch_refreshable_plugin.h",
     ],
     link_whole = True,
+    tests = [":killswitch_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/core:core"),
@@ -31,7 +32,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "killswitch_tests",
     srcs = [
         "tests/killswitch_tests.cpp",
     ],

--- a/osquery/killswitch/plugins/BUCK
+++ b/osquery/killswitch/plugins/BUCK
@@ -19,6 +19,7 @@ osquery_cxx_library(
         "killswitch_filesystem.h",
     ],
     link_whole = True,
+    tests = [":killswitch_filesystem_plugin_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/killswitch:killswitch"),
@@ -45,7 +46,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "killswitch_filesystem_plugin_tests",
     srcs = [
         "tests/killswitch_filesystem_tests.cpp",
     ],

--- a/osquery/remote/enroll/BUCK
+++ b/osquery/remote/enroll/BUCK
@@ -37,7 +37,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "remote_enroll_tests",
     srcs = [
         "tests/enroll_tests.cpp",
     ],

--- a/osquery/remote/serializers/BUCK
+++ b/osquery/remote/serializers/BUCK
@@ -15,6 +15,7 @@ osquery_cxx_library(
     srcs = ["json.cpp"],
     header_namespace = "osquery/remote/serializers",
     exported_headers = ["json.h"],
+    tests = [":remote_json_serializers_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/remote:requests"),
@@ -24,7 +25,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "remote_json_serializers_tests",
     srcs = [
         "tests/json_serializers_tests.cpp",
     ],

--- a/osquery/remote/transports/BUCK
+++ b/osquery/remote/transports/BUCK
@@ -16,6 +16,7 @@ osquery_cxx_library(
     srcs = ["tls.cpp"],
     header_namespace = "osquery/remote/transports",
     exported_headers = ["tls.h"],
+    tests = [":remote_transports_tls_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery:headers"),
@@ -28,7 +29,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "remote_transports_tls_tests",
     env = {
         "TEST_CONF_FILES_DIR": "$(location {})".format(
             osquery_target("tools/tests:test_files"),

--- a/osquery/utils/BUCK
+++ b/osquery/utils/BUCK
@@ -51,6 +51,7 @@ osquery_cxx_library(
             ],
         ),
     ],
+    tests = [":utils_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_tp_target("glog"),
@@ -66,7 +67,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "utils_tests",
     srcs = [
         "tests/base64.cpp",
         "tests/chars.cpp",

--- a/osquery/utils/conversions/BUCK
+++ b/osquery/utils/conversions/BUCK
@@ -59,6 +59,7 @@ osquery_cxx_library(
             ],
         ),
     ],
+    tests = [":conversions_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils/expected:expected"),
@@ -68,7 +69,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "conversions_tests",
     srcs = [
         "tests/join.cpp",
         "tests/split.cpp",

--- a/osquery/utils/debug/BUCK
+++ b/osquery/utils/debug/BUCK
@@ -15,6 +15,7 @@ osquery_cxx_library(
     exported_headers = [
         "debug_only.h",
     ],
+    tests = [":debug_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_tp_target("boost"),
@@ -22,7 +23,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "debug_tests",
     srcs = [
         "tests/debug_only.cpp",
     ],

--- a/osquery/utils/error/BUCK
+++ b/osquery/utils/error/BUCK
@@ -15,6 +15,7 @@ osquery_cxx_library(
     exported_headers = [
         "error.h",
     ],
+    tests = [":error_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_tp_target("boost"),
@@ -22,7 +23,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "error_tests",
     srcs = [
         "tests/error.cpp",
     ],

--- a/osquery/utils/expected/BUCK
+++ b/osquery/utils/expected/BUCK
@@ -16,6 +16,7 @@ osquery_cxx_library(
     exported_headers = [
         "expected.h",
     ],
+    tests = [":expected_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils/debug:debug"),
@@ -25,7 +26,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "expected_tests",
     srcs = [
         "tests/expected.cpp",
     ],

--- a/osquery/utils/json/BUCK
+++ b/osquery/utils/json/BUCK
@@ -23,6 +23,7 @@ osquery_cxx_library(
         "-DRAPIDJSON_NO_SIZETYPEDEFINE",
         "-DRAPIDJSON_HAS_STDSTRING=1",
     ],
+    tests = [":json_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils:utils"),
@@ -34,7 +35,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "json_tests",
     srcs = [
         "tests/json.cpp",
     ],

--- a/osquery/utils/status/BUCK
+++ b/osquery/utils/status/BUCK
@@ -18,6 +18,7 @@ osquery_cxx_library(
     exported_headers = [
         "status.h",
     ],
+    tests = [":status_tests"],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils/error:error"),
@@ -26,7 +27,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "tests",
+    name = "status_tests",
     srcs = [
         "tests/status.cpp",
     ],


### PR DESCRIPTION
Summary: xcode needs unique target names not to fail on buck generated project

Reviewed By: marekcirkos, akindyakov

Differential Revision: D13449869
