### PR TITLE
Semantic version parser

### DIFF
--- a/osquery/utils/versioning/BUCK
+++ b/osquery/utils/versioning/BUCK
@@ -1,0 +1,30 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "semantic",
+    srcs = [
+        "semantic.cpp",
+    ],
+    header_namespace = "osquery/utils/versioning",
+    exported_headers = [
+        "semantic.h",
+    ],
+    tests = [
+        osquery_target("osquery/utils/versioning/tests:semantic_version_test"),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_tp_target("boost"),
+        osquery_target("osquery/utils/conversions:conversions"),
+    ],
+)

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/versioning/semantic.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+namespace osquery {
+
+using boost::io::quoted;
+
+Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
+    const std::string& str) {
+  auto version = SemanticVersion{};
+  auto const major_number_pos = str.find(SemanticVersion::separator);
+  {
+    if (major_number_pos == std::string::npos) {
+      return createError(ConversionError::InvalidArgument,
+                         "invalid format: expected 2 separators, found 0")
+             << quoted(str);
+    }
+    auto major_exp = tryTo<unsigned>(str.substr(0, major_number_pos));
+    if (major_exp.isError()) {
+      return createError(ConversionError::InvalidArgument,
+                         "Invalid major version number, expected unsigned "
+                         "integer, found ",
+                         major_exp.takeError())
+             << quoted(str);
+    }
+    version.major = major_exp.take();
+  }
+  auto const minor_number_pos =
+      str.find(SemanticVersion::separator, major_number_pos + 1);
+  {
+    if (minor_number_pos == std::string::npos) {
+      return createError(ConversionError::InvalidArgument,
+                         " there are must be 2 separators, found 1")
+             << quoted(str);
+    }
+    auto minor_exp = tryTo<unsigned>(
+        str.substr(major_number_pos + 1, minor_number_pos - major_number_pos));
+    if (minor_exp.isError()) {
+      return createError(ConversionError::InvalidArgument,
+                         "Invalid minor version number, expected unsigned "
+                         "integer, found: ",
+                         minor_exp.takeError())
+             << quoted(str);
+    }
+    version.minor = minor_exp.take();
+  }
+  {
+    auto const patch_number_pos =
+        str.find_first_not_of("0123456789", minor_number_pos + 1);
+    auto patches_exp = tryTo<unsigned>(
+        str.substr(minor_number_pos + 1, patch_number_pos - minor_number_pos));
+    if (patches_exp.isError()) {
+      return createError(
+                 ConversionError::InvalidArgument,
+                 "Invalid patches number, expected unsigned integer, found: ")
+             << quoted(str);
+    }
+    version.patches = patches_exp.take();
+  }
+  return version;
+}
+
+} // namespace osquery

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/conversions/tryto.h>
+#include <osquery/utils/expected/expected.h>
+
+#include <string>
+
+namespace osquery {
+
+class SemanticVersion {
+ public:
+  unsigned major = 0;
+  unsigned minor = 0;
+  unsigned patches = 0;
+
+ public:
+  static constexpr auto separator = '.';
+
+ public:
+  static Expected<SemanticVersion, ConversionError> tryFromString(
+      const std::string& str);
+};
+
+template <typename ToType>
+inline typename std::enable_if<std::is_same<ToType, SemanticVersion>::value,
+                               Expected<ToType, ConversionError>>::type
+tryTo(const std::string& str) {
+  return SemanticVersion::tryFromString(str);
+}
+
+} // namespace osquery

--- a/osquery/utils/versioning/tests/BUCK
+++ b/osquery/utils/versioning/tests/BUCK
@@ -1,0 +1,21 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_test(
+    name = "semantic_version_test",
+    srcs = [
+        "semantic.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/versioning:semantic"),
+    ],
+)

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -1,0 +1,93 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/utils/versioning/semantic.h>
+
+namespace osquery {
+namespace {
+
+class SemanticVersionTests : public testing::Test {};
+
+TEST_F(SemanticVersionTests, pass) {
+  auto exp = tryTo<SemanticVersion>("1.6.9");
+  ASSERT_TRUE(exp.isValue());
+  EXPECT_EQ(exp.get().major, 1u);
+  EXPECT_EQ(exp.get().minor, 6u);
+  EXPECT_EQ(exp.get().patches, 9u);
+}
+
+TEST_F(SemanticVersionTests, pass_2) {
+  auto exp = tryTo<SemanticVersion>("7.25.999");
+  ASSERT_TRUE(exp.isValue());
+  EXPECT_EQ(exp.get().major, 7u);
+  EXPECT_EQ(exp.get().minor, 25u);
+  EXPECT_EQ(exp.get().patches, 999u);
+}
+
+TEST_F(SemanticVersionTests, pass_suffix) {
+  auto exp = tryTo<SemanticVersion>("0.8.2_50_302b_1");
+  ASSERT_TRUE(exp.isValue());
+  EXPECT_EQ(exp.get().major, 0u);
+  EXPECT_EQ(exp.get().minor, 8u);
+  EXPECT_EQ(exp.get().patches, 2u);
+}
+
+TEST_F(SemanticVersionTests, fail_major) {
+  auto exp = tryTo<SemanticVersion>("a4.5.9");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_minor) {
+  auto exp = tryTo<SemanticVersion>("9.f1.9");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_patches) {
+  auto exp = tryTo<SemanticVersion>("1.6.c9");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_separator_minus) {
+  auto exp = tryTo<SemanticVersion>("1-6-9");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_separator_colon) {
+  auto exp = tryTo<SemanticVersion>("1:6:9");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_empty) {
+  auto exp = tryTo<SemanticVersion>("");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_one_digit) {
+  auto exp = tryTo<SemanticVersion>("818");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+TEST_F(SemanticVersionTests, fail_two_digits) {
+  auto exp = tryTo<SemanticVersion>("66.66");
+  ASSERT_TRUE(exp.isError());
+  EXPECT_EQ(exp.getErrorCode(), ConversionError::InvalidArgument);
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary: Just a parser for the semantic version in string. I gonna use it later to parse kernel version from the `int uname()` result.

Reviewed By: guliashvili

Differential Revision: D13607313
