### PR TITLE
eBPF output via perf_event_output kernel mechanism

### DIFF
--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -20,6 +20,8 @@ osquery_cxx_library(
             [
                 "ebpf.h",
                 "map.h",
+                "perf_output.h",
+                "perf_output_impl.h",
                 "program.h",
             ],
         ),
@@ -40,10 +42,13 @@ osquery_cxx_library(
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("osquery/utils/system/linux/perf_event:perf_event"),
+        osquery_target("osquery/utils/system:cpu"),
         osquery_target("osquery/utils/expected:expected"),
         osquery_target("osquery/utils/versioning:semantic"),
         osquery_target("osquery/utils/system:errno"),
         osquery_target("osquery/logger:logger"),
         osquery_tp_target("boost"),
+        osquery_tp_target("googletest", "gtest"),
     ],
 )

--- a/osquery/utils/system/linux/ebpf/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/ebpf.cpp
@@ -11,8 +11,6 @@
 #include <osquery/utils/system/linux/ebpf/ebpf.h>
 #include <osquery/utils/versioning/semantic.h>
 
-#include <osquery/logger.h>
-
 #include <boost/io/detail/quoted_manip.hpp>
 
 #include <linux/version.h>

--- a/osquery/utils/system/linux/ebpf/perf_output.h
+++ b/osquery/utils/system/linux/ebpf/perf_output.h
@@ -1,0 +1,123 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/system/linux/perf_event/perf_event.h>
+
+#include <osquery/logger.h>
+
+#include <gtest/gtest_prod.h>
+
+#include <chrono>
+#include <type_traits>
+#include <vector>
+
+#include <poll.h>
+
+namespace osquery {
+namespace ebpf {
+
+enum class PerfOutputError {
+  Unknown = 1,
+  SystemError = 2,
+  LogicError = 3,
+};
+
+template <typename MessageType>
+class PerfOutput final {
+ public:
+  PerfOutput(PerfOutput&&);
+  PerfOutput& operator=(PerfOutput&&);
+
+  PerfOutput(PerfOutput const&) = delete;
+  PerfOutput& operator=(PerfOutput const&) = delete;
+
+  ~PerfOutput();
+
+  static Expected<PerfOutput<MessageType>, PerfOutputError> load(
+      std::size_t cpu, std::size_t size);
+
+  int fd() const;
+
+  void const* data() const;
+
+  std::size_t size() const;
+
+  using MessageBatchType = std::vector<MessageType>;
+
+  struct WrappedMessage {
+    struct perf_event_header header;
+    std::uint32_t size;
+    MessageType msg;
+  };
+
+  ExpectedSuccess<PerfOutputError> read(MessageBatchType& dst);
+
+ private:
+  explicit PerfOutput() = default;
+  ExpectedSuccess<PerfOutputError> unload();
+
+  void forceUnload();
+
+  static_assert(
+      sizeof(WrappedMessage) <
+          std::numeric_limits<
+              decltype(std::declval<struct perf_event_header>().size)>::max(),
+      "A MessageType is too big, linux perf event can not support it");
+
+  FRIEND_TEST(PerfOutputTests, move_constructor);
+  FRIEND_TEST(PerfOutputTests, assigning_constructor);
+
+ private:
+  std::size_t size_;
+  int fd_ = -1;
+  void* data_ptr_ = nullptr;
+};
+
+template <typename MessageType>
+class PerfOutputsPoll final {
+ public:
+  explicit PerfOutputsPoll() noexcept = default;
+
+  PerfOutputsPoll(PerfOutputsPoll&&);
+  PerfOutputsPoll& operator=(PerfOutputsPoll&&);
+
+  PerfOutputsPoll(PerfOutputsPoll const&) = delete;
+  PerfOutputsPoll& operator=(PerfOutputsPoll const&) = delete;
+
+  std::size_t size() const;
+
+  /**
+   * Add new perf output to the poll
+   */
+  ExpectedSuccess<PerfOutputError> add(PerfOutput<MessageType> output);
+
+  using MessageBatchType = typename PerfOutput<MessageType>::MessageBatchType;
+
+  /**
+   * Blocking method of reading new messages from the polling outputs
+   */
+  ExpectedSuccess<PerfOutputError> read(MessageBatchType& batch);
+
+ private:
+  static constexpr std::chrono::milliseconds kPollTimeout =
+      std::chrono::seconds{2};
+
+ private:
+  std::vector<PerfOutput<MessageType>> outputs_;
+  std::vector<struct pollfd> fds_;
+};
+
+} // namespace ebpf
+} // namespace osquery
+
+#include <osquery/utils/system/linux/ebpf/perf_output_impl.h>

--- a/osquery/utils/system/linux/ebpf/perf_output_impl.h
+++ b/osquery/utils/system/linux/ebpf/perf_output_impl.h
@@ -1,0 +1,319 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/system/linux/cpu.h>
+#include <osquery/utils/system/linux/perf_event/perf_event.h>
+
+#include <osquery/logger.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <linux/hw_breakpoint.h>
+#include <linux/perf_event.h>
+
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+
+#include <unistd.h>
+
+#include <utility>
+
+namespace osquery {
+namespace ebpf {
+
+template <typename MessageType>
+PerfOutput<MessageType>::~PerfOutput() {
+  forceUnload();
+}
+
+template <typename MessageType>
+PerfOutput<MessageType>::PerfOutput(PerfOutput&& other)
+    : size_(other.size_), fd_(other.fd_), data_ptr_(other.data_ptr_) {
+  other.fd_ = -1;
+  other.data_ptr_ = nullptr;
+}
+
+template <typename MessageType>
+PerfOutput<MessageType>& PerfOutput<MessageType>::operator=(
+    PerfOutput&& other) {
+  std::swap(size_, other.size_);
+  std::swap(fd_, other.fd_);
+  std::swap(data_ptr_, other.data_ptr_);
+  return *this;
+}
+
+template <typename MessageType>
+Expected<PerfOutput<MessageType>, PerfOutputError>
+PerfOutput<MessageType>::load(std::size_t const cpu, std::size_t const size) {
+  auto instance = PerfOutput<MessageType>{};
+  instance.size_ = size;
+
+  struct perf_event_attr attr;
+  memset(&attr, 0, sizeof(struct perf_event_attr));
+  attr.type = PERF_TYPE_SOFTWARE;
+  attr.size = sizeof(struct perf_event_attr);
+  attr.config = PERF_COUNT_SW_BPF_OUTPUT;
+  attr.sample_period = 1;
+  attr.sample_type = PERF_SAMPLE_RAW;
+  attr.wakeup_events = 1;
+  attr.disabled = 1;
+
+  pid_t const pid = -1;
+  int const group_fd = -1;
+  unsigned long const flags = 0;
+  auto exp_fd = perf_event_open::syscall(
+      &attr, pid, static_cast<int>(cpu), group_fd, flags);
+  if (exp_fd.isError()) {
+    return createError(PerfOutputError::SystemError,
+                       "Fail to create perf_event output point",
+                       exp_fd.takeError());
+  }
+  instance.fd_ = exp_fd.take();
+
+  instance.data_ptr_ = mmap(NULL,
+                            instance.size_,
+                            PROT_READ | PROT_WRITE,
+                            MAP_SHARED,
+                            instance.fd_,
+                            0);
+  if (instance.data_ptr_ == MAP_FAILED) {
+    instance.data_ptr_ = nullptr;
+    return createError(PerfOutputError::SystemError,
+                       "Fail to mmap memory for perf event of PerfOutput ")
+           << boost::io::quoted(strerror(errno));
+  }
+  if (ioctl(instance.fd_, PERF_EVENT_IOC_ENABLE, 0) < 0) {
+    return createError(PerfOutputError::SystemError,
+                       "Fail to enable perf event of PerfOutput ")
+           << boost::io::quoted(strerror(errno));
+  }
+  return Expected<PerfOutput<MessageType>, PerfOutputError>(
+      std::move(instance));
+}
+
+template <typename MessageType>
+ExpectedSuccess<PerfOutputError> PerfOutput<MessageType>::unload() {
+  if (fd_ < 0) {
+    return Success{};
+  }
+  bool failed = false;
+  std::string err_msg;
+  int ret = ioctl(fd_, PERF_EVENT_IOC_DISABLE, 0);
+  if (ret < 0) {
+    failed = true;
+    err_msg += " perf event disabling failed: \"";
+    err_msg += strerror(errno);
+    err_msg += "\". ";
+  }
+  if (data_ptr_ != nullptr) {
+    ret = munmap(data_ptr_, size_);
+    if (ret < 0) {
+      failed = true;
+      err_msg += " Memory unmap failed: \"";
+      err_msg += strerror(errno);
+      err_msg += "\".";
+    }
+    data_ptr_ = nullptr;
+  }
+  ret = close(fd_);
+  if (ret < 0) {
+    failed = true;
+    err_msg += " File descriptor was closed with error: \"";
+    err_msg += strerror(errno);
+    err_msg += "\".";
+  }
+  fd_ = -1;
+  if (failed) {
+    return createError(PerfOutputError::SystemError, err_msg);
+  }
+  return Success{};
+}
+
+template <typename MessageType>
+void PerfOutput<MessageType>::forceUnload() {
+  auto const exp = unload();
+  if (exp.isError()) {
+    LOG(ERROR) << "Could not unload perf event output point "
+               << boost::io::quoted(exp.getError().getFullMessage());
+  }
+}
+
+template <typename MessageType>
+int PerfOutput<MessageType>::fd() const {
+  return fd_;
+}
+
+template <typename MessageType>
+void const* PerfOutput<MessageType>::data() const {
+  return data_ptr_;
+}
+
+template <typename MessageType>
+std::size_t PerfOutput<MessageType>::size() const {
+  return size_;
+}
+
+namespace impl {
+
+using ByteType = std::uint8_t;
+/**
+ * Circular buffer reading is in separate function only for the tests
+ *
+ * |<--------------- mapped memory ------------------------------------------->|
+ * [header]   |<---------------------- data_size ----------------------------->|
+ * [xxxx.....................xxxxxxxxxxxxxxxxxxxxxxxxxxx.......................]
+ *            |              |            ^             |
+ *         data_ptr      data_tail        |         data_head
+ *                                 wrapped messages
+ */
+template <typename WrappedMessage,
+          typename MessageType = decltype(std::declval<WrappedMessage>().msg)>
+inline ExpectedSuccess<PerfOutputError>
+consumeWrappedMessagesFromCircularBuffer(ByteType const* data_ptr,
+                                         __u64 data_tail,
+                                         __u64 const data_head,
+                                         __u64 const buffer_size,
+                                         std::vector<MessageType>& messages) {
+  __u64 offset = data_tail % buffer_size;
+  while (data_tail < data_head) {
+    if (offset + sizeof(WrappedMessage) > buffer_size) {
+      // wrapped_message is probably splited, let's do continious copy
+      auto wrapped_message = WrappedMessage{};
+      __u64 record_offset = buffer_size - offset;
+      std::copy(data_ptr + offset,
+                data_ptr + buffer_size,
+                reinterpret_cast<ByteType*>(&wrapped_message));
+      offset = 0u;
+      auto const header_size = sizeof(wrapped_message.header);
+      if (record_offset < header_size) {
+        __u64 const header_remain_len = header_size - record_offset;
+        std::copy(
+            data_ptr,
+            data_ptr + header_remain_len,
+            reinterpret_cast<ByteType*>(&wrapped_message) + record_offset);
+        record_offset += header_remain_len;
+        offset += header_remain_len;
+      }
+      if (wrapped_message.header.size > record_offset) {
+        __u64 remain_len = wrapped_message.header.size - record_offset;
+        std::copy(
+            data_ptr + offset,
+            data_ptr + offset + remain_len,
+            reinterpret_cast<ByteType*>(&wrapped_message) + record_offset);
+      }
+      messages.push_back(wrapped_message.msg);
+      data_tail += wrapped_message.header.size;
+      offset = data_tail % buffer_size;
+    } else {
+      auto wrapped_message =
+          reinterpret_cast<WrappedMessage const*>(data_ptr + offset);
+      messages.emplace_back(wrapped_message->msg);
+      offset += wrapped_message->header.size;
+      data_tail += wrapped_message->header.size;
+    }
+  }
+  return Success{};
+}
+
+} // namespace impl
+
+template <typename MessageType>
+ExpectedSuccess<PerfOutputError> PerfOutput<MessageType>::read(
+    MessageBatchType& dst) {
+  static_assert(std::is_trivial<MessageType>::value,
+                "message type must be trivial, because it comes from ASM code "
+                "at the end");
+  if (fd_ < 0) {
+    return createError(PerfOutputError::LogicError,
+                       "Attept to read from not loaded perf output");
+  }
+  auto header = static_cast<struct perf_event_mmap_page*>(data_ptr_);
+  if (header->data_head == header->data_tail) {
+    return Success{};
+  }
+  auto status = impl::consumeWrappedMessagesFromCircularBuffer<WrappedMessage>(
+      (impl::ByteType const*)data() + header->data_offset,
+      header->data_tail,
+      header->data_head,
+      header->data_size,
+      dst);
+  header->data_tail = header->data_head;
+  return status;
+}
+
+template <typename MessageType>
+PerfOutputsPoll<MessageType>::PerfOutputsPoll(PerfOutputsPoll&& other)
+    : outputs_(std::move(other.outputs_)), fds_(std::move(other.fds_)) {
+  other.outputs_.clear();
+  other.fds_.clear();
+}
+
+template <typename MessageType>
+PerfOutputsPoll<MessageType>& PerfOutputsPoll<MessageType>::operator=(
+    PerfOutputsPoll&& other) {
+  std::swap(outputs_, other.outputs_);
+  std::swap(fds_, other.fds_);
+  return *this;
+}
+
+template <typename MessageType>
+std::size_t PerfOutputsPoll<MessageType>::size() const {
+  return outputs_.size();
+}
+
+template <typename MessageType>
+ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::add(
+    PerfOutput<MessageType> output) {
+  if (outputs_.size() == cpu::kMaskSize) {
+    return createError(PerfOutputError::LogicError,
+                       "osquery support no more than ")
+           << cpu::kMaskSize << " cpu, change cpu::kMaskSize and recompile";
+  }
+  struct pollfd pfd;
+  pfd.fd = output.fd();
+  pfd.events = POLLIN;
+  fds_.push_back(pfd);
+  outputs_.push_back(std::move(output));
+  return Success{};
+}
+
+template <typename MessageType>
+ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
+    PerfOutputsPoll<MessageType>::MessageBatchType& batch) {
+  while (true) {
+    int ret = ::poll(fds_.data(), fds_.size(), kPollTimeout.count());
+    if (ret < 0) {
+      return createError(PerfOutputError::SystemError,
+                         "perf output polling failed")
+             << strerror(errno);
+    } else if (ret == 0) {
+      // timeout; no event detected
+    } else {
+      batch.clear();
+      for (std::size_t index = 0; index < fds_.size(); ++index) {
+        if ((fds_[index].revents & POLLIN) != 0) {
+          fds_[index].revents = 0;
+          auto status = outputs_[index].read(batch);
+          if (status.isError()) {
+            return createError(PerfOutputError::LogicError,
+                               "read in perf output poll failed",
+                               status.takeError());
+          }
+        }
+      }
+      return Success{};
+    }
+  }
+}
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/ebpf/tests/BUCK
+++ b/osquery/utils/system/linux/ebpf/tests/BUCK
@@ -21,6 +21,7 @@ osquery_cxx_test(
             [
                 "ebpf.cpp",
                 "map.cpp",
+                "perf_output.cpp",
                 "program.cpp",
             ],
         ),

--- a/osquery/utils/system/linux/ebpf/tests/perf_output.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/perf_output.cpp
@@ -1,0 +1,212 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/ebpf/perf_output.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+namespace osquery {
+namespace ebpf {
+
+class PerfOutputTests : public testing::Test {};
+
+struct TestMessage {
+  int a_;
+  int b_;
+  char c_;
+  char d_;
+};
+
+TEST_F(PerfOutputTests, load) {
+  auto output_exp = ebpf::PerfOutput<TestMessage>::load(0u, 512u);
+  // permission denied, test runs under non root user
+  ASSERT_TRUE(output_exp.isError());
+}
+
+TEST_F(PerfOutputTests, move_constructor) {
+  auto buf = std::array<char, 4>{};
+  auto from_obj = ebpf::PerfOutput<TestMessage>{};
+  from_obj.size_ = buf.size();
+  from_obj.fd_ = 42;
+  from_obj.data_ptr_ = static_cast<void*>(buf.data());
+
+  auto to_obj = std::move(from_obj);
+
+  EXPECT_EQ(to_obj.size_, buf.size());
+  EXPECT_EQ(to_obj.fd_, 42);
+  EXPECT_EQ(to_obj.data_ptr_, static_cast<void*>(buf.data()));
+
+  EXPECT_LE(from_obj.fd_, 0);
+  EXPECT_EQ(from_obj.data_ptr_, nullptr);
+
+  // to prevent closing non existing file descriptor
+  to_obj.fd_ = -1;
+}
+
+TEST_F(PerfOutputTests, assigning_constructor) {
+  auto buf = std::array<char, 8>{};
+  auto from_obj = ebpf::PerfOutput<TestMessage>{};
+  from_obj.size_ = buf.size();
+  from_obj.fd_ = 42;
+  from_obj.data_ptr_ = static_cast<void*>(buf.data());
+
+  auto to_obj = ebpf::PerfOutput<TestMessage>{};
+  to_obj = std::move(from_obj);
+
+  EXPECT_EQ(to_obj.size_, buf.size());
+  EXPECT_EQ(to_obj.fd_, 42);
+  EXPECT_EQ(to_obj.data_ptr_, static_cast<void*>(buf.data()));
+
+  EXPECT_LE(from_obj.fd_, 0);
+  EXPECT_EQ(from_obj.data_ptr_, nullptr);
+
+  // to prevent closing non existing file descriptor
+  to_obj.fd_ = -1;
+}
+
+TEST_F(PerfOutputTests,
+       impl_consumeWrappedMessagesFromCircularBuffer_without_wrapping) {
+  using WrappedMessage = ebpf::PerfOutput<TestMessage>::WrappedMessage;
+  auto const test_size = std::size_t{9};
+  auto buf = std::vector<ebpf::impl::ByteType>(
+      sizeof(WrappedMessage) * test_size + 128, 0);
+  auto buf_ptr = &buf[0];
+  for (std::size_t i = 0; i < test_size; ++i) {
+    auto wrapped = WrappedMessage{};
+    wrapped.msg.a_ = i + 1;
+    wrapped.msg.b_ = i * 2 + 2;
+    wrapped.msg.c_ = 'j';
+    wrapped.msg.d_ = 'k';
+    wrapped.size = sizeof(TestMessage);
+    wrapped.header.type = PERF_RECORD_SAMPLE;
+    wrapped.header.size = sizeof(WrappedMessage);
+    auto const wrapped_ptr =
+        reinterpret_cast<ebpf::impl::ByteType const*>(&wrapped);
+    std::copy(wrapped_ptr, wrapped_ptr + sizeof(WrappedMessage), buf_ptr);
+    buf_ptr += sizeof(WrappedMessage);
+  }
+  auto dst = std::vector<TestMessage>{};
+  auto status =
+      ebpf::impl::consumeWrappedMessagesFromCircularBuffer<WrappedMessage>(
+          &buf[0],
+          0,
+          static_cast<std::size_t>(buf_ptr - &buf[0]),
+          buf.size(),
+          dst);
+  ASSERT_FALSE(status.isError());
+  ASSERT_EQ(dst.size(), test_size);
+  for (std::size_t i = 0; i < test_size; ++i) {
+    EXPECT_EQ(dst[i].a_, static_cast<int>(i + 1));
+    EXPECT_EQ(dst[i].b_, static_cast<int>(i * 2 + 2));
+    EXPECT_EQ(dst[i].c_, 'j');
+    EXPECT_EQ(dst[i].d_, 'k');
+  }
+}
+
+TEST_F(PerfOutputTests,
+       impl_consumeWrappedMessagesFromCircularBuffer_simply_wrapped) {
+  using WrappedMessage = ebpf::PerfOutput<TestMessage>::WrappedMessage;
+  auto const test_size = std::size_t{9};
+  auto buf =
+      std::vector<ebpf::impl::ByteType>(sizeof(WrappedMessage) * test_size, 0);
+  auto buf_ptr = &buf[0];
+  for (std::size_t i = 0; i < test_size; ++i) {
+    auto wrapped = WrappedMessage{};
+    wrapped.msg.a_ = i + 1;
+    wrapped.msg.b_ = i * 2 + 2;
+    wrapped.msg.c_ = 'y';
+    wrapped.msg.d_ = 'x';
+    wrapped.size = sizeof(TestMessage);
+    wrapped.header.type = PERF_RECORD_SAMPLE;
+    wrapped.header.size = sizeof(WrappedMessage);
+    auto const wrapped_ptr =
+        reinterpret_cast<ebpf::impl::ByteType const*>(&wrapped);
+    std::copy(wrapped_ptr, wrapped_ptr + sizeof(WrappedMessage), buf_ptr);
+    buf_ptr += sizeof(WrappedMessage);
+  }
+  auto dst = std::vector<TestMessage>{};
+  auto status =
+      ebpf::impl::consumeWrappedMessagesFromCircularBuffer<WrappedMessage>(
+          &buf[0],
+          sizeof(WrappedMessage),
+          buf.size() + sizeof(WrappedMessage),
+          buf.size(),
+          dst);
+  ASSERT_FALSE(status.isError()) << status.getError().getFullMessageRecursive();
+  ASSERT_EQ(dst.size(), test_size);
+  for (std::size_t i = 0; i < test_size; ++i) {
+    EXPECT_EQ(dst[i].c_, 'y') << i;
+    EXPECT_EQ(dst[i].d_, 'x');
+  }
+  EXPECT_EQ(dst.back().a_, 1);
+  EXPECT_EQ(dst.back().b_, 2);
+  EXPECT_EQ(dst[0].a_, 2);
+  EXPECT_EQ(dst[0].b_, 4);
+}
+
+TEST_F(PerfOutputTests,
+       impl_consumeWrappedMessagesFromCircularBuffer_splited_record_wrapping) {
+  using WrappedMessage = ebpf::PerfOutput<TestMessage>::WrappedMessage;
+  auto const test_size = std::size_t{3};
+  auto buf = std::vector<ebpf::impl::ByteType>(
+      sizeof(WrappedMessage) * test_size + 154, 0);
+  auto const first_part_size = 8;
+  auto const tail = buf.size() - sizeof(WrappedMessage) - first_part_size;
+  auto const head = tail + sizeof(WrappedMessage) * test_size;
+
+  auto wrapped = WrappedMessage{};
+  wrapped.msg.a_ = 1;
+  wrapped.msg.b_ = 2;
+  wrapped.msg.c_ = 't';
+  wrapped.msg.d_ = 'i';
+  wrapped.size = sizeof(TestMessage);
+  wrapped.header.type = PERF_RECORD_SAMPLE;
+  wrapped.header.size = sizeof(WrappedMessage);
+  auto const wrapped_ptr =
+      reinterpret_cast<ebpf::impl::ByteType const*>(&wrapped);
+  std::copy(wrapped_ptr, wrapped_ptr + sizeof(WrappedMessage), &buf[0] + tail);
+
+  wrapped.msg.a_ = 3;
+  wrapped.msg.b_ = 4;
+  std::copy(wrapped_ptr,
+            wrapped_ptr + first_part_size,
+            &buf[0] + tail + sizeof(WrappedMessage));
+  std::copy(wrapped_ptr + first_part_size,
+            wrapped_ptr + sizeof(WrappedMessage),
+            &buf[0]);
+
+  wrapped.msg.a_ = 5;
+  wrapped.msg.b_ = 6;
+  std::copy(wrapped_ptr,
+            wrapped_ptr + sizeof(WrappedMessage),
+            &buf[0] + sizeof(WrappedMessage) - first_part_size);
+
+  auto dst = std::vector<TestMessage>{};
+  auto status =
+      ebpf::impl::consumeWrappedMessagesFromCircularBuffer<WrappedMessage>(
+          &buf[0], tail, head, buf.size(), dst);
+  ASSERT_FALSE(status.isError()) << status.getError().getFullMessageRecursive();
+  ASSERT_EQ(dst.size(), test_size);
+  for (std::size_t i = 0; i < test_size; ++i) {
+    EXPECT_EQ(dst[i].c_, 't');
+    EXPECT_EQ(dst[i].d_, 'i');
+  }
+  EXPECT_EQ(dst[0].a_, 1);
+  EXPECT_EQ(dst[0].b_, 2);
+  EXPECT_EQ(dst[1].a_, 3);
+  EXPECT_EQ(dst[1].b_, 4);
+  EXPECT_EQ(dst[2].a_, 5);
+  EXPECT_EQ(dst[2].b_, 6);
+}
+
+} // namespace ebpf
+} // namespace osquery

--- a/osquery/utils/system/linux/perf_event/BUCK
+++ b/osquery/utils/system/linux/perf_event/BUCK
@@ -1,0 +1,39 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under both the Apache 2.0 license (found in the
+#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+#  in the COPYING file in the root directory of this source tree).
+#  You may select, at your option, one of the above-listed licenses.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "perf_event",
+    header_namespace = "osquery/utils/system/linux/perf_event",
+    exported_platform_headers = [
+        (
+            LINUX,
+            [
+                "perf_event.h",
+            ],
+        ),
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "perf_event.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/expected:expected"),
+        osquery_target("osquery/utils/system:errno"),
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/utils/system/linux/perf_event/perf_event.cpp
+++ b/osquery/utils/system/linux/perf_event/perf_event.cpp
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <osquery/utils/system/linux/perf_event/perf_event.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <linux/hw_breakpoint.h>
+#include <linux/perf_event.h>
+
+#include <unistd.h>
+
+#ifndef __NR_perf_event_open
+#if defined(__PPC__)
+#define __NR_perf_event_open 319
+#elif defined(__i386__)
+#define __NR_perf_event_open 336
+#elif defined(__x86_64__)
+#define __NR_perf_event_open 298
+#else
+#error __NR_perf_event_open must be defined
+#endif
+#endif
+
+namespace osquery {
+namespace perf_event_open {
+
+Expected<int, PosixError> syscall(struct perf_event_attr* attr,
+                                  pid_t const pid,
+                                  int const cpu,
+                                  int const group_fd,
+                                  unsigned long const flags) {
+  auto ret = ::syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+  if (ret < 0) {
+    return createError(to<PosixError>(errno), "syscall perf_event_open failed ")
+           << boost::io::quoted(strerror(errno));
+  }
+  return ret;
+}
+
+} // namespace perf_event_open
+} // namespace osquery

--- a/osquery/utils/system/linux/perf_event/perf_event.h
+++ b/osquery/utils/system/linux/perf_event/perf_event.h
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#pragma once
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/system/posix/errno.h>
+
+#include <linux/perf_event.h>
+
+namespace osquery {
+namespace perf_event_open {
+
+Expected<int, PosixError> syscall(struct perf_event_attr* attr,
+                                  pid_t pid,
+                                  int cpu,
+                                  int group_fd,
+                                  unsigned long const flags);
+
+} // namespace perf_event_open
+} // namespace osquery


### PR DESCRIPTION
Summary: Part of a linux `syscalls` tracing system, blueprint: [#5218](https://github.com/facebook/osquery/issues/5218)

Reviewed By: mkareta

Differential Revision: D13622579
