### PR TITLE
windows/logical_drives: Fix bugs in type and boot_partition columns

### DIFF
--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -16,7 +16,7 @@ QueryData genLogicalDrives(QueryContext& context) {
   QueryData results;
 
   const WmiRequest wmiLogicalDiskReq(
-      "select DeviceID, DriveType, FreeSpace, Size, FileSystem from "
+      "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
   const std::vector<WmiResultItem>& wmiResults = wmiLogicalDiskReq.results();
   for (unsigned int i = 0; i < wmiResults.size(); ++i) {

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -39,6 +39,7 @@ QueryData genLogicalDrives(QueryContext& context) {
       std::string bootDirectory;
       bootConfiguration.GetString("BootDirectory", bootDirectory);
 
+      // e.g., "C:\\Windows".find("D:")
       if (bootDirectory.find(deviceId) == 0) {
         bootPartition = 1;
         break;

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -26,18 +26,14 @@ QueryData genLogicalDrives(QueryContext& context) {
 
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
-    std::string driveType;
     std::string deviceId;
-    logicalDisk.GetString("Description", driveType);
+    int bootPartition = 0;
+
+    logicalDisk.GetString("Description", r["type"]);
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("FreeSpace", r["free_space"]);
     logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
-
-    r["type"] = driveType;
-    r["device_id"] = deviceId;
-
-    int bootPartition = 0;
 
     for (const auto& bootConfiguration : bootConfigurations) {
       std::string bootDirectory;
@@ -49,6 +45,7 @@ QueryData genLogicalDrives(QueryContext& context) {
       }
     }
 
+    r["device_id"] = deviceId;
     r["boot_partition"] = INTEGER(bootPartition);
     results.push_back(r);
   }

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -21,40 +21,16 @@ QueryData genLogicalDrives(QueryContext& context) {
   const std::vector<WmiResultItem>& wmiResults = wmiLogicalDiskReq.results();
   for (unsigned int i = 0; i < wmiResults.size(); ++i) {
     Row r;
-    unsigned int driveType = 0;
+    std::string driveType;
     std::string deviceId;
+    wmiResults[i].GetString("Description", driveType);
     wmiResults[i].GetString("DeviceID", deviceId);
-    wmiResults[i].GetUnsignedInt32("DriveType", driveType);
     wmiResults[i].GetString("FreeSpace", r["free_space"]);
     wmiResults[i].GetString("Size", r["size"]);
     wmiResults[i].GetString("FileSystem", r["file_system"]);
 
+    r["type"] = driveType;
     r["device_id"] = deviceId;
-
-    switch (driveType) {
-    default:
-      r["type"] = TEXT("Unknown");
-      break;
-    case 1:
-      r["type"] = TEXT("No Root Directory");
-      break;
-    case 2:
-      r["type"] = TEXT("Removable Disk");
-      break;
-    case 3:
-      r["type"] = TEXT("Local Disk");
-      break;
-    case 4:
-      r["type"] = TEXT("Network Drive");
-      break;
-    case 5:
-      r["type"] = TEXT("Compact Disc");
-      break;
-    case 6:
-      r["type"] = TEXT("RAM Disk");
-      break;
-    }
-
     r["boot_partition"] = INTEGER(0);
 
     std::string assocQuery =

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -18,11 +18,10 @@ QueryData genLogicalDrives(QueryContext& context) {
   const WmiRequest wmiLogicalDiskReq(
       "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
-  const std::vector<WmiResultItem>& logicalDisks = wmiLogicalDiskReq.results();
+  auto const& logicalDisks = wmiLogicalDiskReq.results();
   const WmiRequest wmiBootConfigurationReq(
       "select BootDirectory from Win32_BootConfiguration");
-  const std::vector<WmiResultItem>& bootConfigurations =
-      wmiBootConfigurationReq.results();
+  auto const& bootConfigurations = wmiBootConfigurationReq.results();
 
   for (const auto& logicalDisk : logicalDisks) {
     Row r;

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -19,7 +19,8 @@ QueryData genLogicalDrives(QueryContext& context) {
       "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
   const std::vector<WmiResultItem>& logicalDisks = wmiLogicalDiskReq.results();
-  const WmiRequest wmiBootConfigurationReq("select * from Win32_BootConfiguration;");
+  const WmiRequest wmiBootConfigurationReq(
+      "select BootDirectory from Win32_BootConfiguration");
   const std::vector<WmiResultItem>& bootConfigurations =
       wmiBootConfigurationReq.results();
 

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -18,9 +18,10 @@ QueryData genLogicalDrives(QueryContext& context) {
   const auto& wmiLogicalDiskReq(
       "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
-  const auto& logicalDisks = wmiLogicalDiskReq.results();
+  const std::vector<WmiResultItem>& logicalDisks = wmiLogicalDiskReq.results();
   const auto& wmiBootConfigurationReq("select * from Win32_BootConfiguration;");
-  const auto& bootConfigurations = wmiBootConfigurationReq.results();
+  const std::vector<WmiResultItem>& bootConfigurations =
+      wmiBootConfigurationReq.results();
 
   for (const auto& logicalDisk : logicalDisks) {
     Row r;

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -15,11 +15,11 @@ namespace tables {
 QueryData genLogicalDrives(QueryContext& context) {
   QueryData results;
 
-  const auto& wmiLogicalDiskReq(
+  const WmiRequest wmiLogicalDiskReq(
       "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
   const std::vector<WmiResultItem>& logicalDisks = wmiLogicalDiskReq.results();
-  const auto& wmiBootConfigurationReq("select * from Win32_BootConfiguration;");
+  const WmiRequest wmiBootConfigurationReq("select * from Win32_BootConfiguration;");
   const std::vector<WmiResultItem>& bootConfigurations =
       wmiBootConfigurationReq.results();
 

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -2,7 +2,7 @@ table_name("logical_drives")
 description("Details for logical drives on the system. A logical drive generally represents a single partition.")
 schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
-    Column("type", TEXT, "The type of disk drive this logical drive represents."),
+    Column("type", TEXT, "The type of disk drive this logical drive represents, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
     Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),

--- a/tests/integration/tables/logical_drives.cpp
+++ b/tests/integration/tables/logical_drives.cpp
@@ -27,13 +27,13 @@ TEST_F(logicalDrives, test_sanity) {
   ASSERT_GE(data.size(), 1ul);
 
   ValidatatioMap row_map = {
-       {"device_id", NormalType}
-       {"type", NormalType}
-       {"free_space", IntType}
-       {"size", IntType}
-       {"file_system", NormalType}
-       {"boot_partition", IntType}
-  }
+      {"device_id", NormalType},
+      {"type", NormalType},
+      {"free_space", IntType},
+      {"size", IntType},
+      {"file_system", NormalType},
+      {"boot_partition", IntType},
+  };
 
   validate_rows(data, row_map);
 }

--- a/tests/integration/tables/logical_drives.cpp
+++ b/tests/integration/tables/logical_drives.cpp
@@ -23,25 +23,19 @@ class logicalDrives : public testing::Test {
 };
 
 TEST_F(logicalDrives, test_sanity) {
-  // 1. Query data
   auto const data = execute_query("select * from logical_drives");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidatatioMap row_map = {
-  //      {"device_id", NormalType}
-  //      {"type", NormalType}
-  //      {"free_space", IntType}
-  //      {"size", IntType}
-  //      {"file_system", NormalType}
-  //      {"boot_partition", IntType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidatatioMap row_map = {
+       {"device_id", NormalType}
+       {"type", NormalType}
+       {"free_space", IntType}
+       {"size", IntType}
+       {"file_system", NormalType}
+       {"boot_partition", IntType}
+  }
+
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
This generally refactors the `logical_drives` table on Windows and fixes two bugs:

1. The `type` column would occasionally report `Unknown`, even for correctly-typed drives within the WMI query. I've replaced its source with the `Description` column on the WMI side, which provides a convenient stringification of the drive type for us.
2. The `boot_partition` column was not correctly toggled for bootable drives due to an incorrect query (the `DeviceID` used by `Win32_DiskPartition` is not in the `X:\` format that we supply, resulting in consistently empty results). This was fixed by switching to the `Win32_BootConfiguration` WMI table and doing a string-prefix test.
