### PR TITLE
sudoers table: Support file and directory includes

### DIFF
--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -34,6 +34,7 @@ osquery_cxx_library(
             [
                 "posix/known_hosts.h",
                 "posix/shell_history.h",
+                "posix/sudoers.h",
                 "posix/sysctl_utils.h",
             ],
         ),

--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -289,6 +289,7 @@ osquery_cxx_library(
         osquery_target("osquery/tables/system/tests:users_tests"),
         osquery_target("osquery/tables/system/tests:known_hosts_tests"),
         osquery_target("osquery/tables/system/tests:shell_history_tests"),
+        osquery_target("osquery/tables/system/tests:sudoers_tests"),
         osquery_target("osquery/tables/system/tests:yum_sources_tests"),
         osquery_target("osquery/tables/system/tests:system_tables_tests"),
         osquery_target("osquery/tables/system/tests:apps_tests"),

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -35,8 +35,9 @@ const std::string kSudoFile = "/usr/local/etc/sudoers";
 // a new layer of nesting, but what does sudo do?
 static const int kMaxNest = 128;
 
-void genSudoersFile(const std::string& filename, int level, QueryData& results)
-{
+void genSudoersFile(const std::string& filename,
+                    int level,
+                    QueryData& results) {
   if (level > kMaxNest) {
     TLOG << "sudoers file recursion maximum reached";
     return;
@@ -66,8 +67,7 @@ void genSudoersFile(const std::string& filename, int level, QueryData& results)
       r["rule_details"] = join(cols, " ");
 
       results.push_back(r);
-    }
-    else if (line.find("#includedir") == 0) {
+    } else if (line.find("#includedir") == 0) {
       auto space = line.find_first_of(' ');
 
       // If #includedir doesn't look like it's followed by
@@ -107,10 +107,8 @@ void genSudoersFile(const std::string& filename, int level, QueryData& results)
         // Build and push the row before recursing.
         genSudoersFile(inc_file, ++level, results);
       }
-    }
-    else if (line.find("#include") == 0) {
+    } else if (line.find("#include") == 0) {
       auto space = line.find_first_of(' ');
-
 
       // If #include doesn't look like it's followed by
       // a path, treat it like a normal comment.
@@ -139,7 +137,6 @@ void genSudoersFile(const std::string& filename, int level, QueryData& results)
 
 QueryData genSudoers(QueryContext& context) {
   QueryData results;
-
 
   if (!isReadable(kSudoFile).ok()) {
     return results;

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -32,8 +32,6 @@ const std::string kSudoFile = "/usr/local/etc/sudoers";
 #endif
 
 // sudoers(5): No more than 128 files are allowed to be nested.
-// NOTE(ww): We count each individual file in an included dir as
-// a new layer of nesting, but what does sudo do?
 static const unsigned int kMaxNest = 128;
 
 void genSudoersFile(const std::string& filename,

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -12,11 +12,14 @@
 #include <vector>
 
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
+
+namespace fs = boost::filesystem;
 
 namespace osquery {
 namespace tables {
@@ -27,40 +30,122 @@ const std::string kSudoFile = "/etc/sudoers";
 const std::string kSudoFile = "/usr/local/etc/sudoers";
 #endif
 
-QueryData genSudoers(QueryContext& context) {
-  QueryData results;
+// sudoers(5): No more than 128 files are allowed to be nested.
+// NOTE(ww): We count each individual file in an included dir as
+// a new layer of nesting, but what does sudo do?
+static const int kMaxNest = 128;
 
-  if (!isReadable(kSudoFile).ok()) {
-    return results;
+void genSudoersFile(const std::string& filename, int level, QueryData& results)
+{
+  if (level > kMaxNest) {
+    TLOG << "sudoers file recursion maximum reached";
+    return;
   }
 
   std::string contents;
-  if (!forensicReadFile(kSudoFile, contents).ok()) {
-    return results;
+  if (!forensicReadFile(filename, contents).ok()) {
+    TLOG << "couldn't read sudoers file: " << filename;
+    return;
   }
 
   auto lines = split(contents, "\n");
   std::vector<std::string> valid_lines;
 
   for (auto& line : lines) {
+    Row r;
     boost::trim(line);
 
     // Only add lines that are not comments or blank.
     if (line.size() > 0 && line.at(0) != '#') {
-      valid_lines.push_back(line);
+      r["source"] = filename;
+
+      auto cols = split(line);
+      r["header"] = cols.at(0);
+
+      cols.erase(cols.begin());
+      r["rule_details"] = join(cols, " ");
+
+      results.push_back(r);
+    }
+    else if (line.find("#includedir") == 0) {
+      auto space = line.find_first_of(' ');
+
+      // If #includedir doesn't look like it's followed by
+      // a path, treat it like a normal comment.
+      if (space == std::string::npos) {
+        continue;
+      }
+
+      auto inc_dir = line.substr(space + 1);
+
+      // Build and push the row before recursing.
+      r["source"] = filename;
+      r["header"] = "includedir";
+      r["rule_details"] = inc_dir;
+      results.push_back(r);
+
+      std::vector<std::string> inc_files;
+
+      // TODO(ww): sudoers(5) doesn't say anything about relative
+      // include directories. Need to test them -- if they work
+      // like relative include files, we need to support them.
+      if (!listFilesInDirectory(inc_dir, inc_files).ok()) {
+        TLOG << "couldn't list includedir: " << inc_dir;
+      }
+
+      for (const auto& inc_file : inc_files) {
+        std::string inc_basename = fs::path(inc_file).filename().string();
+
+        // Per sudoers(5): Any files in the included directory that
+        // contain a '.' or end with '~' are ignored.
+        if (inc_basename.empty() ||
+            inc_basename.find('.') != std::string::npos ||
+            inc_basename.back() == '~') {
+          continue;
+        }
+
+        // Build and push the row before recursing.
+        genSudoersFile(inc_file, ++level, results);
+      }
+    }
+    else if (line.find("#include") == 0) {
+      auto space = line.find_first_of(' ');
+
+
+      // If #include doesn't look like it's followed by
+      // a path, treat it like a normal comment.
+      if (space == std::string::npos) {
+        continue;
+      }
+
+      auto inc_file = line.substr(space + 1);
+
+      // Per sudoers(5): If the included file doesn't
+      // start with /, read it relative to the current file.
+      if (inc_file.at(0) != '/') {
+        fs::path inc_path = fs::path(filename).parent_path() / inc_file;
+        inc_file = inc_path.string();
+      }
+
+      r["source"] = filename;
+      r["header"] = "include";
+      r["rule_details"] = inc_file;
+      results.push_back(r);
+
+      genSudoersFile(inc_file, ++level, results);
     }
   }
+}
 
-  for (const auto& line : valid_lines) {
-    Row r;
-    auto cols = split(line);
-    r["header"] = cols.at(0);
+QueryData genSudoers(QueryContext& context) {
+  QueryData results;
 
-    cols.erase(cols.begin());
-    r["rule_details"] = join(cols, " ");
 
-    results.push_back(r);
+  if (!isReadable(kSudoFile).ok()) {
+    return results;
   }
+
+  genSudoersFile(kSudoFile, 1, results);
 
   return results;
 }

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -15,6 +15,7 @@
 #include <boost/filesystem/path.hpp>
 
 #include <osquery/filesystem/filesystem.h>
+#include <osquery/logger.h>
 #include <osquery/tables.h>
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
@@ -50,8 +51,6 @@ void genSudoersFile(const std::string& filename,
   }
 
   auto lines = split(contents, "\n");
-  std::vector<std::string> valid_lines;
-
   for (auto& line : lines) {
     Row r;
     boost::trim(line);
@@ -91,6 +90,7 @@ void genSudoersFile(const std::string& filename,
       // like relative include files, we need to support them.
       if (!listFilesInDirectory(inc_dir, inc_files).ok()) {
         TLOG << "couldn't list includedir: " << inc_dir;
+        continue;
       }
 
       for (const auto& inc_file : inc_files) {
@@ -104,7 +104,6 @@ void genSudoersFile(const std::string& filename,
           continue;
         }
 
-        // Build and push the row before recursing.
         genSudoersFile(inc_file, ++level, results);
       }
     } else if (line.find("#include") == 0) {
@@ -146,5 +145,5 @@ QueryData genSudoers(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/posix/sudoers.h
+++ b/osquery/tables/system/posix/sudoers.h
@@ -16,7 +16,9 @@
 namespace osquery {
 namespace tables {
 
-void genSudoersFile(const std::string& filename, int level, QueryData& results);
+void genSudoersFile(const std::string& filename,
+                    unsigned int level,
+                    QueryData& results);
 
 QueryData genSudoers(QueryContext& context);
 

--- a/osquery/tables/system/posix/sudoers.h
+++ b/osquery/tables/system/posix/sudoers.h
@@ -1,0 +1,24 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/query.h>
+#include <osquery/tables.h>
+
+#include <string>
+
+namespace osquery {
+namespace tables {
+
+void genSudoersFile(const std::string& filename, int level, QueryData& results);
+
+QueryData genSudoers(QueryContext& context);
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -173,6 +173,33 @@ osquery_cxx_test(
 )
 
 osquery_cxx_test(
+    name = "sudoers_tests",
+    platform_srcs = [
+        (
+            POSIX,
+            [
+                "posix/sudoers_tests.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/tables/system:system"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/filesystem:filesystem"),
+        osquery_target("osquery/utils:utils"),
+        osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("osquery/tables/system:system"),
+        osquery_target("osquery/config/tests:test_utils"),
+        osquery_target("osquery/remote/tests:remote_test_utils"),
+        osquery_target("osquery/filesystem:filesystem"),
+        osquery_target("osquery/database:database"),
+        osquery_target("osquery/database/plugins:ephemeral"),
+        osquery_target("osquery/core/sql:sql"),
+    ],
+)
+
+osquery_cxx_test(
     name = "yum_sources_tests",
     platform_srcs = [
         (

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -184,18 +184,18 @@ osquery_cxx_test(
     ],
     visibility = ["PUBLIC"],
     deps = [
-        osquery_target("osquery/tables/system:system"),
+        osquery_target("osquery/tables/system:system_table"),
         osquery_target("osquery/core:core"),
-        osquery_target("osquery/filesystem:filesystem"),
+        osquery_target("osquery/filesystem:osquery_filesystem"),
         osquery_target("osquery/utils:utils"),
         osquery_target("osquery/utils/conversions:conversions"),
-        osquery_target("osquery/tables/system:system"),
+        osquery_target("osquery/tables/system:system_table"),
         osquery_target("osquery/config/tests:test_utils"),
         osquery_target("osquery/remote/tests:remote_test_utils"),
-        osquery_target("osquery/filesystem:filesystem"),
+        osquery_target("osquery/filesystem:osquery_filesystem"),
         osquery_target("osquery/database:database"),
         osquery_target("osquery/database/plugins:ephemeral"),
-        osquery_target("osquery/core/sql:sql"),
+        osquery_target("osquery/core/sql:core_sql"),
     ],
 )
 

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -51,7 +51,7 @@ TEST_F(SudoersTests, basic_sudoers) {
   }
 
   auto results = QueryData{};
-  genSudoersFile(sudoers_file.string(), 0, results);
+  genSudoersFile(sudoers_file.string(), 1, results);
 
   ASSERT_EQ(results.size(), 1);
 
@@ -82,7 +82,7 @@ TEST_F(SudoersTests, include_file) {
   }
 
   auto results = QueryData{};
-  genSudoersFile(sudoers_top.string(), 0, results);
+  genSudoersFile(sudoers_top.string(), 1, results);
 
   ASSERT_EQ(results.size(), 2);
 
@@ -121,7 +121,7 @@ TEST_F(SudoersTests, include_dir) {
   }
 
   auto results = QueryData{};
-  genSudoersFile(sudoers_top.string(), 0, results);
+  genSudoersFile(sudoers_top.string(), 1, results);
 
   ASSERT_EQ(results.size(), 2);
 

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -88,7 +88,7 @@ TEST_F(SudoersTests, include_file) {
 
   const auto& first_row = results[0];
   ASSERT_EQ(first_row.at("source"), sudoers_top.string());
-  ASSERT_EQ(first_row.at("header"), "include");
+  ASSERT_EQ(first_row.at("header"), "#include");
   ASSERT_EQ(first_row.at("rule_details"), sudoers_inc.string());
 
   const auto& second_row = results[1];
@@ -127,7 +127,7 @@ TEST_F(SudoersTests, include_dir) {
 
   const auto& first_row = results[0];
   ASSERT_EQ(first_row.at("source"), sudoers_top.string());
-  ASSERT_EQ(first_row.at("header"), "includedir");
+  ASSERT_EQ(first_row.at("header"), "#includedir");
   ASSERT_EQ(first_row.at("rule_details"), sudoers_dir.string());
 
   const auto& second_row = results[1];

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -1,0 +1,140 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <fstream>
+
+#include <boost/filesystem.hpp>
+
+#include <gtest/gtest.h>
+
+#include <osquery/sql.h>
+#include <osquery/tables/system/posix/sudoers.h>
+#include <osquery/utils/scope_guard.h>
+
+namespace fs = boost::filesystem;
+
+namespace osquery {
+namespace tables {
+
+static fs::path real_temp_path() {
+  auto temp_dir = fs::temp_directory_path();
+
+  // NOTE(ww): The sudoers table expands paths to their canonical
+  // form when listing directories, so we need to make sure that
+  // the temp directory is canonicalized as well.
+  return fs::canonical(temp_dir);
+}
+
+class SudoersTests : public testing::Test {};
+
+TEST_F(SudoersTests, basic_sudoers) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_file = directory / fs::path("sudoers");
+
+  {
+    auto fout = std::ofstream(sudoers_file.native());
+    fout << "Defaults env_reset" << '\n';
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_file.string(), 0, results);
+
+  ASSERT_EQ(results.size(), 1);
+
+  const auto& row = results[0];
+  ASSERT_EQ(row.at("source"), sudoers_file.string());
+  ASSERT_EQ(row.at("header"), "Defaults");
+  ASSERT_EQ(row.at("rule_details"), "env_reset");
+}
+
+TEST_F(SudoersTests, include_file) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_top = directory / fs::path("sudoers");
+  auto sudoers_inc = directory / fs::path("sudoers_inc");
+
+  {
+    auto fout_top = std::ofstream(sudoers_top.native());
+    fout_top << "#include sudoers_inc" << '\n';
+
+    auto fout_inc = std::ofstream(sudoers_inc.native());
+    fout_inc << "Defaults env_reset" << '\n';
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_top.string(), 0, results);
+
+  ASSERT_EQ(results.size(), 2);
+
+  const auto& first_row = results[0];
+  ASSERT_EQ(first_row.at("source"), sudoers_top.string());
+  ASSERT_EQ(first_row.at("header"), "include");
+  ASSERT_EQ(first_row.at("rule_details"), sudoers_inc.string());
+
+  const auto& second_row = results[1];
+  ASSERT_EQ(second_row.at("source"), sudoers_inc.string());
+  ASSERT_EQ(second_row.at("header"), "Defaults");
+  ASSERT_EQ(second_row.at("rule_details"), "env_reset");
+}
+
+TEST_F(SudoersTests, include_dir) {
+  auto directory =
+      real_temp_path() / fs::unique_path("osquery.sudoers_tests.%%%%-%%%%");
+
+  ASSERT_TRUE(fs::create_directories(directory));
+
+  auto const path_guard =
+      scope_guard::create([directory]() { fs::remove_all(directory); });
+
+  auto sudoers_top = directory / fs::path("sudoers");
+  auto sudoers_dir = directory / fs::path("sudoers.d");
+  auto sudoers_inc = sudoers_dir / fs::path("sudoers_inc");
+
+  ASSERT_TRUE(fs::create_directories(sudoers_dir));
+
+  {
+    auto fout_top = std::ofstream(sudoers_top.native());
+    fout_top << "#includedir " << sudoers_dir.string() << '\n';
+
+    auto fout_inc = std::ofstream(sudoers_inc.native());
+    fout_inc << "Defaults env_reset" << '\n';
+  }
+
+  auto results = QueryData{};
+  genSudoersFile(sudoers_top.string(), 0, results);
+
+  ASSERT_EQ(results.size(), 2);
+
+  const auto& first_row = results[0];
+  ASSERT_EQ(first_row.at("source"), sudoers_top.string());
+  ASSERT_EQ(first_row.at("header"), "includedir");
+  ASSERT_EQ(first_row.at("rule_details"), sudoers_dir.string());
+
+  const auto& second_row = results[1];
+  ASSERT_EQ(second_row.at("source"), sudoers_inc.string());
+  ASSERT_EQ(second_row.at("header"), "Defaults");
+  ASSERT_EQ(second_row.at("rule_details"), "env_reset");
+}
+
+} // namespace tables
+} // namespace osquery

--- a/specs/posix/sudoers.table
+++ b/specs/posix/sudoers.table
@@ -1,6 +1,7 @@
 table_name("sudoers")
 description("Rules for running commands as other users via sudo.")
 schema([
+    Column("source", TEXT, "Source file containing the given rule"),
     Column("header", TEXT, "Symbol for given rule"),
     Column("rule_details", TEXT, "Rule definition")
 ])


### PR DESCRIPTION
This adds support for the `#includedir` and `#include` directives to the `sudoers` table, making `sudoers` behave more like the actual `sudo` rule parser:

* When an `includefile` directive is encountered, the referenced file will be parsed using the same rules as the top-level sudoers file.
* When an `includedir` directive is encountered, the referenced directory will be listed and each valid file within (i.e., each file *not* containing a `.` and *not* ending with `~`) will be parsed using the same rules as the top-level sudoers file.
* An additional `source` column tracks the file that provides the row's rule.
* Like `sudoers(5)`, nesting is limited to 128 individual files, with directory inclusions being counted once for each file they contain.