### PR TITLE
Added is_hidden user attribute to account_policy_data table.

### DIFF
--- a/osquery/tables/system/darwin/account_policy_data.mm
+++ b/osquery/tables/system/darwin/account_policy_data.mm
@@ -9,12 +9,12 @@
  */
 
 #include <osquery/core.h>
-#include <osquery/utils/darwin/plist.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger.h>
 #include <osquery/sql/sqlite_util.h>
 #include <osquery/tables.h>
 #include <osquery/tables/system/system_utils.h>
+#include <osquery/utils/darwin/plist.h>
 
 #import <OpenDirectory/OpenDirectory.h>
 
@@ -39,7 +39,10 @@ void genAccountPolicyDataRow(const std::string& uid, Row& r) {
                    attribute:kODAttributeTypeUniqueID
                    matchType:kODMatchEqualTo
                  queryValues:[NSString stringWithFormat:@"%s", uid.c_str()]
-            returnAttributes:@[@"dsAttrTypeNative:accountPolicyData",@"dsAttrTypeNative:IsHidden"]
+            returnAttributes:@[
+              @"dsAttrTypeNative:accountPolicyData",
+              @"dsAttrTypeNative:IsHidden"
+            ]
               maximumResults:0
                        error:&err];
   if (err != nullptr) {
@@ -88,13 +91,14 @@ void genAccountPolicyDataRow(const std::string& uid, Row& r) {
       TLOG << "Error parsing Account Policy data plist";
       return;
     }
-      auto isHiddenValue = [re valuesForAttribute:@"dsAttrTypeNative:IsHidden" error:&attrErr];
-      if(isHiddenValue.count >= 1){
-       isHidden = std::string([isHiddenValue[0] UTF8String]);
-      } else {
-       isHidden = "0";
-}
-}
+    auto isHiddenValue = [re valuesForAttribute:@"dsAttrTypeNative:IsHidden"
+                                          error:&attrErr];
+    if (isHiddenValue.count >= 1) {
+      isHidden = std::string([isHiddenValue[0] UTF8String]);
+    } else {
+      isHidden = "0";
+    }
+  }
 
   r["uid"] = BIGINT(uid);
   r["creation_time"] = DOUBLE(tree.get("creationTime", ""));

--- a/specs/darwin/account_policy_data.table
+++ b/specs/darwin/account_policy_data.table
@@ -6,6 +6,7 @@ schema([
     Column("failed_login_count", BIGINT, "The number of times the user failed to login with the correct password. Resets after a correct password is entered"),
     Column("failed_login_timestamp", DOUBLE, "The time of the last failed login attempt. Resets after a correct password is entered"),
     Column("password_last_set_time", DOUBLE, "The time the password was last changed"),
+    Column("is_hidden", INTEGER, "IsHidden attribute set "),
     ForeignKey(column="uid", table="users"),
 ])
 implementation("account_policy_data@genAccountPolicyData")


### PR DESCRIPTION
Adds `is_hidden`  field to the account_policy_data table that exposes the `IsHidden` in a user's OpenDirectory record. If this attribute is set those user accounts are not visible to the user in preferences. 

I originally was going to add this to the user table but the comment @terracatta made in his original account_policy_data PR (#4165) made me think this is a better option. 
