### PR TITLE
detects when a proc is tapping keyboard event

### DIFF
--- a/packs/osx-attacks.conf
+++ b/packs/osx-attacks.conf
@@ -595,6 +595,13 @@
       "version": "1.4.5",
       "description": "OSX Dummy Malware (https://objective-see.com/blog/blog_0x32.html and https://isc.sans.edu/diary/23816)",
       "value": "Artifacts created by this malware"
+    },
+    "Keyboard_Event_Taps": {
+      "query": "SELECT * FROM processes JOIN event_taps ON processes.pid = event_taps.tapping_process where event_taps.enabled = 1;",
+      "interval" : "3600",
+      "version": "3.3.0",
+      "description": "Finds processes that have active keyboard event taps, typically used by RATs and other malicious software for keylogging",
+      "value": "Process with keyboard event taps"
     }
   }
 }


### PR DESCRIPTION
added osx-attack query that detects when a proc is tapping keyboard event, see details at:
https://twitter.com/d1vious/status/1083447632188579841
 inspiration:
https://t.co/8SEd2dgP5Y

not sure if a test is needed