### PR TITLE
Fix LICENSE information on file headers

### DIFF
--- a/osquery/BUCK
+++ b/osquery/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_binary", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:globs.bzl", "osquery_subdir_glob")

--- a/osquery/carver/BUCK
+++ b/osquery/carver/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/carver/carver.h
+++ b/osquery/carver/carver.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/carver/tests/BUCK
+++ b/osquery/carver/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/config/BUCK
+++ b/osquery/config/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/config/packs.cpp
+++ b/osquery/config/packs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/config/parsers/BUCK
+++ b/osquery/config/parsers/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/config/parsers/auto_constructed_tables.cpp
+++ b/osquery/config/parsers/auto_constructed_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/parsers/auto_constructed_tables.h
+++ b/osquery/config/parsers/auto_constructed_tables.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/config/parsers/decorators.cpp
+++ b/osquery/config/parsers/decorators.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/parsers/decorators.h>

--- a/osquery/config/parsers/decorators.h
+++ b/osquery/config/parsers/decorators.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/config/parsers/events_parser.cpp
+++ b/osquery/config/parsers/events_parser.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/parsers/feature_vectors.cpp
+++ b/osquery/config/parsers/feature_vectors.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/parsers/feature_vectors.h
+++ b/osquery/config/parsers/feature_vectors.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #pragma once
 

--- a/osquery/config/parsers/file_paths.cpp
+++ b/osquery/config/parsers/file_paths.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/parsers/kafka_topics.cpp
+++ b/osquery/config/parsers/kafka_topics.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/config/parsers/kafka_topics.h
+++ b/osquery/config/parsers/kafka_topics.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/config/parsers/logger.cpp
+++ b/osquery/config/parsers/logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/parsers/logger.h>

--- a/osquery/config/parsers/logger.h
+++ b/osquery/config/parsers/logger.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/parsers/options.cpp
+++ b/osquery/config/parsers/options.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/config/parsers/prometheus_targets.cpp
+++ b/osquery/config/parsers/prometheus_targets.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/config/parsers/prometheus_targets.h
+++ b/osquery/config/parsers/prometheus_targets.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #pragma once
 

--- a/osquery/config/parsers/tests/BUCK
+++ b/osquery/config/parsers/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/config/parsers/tests/decorators_tests.cpp
+++ b/osquery/config/parsers/tests/decorators_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/config/parsers/tests/events_parser_tests.cpp
+++ b/osquery/config/parsers/tests/events_parser_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #include <vector>
 

--- a/osquery/config/parsers/tests/file_paths_tests.cpp
+++ b/osquery/config/parsers/tests/file_paths_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gflags/gflags.h>

--- a/osquery/config/parsers/tests/options_tests.cpp
+++ b/osquery/config/parsers/tests/options_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/config/parsers/tests/views_tests.cpp
+++ b/osquery/config/parsers/tests/views_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gflags/gflags.h>

--- a/osquery/config/parsers/views.cpp
+++ b/osquery/config/parsers/views.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/config/plugins/BUCK
+++ b/osquery/config/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/config/plugins/filesystem_config.cpp
+++ b/osquery/config/plugins/filesystem_config.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/osquery/config/plugins/tls_config.cpp
+++ b/osquery/config/plugins/tls_config.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/config/plugins/tls_config.h
+++ b/osquery/config/plugins/tls_config.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/config/tests/BUCK
+++ b/osquery/config/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/tests/packs.cpp
+++ b/osquery/config/tests/packs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/config/tests/test_utils.cpp
+++ b/osquery/config/tests/test_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/tests/test_utils.h>

--- a/osquery/config/tests/test_utils.h
+++ b/osquery/config/tests/test_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/config/update.cpp
+++ b/osquery/config/update.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/core/BUCK
+++ b/osquery/core/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/core/database/database.cpp
+++ b/osquery/core/database/database.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core/database/database.h>

--- a/osquery/core/database/database.h
+++ b/osquery/core/database/database.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/database/in_memory_database.cpp
+++ b/osquery/core/database/in_memory_database.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core/database/in_memory_database.h>

--- a/osquery/core/database/in_memory_database.h
+++ b/osquery/core/database/in_memory_database.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/database/rocksdb_database.cpp
+++ b/osquery/core/database/rocksdb_database.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef OSQUERY_WINDOWS

--- a/osquery/core/database/rocksdb_database.h
+++ b/osquery/core/database/rocksdb_database.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/database/rocksdb_migration.cpp
+++ b/osquery/core/database/rocksdb_migration.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <rocksdb/db.h>

--- a/osquery/core/database/rocksdb_migration.h
+++ b/osquery/core/database/rocksdb_migration.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/flagalias.h>

--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/core/plugins/BUCK
+++ b/osquery/core/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/core/plugins/logger.cpp
+++ b/osquery/core/plugins/logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "logger.h"

--- a/osquery/core/plugins/logger.h
+++ b/osquery/core/plugins/logger.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/plugins/plugin.cpp
+++ b/osquery/core/plugins/plugin.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "plugin.h"

--- a/osquery/core/plugins/plugin.h
+++ b/osquery/core/plugins/plugin.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #pragma once
 

--- a/osquery/core/plugins/tests/in_memory_database_tests.cpp
+++ b/osquery/core/plugins/tests/in_memory_database_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/core/plugins/tests/rocksdb_database_tests.cpp
+++ b/osquery/core/plugins/tests/rocksdb_database_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/core/posix/initializer.cpp
+++ b/osquery/core/posix/initializer.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/system.h>

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/core/sql/BUCK
+++ b/osquery/core/sql/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/core/sql/column.cpp
+++ b/osquery/core/sql/column.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "column.h"

--- a/osquery/core/sql/column.h
+++ b/osquery/core/sql/column.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/diff_results.cpp
+++ b/osquery/core/sql/diff_results.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "diff_results.h"

--- a/osquery/core/sql/diff_results.h
+++ b/osquery/core/sql/diff_results.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/query_data.cpp
+++ b/osquery/core/sql/query_data.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "query_data.h"

--- a/osquery/core/sql/query_data.h
+++ b/osquery/core/sql/query_data.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/query_performance.cpp
+++ b/osquery/core/sql/query_performance.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "query_performance.h"

--- a/osquery/core/sql/query_performance.h
+++ b/osquery/core/sql/query_performance.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/row.cpp
+++ b/osquery/core/sql/row.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "row.h"

--- a/osquery/core/sql/row.h
+++ b/osquery/core/sql/row.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/scheduled_query.cpp
+++ b/osquery/core/sql/scheduled_query.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "scheduled_query.h"

--- a/osquery/core/sql/scheduled_query.h
+++ b/osquery/core/sql/scheduled_query.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/table_row.h
+++ b/osquery/core/sql/table_row.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/sql/table_rows.cpp
+++ b/osquery/core/sql/table_rows.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "table_rows.h"

--- a/osquery/core/sql/table_rows.h
+++ b/osquery/core/sql/table_rows.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fcntl.h>

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/json/json.h>

--- a/osquery/core/tests/BUCK
+++ b/osquery/core/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/core/tests/flags_tests.cpp
+++ b/osquery/core/tests/flags_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef WIN32

--- a/osquery/core/tests/posix/permissions_tests.cpp
+++ b/osquery/core/tests/posix/permissions_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <poll.h>

--- a/osquery/core/tests/query_tests.cpp
+++ b/osquery/core/tests/query_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/core/tests/system_test.cpp
+++ b/osquery/core/tests/system_test.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/core/tests/tables_tests.cpp
+++ b/osquery/core/tests/tables_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/core/tests/watcher_tests.cpp
+++ b/osquery/core/tests/watcher_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gmock/gmock.h>

--- a/osquery/core/watcher.cpp
+++ b/osquery/core/watcher.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/core/watcher.h
+++ b/osquery/core/watcher.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/windows/handle.cpp
+++ b/osquery/core/windows/handle.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/core/windows/handle.h
+++ b/osquery/core/windows/handle.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/core/windows/initializer.cpp
+++ b/osquery/core/windows/initializer.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <Objbase.h>

--- a/osquery/core/windows/ntapi.h
+++ b/osquery/core/windows/ntapi.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <locale>

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/database/BUCK
+++ b/osquery/database/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/database/benchmarks/database_benchmarks.cpp
+++ b/osquery/database/benchmarks/database_benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/database/plugins/BUCK
+++ b/osquery/database/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/database/plugins/ephemeral.h
+++ b/osquery/database/plugins/ephemeral.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/database.h>

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/stat.h>

--- a/osquery/database/plugins/rocksdb.h
+++ b/osquery/database/plugins/rocksdb.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <atomic>

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/database/plugins/sqlite.h
+++ b/osquery/database/plugins/sqlite.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mutex>

--- a/osquery/database/plugins/tests/BUCK
+++ b/osquery/database/plugins/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/database/plugins/tests/rocksdb.cpp
+++ b/osquery/database/plugins/tests/rocksdb.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/filesystem.h>

--- a/osquery/database/plugins/tests/sqlite.cpp
+++ b/osquery/database/plugins/tests/sqlite.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/database/plugins/tests/utils.h>

--- a/osquery/database/plugins/tests/utils.cpp
+++ b/osquery/database/plugins/tests/utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <future>

--- a/osquery/database/plugins/tests/utils.h
+++ b/osquery/database/plugins/tests/utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/database/tests/BUCK
+++ b/osquery/database/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/database/tests/database.cpp
+++ b/osquery/database/tests/database.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 

--- a/osquery/database/tests/results.cpp
+++ b/osquery/database/tests/results.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/database.h>

--- a/osquery/devtools/BUCK
+++ b/osquery/devtools/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/devtools/devtools.h
+++ b/osquery/devtools/devtools.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/devtools/printer.cpp
+++ b/osquery/devtools/printer.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/devtools/tests/BUCK
+++ b/osquery/devtools/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/devtools/tests/printer_tests.cpp
+++ b/osquery/devtools/tests/printer_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/dispatcher/BUCK
+++ b/osquery/dispatcher/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/dispatcher.h>

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/dispatcher/distributed_runner.h
+++ b/osquery/dispatcher/distributed_runner.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/dispatcher/scheduler.cpp
+++ b/osquery/dispatcher/scheduler.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/dispatcher/scheduler.h
+++ b/osquery/dispatcher/scheduler.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/dispatcher/tests/BUCK
+++ b/osquery/dispatcher/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/dispatcher/tests/dispatcher.cpp
+++ b/osquery/dispatcher/tests/dispatcher.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/dispatcher/tests/scheduler.cpp
+++ b/osquery/dispatcher/tests/scheduler.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/distributed/BUCK
+++ b/osquery/distributed/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/distributed/plugins/BUCK
+++ b/osquery/distributed/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/distributed/plugins/tls_distributed.cpp
+++ b/osquery/distributed/plugins/tls_distributed.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/distributed/tests/distributed_tests.cpp
+++ b/osquery/distributed/tests/distributed_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/events/BUCK
+++ b/osquery/events/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/events/darwin/diskarbitration.h
+++ b/osquery/events/darwin/diskarbitration.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/darwin/event_taps.cpp
+++ b/osquery/events/darwin/event_taps.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/flags.h>

--- a/osquery/events/darwin/event_taps.h
+++ b/osquery/events/darwin/event_taps.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fnmatch.h>

--- a/osquery/events/darwin/fsevents.h
+++ b/osquery/events/darwin/fsevents.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <IOKit/IOMessage.h>

--- a/osquery/events/darwin/iokit.h
+++ b/osquery/events/darwin/iokit.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/darwin/openbsm.cpp
+++ b/osquery/events/darwin/openbsm.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <bsm/libbsm.h>

--- a/osquery/events/darwin/openbsm.h
+++ b/osquery/events/darwin/openbsm.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <arpa/inet.h>

--- a/osquery/events/darwin/scnetwork.h
+++ b/osquery/events/darwin/scnetwork.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <linux/audit.h>

--- a/osquery/events/linux/auditdnetlink.h
+++ b/osquery/events/linux/auditdnetlink.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <array>

--- a/osquery/events/linux/auditeventpublisher.h
+++ b/osquery/events/linux/auditeventpublisher.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/events/linux/inotify.h
+++ b/osquery/events/linux/inotify.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/process_events.h
+++ b/osquery/events/linux/process_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/process_file_events.h
+++ b/osquery/events/linux/process_file_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/selinux_events.h
+++ b/osquery/events/linux/selinux_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/socket_events.h
+++ b/osquery/events/linux/socket_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fcntl.h>

--- a/osquery/events/linux/syslog.h
+++ b/osquery/events/linux/syslog.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <poll.h>

--- a/osquery/events/linux/udev.h
+++ b/osquery/events/linux/udev.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/pathset.h
+++ b/osquery/events/pathset.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/events/tests/BUCK
+++ b/osquery/events/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/events/tests/darwin/fsevents_tests.cpp
+++ b/osquery/events/tests/darwin/fsevents_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem/operations.hpp>

--- a/osquery/events/tests/events_database_tests.cpp
+++ b/osquery/events/tests/events_database_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem/operations.hpp>

--- a/osquery/events/tests/linux/audit_tests.cpp
+++ b/osquery/events/tests/linux/audit_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/osquery/events/tests/linux/process_file_events_tests.cpp
+++ b/osquery/events/tests/linux/process_file_events_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/events/tests/linux/syslog_tests.cpp
+++ b/osquery/events/tests/linux/syslog_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/events/windows/windows_event_log.h
+++ b/osquery/events/windows/windows_event_log.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/sdk.h>

--- a/osquery/examples/example_test.cpp
+++ b/osquery/examples/example_test.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/examples/example_writable_table.cpp
+++ b/osquery/examples/example_writable_table.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/sdk.h>

--- a/osquery/examples/extension_group_example/src/example.cpp
+++ b/osquery/examples/extension_group_example/src/example.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "example.h"

--- a/osquery/examples/extension_group_example/src/example.h
+++ b/osquery/examples/extension_group_example/src/example.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/extensions/BUCK
+++ b/osquery/extensions/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/extensions/impl_fbthrift.cpp
+++ b/osquery/extensions/impl_fbthrift.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/extensions/interface.h
+++ b/osquery/extensions/interface.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/extensions/tests/BUCK
+++ b/osquery/extensions/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef GTEST_HAS_TR1_TUPLE

--- a/osquery/extensions/thrift/BUCK
+++ b/osquery/extensions/thrift/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")

--- a/osquery/filesystem/BUCK
+++ b/osquery/filesystem/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/filesystem/darwin/benchmarks/plist_benchmarks.cpp
+++ b/osquery/filesystem/darwin/benchmarks/plist_benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/filesystem/filesystem.h
+++ b/osquery/filesystem/filesystem.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/filesystem/linux/mem.cpp
+++ b/osquery/filesystem/linux/mem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/mman.h>

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <linux/limits.h>

--- a/osquery/filesystem/linux/proc.h
+++ b/osquery/filesystem/linux/proc.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/filesystem/mock_file_structure.cpp
+++ b/osquery/filesystem/mock_file_structure.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/filesystem.h>

--- a/osquery/filesystem/mock_file_structure.h
+++ b/osquery/filesystem/mock_file_structure.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/filesystem.h>

--- a/osquery/filesystem/tests/darwin/plist_tests.cpp
+++ b/osquery/filesystem/tests/darwin/plist_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/filesystem/tests/fileops.cpp
+++ b/osquery/filesystem/tests/fileops.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/fileops.h>

--- a/osquery/filesystem/tests/filesystem.cpp
+++ b/osquery/filesystem/tests/filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/fileops.h>

--- a/osquery/hashing/BUCK
+++ b/osquery/hashing/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/hashing/hashing.cpp
+++ b/osquery/hashing/hashing.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <algorithm>

--- a/osquery/hashing/hashing.h
+++ b/osquery/hashing/hashing.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/core.h
+++ b/osquery/include/osquery/core.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/data_logger.h
+++ b/osquery/include/osquery/data_logger.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/database.h
+++ b/osquery/include/osquery/database.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/dispatcher.h
+++ b/osquery/include/osquery/dispatcher.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/distributed.h
+++ b/osquery/include/osquery/distributed.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/enroll.h
+++ b/osquery/include/osquery/enroll.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/events.h
+++ b/osquery/include/osquery/events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/extensions.h
+++ b/osquery/include/osquery/extensions.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/flagalias.h
+++ b/osquery/include/osquery/flagalias.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/flags.h
+++ b/osquery/include/osquery/flags.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/killswitch.h
+++ b/osquery/include/osquery/killswitch.h
@@ -4,7 +4,6 @@
  *
  *  This source code is licensed under both the Apache 2.0 license (found in
  * the LICENSE file in the root directory of this source tree) and the GPLv2
- * (found in the COPYING file in the root directory of this source tree). You
  * may select, at your option, one of the above-listed licenses.
  */
 

--- a/osquery/include/osquery/numeric_monitoring.h
+++ b/osquery/include/osquery/numeric_monitoring.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/packs.h
+++ b/osquery/include/osquery/packs.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/query.h
+++ b/osquery/include/osquery/query.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/registry.h
+++ b/osquery/include/osquery/registry.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/registry_factory.h
+++ b/osquery/include/osquery/registry_factory.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/registry_interface.h
+++ b/osquery/include/osquery/registry_interface.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/sdk.h
+++ b/osquery/include/osquery/sdk.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/sql.h
+++ b/osquery/include/osquery/sql.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/include/osquery/tables.h
+++ b/osquery/include/osquery/tables.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/killswitch/BUCK
+++ b/osquery/killswitch/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/killswitch/killswitch_plugin.cpp
+++ b/osquery/killswitch/killswitch_plugin.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/killswitch/killswitch_plugin.h
+++ b/osquery/killswitch/killswitch_plugin.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/killswitch/killswitch_refreshable_plugin.cpp
+++ b/osquery/killswitch/killswitch_refreshable_plugin.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/killswitch/killswitch_refreshable_plugin.h
+++ b/osquery/killswitch/killswitch_refreshable_plugin.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/killswitch/plugins/BUCK
+++ b/osquery/killswitch/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/killswitch/plugins/killswitch_filesystem.cpp
+++ b/osquery/killswitch/plugins/killswitch_filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/killswitch/plugins/killswitch_filesystem.h
+++ b/osquery/killswitch/plugins/killswitch_filesystem.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/killswitch/plugins/killswitch_tls.cpp
+++ b/osquery/killswitch/plugins/killswitch_tls.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/killswitch/plugins/killswitch_tls.h
+++ b/osquery/killswitch/plugins/killswitch_tls.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/killswitch/plugins/tests/killswitch_filesystem_tests.cpp
+++ b/osquery/killswitch/plugins/tests/killswitch_filesystem_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/killswitch/tests/killswitch_tests.cpp
+++ b/osquery/killswitch/tests/killswitch_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/logger/BUCK
+++ b/osquery/logger/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/logger/benchmarks/logger_benchmarks.cpp
+++ b/osquery/logger/benchmarks/logger_benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifndef WIN32

--- a/osquery/logger/logger.h
+++ b/osquery/logger/logger.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/BUCK
+++ b/osquery/logger/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/logger/plugins/aws_firehose.cpp
+++ b/osquery/logger/plugins/aws_firehose.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "aws_firehose.h"

--- a/osquery/logger/plugins/aws_firehose.h
+++ b/osquery/logger/plugins/aws_firehose.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/aws_kinesis.cpp
+++ b/osquery/logger/plugins/aws_kinesis.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "aws_kinesis.h"

--- a/osquery/logger/plugins/aws_kinesis.h
+++ b/osquery/logger/plugins/aws_kinesis.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/aws_log_forwarder.h
+++ b/osquery/logger/plugins/aws_log_forwarder.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/buffered.cpp
+++ b/osquery/logger/plugins/buffered.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "buffered.h"

--- a/osquery/logger/plugins/buffered.h
+++ b/osquery/logger/plugins/buffered.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/filesystem_logger.cpp
+++ b/osquery/logger/plugins/filesystem_logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "filesystem_logger.h"

--- a/osquery/logger/plugins/filesystem_logger.h
+++ b/osquery/logger/plugins/filesystem_logger.h
@@ -4,10 +4,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <exception>

--- a/osquery/logger/plugins/kafka_producer.cpp
+++ b/osquery/logger/plugins/kafka_producer.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/logger/plugins/kafka_producer.h
+++ b/osquery/logger/plugins/kafka_producer.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/stdout.cpp
+++ b/osquery/logger/plugins/stdout.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "stdout.h"

--- a/osquery/logger/plugins/stdout.h
+++ b/osquery/logger/plugins/stdout.h
@@ -4,10 +4,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/plugins/logger.h>

--- a/osquery/logger/plugins/syslog_logger.cpp
+++ b/osquery/logger/plugins/syslog_logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "syslog_logger.h"

--- a/osquery/logger/plugins/syslog_logger.h
+++ b/osquery/logger/plugins/syslog_logger.h
@@ -4,10 +4,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <syslog.h>

--- a/osquery/logger/plugins/tests/aws_kinesis_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/aws_kinesis_logger_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/logger/plugins/tests/buffered_tests.cpp
+++ b/osquery/logger/plugins/tests/buffered_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/logger/plugins/tests/filesystem_logger.cpp
+++ b/osquery/logger/plugins/tests/filesystem_logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger/plugins/filesystem_logger.h>

--- a/osquery/logger/plugins/tests/kafka_producer_tests.cpp
+++ b/osquery/logger/plugins/tests/kafka_producer_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gflags/gflags.h>

--- a/osquery/logger/plugins/tests/syslog_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/syslog_logger_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/logger/plugins/tests/tls_logger_tests.cpp
+++ b/osquery/logger/plugins/tests/tls_logger_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/logger/plugins/tls_logger.cpp
+++ b/osquery/logger/plugins/tls_logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/logger/plugins/tls_logger.h
+++ b/osquery/logger/plugins/tls_logger.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/logger/plugins/windows_event_log.cpp
+++ b/osquery/logger/plugins/windows_event_log.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger/plugins/windows_event_log.h>

--- a/osquery/logger/plugins/windows_event_log.h
+++ b/osquery/logger/plugins/windows_event_log.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <thread>

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/main/benchmarks.cpp
+++ b/osquery/main/benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/main/empty.cpp
+++ b/osquery/main/empty.cpp
@@ -2,8 +2,6 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */

--- a/osquery/main/fuzz.cpp
+++ b/osquery/main/fuzz.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cstdio>

--- a/osquery/main/main.h
+++ b/osquery/main/main.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/main/posix/main.cpp
+++ b/osquery/main/posix/main.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef WIN32

--- a/osquery/main/windows/main.cpp
+++ b/osquery/main/windows/main.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/numeric_monitoring/BUCK
+++ b/osquery/numeric_monitoring/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <unordered_map>

--- a/osquery/numeric_monitoring/plugin_interface.cpp
+++ b/osquery/numeric_monitoring/plugin_interface.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/plugins/plugin.h>

--- a/osquery/numeric_monitoring/plugin_interface.h
+++ b/osquery/numeric_monitoring/plugin_interface.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/numeric_monitoring/plugins/BUCK
+++ b/osquery/numeric_monitoring/plugins/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/numeric_monitoring/plugins/filesystem.cpp
+++ b/osquery/numeric_monitoring/plugins/filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/format.hpp>

--- a/osquery/numeric_monitoring/plugins/filesystem.h
+++ b/osquery/numeric_monitoring/plugins/filesystem.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/numeric_monitoring/plugins/tests/BUCK
+++ b/osquery/numeric_monitoring/plugins/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/numeric_monitoring/plugins/tests/filesystem.cpp
+++ b/osquery/numeric_monitoring/plugins/tests/filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/numeric_monitoring/pre_aggregation_cache.cpp
+++ b/osquery/numeric_monitoring/pre_aggregation_cache.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/io/detail/quoted_manip.hpp>

--- a/osquery/numeric_monitoring/pre_aggregation_cache.h
+++ b/osquery/numeric_monitoring/pre_aggregation_cache.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/numeric_monitoring/tests/BUCK
+++ b/osquery/numeric_monitoring/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/tests/numeric_monitoring.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/numeric_monitoring/tests/pre_aggregation_cache.cpp
+++ b/osquery/numeric_monitoring/tests/pre_aggregation_cache.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/process/BUCK
+++ b/osquery/process/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/process/posix/process.cpp
+++ b/osquery/process/posix/process.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <errno.h>

--- a/osquery/process/posix/process_ops.cpp
+++ b/osquery/process/posix/process_ops.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/process/process.h
+++ b/osquery/process/process.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/process/windows/process.cpp
+++ b/osquery/process/windows/process.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/process/windows/process_ops.cpp
+++ b/osquery/process/windows/process_ops.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/process/windows/process_ops.h>

--- a/osquery/process/windows/process_ops.h
+++ b/osquery/process/windows/process_ops.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/profiler/BUCK
+++ b/osquery/profiler/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/profiler/posix/profiler.cpp
+++ b/osquery/profiler/posix/profiler.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef __linux__

--- a/osquery/profiler/profiler.h
+++ b/osquery/profiler/profiler.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/profiler/windows/profiler.cpp
+++ b/osquery/profiler/windows/profiler.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/registry/BUCK
+++ b/osquery/registry/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/registry/registry_factory.cpp
+++ b/osquery/registry/registry_factory.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/extensions.h>

--- a/osquery/registry/tests/BUCK
+++ b/osquery/registry/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/registry/tests/registry.cpp
+++ b/osquery/registry/tests/registry.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/remote/BUCK
+++ b/osquery/remote/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/remote/enroll/BUCK
+++ b/osquery/remote/enroll/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/trim.hpp>

--- a/osquery/remote/enroll/tests/enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/enroll_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/remote/enroll/tests/plugins/tls_enroll_tests.cpp
+++ b/osquery/remote/enroll/tests/plugins/tls_enroll_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/remote/enroll/tls_enroll.h
+++ b/osquery/remote/enroll/tls_enroll.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/http_client.cpp
+++ b/osquery/remote/http_client.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/requests.cpp
+++ b/osquery/remote/requests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cstring>

--- a/osquery/remote/requests.h
+++ b/osquery/remote/requests.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/serializers/BUCK
+++ b/osquery/remote/serializers/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/remote/serializers/json.cpp
+++ b/osquery/remote/serializers/json.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "json.h"

--- a/osquery/remote/serializers/json.h
+++ b/osquery/remote/serializers/json.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/serializers/tests/json_serializers_tests.cpp
+++ b/osquery/remote/serializers/tests/json_serializers_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/remote/tests/BUCK
+++ b/osquery/remote/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/remote/tests/requests_tests.cpp
+++ b/osquery/remote/tests/requests_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/remote/tests/test_utils.cpp
+++ b/osquery/remote/tests/test_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <csignal>

--- a/osquery/remote/tests/test_utils.h
+++ b/osquery/remote/tests/test_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/transports/BUCK
+++ b/osquery/remote/transports/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "tls.h"

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/uri.cpp
+++ b/osquery/remote/uri.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cctype>

--- a/osquery/remote/uri.h
+++ b/osquery/remote/uri.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/sql/BUCK
+++ b/osquery/sql/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/sql/benchmarks/sql_benchmarks.cpp
+++ b/osquery/sql/benchmarks/sql_benchmarks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <benchmark/benchmark.h>

--- a/osquery/sql/dynamic_table_row.cpp
+++ b/osquery/sql/dynamic_table_row.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "dynamic_table_row.h"

--- a/osquery/sql/dynamic_table_row.h
+++ b/osquery/sql/dynamic_table_row.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/sql/sqlite_encoding.cpp
+++ b/osquery/sql/sqlite_encoding.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/sql/sqlite_filesystem.cpp
+++ b/osquery/sql/sqlite_filesystem.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/sql/sqlite_hashing.cpp
+++ b/osquery/sql/sqlite_hashing.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cstring>

--- a/osquery/sql/sqlite_math.cpp
+++ b/osquery/sql/sqlite_math.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef WIN32

--- a/osquery/sql/sqlite_operations.cpp
+++ b/osquery/sql/sqlite_operations.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/sql/sqlite_string.cpp
+++ b/osquery/sql/sqlite_string.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <assert.h>

--- a/osquery/sql/sqlite_util.cpp
+++ b/osquery/sql/sqlite_util.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "osquery/sql/sqlite_util.h"

--- a/osquery/sql/sqlite_util.h
+++ b/osquery/sql/sqlite_util.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/sql/tests/BUCK
+++ b/osquery/sql/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/sql/tests/sql.cpp
+++ b/osquery/sql/tests/sql.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/format.hpp>

--- a/osquery/sql/tests/sqlite_util_tests.cpp
+++ b/osquery/sql/tests/sqlite_util_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/sql/tests/virtual_table.cpp
+++ b/osquery/sql/tests/virtual_table.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/sql/virtual_table.cpp
+++ b/osquery/sql/virtual_table.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <atomic>

--- a/osquery/sql/virtual_table.h
+++ b/osquery/sql/virtual_table.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/BUCK
+++ b/osquery/tables/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/applications/BUCK
+++ b/osquery/tables/applications/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/applications/atom_packages.cpp
+++ b/osquery/tables/applications/atom_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/applications/browser_chrome.cpp
+++ b/osquery/tables/applications/browser_chrome.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables/applications/browser_utils.h>

--- a/osquery/tables/applications/browser_utils.cpp
+++ b/osquery/tables/applications/browser_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/join.hpp>

--- a/osquery/tables/applications/browser_utils.h
+++ b/osquery/tables/applications/browser_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/applications/darwin/browser_plugins.cpp
+++ b/osquery/tables/applications/darwin/browser_plugins.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 extern "C" {

--- a/osquery/tables/applications/posix/browser_firefox.cpp
+++ b/osquery/tables/applications/posix/browser_firefox.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/property_tree/json_parser.hpp>

--- a/osquery/tables/applications/posix/browser_opera.cpp
+++ b/osquery/tables/applications/posix/browser_opera.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables/applications/browser_utils.h>

--- a/osquery/tables/applications/posix/carbon_black.cpp
+++ b/osquery/tables/applications/posix/carbon_black.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cstdlib>

--- a/osquery/tables/applications/posix/prometheus_metrics.cpp
+++ b/osquery/tables/applications/posix/prometheus_metrics.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/applications/posix/prometheus_metrics.h
+++ b/osquery/tables/applications/posix/prometheus_metrics.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #pragma once
 

--- a/osquery/tables/applications/posix/tests/BUCK
+++ b/osquery/tables/applications/posix/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/applications/posix/tests/prometheus_metrics_tests.cpp
+++ b/osquery/tables/applications/posix/tests/prometheus_metrics_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #include <gtest/gtest.h>
 

--- a/osquery/tables/applications/windows/carbon_black.cpp
+++ b/osquery/tables/applications/windows/carbon_black.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/tables/cloud/BUCK
+++ b/osquery/tables/cloud/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/cloud/ec2_instance_metadata.cpp
+++ b/osquery/tables/cloud/ec2_instance_metadata.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/cloud/ec2_instance_tags.cpp
+++ b/osquery/tables/cloud/ec2_instance_tags.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/events/BUCK
+++ b/osquery/tables/events/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/events/darwin/disk_events.cpp
+++ b/osquery/tables/events/darwin/disk_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/lexical_cast.hpp>

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <future>

--- a/osquery/tables/events/darwin/hardware_events.cpp
+++ b/osquery/tables/events/darwin/hardware_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events/darwin/iokit.h>

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #include <arpa/inet.h>
 

--- a/osquery/tables/events/darwin/user_interaction_events.cpp
+++ b/osquery/tables/events/darwin/user_interaction_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events/darwin/event_taps.h>

--- a/osquery/tables/events/event_utils.cpp
+++ b/osquery/tables/events/event_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events.h>

--- a/osquery/tables/events/event_utils.h
+++ b/osquery/tables/events/event_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <asm/unistd_64.h>

--- a/osquery/tables/events/linux/process_events.h
+++ b/osquery/tables/events/linux/process_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events/linux/auditeventpublisher.h>

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <asm/unistd_64.h>

--- a/osquery/tables/events/linux/process_file_events.h
+++ b/osquery/tables/events/linux/process_file_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/events/linux/selinux_events.cpp
+++ b/osquery/tables/events/linux/selinux_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/events/linux/selinux_events.h
+++ b/osquery/tables/events/linux/selinux_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <asm/unistd_64.h>

--- a/osquery/tables/events/linux/socket_events.h
+++ b/osquery/tables/events/linux/socket_events.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events/linux/auditeventpublisher.h>

--- a/osquery/tables/events/linux/syslog_events.cpp
+++ b/osquery/tables/events/linux/syslog_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/events/linux/auditeventpublisher.h>

--- a/osquery/tables/events/tests/BUCK
+++ b/osquery/tables/events/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/events/tests/file_events_tests.cpp
+++ b/osquery/tables/events/tests/file_events_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/events/tests/linux/selinux_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/selinux_events_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cmath>

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/forensic/BUCK
+++ b/osquery/tables/forensic/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/forensic/carves.cpp
+++ b/osquery/tables/forensic/carves.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/join.hpp>

--- a/osquery/tables/lldpd/BUCK
+++ b/osquery/tables/lldpd/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/lldpd/lldp_neighbors.cpp
+++ b/osquery/tables/lldpd/lldp_neighbors.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/osquery/tables/networking/BUCK
+++ b/osquery/tables/networking/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Include system.h before openssl, because windows.h should be included in

--- a/osquery/tables/networking/darwin/interface_ip.cpp
+++ b/osquery/tables/networking/darwin/interface_ip.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/networking/darwin/wifi.mm
+++ b/osquery/tables/networking/darwin/wifi.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/networking/darwin/wifi_status.mm
+++ b/osquery/tables/networking/darwin/wifi_status.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreWLAN/CoreWLAN.h>

--- a/osquery/tables/networking/darwin/wifi_survey.mm
+++ b/osquery/tables/networking/darwin/wifi_survey.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreWLAN/CoreWLAN.h>

--- a/osquery/tables/networking/darwin/wifi_utils.h
+++ b/osquery/tables/networking/darwin/wifi_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreWLAN/CoreWLAN.h>

--- a/osquery/tables/networking/darwin/wifi_utils.mm
+++ b/osquery/tables/networking/darwin/wifi_utils.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #include <CoreFoundation/CoreFoundation.h>
 

--- a/osquery/tables/networking/etc_hosts.cpp
+++ b/osquery/tables/networking/etc_hosts.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/networking/etc_protocols.cpp
+++ b/osquery/tables/networking/etc_protocols.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/networking/etc_services.cpp
+++ b/osquery/tables/networking/etc_services.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/networking/freebsd/interface_ip.cpp
+++ b/osquery/tables/networking/freebsd/interface_ip.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/networking/freebsd/process_open_sockets.cpp
+++ b/osquery/tables/networking/freebsd/process_open_sockets.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <netinet/in.h>

--- a/osquery/tables/networking/freebsd/routes.cpp
+++ b/osquery/tables/networking/freebsd/routes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/networking/linux/arp_cache.cpp
+++ b/osquery/tables/networking/linux/arp_cache.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/networking/linux/inet_diag.h
+++ b/osquery/tables/networking/linux/inet_diag.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifndef _UAPI_INET_DIAG_H_

--- a/osquery/tables/networking/linux/interface_ip.cpp
+++ b/osquery/tables/networking/linux/interface_ip.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/trim.hpp>

--- a/osquery/tables/networking/linux/iptables.cpp
+++ b/osquery/tables/networking/linux/iptables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/networking/linux/iptc_proxy.c
+++ b/osquery/tables/networking/linux/iptc_proxy.c
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <arpa/inet.h>

--- a/osquery/tables/networking/linux/iptc_proxy.h
+++ b/osquery/tables/networking/linux/iptc_proxy.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/networking/linux/process_open_sockets.cpp
+++ b/osquery/tables/networking/linux/process_open_sockets.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/socket.h>

--- a/osquery/tables/networking/listening_ports.cpp
+++ b/osquery/tables/networking/listening_ports.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/sql.h>

--- a/osquery/tables/networking/posix/dns_resolvers.cpp
+++ b/osquery/tables/networking/posix/dns_resolvers.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <netinet/in.h>

--- a/osquery/tables/networking/posix/interfaces.cpp
+++ b/osquery/tables/networking/posix/interfaces.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/networking/posix/interfaces.h
+++ b/osquery/tables/networking/posix/interfaces.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/networking/posix/utils.cpp
+++ b/osquery/tables/networking/posix/utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/networking/posix/utils.h
+++ b/osquery/tables/networking/posix/utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/networking/tests/BUCK
+++ b/osquery/tables/networking/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/networking/tests/darwin/wifi_tests.mm
+++ b/osquery/tables/networking/tests/darwin/wifi_tests.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/networking/tests/linux/iptables_tests.cpp
+++ b/osquery/tables/networking/tests/linux/iptables_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/networking/tests/networking_tables_tests.cpp
+++ b/osquery/tables/networking/tests/networking_tables_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/networking/windows/arp_cache.cpp
+++ b/osquery/tables/networking/windows/arp_cache.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/replace.hpp>

--- a/osquery/tables/networking/windows/interfaces.cpp
+++ b/osquery/tables/networking/windows/interfaces.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/networking/windows/interfaces.h
+++ b/osquery/tables/networking/windows/interfaces.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/networking/windows/process_open_sockets.cpp
+++ b/osquery/tables/networking/windows/process_open_sockets.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger.h>

--- a/osquery/tables/networking/windows/routes.cpp
+++ b/osquery/tables/networking/windows/routes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/networking/windows/win_sockets.h
+++ b/osquery/tables/networking/windows/win_sockets.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/sleuthkit/BUCK
+++ b/osquery/tables/sleuthkit/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/smart/BUCK
+++ b/osquery/tables/smart/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/smart/tests/BUCK
+++ b/osquery/tables/smart/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/smart/tests/smart_drives_tests.cpp
+++ b/osquery/tables/smart/tests/smart_drives_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gmock/gmock.h>

--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifdef WIN32

--- a/osquery/tables/system/darwin/account_policy_data.mm
+++ b/osquery/tables/system/darwin/account_policy_data.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/darwin/acpi_tables.cpp
+++ b/osquery/tables/system/darwin/acpi_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/system/darwin/ad_config.cpp
+++ b/osquery/tables/system/darwin/ad_config.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/filesystem.h>

--- a/osquery/tables/system/darwin/apps.mm
+++ b/osquery/tables/system/darwin/apps.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #import <Foundation/Foundation.h>

--- a/osquery/tables/system/darwin/asl.cpp
+++ b/osquery/tables/system/darwin/asl.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables/system/darwin/asl_utils.h>

--- a/osquery/tables/system/darwin/asl_utils.cpp
+++ b/osquery/tables/system/darwin/asl_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/replace.hpp>

--- a/osquery/tables/system/darwin/asl_utils.h
+++ b/osquery/tables/system/darwin/asl_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/darwin/authorizations.mm
+++ b/osquery/tables/system/darwin/authorizations.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/system/darwin/battery.mm
+++ b/osquery/tables/system/darwin/battery.mm
@@ -3,10 +3,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/system/darwin/block_devices.cpp
+++ b/osquery/tables/system/darwin/block_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <DiskArbitration/DADisk.h>

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <openssl/x509.h>

--- a/osquery/tables/system/darwin/cpu_time.cpp
+++ b/osquery/tables/system/darwin/cpu_time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/osquery/tables/system/darwin/crashes.cpp
+++ b/osquery/tables/system/darwin/crashes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/erase.hpp>

--- a/osquery/tables/system/darwin/cups_destinations.cpp
+++ b/osquery/tables/system/darwin/cups_destinations.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cups/cups.h>

--- a/osquery/tables/system/darwin/cups_jobs.cpp
+++ b/osquery/tables/system/darwin/cups_jobs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cups/cups.h>

--- a/osquery/tables/system/darwin/disk_encryption.mm
+++ b/osquery/tables/system/darwin/disk_encryption.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <DiskArbitration/DiskArbitration.h>

--- a/osquery/tables/system/darwin/event_taps.mm
+++ b/osquery/tables/system/darwin/event_taps.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <ApplicationServices/ApplicationServices.h>

--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreServices/CoreServices.h>

--- a/osquery/tables/system/darwin/firewall.cpp
+++ b/osquery/tables/system/darwin/firewall.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/filesystem/filesystem.h>

--- a/osquery/tables/system/darwin/firewall.h
+++ b/osquery/tables/system/darwin/firewall.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/join.hpp>

--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/join.hpp>

--- a/osquery/tables/system/darwin/iokit_registry.cpp
+++ b/osquery/tables/system/darwin/iokit_registry.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/conversions/darwin/iokit.h>

--- a/osquery/tables/system/darwin/kernel_extensions.cpp
+++ b/osquery/tables/system/darwin/kernel_extensions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <IOKit/kext/KextManager.h>

--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/darwin/kernel_panics.cpp
+++ b/osquery/tables/system/darwin/kernel_panics.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/darwin/keychain_items.cpp
+++ b/osquery/tables/system/darwin/keychain_items.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/darwin/launchd.cpp
+++ b/osquery/tables/system/darwin/launchd.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/darwin/managed_policies.cpp
+++ b/osquery/tables/system/darwin/managed_policies.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/darwin/mdfind.mm
+++ b/osquery/tables/system/darwin/mdfind.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreServices/CoreServices.h>

--- a/osquery/tables/system/darwin/mounts.cpp
+++ b/osquery/tables/system/darwin/mounts.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/osquery/tables/system/darwin/nvram.cpp
+++ b/osquery/tables/system/darwin/nvram.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/system/darwin/os_version.cpp
+++ b/osquery/tables/system/darwin/os_version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/darwin/packages.h
+++ b/osquery/tables/system/darwin/packages.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/darwin/packages.mm
+++ b/osquery/tables/system/darwin/packages.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #import <Foundation/Foundation.h>

--- a/osquery/tables/system/darwin/pci_devices.cpp
+++ b/osquery/tables/system/darwin/pci_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/conversions/darwin/iokit.h>

--- a/osquery/tables/system/darwin/preferences.cpp
+++ b/osquery/tables/system/darwin/preferences.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreFoundation/CoreFoundation.h>

--- a/osquery/tables/system/darwin/process_open_descriptors.cpp
+++ b/osquery/tables/system/darwin/process_open_descriptors.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/tables/system/darwin/processes.cpp
+++ b/osquery/tables/system/darwin/processes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <libproc.h>

--- a/osquery/tables/system/darwin/quicklook_cache.cpp
+++ b/osquery/tables/system/darwin/quicklook_cache.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/property_tree/ptree.hpp>

--- a/osquery/tables/system/darwin/running_apps.mm
+++ b/osquery/tables/system/darwin/running_apps.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #import <AppKit/AppKit.h>

--- a/osquery/tables/system/darwin/sandboxes.cpp
+++ b/osquery/tables/system/darwin/sandboxes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/system/darwin/shared_folders.mm
+++ b/osquery/tables/system/darwin/shared_folders.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #import <OpenDirectory/OpenDirectory.h>

--- a/osquery/tables/system/darwin/sharing_preferences.cpp
+++ b/osquery/tables/system/darwin/sharing_preferences.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem/operations.hpp>

--- a/osquery/tables/system/darwin/signature.mm
+++ b/osquery/tables/system/darwin/signature.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/darwin/sip_config.cpp
+++ b/osquery/tables/system/darwin/sip_config.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/darwin/smbios_tables.cpp
+++ b/osquery/tables/system/darwin/smbios_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/darwin/smbios_utils.h
+++ b/osquery/tables/system/darwin/smbios_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/darwin/startup_items.cpp
+++ b/osquery/tables/system/darwin/startup_items.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/system/darwin/sysctl_utils.cpp
+++ b/osquery/tables/system/darwin/sysctl_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/sysctl.h>

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mach/mach.h>

--- a/osquery/tables/system/darwin/time_machine.cpp
+++ b/osquery/tables/system/darwin/time_machine.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/darwin/usb_devices.cpp
+++ b/osquery/tables/system/darwin/usb_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <IOKit/usb/IOUSBLib.h>

--- a/osquery/tables/system/darwin/user_groups.mm
+++ b/osquery/tables/system/darwin/user_groups.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #import <OpenDirectory/OpenDirectory.h>

--- a/osquery/tables/system/darwin/virtual_memory_info.cpp
+++ b/osquery/tables/system/darwin/virtual_memory_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mach/mach.h>

--- a/osquery/tables/system/darwin/xprotect.cpp
+++ b/osquery/tables/system/darwin/xprotect.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/hex.hpp>

--- a/osquery/tables/system/efi_misc.h
+++ b/osquery/tables/system/efi_misc.h
@@ -3,10 +3,8 @@
  *  Copyright (c) 2004, Intel Corporation
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/freebsd/fbsd_kmods.cpp
+++ b/osquery/tables/system/freebsd/fbsd_kmods.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/freebsd/groups.cpp
+++ b/osquery/tables/system/freebsd/groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/tables/system/freebsd/mounts.cpp
+++ b/osquery/tables/system/freebsd/mounts.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/osquery/tables/system/freebsd/os_version.cpp
+++ b/osquery/tables/system/freebsd/os_version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <unistd.h>

--- a/osquery/tables/system/freebsd/pkg_packages.cpp
+++ b/osquery/tables/system/freebsd/pkg_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/join.hpp>

--- a/osquery/tables/system/freebsd/process_open_files.cpp
+++ b/osquery/tables/system/freebsd/process_open_files.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/osquery/tables/system/freebsd/processes.cpp
+++ b/osquery/tables/system/freebsd/processes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/freebsd/procstat.cpp
+++ b/osquery/tables/system/freebsd/procstat.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/osquery/tables/system/freebsd/procstat.h
+++ b/osquery/tables/system/freebsd/procstat.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/freebsd/sysctl_utils.cpp
+++ b/osquery/tables/system/freebsd/sysctl_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stddef.h>

--- a/osquery/tables/system/freebsd/users.cpp
+++ b/osquery/tables/system/freebsd/users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/system/freenux/cpu_time.cpp
+++ b/osquery/tables/system/freenux/cpu_time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/osquery/tables/system/hash.cpp
+++ b/osquery/tables/system/hash.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/system/intel_me.hpp
+++ b/osquery/tables/system/intel_me.hpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/linux/acpi_tables.cpp
+++ b/osquery/tables/system/linux/acpi_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/system/linux/block_devices.cpp
+++ b/osquery/tables/system/linux/block_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/linux/deb_packages.cpp
+++ b/osquery/tables/system/linux/deb_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // see README.api of libdpkg-dev

--- a/osquery/tables/system/linux/disk_encryption.cpp
+++ b/osquery/tables/system/linux/disk_encryption.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <unistd.h>

--- a/osquery/tables/system/linux/elf_info.cpp
+++ b/osquery/tables/system/linux/elf_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <elf.h>

--- a/osquery/tables/system/linux/groups.cpp
+++ b/osquery/tables/system/linux/groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <set>

--- a/osquery/tables/system/linux/intel_me.cpp
+++ b/osquery/tables/system/linux/intel_me.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fcntl.h>

--- a/osquery/tables/system/linux/kernel_info.cpp
+++ b/osquery/tables/system/linux/kernel_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/linux/kernel_modules.cpp
+++ b/osquery/tables/system/linux/kernel_modules.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/linux/md_tables.cpp
+++ b/osquery/tables/system/linux/md_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <errno.h>

--- a/osquery/tables/system/linux/md_tables.h
+++ b/osquery/tables/system/linux/md_tables.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/linux/memory_info.cpp
+++ b/osquery/tables/system/linux/memory_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/linux/memory_map.cpp
+++ b/osquery/tables/system/linux/memory_map.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/linux/model_specific_register.cpp
+++ b/osquery/tables/system/linux/model_specific_register.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <dirent.h>

--- a/osquery/tables/system/linux/mounts.cpp
+++ b/osquery/tables/system/linux/mounts.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mntent.h>

--- a/osquery/tables/system/linux/npm_packages.cpp
+++ b/osquery/tables/system/linux/npm_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/linux/os_version.cpp
+++ b/osquery/tables/system/linux/os_version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/system/linux/pci_devices.cpp
+++ b/osquery/tables/system/linux/pci_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/linux/pci_devices.h
+++ b/osquery/tables/system/linux/pci_devices.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/tables/system/linux/portage.cpp
+++ b/osquery/tables/system/linux/portage.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  *
  *  Portage support by J.O. Aho <trizt@aho.hk>
  */

--- a/osquery/tables/system/linux/process_open_files.cpp
+++ b/osquery/tables/system/linux/process_open_files.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/system/linux/rpm_packages.cpp
+++ b/osquery/tables/system/linux/rpm_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <rpm/header.h>

--- a/osquery/tables/system/linux/shadow.cpp
+++ b/osquery/tables/system/linux/shadow.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mutex>

--- a/osquery/tables/system/linux/shared_memory.cpp
+++ b/osquery/tables/system/linux/shared_memory.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/shm.h>

--- a/osquery/tables/system/linux/smbios_tables.cpp
+++ b/osquery/tables/system/linux/smbios_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/linux/smbios_utils.h
+++ b/osquery/tables/system/linux/smbios_utils.h
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/linux/sysctl_utils.cpp
+++ b/osquery/tables/system/linux/sysctl_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sys/sysctl.h>

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <thread>

--- a/osquery/tables/system/linux/usb_devices.cpp
+++ b/osquery/tables/system/linux/usb_devices.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/linux/user_groups.cpp
+++ b/osquery/tables/system/linux/user_groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables/system/user_groups.h>

--- a/osquery/tables/system/linux/users.cpp
+++ b/osquery/tables/system/linux/users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/system/posix/apt_sources.cpp
+++ b/osquery/tables/system/posix/apt_sources.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/replace.hpp>

--- a/osquery/tables/system/posix/augeas.cpp
+++ b/osquery/tables/system/posix/augeas.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <augeas.h>

--- a/osquery/tables/system/posix/authorized_keys.cpp
+++ b/osquery/tables/system/posix/authorized_keys.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/posix/crontab.cpp
+++ b/osquery/tables/system/posix/crontab.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/osquery/tables/system/posix/known_hosts.cpp
+++ b/osquery/tables/system/posix/known_hosts.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/posix/known_hosts.h
+++ b/osquery/tables/system/posix/known_hosts.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/query.h>

--- a/osquery/tables/system/posix/last.cpp
+++ b/osquery/tables/system/posix/last.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/osquery/tables/system/posix/load_average.cpp
+++ b/osquery/tables/system/posix/load_average.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/osquery/tables/system/posix/logged_in_users.cpp
+++ b/osquery/tables/system/posix/logged_in_users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/core.h>

--- a/osquery/tables/system/posix/magic.cpp
+++ b/osquery/tables/system/posix/magic.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdio.h>

--- a/osquery/tables/system/posix/shell_history.cpp
+++ b/osquery/tables/system/posix/shell_history.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/posix/shell_history.h
+++ b/osquery/tables/system/posix/shell_history.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/query.h>

--- a/osquery/tables/system/posix/smbios_utils.cpp
+++ b/osquery/tables/system/posix/smbios_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/posix/ssh_configs.cpp
+++ b/osquery/tables/system/posix/ssh_configs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/posix/ssh_keys.cpp
+++ b/osquery/tables/system/posix/ssh_keys.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/posix/sudoers.cpp
+++ b/osquery/tables/system/posix/sudoers.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <locale>

--- a/osquery/tables/system/posix/sudoers.h
+++ b/osquery/tables/system/posix/sudoers.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/query.h>

--- a/osquery/tables/system/posix/suid_bin.cpp
+++ b/osquery/tables/system/posix/suid_bin.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/system/posix/sysctl_utils.h
+++ b/osquery/tables/system/posix/sysctl_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/posix/system_controls.cpp
+++ b/osquery/tables/system/posix/system_controls.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/trim.hpp>

--- a/osquery/tables/system/posix/ulimit_info.cpp
+++ b/osquery/tables/system/posix/ulimit_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <cerrno>

--- a/osquery/tables/system/posix/yum_sources.cpp
+++ b/osquery/tables/system/posix/yum_sources.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/property_tree/ini_parser.hpp>

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/system/smbios_utils.h
+++ b/osquery/tables/system/smbios_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/system_utils.cpp
+++ b/osquery/tables/system/system_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/sql.h>

--- a/osquery/tables/system/system_utils.h
+++ b/osquery/tables/system/system_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/tests/BUCK
+++ b/osquery/tables/system/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/system/tests/darwin/apps_tests.cpp
+++ b/osquery/tables/system/tests/darwin/apps_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/asl_tests.cpp
+++ b/osquery/tables/system/tests/darwin/asl_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/extended_attributes_tests.cpp
+++ b/osquery/tables/system/tests/darwin/extended_attributes_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/firewall_tests.cpp
+++ b/osquery/tables/system/tests/darwin/firewall_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/launchd_tests.cpp
+++ b/osquery/tables/system/tests/darwin/launchd_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/mdfind_tests.cpp
+++ b/osquery/tables/system/tests/darwin/mdfind_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreServices/CoreServices.h>

--- a/osquery/tables/system/tests/darwin/processes_tests.cpp
+++ b/osquery/tables/system/tests/darwin/processes_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <CoreServices/CoreServices.h>

--- a/osquery/tables/system/tests/darwin/signature_tests.mm
+++ b/osquery/tables/system/tests/darwin/signature_tests.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <mach-o/dyld.h>

--- a/osquery/tables/system/tests/darwin/smc_tests.cpp
+++ b/osquery/tables/system/tests/darwin/smc_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/darwin/startup_items_tests.cpp
+++ b/osquery/tables/system/tests/darwin/startup_items_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/system/tests/linux/md_tables_tests.cpp
+++ b/osquery/tables/system/tests/linux/md_tables_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <linux/raid/md_p.h>

--- a/osquery/tables/system/tests/linux/pci_devices_tests.cpp
+++ b/osquery/tables/system/tests/linux/pci_devices_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gmock/gmock.h>

--- a/osquery/tables/system/tests/linux/portage_tests.cpp
+++ b/osquery/tables/system/tests/linux/portage_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/system/tests/linux/users_tests.cpp
+++ b/osquery/tables/system/tests/linux/users_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <pwd.h>

--- a/osquery/tables/system/tests/posix/known_hosts_tests.cpp
+++ b/osquery/tables/system/tests/posix/known_hosts_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/tests/posix/shell_history_tests.cpp
+++ b/osquery/tables/system/tests/posix/shell_history_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/tests/posix/sudoers_tests.cpp
+++ b/osquery/tables/system/tests/posix/sudoers_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <fstream>

--- a/osquery/tables/system/tests/posix/yum_sources_tests.cpp
+++ b/osquery/tables/system/tests/posix/yum_sources_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/tests/system_tables_tests.cpp
+++ b/osquery/tables/system/tests/system_tables_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gflags/gflags.h>

--- a/osquery/tables/system/uptime.cpp
+++ b/osquery/tables/system/uptime.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/tables/system/user_groups.h
+++ b/osquery/tables/system/user_groups.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <codecvt>

--- a/osquery/tables/system/windows/autoexec.cpp
+++ b/osquery/tables/system/windows/autoexec.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger.h>

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/chocolatey_packages.cpp
+++ b/osquery/tables/system/windows/chocolatey_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/system/windows/cpu_info.cpp
+++ b/osquery/tables/system/windows/cpu_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger.h>

--- a/osquery/tables/system/windows/disk_info.cpp
+++ b/osquery/tables/system/windows/disk_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger.h>

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/windows/groups.cpp
+++ b/osquery/tables/system/windows/groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/intel_me.cpp
+++ b/osquery/tables/system/windows/intel_me.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/tables/system/windows/kernel_info.cpp
+++ b/osquery/tables/system/windows/kernel_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/kva_speculative_info.cpp
+++ b/osquery/tables/system/windows/kva_speculative_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright 2018 Alex Ionescu.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <ntstatus.h>

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 #include <osquery/tables.h>
 

--- a/osquery/tables/system/windows/logon_sessions.cpp
+++ b/osquery/tables/system/windows/logon_sessions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format is turned off to ensure windows.h is first

--- a/osquery/tables/system/windows/ntdomains.cpp
+++ b/osquery/tables/system/windows/ntdomains.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/logger.h>

--- a/osquery/tables/system/windows/ntfs_acl_permissions.cpp
+++ b/osquery/tables/system/windows/ntfs_acl_permissions.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <AccCtrl.h>

--- a/osquery/tables/system/windows/objects.cpp
+++ b/osquery/tables/system/windows/objects.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/os_version.cpp
+++ b/osquery/tables/system/windows/os_version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/tables/system/windows/patches.cpp
+++ b/osquery/tables/system/windows/patches.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/tables/system/windows/physical_disk_performance.cpp
+++ b/osquery/tables/system/windows/physical_disk_performance.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tables.h>

--- a/osquery/tables/system/windows/pipes.cpp
+++ b/osquery/tables/system/windows/pipes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/processes.cpp
+++ b/osquery/tables/system/windows/processes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/regex.hpp>

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/registry.h
+++ b/osquery/tables/system/windows/registry.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/tables/system/windows/scheduled_tasks.cpp
+++ b/osquery/tables/system/windows/scheduled_tasks.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/shared_resources.cpp
+++ b/osquery/tables/system/windows/shared_resources.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/windows/smbios_tables.cpp
+++ b/osquery/tables/system/windows/smbios_tables.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iomanip>

--- a/osquery/tables/system/windows/startup_items.cpp
+++ b/osquery/tables/system/windows/startup_items.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/system_info.cpp
+++ b/osquery/tables/system/windows/system_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/windows/user_groups.cpp
+++ b/osquery/tables/system/windows/user_groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/users.cpp
+++ b/osquery/tables/system/windows/users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/system.h>

--- a/osquery/tables/system/windows/video_info.cpp
+++ b/osquery/tables/system/windows/video_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/tables/system/windows/wmi_bios_info.cpp
+++ b/osquery/tables/system/windows/wmi_bios_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <sstream>

--- a/osquery/tables/utility/BUCK
+++ b/osquery/tables/utility/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #if !defined(WIN32)

--- a/osquery/tables/utility/osquery.cpp
+++ b/osquery/tables/utility/osquery.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/config/config.h>

--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <ctime>

--- a/osquery/tables/yara/BUCK
+++ b/osquery/tables/yara/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/yara/tests/BUCK
+++ b/osquery/tables/yara/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/tables/yara/tests/yara_tests.cpp
+++ b/osquery/tables/yara/tests/yara_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/tables/yara/tests/yara_tests_win_empty.cpp
+++ b/osquery/tables/yara/tests/yara_tests_win_empty.cpp
@@ -2,8 +2,6 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/filesystem.hpp>

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <map>

--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2015, Welsey Shields
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/BUCK
+++ b/osquery/utils/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/attribute.h
+++ b/osquery/utils/attribute.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/aws/BUCK
+++ b/osquery/utils/aws/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // clang-format off

--- a/osquery/utils/aws/aws_util.h
+++ b/osquery/utils/aws/aws_util.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/aws/tests/aws_util_tests.cpp
+++ b/osquery/utils/aws/tests/aws_util_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <stdlib.h>

--- a/osquery/utils/base64.cpp
+++ b/osquery/utils/base64.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "base64.h"

--- a/osquery/utils/base64.h
+++ b/osquery/utils/base64.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/chars.cpp
+++ b/osquery/utils/chars.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/chars.h
+++ b/osquery/utils/chars.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/config/BUCK
+++ b/osquery/utils/config/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 

--- a/osquery/utils/config/default_paths.cpp
+++ b/osquery/utils/config/default_paths.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "default_paths.h"

--- a/osquery/utils/config/default_paths.h
+++ b/osquery/utils/config/default_paths.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /**

--- a/osquery/utils/conversions/BUCK
+++ b/osquery/utils/conversions/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/conversions/darwin/cfdata.cpp
+++ b/osquery/utils/conversions/darwin/cfdata.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "cfdata.h"

--- a/osquery/utils/conversions/darwin/cfdata.h
+++ b/osquery/utils/conversions/darwin/cfdata.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/darwin/cfnumber.cpp
+++ b/osquery/utils/conversions/darwin/cfnumber.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "cfnumber.h"

--- a/osquery/utils/conversions/darwin/cfnumber.h
+++ b/osquery/utils/conversions/darwin/cfnumber.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/darwin/cfstring.cpp
+++ b/osquery/utils/conversions/darwin/cfstring.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "cfstring.h"

--- a/osquery/utils/conversions/darwin/cfstring.h
+++ b/osquery/utils/conversions/darwin/cfstring.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/darwin/cftime.cpp
+++ b/osquery/utils/conversions/darwin/cftime.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "cftime.h"

--- a/osquery/utils/conversions/darwin/cftime.h
+++ b/osquery/utils/conversions/darwin/cftime.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/darwin/iokit.cpp
+++ b/osquery/utils/conversions/darwin/iokit.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <IOKit/IOKitLib.h>

--- a/osquery/utils/conversions/darwin/iokit.h
+++ b/osquery/utils/conversions/darwin/iokit.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/darwin/tests/cfstring.cpp
+++ b/osquery/utils/conversions/darwin/tests/cfstring.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/conversions/join.h
+++ b/osquery/utils/conversions/join.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/split.cpp
+++ b/osquery/utils/conversions/split.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "split.h"

--- a/osquery/utils/conversions/split.h
+++ b/osquery/utils/conversions/split.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/tests/join.cpp
+++ b/osquery/utils/conversions/tests/join.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/conversions/tests/split.cpp
+++ b/osquery/utils/conversions/tests/split.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/conversions/tests/tryto.cpp
+++ b/osquery/utils/conversions/tests/tryto.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/conversions/tryto.cpp
+++ b/osquery/utils/conversions/tryto.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "tryto.h"

--- a/osquery/utils/conversions/tryto.h
+++ b/osquery/utils/conversions/tryto.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/conversions/windows/strings.cpp
+++ b/osquery/utils/conversions/windows/strings.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <codecvt>

--- a/osquery/utils/conversions/windows/strings.h
+++ b/osquery/utils/conversions/windows/strings.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/darwin/plist.h
+++ b/osquery/utils/darwin/plist.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/darwin/plist.mm
+++ b/osquery/utils/darwin/plist.mm
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "plist.h"

--- a/osquery/utils/debug/BUCK
+++ b/osquery/utils/debug/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")

--- a/osquery/utils/debug/debug_only.h
+++ b/osquery/utils/debug/debug_only.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/debug/tests/debug_only.cpp
+++ b/osquery/utils/debug/tests/debug_only.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/error/BUCK
+++ b/osquery/utils/error/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/error/tests/error.cpp
+++ b/osquery/utils/error/tests/error.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/utils/expected/BUCK
+++ b/osquery/utils/expected/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/expected/expected.h
+++ b/osquery/utils/expected/expected.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/expected/tests/expected.cpp
+++ b/osquery/utils/expected/tests/expected.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string.hpp>

--- a/osquery/utils/info/BUCK
+++ b/osquery/utils/info/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/info/platform_type.cpp
+++ b/osquery/utils/info/platform_type.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/info/platform_type.h>

--- a/osquery/utils/info/platform_type.h
+++ b/osquery/utils/info/platform_type.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/info/tool_type.cpp
+++ b/osquery/utils/info/tool_type.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
  #include <osquery/utils/info/tool_type.h>

--- a/osquery/utils/info/tool_type.h
+++ b/osquery/utils/info/tool_type.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/info/version.cpp
+++ b/osquery/utils/info/version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/info/version.h>

--- a/osquery/utils/info/version.h
+++ b/osquery/utils/info/version.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/json/BUCK
+++ b/osquery/utils/json/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/json/json.cpp
+++ b/osquery/utils/json/json.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "json.h"

--- a/osquery/utils/json/json.h
+++ b/osquery/utils/json/json.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/json/tests/json.cpp
+++ b/osquery/utils/json/tests/json.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/macros/BUCK
+++ b/osquery/utils/macros/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 

--- a/osquery/utils/macros/macros.h
+++ b/osquery/utils/macros/macros.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/mutex.h
+++ b/osquery/utils/mutex.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2018-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/only_movable.cpp
+++ b/osquery/utils/only_movable.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "only_movable.h"

--- a/osquery/utils/only_movable.h
+++ b/osquery/utils/only_movable.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/status/BUCK
+++ b/osquery/utils/status/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/status/status.cpp
+++ b/osquery/utils/status/status.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include "status.h"

--- a/osquery/utils/status/status.h
+++ b/osquery/utils/status/status.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/status/tests/status.cpp
+++ b/osquery/utils/status/tests/status.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/status/status.h>

--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/system/env.h
+++ b/osquery/utils/system/env.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/errno.h
+++ b/osquery/utils/system/errno.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/filepath.h
+++ b/osquery/utils/system/filepath.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/system/linux/ebpf/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/ebpf.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/ebpf/ebpf.h>

--- a/osquery/utils/system/linux/ebpf/ebpf.h
+++ b/osquery/utils/system/linux/ebpf/ebpf.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/linux/ebpf/map.cpp
+++ b/osquery/utils/system/linux/ebpf/map.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/ebpf/map.h>

--- a/osquery/utils/system/linux/ebpf/map.h
+++ b/osquery/utils/system/linux/ebpf/map.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/linux/ebpf/program.cpp
+++ b/osquery/utils/system/linux/ebpf/program.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/ebpf/program.h>

--- a/osquery/utils/system/linux/ebpf/program.h
+++ b/osquery/utils/system/linux/ebpf/program.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/linux/ebpf/tests/BUCK
+++ b/osquery/utils/system/linux/ebpf/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/system/linux/ebpf/tests/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/ebpf.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/utils/system/linux/ebpf/tests/empty.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/empty.cpp
@@ -2,8 +2,6 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */

--- a/osquery/utils/system/linux/ebpf/tests/map.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/map.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/ebpf/map.h>

--- a/osquery/utils/system/linux/ebpf/tests/program.cpp
+++ b/osquery/utils/system/linux/ebpf/tests/program.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/ebpf/program.h>

--- a/osquery/utils/system/linux/tracing/BUCK
+++ b/osquery/utils/system/linux/tracing/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/system/linux/tracing/native_event.cpp
+++ b/osquery/utils/system/linux/tracing/native_event.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/linux/tracing/native_event.h>

--- a/osquery/utils/system/linux/tracing/native_event.h
+++ b/osquery/utils/system/linux/tracing/native_event.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/linux/tracing/tests/BUCK
+++ b/osquery/utils/system/linux/tracing/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/system/linux/tracing/tests/empty.cpp
+++ b/osquery/utils/system/linux/tracing/tests/empty.cpp
@@ -2,8 +2,6 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */

--- a/osquery/utils/system/linux/tracing/tests/native_event.cpp
+++ b/osquery/utils/system/linux/tracing/tests/native_event.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/utils/system/linux/tracing/types.h
+++ b/osquery/utils/system/linux/tracing/types.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/posix/env.cpp
+++ b/osquery/utils/system/posix/env.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/env.h>

--- a/osquery/utils/system/posix/errno.cpp
+++ b/osquery/utils/system/posix/errno.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/errno.h>

--- a/osquery/utils/system/posix/filepath.cpp
+++ b/osquery/utils/system/posix/filepath.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/filepath.h>

--- a/osquery/utils/system/posix/system.cpp
+++ b/osquery/utils/system/posix/system.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
  #include "system.h"

--- a/osquery/utils/system/posix/system.h
+++ b/osquery/utils/system/posix/system.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/posix/time.cpp
+++ b/osquery/utils/system/posix/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/time.h>

--- a/osquery/utils/system/tests/cpu.cpp
+++ b/osquery/utils/system/tests/cpu.cpp
@@ -2,8 +2,6 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */

--- a/osquery/utils/system/tests/time.cpp
+++ b/osquery/utils/system/tests/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/utils/system/time.cpp
+++ b/osquery/utils/system/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/time.h>

--- a/osquery/utils/system/time.h
+++ b/osquery/utils/system/time.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/uptime.cpp
+++ b/osquery/utils/system/uptime.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/uptime.h>

--- a/osquery/utils/system/uptime.h
+++ b/osquery/utils/system/uptime.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/windows/env.cpp
+++ b/osquery/utils/system/windows/env.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/env.h>

--- a/osquery/utils/system/windows/errno.cpp
+++ b/osquery/utils/system/windows/errno.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/errno.h>

--- a/osquery/utils/system/windows/system.cpp
+++ b/osquery/utils/system/windows/system.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
  #include <osquery/utils/system/system.h>

--- a/osquery/utils/system/windows/system.h
+++ b/osquery/utils/system/windows/system.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/osquery/utils/system/windows/time.cpp
+++ b/osquery/utils/system/windows/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/system/time.h>

--- a/osquery/utils/tests/base64.cpp
+++ b/osquery/utils/tests/base64.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/osquery/utils/tests/chars.cpp
+++ b/osquery/utils/tests/chars.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <string>

--- a/osquery/utils/versioning/BUCK
+++ b/osquery/utils/versioning/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/versioning/semantic.h>

--- a/osquery/utils/versioning/semantic.h
+++ b/osquery/utils/versioning/semantic.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/utils/conversions/tryto.h>

--- a/osquery/utils/versioning/tests/BUCK
+++ b/osquery/utils/versioning/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/osquery/utils/versioning/tests/semantic.cpp
+++ b/osquery/utils/versioning/tests/semantic.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/specs/BUCK
+++ b/specs/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:codegen.bzl", "osquery_gentable_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_filegroup", "osquery_target")

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/tests/integration/tables/BUCK
+++ b/tests/integration/tables/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")

--- a/tests/integration/tables/account_policy_data.cpp
+++ b/tests/integration/tables/account_policy_data.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for account_policy_data

--- a/tests/integration/tables/acpi_tables.cpp
+++ b/tests/integration/tables/acpi_tables.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for acpi_tables

--- a/tests/integration/tables/ad_config.cpp
+++ b/tests/integration/tables/ad_config.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ad_config

--- a/tests/integration/tables/alf.cpp
+++ b/tests/integration/tables/alf.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for alf

--- a/tests/integration/tables/alf_exceptions.cpp
+++ b/tests/integration/tables/alf_exceptions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for alf_exceptions

--- a/tests/integration/tables/alf_explicit_auths.cpp
+++ b/tests/integration/tables/alf_explicit_auths.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for alf_explicit_auths

--- a/tests/integration/tables/alf_services.cpp
+++ b/tests/integration/tables/alf_services.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for alf_services

--- a/tests/integration/tables/app_schemes.cpp
+++ b/tests/integration/tables/app_schemes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for app_schemes

--- a/tests/integration/tables/appcompat_shims.cpp
+++ b/tests/integration/tables/appcompat_shims.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for appcompat_shims

--- a/tests/integration/tables/apps.cpp
+++ b/tests/integration/tables/apps.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for apps

--- a/tests/integration/tables/apt_sources.cpp
+++ b/tests/integration/tables/apt_sources.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for apt_sources

--- a/tests/integration/tables/arp_cache.cpp
+++ b/tests/integration/tables/arp_cache.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for arp_cache

--- a/tests/integration/tables/asl.cpp
+++ b/tests/integration/tables/asl.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for asl

--- a/tests/integration/tables/atom_packages.cpp
+++ b/tests/integration/tables/atom_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for atom_packages

--- a/tests/integration/tables/augeas.cpp
+++ b/tests/integration/tables/augeas.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for augeas

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for authenticode

--- a/tests/integration/tables/authorization_mechanisms.cpp
+++ b/tests/integration/tables/authorization_mechanisms.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for authorization_mechanisms

--- a/tests/integration/tables/authorizations.cpp
+++ b/tests/integration/tables/authorizations.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for authorizations

--- a/tests/integration/tables/authorized_keys.cpp
+++ b/tests/integration/tables/authorized_keys.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for authorized_keys

--- a/tests/integration/tables/autoexec.cpp
+++ b/tests/integration/tables/autoexec.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for autoexec

--- a/tests/integration/tables/battery.cpp
+++ b/tests/integration/tables/battery.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for battery

--- a/tests/integration/tables/bitlocker_info.cpp
+++ b/tests/integration/tables/bitlocker_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for bitlocker_info

--- a/tests/integration/tables/block_devices.cpp
+++ b/tests/integration/tables/block_devices.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for block_devices

--- a/tests/integration/tables/browser_plugins.cpp
+++ b/tests/integration/tables/browser_plugins.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for browser_plugins

--- a/tests/integration/tables/carbon_black_info.cpp
+++ b/tests/integration/tables/carbon_black_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for carbon_black_info

--- a/tests/integration/tables/carves.cpp
+++ b/tests/integration/tables/carves.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for carves

--- a/tests/integration/tables/certificates.cpp
+++ b/tests/integration/tables/certificates.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for certificates

--- a/tests/integration/tables/chocolatey_packages.cpp
+++ b/tests/integration/tables/chocolatey_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for chocolatey_packages

--- a/tests/integration/tables/chrome_extensions.cpp
+++ b/tests/integration/tables/chrome_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for chrome_extensions

--- a/tests/integration/tables/cpu_info.cpp
+++ b/tests/integration/tables/cpu_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for cpu_info

--- a/tests/integration/tables/cpu_time.cpp
+++ b/tests/integration/tables/cpu_time.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for cpu_time

--- a/tests/integration/tables/cpuid.cpp
+++ b/tests/integration/tables/cpuid.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for cpuid

--- a/tests/integration/tables/crashes.cpp
+++ b/tests/integration/tables/crashes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for crashes

--- a/tests/integration/tables/crontab.cpp
+++ b/tests/integration/tables/crontab.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for crontab

--- a/tests/integration/tables/cups_destinations.cpp
+++ b/tests/integration/tables/cups_destinations.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for cups_destinations

--- a/tests/integration/tables/cups_jobs.cpp
+++ b/tests/integration/tables/cups_jobs.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for cups_jobs

--- a/tests/integration/tables/curl.cpp
+++ b/tests/integration/tables/curl.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for curl

--- a/tests/integration/tables/curl_certificate.cpp
+++ b/tests/integration/tables/curl_certificate.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for curl_certificate

--- a/tests/integration/tables/deb_packages.cpp
+++ b/tests/integration/tables/deb_packages.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for deb_packages

--- a/tests/integration/tables/device_file.cpp
+++ b/tests/integration/tables/device_file.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for device_file

--- a/tests/integration/tables/device_firmware.cpp
+++ b/tests/integration/tables/device_firmware.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for device_firmware

--- a/tests/integration/tables/device_hash.cpp
+++ b/tests/integration/tables/device_hash.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for device_hash

--- a/tests/integration/tables/device_partitions.cpp
+++ b/tests/integration/tables/device_partitions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for device_partitions

--- a/tests/integration/tables/disk_encryption.cpp
+++ b/tests/integration/tables/disk_encryption.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for disk_encryption

--- a/tests/integration/tables/disk_events.cpp
+++ b/tests/integration/tables/disk_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for disk_events

--- a/tests/integration/tables/disk_info.cpp
+++ b/tests/integration/tables/disk_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for disk_info

--- a/tests/integration/tables/dns_resolvers.cpp
+++ b/tests/integration/tables/dns_resolvers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for dns_resolvers

--- a/tests/integration/tables/docker_container_labels.cpp
+++ b/tests/integration/tables/docker_container_labels.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_labels

--- a/tests/integration/tables/docker_container_mounts.cpp
+++ b/tests/integration/tables/docker_container_mounts.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_mounts

--- a/tests/integration/tables/docker_container_networks.cpp
+++ b/tests/integration/tables/docker_container_networks.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_networks

--- a/tests/integration/tables/docker_container_ports.cpp
+++ b/tests/integration/tables/docker_container_ports.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_ports

--- a/tests/integration/tables/docker_container_processes.cpp
+++ b/tests/integration/tables/docker_container_processes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_processes

--- a/tests/integration/tables/docker_container_stats.cpp
+++ b/tests/integration/tables/docker_container_stats.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_container_stats

--- a/tests/integration/tables/docker_containers.cpp
+++ b/tests/integration/tables/docker_containers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_containers

--- a/tests/integration/tables/docker_image_labels.cpp
+++ b/tests/integration/tables/docker_image_labels.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_image_labels

--- a/tests/integration/tables/docker_images.cpp
+++ b/tests/integration/tables/docker_images.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_images

--- a/tests/integration/tables/docker_info.cpp
+++ b/tests/integration/tables/docker_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_info

--- a/tests/integration/tables/docker_network_labels.cpp
+++ b/tests/integration/tables/docker_network_labels.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_network_labels

--- a/tests/integration/tables/docker_networks.cpp
+++ b/tests/integration/tables/docker_networks.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_networks

--- a/tests/integration/tables/docker_version.cpp
+++ b/tests/integration/tables/docker_version.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_version

--- a/tests/integration/tables/docker_volume_labels.cpp
+++ b/tests/integration/tables/docker_volume_labels.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_volume_labels

--- a/tests/integration/tables/docker_volumes.cpp
+++ b/tests/integration/tables/docker_volumes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for docker_volumes

--- a/tests/integration/tables/drivers.cpp
+++ b/tests/integration/tables/drivers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for drivers

--- a/tests/integration/tables/ec2_instance_metadata.cpp
+++ b/tests/integration/tables/ec2_instance_metadata.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ec2_instance_metadata

--- a/tests/integration/tables/ec2_instance_tags.cpp
+++ b/tests/integration/tables/ec2_instance_tags.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ec2_instance_tags

--- a/tests/integration/tables/elf_dynamic.cpp
+++ b/tests/integration/tables/elf_dynamic.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for elf_dynamic

--- a/tests/integration/tables/elf_info.cpp
+++ b/tests/integration/tables/elf_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for elf_info

--- a/tests/integration/tables/elf_sections.cpp
+++ b/tests/integration/tables/elf_sections.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for elf_sections

--- a/tests/integration/tables/elf_segments.cpp
+++ b/tests/integration/tables/elf_segments.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for elf_segments

--- a/tests/integration/tables/elf_symbols.cpp
+++ b/tests/integration/tables/elf_symbols.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for elf_symbols

--- a/tests/integration/tables/etc_hosts.cpp
+++ b/tests/integration/tables/etc_hosts.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for etc_hosts

--- a/tests/integration/tables/etc_protocols.cpp
+++ b/tests/integration/tables/etc_protocols.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for etc_protocols

--- a/tests/integration/tables/etc_services.cpp
+++ b/tests/integration/tables/etc_services.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for etc_services

--- a/tests/integration/tables/event_taps.cpp
+++ b/tests/integration/tables/event_taps.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for event_taps

--- a/tests/integration/tables/example.cpp
+++ b/tests/integration/tables/example.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for example

--- a/tests/integration/tables/extended_attributes.cpp
+++ b/tests/integration/tables/extended_attributes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for extended_attributes

--- a/tests/integration/tables/fan_speed_sensors.cpp
+++ b/tests/integration/tables/fan_speed_sensors.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for fan_speed_sensors

--- a/tests/integration/tables/fbsd_kmods.cpp
+++ b/tests/integration/tables/fbsd_kmods.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for fbsd_kmods

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for file

--- a/tests/integration/tables/file_events.cpp
+++ b/tests/integration/tables/file_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for file_events

--- a/tests/integration/tables/firefox_addons.cpp
+++ b/tests/integration/tables/firefox_addons.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for firefox_addons

--- a/tests/integration/tables/gatekeeper.cpp
+++ b/tests/integration/tables/gatekeeper.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for gatekeeper

--- a/tests/integration/tables/gatekeeper_approved_apps.cpp
+++ b/tests/integration/tables/gatekeeper_approved_apps.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for gatekeeper_approved_apps

--- a/tests/integration/tables/groups.cpp
+++ b/tests/integration/tables/groups.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for groups

--- a/tests/integration/tables/hardware_events.cpp
+++ b/tests/integration/tables/hardware_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for hardware_events

--- a/tests/integration/tables/hash.cpp
+++ b/tests/integration/tables/hash.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for hash

--- a/tests/integration/tables/helper.cpp
+++ b/tests/integration/tables/helper.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tests/integration/tables/helper.h>

--- a/tests/integration/tables/helper.h
+++ b/tests/integration/tables/helper.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <unordered_set>

--- a/tests/integration/tables/homebrew_packages.cpp
+++ b/tests/integration/tables/homebrew_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for homebrew_packages

--- a/tests/integration/tables/ie_extensions.cpp
+++ b/tests/integration/tables/ie_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ie_extensions

--- a/tests/integration/tables/intel_me_info.cpp
+++ b/tests/integration/tables/intel_me_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for intel_me_info

--- a/tests/integration/tables/interface_addresses.cpp
+++ b/tests/integration/tables/interface_addresses.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for interface_addresses

--- a/tests/integration/tables/interface_details.cpp
+++ b/tests/integration/tables/interface_details.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for interface_details

--- a/tests/integration/tables/interface_ipv6.cpp
+++ b/tests/integration/tables/interface_ipv6.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for interface_ipv6

--- a/tests/integration/tables/iokit_devicetree.cpp
+++ b/tests/integration/tables/iokit_devicetree.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for iokit_devicetree

--- a/tests/integration/tables/iokit_registry.cpp
+++ b/tests/integration/tables/iokit_registry.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for iokit_registry

--- a/tests/integration/tables/iptables.cpp
+++ b/tests/integration/tables/iptables.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for iptables

--- a/tests/integration/tables/kernel_extensions.cpp
+++ b/tests/integration/tables/kernel_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kernel_extensions

--- a/tests/integration/tables/kernel_info.cpp
+++ b/tests/integration/tables/kernel_info.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kernel_info

--- a/tests/integration/tables/kernel_integrity.cpp
+++ b/tests/integration/tables/kernel_integrity.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kernel_integrity

--- a/tests/integration/tables/kernel_modules.cpp
+++ b/tests/integration/tables/kernel_modules.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kernel_modules

--- a/tests/integration/tables/kernel_panics.cpp
+++ b/tests/integration/tables/kernel_panics.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kernel_panics

--- a/tests/integration/tables/keychain_acls.cpp
+++ b/tests/integration/tables/keychain_acls.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for keychain_acls

--- a/tests/integration/tables/keychain_items.cpp
+++ b/tests/integration/tables/keychain_items.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for keychain_items

--- a/tests/integration/tables/known_hosts.cpp
+++ b/tests/integration/tables/known_hosts.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for known_hosts

--- a/tests/integration/tables/kva_speculative_info.cpp
+++ b/tests/integration/tables/kva_speculative_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for kva_speculative_info

--- a/tests/integration/tables/last.cpp
+++ b/tests/integration/tables/last.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for last

--- a/tests/integration/tables/launchd.cpp
+++ b/tests/integration/tables/launchd.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for launchd

--- a/tests/integration/tables/launchd_overrides.cpp
+++ b/tests/integration/tables/launchd_overrides.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for launchd_overrides

--- a/tests/integration/tables/listening_ports.cpp
+++ b/tests/integration/tables/listening_ports.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for listening_ports

--- a/tests/integration/tables/lldp_neighbors.cpp
+++ b/tests/integration/tables/lldp_neighbors.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for lldp_neighbors

--- a/tests/integration/tables/load_average.cpp
+++ b/tests/integration/tables/load_average.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for load_average

--- a/tests/integration/tables/logged_in_users.cpp
+++ b/tests/integration/tables/logged_in_users.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for logged_in_users

--- a/tests/integration/tables/logical_drives.cpp
+++ b/tests/integration/tables/logical_drives.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for logical_drives

--- a/tests/integration/tables/logon_sessions.cpp
+++ b/tests/integration/tables/logon_sessions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for logon_sessions

--- a/tests/integration/tables/magic.cpp
+++ b/tests/integration/tables/magic.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for magic

--- a/tests/integration/tables/managed_policies.cpp
+++ b/tests/integration/tables/managed_policies.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for managed_policies

--- a/tests/integration/tables/md_devices.cpp
+++ b/tests/integration/tables/md_devices.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for md_devices

--- a/tests/integration/tables/md_drives.cpp
+++ b/tests/integration/tables/md_drives.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for md_drives

--- a/tests/integration/tables/md_personalities.cpp
+++ b/tests/integration/tables/md_personalities.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for md_personalities

--- a/tests/integration/tables/mdfind.cpp
+++ b/tests/integration/tables/mdfind.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for mdfind

--- a/tests/integration/tables/memory_array_mapped_addresses.cpp
+++ b/tests/integration/tables/memory_array_mapped_addresses.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_array_mapped_addresses

--- a/tests/integration/tables/memory_arrays.cpp
+++ b/tests/integration/tables/memory_arrays.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_arrays

--- a/tests/integration/tables/memory_device_mapped_addresses.cpp
+++ b/tests/integration/tables/memory_device_mapped_addresses.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_device_mapped_addresses

--- a/tests/integration/tables/memory_devices.cpp
+++ b/tests/integration/tables/memory_devices.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_devices

--- a/tests/integration/tables/memory_error_info.cpp
+++ b/tests/integration/tables/memory_error_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_error_info

--- a/tests/integration/tables/memory_info.cpp
+++ b/tests/integration/tables/memory_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_info

--- a/tests/integration/tables/memory_map.cpp
+++ b/tests/integration/tables/memory_map.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for memory_map

--- a/tests/integration/tables/mounts.cpp
+++ b/tests/integration/tables/mounts.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for mounts

--- a/tests/integration/tables/msr.cpp
+++ b/tests/integration/tables/msr.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for msr

--- a/tests/integration/tables/nfs_shares.cpp
+++ b/tests/integration/tables/nfs_shares.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for nfs_shares

--- a/tests/integration/tables/npm_packages.cpp
+++ b/tests/integration/tables/npm_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for npm_packages

--- a/tests/integration/tables/ntdomains.cpp
+++ b/tests/integration/tables/ntdomains.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for nt_info

--- a/tests/integration/tables/ntfs_acl_permissions.cpp
+++ b/tests/integration/tables/ntfs_acl_permissions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ntfs_acl_permissions

--- a/tests/integration/tables/nvram.cpp
+++ b/tests/integration/tables/nvram.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for nvram

--- a/tests/integration/tables/oem_strings.cpp
+++ b/tests/integration/tables/oem_strings.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for oem_strings

--- a/tests/integration/tables/opera_extensions.cpp
+++ b/tests/integration/tables/opera_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for opera_extensions

--- a/tests/integration/tables/os_version.cpp
+++ b/tests/integration/tables/os_version.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for os_version

--- a/tests/integration/tables/osquery_events.cpp
+++ b/tests/integration/tables/osquery_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_events

--- a/tests/integration/tables/osquery_extensions.cpp
+++ b/tests/integration/tables/osquery_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_extensions

--- a/tests/integration/tables/osquery_flags.cpp
+++ b/tests/integration/tables/osquery_flags.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_flags

--- a/tests/integration/tables/osquery_info.cpp
+++ b/tests/integration/tables/osquery_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_info

--- a/tests/integration/tables/osquery_packs.cpp
+++ b/tests/integration/tables/osquery_packs.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_packs

--- a/tests/integration/tables/osquery_registry.cpp
+++ b/tests/integration/tables/osquery_registry.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_registry

--- a/tests/integration/tables/osquery_schedule.cpp
+++ b/tests/integration/tables/osquery_schedule.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for osquery_schedule

--- a/tests/integration/tables/package_bom.cpp
+++ b/tests/integration/tables/package_bom.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for package_bom

--- a/tests/integration/tables/package_install_history.cpp
+++ b/tests/integration/tables/package_install_history.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for package_install_history

--- a/tests/integration/tables/package_receipts.cpp
+++ b/tests/integration/tables/package_receipts.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for package_receipts

--- a/tests/integration/tables/patches.cpp
+++ b/tests/integration/tables/patches.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for patches

--- a/tests/integration/tables/pci_devices.cpp
+++ b/tests/integration/tables/pci_devices.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for pci_devices

--- a/tests/integration/tables/physical_disk_performance.cpp
+++ b/tests/integration/tables/physical_disk_performance.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for physical_disk_performance

--- a/tests/integration/tables/pipes.cpp
+++ b/tests/integration/tables/pipes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for pipes

--- a/tests/integration/tables/pkg_packages.cpp
+++ b/tests/integration/tables/pkg_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for pkg_packages

--- a/tests/integration/tables/platform_info.cpp
+++ b/tests/integration/tables/platform_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for platform_info

--- a/tests/integration/tables/plist.cpp
+++ b/tests/integration/tables/plist.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for plist

--- a/tests/integration/tables/portage_keywords.cpp
+++ b/tests/integration/tables/portage_keywords.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for portage_keywords

--- a/tests/integration/tables/portage_packages.cpp
+++ b/tests/integration/tables/portage_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for portage_packages

--- a/tests/integration/tables/portage_use.cpp
+++ b/tests/integration/tables/portage_use.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for portage_use

--- a/tests/integration/tables/power_sensors.cpp
+++ b/tests/integration/tables/power_sensors.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for power_sensors

--- a/tests/integration/tables/powershell_events.cpp
+++ b/tests/integration/tables/powershell_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for powershell_events

--- a/tests/integration/tables/preferences.cpp
+++ b/tests/integration/tables/preferences.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for preferences

--- a/tests/integration/tables/process_envs.cpp
+++ b/tests/integration/tables/process_envs.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_envs

--- a/tests/integration/tables/process_events.cpp
+++ b/tests/integration/tables/process_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_events

--- a/tests/integration/tables/process_file_events.cpp
+++ b/tests/integration/tables/process_file_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_file_events

--- a/tests/integration/tables/process_memory_map.cpp
+++ b/tests/integration/tables/process_memory_map.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_memory_map

--- a/tests/integration/tables/process_namespaces.cpp
+++ b/tests/integration/tables/process_namespaces.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_namespaces

--- a/tests/integration/tables/process_open_files.cpp
+++ b/tests/integration/tables/process_open_files.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_open_files

--- a/tests/integration/tables/process_open_sockets.cpp
+++ b/tests/integration/tables/process_open_sockets.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for process_open_sockets

--- a/tests/integration/tables/processes.cpp
+++ b/tests/integration/tables/processes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for processes

--- a/tests/integration/tables/programs.cpp
+++ b/tests/integration/tables/programs.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for programs

--- a/tests/integration/tables/prometheus_metrics.cpp
+++ b/tests/integration/tables/prometheus_metrics.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for prometheus_metrics

--- a/tests/integration/tables/python_packages.cpp
+++ b/tests/integration/tables/python_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for python_packages

--- a/tests/integration/tables/quicklook_cache.cpp
+++ b/tests/integration/tables/quicklook_cache.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for quicklook_cache

--- a/tests/integration/tables/registry.cpp
+++ b/tests/integration/tables/registry.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for registry

--- a/tests/integration/tables/routes.cpp
+++ b/tests/integration/tables/routes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for routes

--- a/tests/integration/tables/rpm_package_files.cpp
+++ b/tests/integration/tables/rpm_package_files.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for rpm_package_files

--- a/tests/integration/tables/rpm_packages.cpp
+++ b/tests/integration/tables/rpm_packages.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for rpm_packages

--- a/tests/integration/tables/running_apps.cpp
+++ b/tests/integration/tables/running_apps.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for running_apps

--- a/tests/integration/tables/safari_extensions.cpp
+++ b/tests/integration/tables/safari_extensions.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for safari_extensions

--- a/tests/integration/tables/sandboxes.cpp
+++ b/tests/integration/tables/sandboxes.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for sandboxes

--- a/tests/integration/tables/scheduled_tasks.cpp
+++ b/tests/integration/tables/scheduled_tasks.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for scheduled_tasks

--- a/tests/integration/tables/selinux_events.cpp
+++ b/tests/integration/tables/selinux_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for selinux_events

--- a/tests/integration/tables/services.cpp
+++ b/tests/integration/tables/services.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for services

--- a/tests/integration/tables/shadow.cpp
+++ b/tests/integration/tables/shadow.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for shadow

--- a/tests/integration/tables/shared_folders.cpp
+++ b/tests/integration/tables/shared_folders.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for shared_folders

--- a/tests/integration/tables/shared_memory.cpp
+++ b/tests/integration/tables/shared_memory.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for shared_memory

--- a/tests/integration/tables/shared_resources.cpp
+++ b/tests/integration/tables/shared_resources.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for shared_resources

--- a/tests/integration/tables/sharing_preferences.cpp
+++ b/tests/integration/tables/sharing_preferences.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for sharing_preferences

--- a/tests/integration/tables/shell_history.cpp
+++ b/tests/integration/tables/shell_history.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for shell_history

--- a/tests/integration/tables/signature.cpp
+++ b/tests/integration/tables/signature.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for signature

--- a/tests/integration/tables/sip_config.cpp
+++ b/tests/integration/tables/sip_config.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for sip_config

--- a/tests/integration/tables/smart_drive_info.cpp
+++ b/tests/integration/tables/smart_drive_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for smart_drive_info

--- a/tests/integration/tables/smbios_tables.cpp
+++ b/tests/integration/tables/smbios_tables.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for smbios_tables

--- a/tests/integration/tables/smc_keys.cpp
+++ b/tests/integration/tables/smc_keys.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for smc_keys

--- a/tests/integration/tables/socket_events.cpp
+++ b/tests/integration/tables/socket_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for socket_events

--- a/tests/integration/tables/ssh_configs.cpp
+++ b/tests/integration/tables/ssh_configs.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ssh_configs

--- a/tests/integration/tables/startup_items.cpp
+++ b/tests/integration/tables/startup_items.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for startup_items

--- a/tests/integration/tables/sudoers.cpp
+++ b/tests/integration/tables/sudoers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for sudoers

--- a/tests/integration/tables/suid_bin.cpp
+++ b/tests/integration/tables/suid_bin.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for suid_bin

--- a/tests/integration/tables/syslog_events.cpp
+++ b/tests/integration/tables/syslog_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for syslog_events

--- a/tests/integration/tables/system_controls.cpp
+++ b/tests/integration/tables/system_controls.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for system_controls

--- a/tests/integration/tables/system_info.cpp
+++ b/tests/integration/tables/system_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for system_info

--- a/tests/integration/tables/temperature_sensors.cpp
+++ b/tests/integration/tables/temperature_sensors.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for temperature_sensors

--- a/tests/integration/tables/time.cpp
+++ b/tests/integration/tables/time.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for time

--- a/tests/integration/tables/time_machine_backups.cpp
+++ b/tests/integration/tables/time_machine_backups.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for time_machine_backups

--- a/tests/integration/tables/time_machine_destinations.cpp
+++ b/tests/integration/tables/time_machine_destinations.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for time_machine_destinations

--- a/tests/integration/tables/ulimit_info.cpp
+++ b/tests/integration/tables/ulimit_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for ulimit_info

--- a/tests/integration/tables/uptime.cpp
+++ b/tests/integration/tables/uptime.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/tests/integration/tables/helper.h>

--- a/tests/integration/tables/usb_devices.cpp
+++ b/tests/integration/tables/usb_devices.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for usb_devices

--- a/tests/integration/tables/user_events.cpp
+++ b/tests/integration/tables/user_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for user_events

--- a/tests/integration/tables/user_groups.cpp
+++ b/tests/integration/tables/user_groups.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for user_groups

--- a/tests/integration/tables/user_interaction_events.cpp
+++ b/tests/integration/tables/user_interaction_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for user_interaction_events

--- a/tests/integration/tables/user_ssh_keys.cpp
+++ b/tests/integration/tables/user_ssh_keys.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for user_ssh_keys

--- a/tests/integration/tables/users.cpp
+++ b/tests/integration/tables/users.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for users

--- a/tests/integration/tables/video_info.cpp
+++ b/tests/integration/tables/video_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for video_info

--- a/tests/integration/tables/virtual_memory_info.cpp
+++ b/tests/integration/tables/virtual_memory_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for virtual_memory_info

--- a/tests/integration/tables/wifi_networks.cpp
+++ b/tests/integration/tables/wifi_networks.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wifi_networks

--- a/tests/integration/tables/wifi_status.cpp
+++ b/tests/integration/tables/wifi_status.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wifi_status

--- a/tests/integration/tables/wifi_survey.cpp
+++ b/tests/integration/tables/wifi_survey.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wifi_survey

--- a/tests/integration/tables/winbaseobj.cpp
+++ b/tests/integration/tables/winbaseobj.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for winbaseobj

--- a/tests/integration/tables/windows_crashes.cpp
+++ b/tests/integration/tables/windows_crashes.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for windows_crashes

--- a/tests/integration/tables/windows_events.cpp
+++ b/tests/integration/tables/windows_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for windows_events

--- a/tests/integration/tables/wmi_bios_info.cpp
+++ b/tests/integration/tables/wmi_bios_info.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wmi_bios_info

--- a/tests/integration/tables/wmi_cli_event_consumers.cpp
+++ b/tests/integration/tables/wmi_cli_event_consumers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wmi_cli_event_consumers

--- a/tests/integration/tables/wmi_event_filters.cpp
+++ b/tests/integration/tables/wmi_event_filters.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wmi_event_filters

--- a/tests/integration/tables/wmi_filter_consumer_binding.cpp
+++ b/tests/integration/tables/wmi_filter_consumer_binding.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wmi_filter_consumer_binding

--- a/tests/integration/tables/wmi_script_event_consumers.cpp
+++ b/tests/integration/tables/wmi_script_event_consumers.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for wmi_script_event_consumers

--- a/tests/integration/tables/xprotect_entries.cpp
+++ b/tests/integration/tables/xprotect_entries.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for xprotect_entries

--- a/tests/integration/tables/xprotect_meta.cpp
+++ b/tests/integration/tables/xprotect_meta.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for xprotect_meta

--- a/tests/integration/tables/xprotect_reports.cpp
+++ b/tests/integration/tables/xprotect_reports.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for xprotect_reports

--- a/tests/integration/tables/yara.cpp
+++ b/tests/integration/tables/yara.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for yara

--- a/tests/integration/tables/yara_events.cpp
+++ b/tests/integration/tables/yara_events.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for yara_events

--- a/tests/integration/tables/yum_sources.cpp
+++ b/tests/integration/tables/yum_sources.cpp
@@ -3,10 +3,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 // Sanity check integration test for yum_sources

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <chrono>

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #pragma once

--- a/tests/unit/config/plugins/tls_config_tests.cpp
+++ b/tests/unit/config/plugins/tls_config_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <vector>

--- a/tests/unit/core/process_tests.cpp
+++ b/tests/unit/core/process_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #ifndef WIN32

--- a/tests/unit/events/windows/windows_event_log_tests.cpp
+++ b/tests/unit/events/windows/windows_event_log_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/tests/unit/tables/system/posix/augeas_tests.cpp
+++ b/tests/unit/tables/system/posix/augeas_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/tests/unit/tables/system/windows/registry_tests.cpp
+++ b/tests/unit/tables/system/windows/registry_tests.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <boost/algorithm/string/predicate.hpp>

--- a/tools/analysis/fuzz.py
+++ b/tools/analysis/fuzz.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/analysis/stress.py
+++ b/tools/analysis/stress.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/analysis/system_stress.py
+++ b/tools/analysis/system_stress.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from multiprocessing import Process, Lock, Value
 import subprocess

--- a/tools/audit.sh
+++ b/tools/audit.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Make a best effort to dot-source our utils script
 $utils = Join-Path $(Get-Location) '.\tools\provision\chocolatey\osquery_utils.ps1'

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/codegen/BUCK
+++ b/tools/codegen/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_filegroup", "osquery_target")
 load("//tools/build_defs/oss/osquery:python.bzl", "osquery_python_binary", "osquery_python_library")

--- a/tools/codegen/amalgamate.py
+++ b/tools/codegen/amalgamate.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/codegen/genapi.py
+++ b/tools/codegen/genapi.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/codegen/gentable.py
+++ b/tools/codegen/gentable.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -11,10 +11,8 @@ Usage:
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -8,10 +8,8 @@ Usage:
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/codegen/substitute.py
+++ b/tools/codegen/substitute.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 """
 Replace every occurrences of pattern in every string of input file and write it in output

--- a/tools/codegen/templates/amalgamation.cpp.in
+++ b/tools/codegen/templates/amalgamation.cpp.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/tools/codegen/templates/blacklist.cpp.in
+++ b/tools/codegen/templates/blacklist.cpp.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/tools/codegen/templates/default.cpp.in
+++ b/tools/codegen/templates/default.cpp.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/tools/codegen/templates/foreign.cpp.in
+++ b/tools/codegen/templates/foreign.cpp.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/tools/codegen/templates/osquery_extension_group_main.cpp.in
+++ b/tools/codegen/templates/osquery_extension_group_main.cpp.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <osquery/sdk.h>

--- a/tools/codegen/templates/typed_row.h.in
+++ b/tools/codegen/templates/typed_row.h.in
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 /*

--- a/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
 $serviceName = 'osqueryd'

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
 $serviceName = 'osqueryd'

--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 $progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
 $targetFolder = Join-Path $progData "osquery"
 $serviceName = 'osqueryd'

--- a/tools/deployment/getfiles.py
+++ b/tools/deployment/getfiles.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/deployment/make_linux_package.sh
+++ b/tools/deployment/make_linux_package.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/deployment/make_osx_package.sh
+++ b/tools/deployment/make_osx_package.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # We make heavy use of Write-Host, because colors are awesome. #dealwithit.
 

--- a/tools/deployment/osqueryctl
+++ b/tools/deployment/osqueryctl
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/formatting/format-check.py
+++ b/tools/formatting/format-check.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 import argparse
 import os

--- a/tools/get_platform.py
+++ b/tools/get_platform.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/lib.sh
+++ b/tools/lib.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 LIB_SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 

--- a/tools/manage-osqueryd.ps1
+++ b/tools/manage-osqueryd.ps1
@@ -1,10 +1,8 @@
 ﻿#  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 param(
   [string] $startupArgs = "",

--- a/tools/provision.ps1
+++ b/tools/provision.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Turn on support for Powershell Cmdlet Bindings
 [CmdletBinding(SupportsShouldProcess = $true)]

--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/provision/amazon.sh
+++ b/tools/provision/amazon.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo yum update -y

--- a/tools/provision/arch.sh
+++ b/tools/provision/arch.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo pacman -Syu

--- a/tools/provision/centos.sh
+++ b/tools/provision/centos.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo yum update -y

--- a/tools/provision/chocolatey/aws-sdk-cpp.ps1
+++ b/tools/provision/chocolatey/aws-sdk-cpp.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 $version = '1.4.55'

--- a/tools/provision/chocolatey/boost-msvc14.ps1
+++ b/tools/provision/chocolatey/boost-msvc14.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # For more information -
 # https://studiofreya.com/2016/09/29/how-to-build-boost-1-62-with-visual-studio-2015/

--- a/tools/provision/chocolatey/gflags-dev.ps1
+++ b/tools/provision/chocolatey/gflags-dev.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/glog.ps1
+++ b/tools/provision/chocolatey/glog.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/llvm-clang.ps1
+++ b/tools/provision/chocolatey/llvm-clang.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/openssl.ps1
+++ b/tools/provision/chocolatey/openssl.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Force Powershell to use TLS 1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12

--- a/tools/provision/chocolatey/rapidjson.ps1
+++ b/tools/provision/chocolatey/rapidjson.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/rocksdb.ps1
+++ b/tools/provision/chocolatey/rocksdb.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/thrift-dev.ps1
+++ b/tools/provision/chocolatey/thrift-dev.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 #

--- a/tools/provision/chocolatey/zstd.ps1
+++ b/tools/provision/chocolatey/zstd.ps1
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # Update-able metadata
 $version = '1.2.0'

--- a/tools/provision/darwin.sh
+++ b/tools/provision/darwin.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 DARWIN_SETUP="\
 if [[ ! -f /var/.osquery_build ]]; then \

--- a/tools/provision/debian.sh
+++ b/tools/provision/debian.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo apt-get -y update

--- a/tools/provision/fedora.sh
+++ b/tools/provision/fedora.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo dnf update -y

--- a/tools/provision/freebsd.sh
+++ b/tools/provision/freebsd.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo pkg update

--- a/tools/provision/lib.sh
+++ b/tools/provision/lib.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 # 1: Path to install brew into
 # 2: Linux or Darwin

--- a/tools/provision/manjaro.sh
+++ b/tools/provision/manjaro.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo pacman -Syu

--- a/tools/provision/oracle.sh
+++ b/tools/provision/oracle.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo yum update -y

--- a/tools/provision/rhel.sh
+++ b/tools/provision/rhel.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo yum update -y

--- a/tools/provision/scientific.sh
+++ b/tools/provision/scientific.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo yum update -y

--- a/tools/provision/suse.sh
+++ b/tools/provision/suse.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo zypper update -y

--- a/tools/provision/ubuntu.sh
+++ b/tools/provision/ubuntu.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 function distro_main() {
   do_sudo apt-get -y update

--- a/tools/release/build_release.sh
+++ b/tools/release/build_release.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/release/commit_schema.sh
+++ b/tools/release/commit_schema.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/release/deps_release.sh
+++ b/tools/release/deps_release.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/release/new_release.sh
+++ b/tools/release/new_release.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/release/sign_release.sh
+++ b/tools/release/sign_release.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2015, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/sync.sh
+++ b/tools/sync.sh
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 set -e
 

--- a/tools/tests/BUCK
+++ b/tools/tests/BUCK
@@ -1,10 +1,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_filegroup")
 load("//tools/build_defs/oss/osquery:python.bzl", "osquery_python_library")

--- a/tools/tests/plist_benchmark.cpp
+++ b/tools/tests/plist_benchmark.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <gtest/gtest.h>

--- a/tools/tests/test.cpp
+++ b/tools/tests/test.cpp
@@ -2,10 +2,8 @@
  *  Copyright (c) 2014-present, Facebook, Inc.
  *  All rights reserved.
  *
- *  This source code is licensed under both the Apache 2.0 license (found in the
- *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
- *  in the COPYING file in the root directory of this source tree).
- *  You may select, at your option, one of the above-listed licenses.
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
  */
 
 #include <iostream>

--- a/tools/tests/test_additional.py
+++ b/tools/tests/test_additional.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_base.py
+++ b/tools/tests/test_base.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_example_queries.py
+++ b/tools/tests/test_example_queries.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_extensions.py
+++ b/tools/tests/test_extensions.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_http_server.py
+++ b/tools/tests/test_http_server.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_osqueryd.py
+++ b/tools/tests/test_osqueryd.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_osqueryi.py
+++ b/tools/tests/test_osqueryi.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/test_windows_service.py
+++ b/tools/tests/test_windows_service.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/utils.py
+++ b/tools/tests/utils.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 
 from __future__ import absolute_import
 from __future__ import division

--- a/tools/tests/winexpect.py
+++ b/tools/tests/winexpect.py
@@ -3,10 +3,8 @@
 #  Copyright (c) 2014-present, Facebook, Inc.
 #  All rights reserved.
 #
-#  This source code is licensed under both the Apache 2.0 license (found in the
-#  LICENSE file in the root directory of this source tree) and the GPLv2 (found
-#  in the COPYING file in the root directory of this source tree).
-#  You may select, at your option, one of the above-listed licenses.
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
 """
     A Windows specific implementation of REPLWrapper from pexpect.
 


### PR DESCRIPTION
Summary:
LICENSE is now defined in a single file on the root of the project, update the
header to contain that information.

*Project LICENSE did not change*.

Reviewed By: akindyakov

Differential Revision: D13750575
