### PR TITLE
Mirror/bridge python.bzl

### DIFF
--- a/tools/build_defs/oss/osquery/native.bzl
+++ b/tools/build_defs/oss/osquery/native.bzl
@@ -1,3 +1,5 @@
+osquery_native = native
+
 def osquery_get_os():
     if native.host_info().os.is_linux:
         return "linux"
@@ -23,10 +25,10 @@ def osquery_target(target):
     )
 
 def osquery_genrule(**kwargs):
-    native.genrule(**kwargs)
+    osquery_native.genrule(**kwargs)
 
 def osquery_filegroup(**kwargs):
-    native.filegroup(**kwargs)
+    osquery_native.filegroup(**kwargs)
 
 def osquery_http_archive(**kwargs):
-    native.http_archive(**kwargs)
+    osquery_native.http_archive(**kwargs)

--- a/tools/build_defs/oss/osquery/python.bzl
+++ b/tools/build_defs/oss/osquery/python.bzl
@@ -1,8 +1,10 @@
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_native")
+
 def osquery_python_library(**kwargs):
-    native.python_library(**kwargs)
+    osquery_native.python_library(**kwargs)
 
 def osquery_python_binary(**kwargs):
-    native.python_binary(**kwargs)
+    osquery_native.python_binary(**kwargs)
 
 def osquery_prebuilt_python_library(**kwargs):
-    native.prebuilt_python_library(**kwargs)
+    osquery_native.prebuilt_python_library(**kwargs)


### PR DESCRIPTION
Summary: Rather than having two copies of the same implementation it would be better to just bridge it's implementation

Reviewed By: akindyakov, fmanco

Differential Revision: D13671460
