### PR TITLE
Added is_hidden column to the users and groups tables on macOS.

### DIFF
--- a/specs/groups.table
+++ b/specs/groups.table
@@ -9,6 +9,10 @@ extended_schema(WINDOWS, [
     Column("group_sid", TEXT, "Unique group ID", index=True),
     Column("comment", TEXT, "Remarks or comments associated with the group"),
 ])
+
+extended_schema(DARWIN, [
+    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory"),
+])
 implementation("groups@genGroups")
 examples([
   "select * from groups where gid = 0",

--- a/specs/users.table
+++ b/specs/users.table
@@ -14,6 +14,10 @@ schema([
 extended_schema(WINDOWS, [
     Column("type", TEXT, "Whether the account is roaming (domain), local, or a system profile"),
 ])
+
+extended_schema(DARWIN, [
+    Column("is_hidden", INTEGER, "IsHidden attribute set in OpenDirectory")
+])
 implementation("users@genUsers")
 examples([
   "select * from users where uid = 1000",

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -53,6 +53,7 @@ TEST_F(UsersTest, test_sanity) {
   }
   if (isPlatform(PlatformType::TYPE_OSX)) {
     row_map.emplace("uuid", ValidUUID);
+    row_map.emplace("is_hidden", IntType);
   } else {
     row_map.emplace("uuid", NormalType);
   }


### PR DESCRIPTION
This PR is the result of the discussion in a previous PR (#5348) after we determined account_policy_data was the wrong place for the column. 

Add `is_hidden` column to the users and groups tables in macOS. `is_hidden` is populated by looking for the `dsAttrTypeNative:IsHidden` attribute in the OpenDirectory record for the user/group if the value is `1`, `True`, or `Yes` is_hidden is 1. If the value is anything else it's set to 0. Invalid values have the same affect as the attribute not existing at all. 

The `dsAttrTypeNative:IsHidden` attribute controls whether a user account is is visible in the preferences panel similar to having a uid < 500. 

One test failed when running buck test:
```
====STANDARD OUT====
tests/integration/tables/helper.cpp:159: Failure
Value of: boost::get<CustomCheckerType>(validator)(value)
  Actual: false
Expected: true
Custom validator of the column "mask" with value "" failed
```
This also fails when I ran the test on the current experimental branch as well. 

Important to note I had to remove the optimization on both the user and group tables that just called `getpwnam` if the query specified the `uid` or `gid` since the struct returned doesn't contain the `IsHidden` attribute.  I'm not sure if or how much this will affect performance since I wasn't able to get the profiling to work with the new version (very likely I'm just doing it incorrectly). 

