### PR TITLE
Reserve vector to upper bound to save reallocations

### DIFF
--- a/osquery/core/database/in_memory_database.cpp
+++ b/osquery/core/database/in_memory_database.cpp
@@ -20,7 +20,6 @@ namespace osquery {
 template <typename StorageType>
 std::vector<std::string> InMemoryStorage<StorageType>::getKeys(
     const std::string& prefix) const {
-    
   std::vector<std::string> result;
   result.reserve(storage_.size());
   for (const auto& iter : storage_) {

--- a/osquery/core/database/in_memory_database.cpp
+++ b/osquery/core/database/in_memory_database.cpp
@@ -20,7 +20,9 @@ namespace osquery {
 template <typename StorageType>
 std::vector<std::string> InMemoryStorage<StorageType>::getKeys(
     const std::string& prefix) const {
+    
   std::vector<std::string> result;
+  result.reserve(storage_.size());
   for (const auto& iter : storage_) {
     if (boost::starts_with(iter.first, prefix)) {
       result.push_back(iter.first);


### PR DESCRIPTION
File: osquery/core/database/in_memory_database.cpp

We know the following loops maximum of 'storage_.size()' times,
 therefore: [number of elements pushed into 'result'] <= [storage_.size()].

Knowing that we can reserve the "vector<string> result" to be 'storage_.size()' to save reallocation costs.

```
 for (const auto& iter : storage_) {
    if (boost::starts_with(iter.first, prefix)) {
      result.push_back(iter.first);
    }
  }
```
