### PR TITLE
eBPF program loader class

### DIFF
--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -19,6 +19,7 @@ osquery_cxx_library(
             LINUX,
             [
                 "ebpf.h",
+                "map.h",
             ],
         ),
     ],
@@ -27,6 +28,7 @@ osquery_cxx_library(
             LINUX,
             [
                 "ebpf.cpp",
+                "map.cpp",
             ],
         ),
     ],

--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -1,0 +1,45 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "ebpf",
+    header_namespace = "osquery/utils/system/linux/ebpf",
+    exported_platform_headers = [
+        (
+            LINUX,
+            [
+                "ebpf.h",
+            ],
+        ),
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "ebpf.cpp",
+            ],
+        ),
+    ],
+    tests = [
+        osquery_target("osquery/utils/system/linux/ebpf/tests:ebpf_tests"),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("osquery/utils/expected:expected"),
+        osquery_target("osquery/utils/versioning:semantic"),
+        osquery_target("osquery/utils/system:errno"),
+        osquery_target("osquery/logger:logger"),
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -20,6 +20,7 @@ osquery_cxx_library(
             [
                 "ebpf.h",
                 "map.h",
+                "program.h",
             ],
         ),
     ],
@@ -29,6 +30,7 @@ osquery_cxx_library(
             [
                 "ebpf.cpp",
                 "map.cpp",
+                "program.cpp",
             ],
         ),
     ],

--- a/osquery/utils/system/linux/ebpf/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/ebpf.cpp
@@ -1,0 +1,73 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+#include <osquery/utils/versioning/semantic.h>
+
+#include <osquery/logger.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <linux/version.h>
+#include <sys/utsname.h>
+
+#ifndef __NR_bpf
+
+#if defined(__i386__)
+#define __NR_bpf 357
+#elif defined(__x86_64__)
+#define __NR_bpf 321
+#elif defined(__aarch64__)
+#define __NR_bpf 280
+#elif defined(__sparc__)
+#define __NR_bpf 349
+#elif defined(__s390__)
+#define __NR_bpf 351
+#else
+#error __NR_bpf is undefined, probably this arch is not supported.
+#endif
+
+#endif // __NR_bpf
+
+namespace osquery {
+namespace ebpf {
+
+constexpr int kMinimalLinuxVersionCode = KERNEL_VERSION(4, 9, 0);
+
+Expected<bool, PosixError> isSupportedBySystem() {
+  struct utsname utsbuf;
+  if (uname(&utsbuf) == -1) {
+    return createError(to<PosixError>(errno), "syscall uname() failed: ")
+           << boost::io::quoted(strerror(errno));
+  }
+  auto release_version_exp =
+      tryTo<SemanticVersion>(std::string(utsbuf.release));
+  if (release_version_exp.isError()) {
+    return createError(PosixError::Unknown,
+                       "uname() release field is malformed",
+                       release_version_exp.takeError())
+           << boost::io::quoted(utsbuf.release);
+  }
+  auto const version = release_version_exp.take();
+  return kMinimalLinuxVersionCode <=
+         KERNEL_VERSION(version.major, version.minor, version.patches);
+}
+
+Expected<int, PosixError> syscall(int cmd, union bpf_attr* attr) {
+  int const ret = ::syscall(__NR_bpf, cmd, attr, sizeof(union bpf_attr));
+  if (ret < 0) {
+    return createError(to<PosixError>(errno), "bpf() syscall failed: ")
+           << boost::io::quoted(strerror(errno));
+  }
+  return ret;
+}
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/ebpf.h
+++ b/osquery/utils/system/linux/ebpf/ebpf.h
@@ -1,0 +1,26 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/system/posix/errno.h>
+
+#include <linux/bpf.h>
+
+namespace osquery {
+namespace ebpf {
+
+Expected<bool, PosixError> isSupportedBySystem();
+
+Expected<int, PosixError> syscall(int cmd, union bpf_attr* attr);
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/map.cpp
+++ b/osquery/utils/system/linux/ebpf/map.cpp
@@ -1,0 +1,104 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/map.h>
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <cerrno>
+#include <cstring>
+
+namespace osquery {
+namespace ebpf {
+
+namespace impl {
+
+Expected<int, MapError> mapCreate(enum bpf_map_type map_type,
+                                  std::size_t key_size,
+                                  std::size_t value_size,
+                                  std::size_t max_entries) {
+  union bpf_attr attr;
+  memset(&attr, 0, sizeof(union bpf_attr));
+  attr.map_type = map_type;
+  attr.key_size = static_cast<std::uint32_t>(key_size);
+  attr.value_size = static_cast<std::uint32_t>(value_size);
+  attr.max_entries = static_cast<std::uint32_t>(max_entries);
+  auto exp_bpf = syscall(BPF_MAP_CREATE, &attr);
+  if (exp_bpf.isError()) {
+    return createError(
+        MapError::Unknown, "Creating eBPF map failed", exp_bpf.takeError());
+  }
+  return exp_bpf.take();
+}
+
+ExpectedSuccess<MapError> mapUpdateElement(const int fd,
+                                           void const* key,
+                                           void const* value,
+                                           unsigned long long flags) {
+  union bpf_attr attr;
+  memset(&attr, 0, sizeof(union bpf_attr));
+  attr.map_fd = fd;
+  attr.key = reinterpret_cast<std::uint64_t>(key);
+  attr.value = reinterpret_cast<std::uint64_t>(value);
+  attr.flags = flags;
+  auto exp_bpf = syscall(BPF_MAP_UPDATE_ELEM, &attr);
+  if (exp_bpf.isError()) {
+    return createError(MapError::Unknown,
+                       "Updating value in eBPF map failed",
+                       exp_bpf.takeError());
+  }
+  return Success{};
+}
+
+ExpectedSuccess<MapError> mapLookupElement(const int fd,
+                                           void const* key,
+                                           void* value) {
+  union bpf_attr attr;
+  memset(&attr, 0, sizeof(union bpf_attr));
+  attr.map_fd = fd;
+  attr.key = reinterpret_cast<std::uint64_t>(key);
+  attr.value = reinterpret_cast<std::uint64_t>(value);
+  auto exp_bpf = syscall(BPF_MAP_LOOKUP_ELEM, &attr);
+  if (exp_bpf.isError()) {
+    if (exp_bpf.getErrorCode() == PosixError::NOENT) {
+      return createError(MapError::NoSuchKey,
+                         "No such key in the eBPF map",
+                         exp_bpf.takeError());
+    }
+    return createError(
+        MapError::Unknown, "Look up in eBPF map failed", exp_bpf.takeError());
+  }
+  return Success{};
+}
+
+ExpectedSuccess<MapError> mapDeleteElement(const int fd, void const* key) {
+  union bpf_attr attr;
+  memset(&attr, 0, sizeof(union bpf_attr));
+  attr.map_fd = fd;
+  attr.key = reinterpret_cast<std::uint64_t>(key);
+  auto exp_bpf = syscall(BPF_MAP_DELETE_ELEM, &attr);
+  if (exp_bpf.isError()) {
+    if (exp_bpf.getErrorCode() == PosixError::NOENT) {
+      return createError(MapError::NoSuchKey,
+                         "No such key in the eBPF map",
+                         exp_bpf.takeError());
+    }
+    return createError(MapError::Unknown,
+                       "Deleting element from eBPF map failed",
+                       exp_bpf.takeError());
+  }
+  return Success{};
+}
+
+} // namespace impl
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/map.h
+++ b/osquery/utils/system/linux/ebpf/map.h
@@ -1,0 +1,138 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/expected/expected.h>
+
+#include <linux/bpf.h>
+
+namespace osquery {
+namespace ebpf {
+
+enum class MapError {
+  Unknown = 1,
+  NoSuchKey = 2,
+};
+
+namespace impl {
+/**
+ * Do not use implementation functions directly, use Map class to create and
+ * manage eBPF map
+ */
+Expected<int, MapError> mapCreate(enum bpf_map_type map_type,
+                                  std::size_t key_size,
+                                  std::size_t value_size,
+                                  std::size_t max_entries);
+ExpectedSuccess<MapError> mapUpdateElement(int fd,
+                                           void const* key,
+                                           void const* value,
+                                           unsigned long long flags);
+ExpectedSuccess<MapError> mapLookupElement(int fd,
+                                           void const* key,
+                                           void* value);
+ExpectedSuccess<MapError> mapDeleteElement(int fd, void const* key);
+
+} // namespace impl
+
+/**
+ * Proxy object for the eBPF map structure in kernel.
+ */
+
+template <typename KeyType, typename ValueType, enum bpf_map_type map_type>
+class Map final {
+ private:
+  static_assert(
+      std::is_pod<KeyType>::value && std::is_pod<ValueType>::value,
+      "Both key type and value type must be a plain old data type (POD)");
+
+  /**
+   * The only constructor of Map is private for purpose. Use createMap function
+   * instead. Map should not be created in case of creating eBPF map failure.
+   */
+  explicit Map(int fd, std::size_t size) : fd_(fd), size_(size) {}
+
+ public:
+  ~Map() {
+    if (fd_ >= 0) {
+      close(fd_);
+    }
+  }
+
+  Map(Map const&) = delete;
+
+  Map(Map && from) : fd_(from.fd_), size_(from.size_) {
+    from.fd_ = -1;
+  }
+
+  Map& operator=(Map const&) = delete;
+
+  Map& operator=(Map&& from) {
+    if (fd_ >= 0) {
+      close(fd_);
+      fd_ = -1;
+    }
+    std::swap(fd_, from.fd_);
+    std::swap(size_, from.size_);
+  }
+
+  Expected<ValueType, MapError> lookupElement(KeyType const& key) const {
+    auto value = ValueType{};
+    auto exp = impl::mapLookupElement(
+        fd_, static_cast<void const*>(&key), static_cast<void*>(&value));
+    if (exp.isError()) {
+      return exp.takeError();
+    }
+    return value;
+  }
+
+  ExpectedSuccess<MapError> updateElement(KeyType const& key,
+                                          ValueType const& value,
+                                          unsigned long long flags = BPF_ANY) {
+    return impl::mapUpdateElement(fd_,
+                                  static_cast<void const*>(&key),
+                                  static_cast<void const*>(&value),
+                                  flags);
+  }
+
+  ExpectedSuccess<MapError> deleteElement(KeyType const& key) {
+    return impl::mapDeleteElement(fd_, static_cast<void const*>(&key));
+  }
+
+  std::size_t size() const {
+    return size_;
+  }
+
+  int fd() const {
+    return fd_;
+  }
+
+  template <typename KType, typename VType, enum bpf_map_type type>
+  friend Expected<Map<KType, VType, type>, MapError> createMap(
+      std::size_t size);
+
+ private:
+  int fd_ = -1;
+  std::size_t size_;
+};
+
+template <typename KeyType, typename ValueType, enum bpf_map_type map_type>
+static Expected<Map<KeyType, ValueType, map_type>, MapError> createMap(
+    std::size_t size) {
+  auto exp =
+      impl::mapCreate(map_type, sizeof(KeyType), sizeof(ValueType), size);
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return Map<KeyType, ValueType, map_type>(exp.take(), size);
+}
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/program.cpp
+++ b/osquery/utils/system/linux/ebpf/program.cpp
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/program.h>
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <linux/version.h>
+
+namespace osquery {
+namespace ebpf {
+
+Program::Program(Program&& other) : fd_(other.fd_) {
+  other.fd_ = -1;
+}
+
+Program& Program::operator=(Program&& other) {
+  std::swap(fd_, other.fd_);
+  return *this;
+}
+
+Program::~Program() {
+  if (fd_ > 0) {
+    close(fd_);
+    fd_ = -1;
+  }
+}
+
+Expected<Program, Program::Error> Program::load(
+    std::vector<struct bpf_insn> const prog,
+    enum bpf_prog_type const program_type,
+    bool const debug) {
+  static char const* kLicense = "GPL";
+  constexpr auto kLogBufSize = std::uint32_t{1 << 16};
+
+  auto bpf_log_buf = std::array<char, kLogBufSize>{};
+  union bpf_attr attr = {
+      .prog_type = program_type,
+      .insns = reinterpret_cast<__aligned_u64>(prog.data()),
+      .insn_cnt = static_cast<std::uint32_t>(prog.size()),
+      .license = reinterpret_cast<__aligned_u64>(kLicense),
+      .log_buf = 0u,
+      .log_size = 0u,
+      .log_level = 0u,
+      .kern_version = LINUX_VERSION_CODE,
+  };
+  if (debug) {
+    bpf_log_buf.fill('\0');
+    attr.log_buf = reinterpret_cast<std::uint64_t>(bpf_log_buf.data());
+    attr.log_size = reinterpret_cast<std::uint32_t>(kLogBufSize);
+    attr.log_level = 1;
+  }
+  auto instance = Program{};
+  auto fd_exp = syscall(BPF_PROG_LOAD, &attr);
+  if (fd_exp.isError()) {
+    return createError(Program::Error::Unknown,
+                       "eBPF program load failed ",
+                       fd_exp.takeError())
+           << " bpf log: " << boost::io::quoted(bpf_log_buf.data());
+  }
+  instance.fd_ = fd_exp.take();
+  return Expected<Program, Program::Error>(std::move(instance));
+}
+
+int Program::fd() const {
+  return fd_;
+}
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/program.h
+++ b/osquery/utils/system/linux/ebpf/program.h
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/expected/expected.h>
+
+#include <linux/bpf.h>
+
+namespace osquery {
+namespace ebpf {
+
+class Program final {
+ public:
+  Program(Program&& other);
+  Program& operator=(Program&& other);
+
+  Program(Program const&) = delete;
+  Program& operator=(Program const&) = delete;
+
+  ~Program();
+
+  enum class Error {
+    Unknown = 1,
+    NotSupportedBySystem = 2,
+  };
+
+  static Expected<Program, Program::Error> load(
+      std::vector<struct bpf_insn> prog,
+      enum bpf_prog_type const program_type = BPF_PROG_TYPE_KPROBE,
+      bool const debug = false);
+
+  int fd() const;
+
+ private:
+  Program() = default;
+
+ private:
+  int fd_ = -1;
+};
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/tests/BUCK
+++ b/osquery/utils/system/linux/ebpf/tests/BUCK
@@ -1,0 +1,30 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+
+osquery_cxx_test(
+    name = "ebpf_tests",
+    srcs = [
+        "empty.cpp",
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "ebpf.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/system/linux/ebpf:ebpf"),
+    ],
+)

--- a/osquery/utils/system/linux/ebpf/tests/BUCK
+++ b/osquery/utils/system/linux/ebpf/tests/BUCK
@@ -20,6 +20,7 @@ osquery_cxx_test(
             LINUX,
             [
                 "ebpf.cpp",
+                "map.cpp",
             ],
         ),
     ],

--- a/osquery/utils/system/linux/ebpf/tests/BUCK
+++ b/osquery/utils/system/linux/ebpf/tests/BUCK
@@ -21,6 +21,7 @@ osquery_cxx_test(
             [
                 "ebpf.cpp",
                 "map.cpp",
+                "program.cpp",
             ],
         ),
     ],

--- a/osquery/utils/system/linux/ebpf/tests/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/ebpf.cpp
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+
+namespace osquery {
+namespace {
+
+class EbpfTests : public testing::Test {};
+
+TEST_F(EbpfTests, isSupportedBySystem) {
+  auto const exp = ebpf::isSupportedBySystem();
+  ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+}
+
+TEST_F(EbpfTests, sysEbpf_null_attr) {
+  auto const exp = ebpf::syscall(BPF_MAP_CREATE, nullptr);
+  ASSERT_TRUE(exp.isError());
+  ASSERT_EQ(exp.getErrorCode(), PosixError::FAULT);
+}
+
+TEST_F(EbpfTests, sysEbpf_create_map) {
+  auto const is_supported_exp = ebpf::isSupportedBySystem();
+  EXPECT_TRUE(is_supported_exp.isValue())
+      << is_supported_exp.getError().getFullMessageRecursive();
+  if (is_supported_exp.get()) {
+    union bpf_attr attr;
+    memset(&attr, 0, sizeof(union bpf_attr));
+    attr.map_type = BPF_MAP_TYPE_ARRAY;
+    attr.key_size = 4;
+    attr.value_size = 4;
+    attr.max_entries = 12;
+    auto exp_bpf = ebpf::syscall(BPF_MAP_CREATE, &attr);
+    ASSERT_TRUE(exp_bpf.isValue());
+    ASSERT_GE(exp_bpf.get(), 0);
+  }
+}
+
+} // namespace
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/tests/empty.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/empty.cpp
@@ -1,0 +1,9 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */

--- a/osquery/utils/system/linux/ebpf/tests/map.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/map.cpp
@@ -1,0 +1,108 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/map.h>
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+
+#include <osquery/logger.h>
+
+#include <gtest/gtest.h>
+
+namespace osquery {
+namespace {
+
+class EbpfMapTests : public testing::Test {};
+
+TEST_F(EbpfMapTests, int_key_int_value) {
+  if (!ebpf::isSupportedBySystem()) {
+    LOG(WARNING) << "This system does not support eBPF of required vesion, "
+                    "test will be skipped";
+    return;
+  }
+  auto const size = std::size_t{12};
+  auto map_exp = ebpf::createMap<int, int, BPF_MAP_TYPE_HASH>(size);
+  ASSERT_TRUE(map_exp.isValue())
+      << map_exp.getError().getFullMessageRecursive();
+  auto map = map_exp.take();
+  ASSERT_EQ(map.size(), size);
+  {
+    auto exp = map.lookupElement(0);
+    ASSERT_TRUE(exp.isError());
+    EXPECT_EQ(exp.getError().getErrorCode(), ebpf::MapError::NoSuchKey);
+  }
+  {
+    auto exp = map.lookupElement(215);
+    ASSERT_TRUE(exp.isError());
+    EXPECT_EQ(exp.getError().getErrorCode(), ebpf::MapError::NoSuchKey);
+  }
+  {
+    auto exp = map.updateElement(5, 53);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+  }
+  {
+    auto exp = map.lookupElement(5);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+    ASSERT_EQ(exp.get(), 53);
+  }
+  {
+    // key could be greater a size, because it is a hash map
+    auto exp = map.updateElement(207, 8042);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+  }
+  {
+    auto exp = map.lookupElement(207);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+    ASSERT_EQ(exp.get(), 8042);
+  }
+  {
+    // let's try to delete some existing key
+    auto exp = map.deleteElement(207);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+  }
+  {
+    auto exp = map.lookupElement(207);
+    ASSERT_TRUE(exp.isError());
+    EXPECT_EQ(exp.getError().getErrorCode(), ebpf::MapError::NoSuchKey);
+  }
+}
+
+TEST_F(EbpfMapTests, int_key_struct_value) {
+  if (!ebpf::isSupportedBySystem()) {
+    LOG(WARNING) << "This system does not support eBPF of required vesion, "
+                    "test will be skipped";
+    return;
+  }
+  struct Value {
+    int left;
+    int right;
+  };
+  auto const size = std::size_t{128};
+  auto map_exp = ebpf::createMap<int, Value, BPF_MAP_TYPE_ARRAY>(size);
+  ASSERT_TRUE(map_exp.isValue());
+  auto map = map_exp.take();
+  ASSERT_EQ(map.size(), size);
+  {
+    auto const v = Value{
+        .left = -9287,
+        .right = 2781,
+    };
+    auto exp = map.updateElement(72, v);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+  }
+  {
+    auto exp = map.lookupElement(72);
+    ASSERT_TRUE(exp.isValue()) << exp.getError().getFullMessageRecursive();
+    EXPECT_EQ(exp.get().left, -9287);
+    EXPECT_EQ(exp.get().right, 2781);
+  }
+}
+
+} // namespace
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/tests/program.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/program.cpp
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/program.h>
+#include <osquery/utils/system/linux/ebpf/ebpf.h>
+
+#include <osquery/logger.h>
+
+#include <gtest/gtest.h>
+
+namespace osquery {
+namespace {
+
+class EbpfProgramTests : public testing::Test {};
+
+bool const kDebug =
+#ifndef NDEBUG
+    true;
+#else
+    false;
+#endif
+
+TEST_F(EbpfProgramTests, empty_debug) {
+  auto const ebpf_exp = ebpf::isSupportedBySystem();
+  EXPECT_TRUE(ebpf_exp.isValue())
+      << ebpf_exp.getError().getFullMessageRecursive();
+  if (!ebpf_exp.get()) {
+    LOG(WARNING) << "This system does not support eBPF of required vesion, "
+                    "test will be skipped";
+    return;
+  }
+  auto program_exp = ebpf::Program::load({}, BPF_PROG_TYPE_KPROBE, kDebug);
+  ASSERT_TRUE(program_exp.isError());
+  ASSERT_EQ(program_exp.getErrorCode(), ebpf::Program::Error::Unknown);
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
C++ wrapper to load and keep track of eBPF program in order to close if afterwards.

Blueprint: [#5218](https://github.com/facebook/osquery/issues/5218)

Reviewed By: guliashvili

Differential Revision: D13609628
