### PR TITLE
splunk is moving towards preferring colons in sourcetype delimiters

### DIFF
--- a/docs/wiki/deployment/log-aggregation.md
+++ b/docs/wiki/deployment/log-aggregation.md
@@ -46,19 +46,19 @@ If you use Splunk, you're probably already familiar with the [Splunk Universal F
 ```
 [monitor:///var/log/osquery/osqueryd.results.log]
 index = main
-sourcetype = osquery_results
+sourcetype = osquery:results
 
 [monitor:///var/log/osquery/osqueryd.*INFO*]
 index = main
-sourcetype = osquery_info
+sourcetype = osquery:info
 
 [monitor:///var/log/osquery/osqueryd.*ERROR*]
 index = main
-sourcetype = osquery_error
+sourcetype = osquery:error
 
 [monitor:///var/log/osquery/osqueryd.*WARNING*]
 index = main
-sourcetype = osquery_warning
+sourcetype = osquery:warning
 ```
 
 ### Fluentd


### PR DESCRIPTION
Just a minor cosmetic change on docs, that changes the Splunk's sourcetype names to have colons instead of underscore as it is the preferred method for delimiting sourcetypes. Not sure if a test is needed for this actual docs change. 