### PR TITLE
Create OSQUERY_NODISCARD to prevent non returning errors

### DIFF
--- a/osquery/core/database/rocksdb_database.cpp
+++ b/osquery/core/database/rocksdb_database.cpp
@@ -256,7 +256,7 @@ ExpectedSuccess<DatabaseError> RocksdbDatabase::putRawBytesInternal(
     Handle* handle, const std::string& key, const std::string& value) {
   auto status = db_->Put(default_write_options_, handle, key, value);
   if (!status.ok()) {
-    createError(DatabaseError::FailToWriteData, status.ToString());
+    return createError(DatabaseError::FailToWriteData, status.ToString());
   }
   return Success();
 }

--- a/osquery/killswitch/plugins/killswitch_filesystem.cpp
+++ b/osquery/killswitch/plugins/killswitch_filesystem.cpp
@@ -42,8 +42,9 @@ KillswitchFilesystem::refresh() {
   boost::system::error_code ec;
   if (!fs::is_regular_file(conf_path_, ec) || ec.value() != errc::success ||
       !readFile(conf_path_, content).ok()) {
-    createError(KillswitchRefreshablePlugin::RefreshError::NoContentReached,
-                "Config file does not exist: " + conf_path_.string());
+    return createError(
+        KillswitchRefreshablePlugin::RefreshError::NoContentReached,
+        "Config file does not exist: " + conf_path_.string());
   }
 
   auto result = KillswitchPlugin::parseMapJSON(content);

--- a/osquery/utils/BUCK
+++ b/osquery/utils/BUCK
@@ -20,6 +20,7 @@ osquery_cxx_library(
     ],
     header_namespace = "osquery/utils",
     exported_headers = [
+        "attribute.h",
         "base64.h",
         "chars.h",
         "map_take.h",
@@ -78,4 +79,13 @@ osquery_cxx_test(
     deps = [
         ":utils",
     ],
+)
+
+osquery_cxx_library(
+    name = "attribute",
+    header_namespace = "osquery/utils",
+    exported_headers = [
+        "attribute.h",
+    ],
+    visibility = ["PUBLIC"],
 )

--- a/osquery/utils/attribute.h
+++ b/osquery/utils/attribute.h
@@ -1,0 +1,23 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#if __cplusplus >= 201703L
+#define OSQUERY_NODISCARD [[nodiscard]]
+#else
+#if defined(POSIX)
+#define OSQUERY_NODISCARD __attribute__((warn_unused_result))
+#elif defined(WIDOWS) && defined(_MSC_VER) && _MSC_VER >= 1700
+#define OSQUERY_NODISCARD _Check_return_
+#else
+#define OSQUERY_NODISCARD
+#endif
+#endif

--- a/osquery/utils/error/BUCK
+++ b/osquery/utils/error/BUCK
@@ -7,6 +7,7 @@
 #  You may select, at your option, one of the above-listed licenses.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
 load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
 
 osquery_cxx_library(
@@ -19,6 +20,7 @@ osquery_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         osquery_tp_target("boost"),
+        osquery_target("osquery/utils:attribute"),
     ],
 )
 

--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <osquery/utils/attribute.h>
+
 #include <boost/core/demangle.hpp>
 #include <memory>
 #include <new>
@@ -141,19 +143,19 @@ inline std::ostream& operator<<(std::ostream& out, const ErrorBase& error) {
 }
 
 template <typename ErrorCodeEnumType>
-Error<ErrorCodeEnumType> createError(
-    ErrorCodeEnumType error_code,
-    std::string message,
-    std::unique_ptr<ErrorBase> underlying_error = nullptr) {
+Error<ErrorCodeEnumType> OSQUERY_NODISCARD
+createError(ErrorCodeEnumType error_code,
+            std::string message,
+            std::unique_ptr<ErrorBase> underlying_error = nullptr) {
   return Error<ErrorCodeEnumType>(
       error_code, std::move(message), std::move(underlying_error));
 }
 
 template <typename ErrorCodeEnumType, typename OtherErrorCodeEnumType>
-Error<ErrorCodeEnumType> createError(
-    ErrorCodeEnumType error_code,
-    std::string message,
-    Error<OtherErrorCodeEnumType> underlying_error) {
+Error<ErrorCodeEnumType> OSQUERY_NODISCARD
+createError(ErrorCodeEnumType error_code,
+            std::string message,
+            Error<OtherErrorCodeEnumType> underlying_error) {
   return Error<ErrorCodeEnumType>(
       error_code,
       std::move(message),


### PR DESCRIPTION
Summary: Let's use attributes to prevent such mistakes (see previous diff in the stack)

Differential Revision: D13504146
