### PR TITLE
One place to define version of api

### DIFF
--- a/osquery/utils/system/windows/system.h
+++ b/osquery/utils/system/windows/system.h
@@ -19,19 +19,11 @@
 #include <SdkDdkVer.h>
 
 #ifndef NTDDI_VERSION
-#define NTDDI_VERSION NTDDI_WIN7
-#else
-#if NTDDI_VERSION != NTDDI_WIN7
-#error "NTDDI_VERSION is already defined and the value differs"
-#endif
+#error "NTDDI_VERSION must be defined, see tools/build_defs/oss/osquery/cxx.bzl"
 #endif
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT _WIN32_WINNT_WIN7
-#else
-#if _WIN32_WINNT != _WIN32_WINNT_WIN7
-#error "_WIN32_WINNT is already defined and the value differs"
-#endif
+#error "_WIN32_WINNT must be defined, see tools/build_defs/oss/osquery/cxx.bzl"
 #endif
 
 #ifndef WIN32_LEAN_AND_MEAN

--- a/tools/build_defs/oss/osquery/cxx.bzl
+++ b/tools/build_defs/oss/osquery/cxx.bzl
@@ -71,7 +71,8 @@ _GLOBAL_PLATFORM_PREPROCESSOR_FLAGS = [
     (
         _WINDOWS,
         [
-            "/D_WIN32_WINNT=0x0601",  # win7, see osquery/utils/system/windows/system.h
+            "/D_WIN32_WINNT=_WIN32_WINNT_WIN7",
+            "/DNTDDI_VERSION=NTDDI_WIN7",
         ],
     ),
 ]


### PR DESCRIPTION
Summary: Let's define win32 api version only inside of buck files, but not in cpp header

Differential Revision: D13635704
