### PR TITLE
Use apple_binary to generate binary for MacOS

### DIFF
--- a/osquery/BUCK
+++ b/osquery/BUCK
@@ -31,7 +31,7 @@ osquery_cxx_library(
         osquery_target("osquery/core/plugins:plugins"),
         osquery_target("osquery/utils/info:info"),
         osquery_target("osquery/utils/macros:macros"),
-        osquery_target("osquery/utils/system:system"),
+        osquery_target("osquery/utils/system:system_utils"),
         osquery_tp_target("gflags"),
         osquery_tp_target("googletest", "gtest"),
         osquery_tp_target("sqlite"),

--- a/osquery/core/BUCK
+++ b/osquery/core/BUCK
@@ -86,7 +86,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/info:info"),
         osquery_target("osquery/utils/system:env"),
-        osquery_target("osquery/utils/system:system"),
+        osquery_target("osquery/utils/system:system_utils"),
         osquery_target("osquery/utils/system:time"),
         osquery_target("osquery/logger:logger"),
         osquery_tp_target("gflags"),

--- a/osquery/tables/system/BUCK
+++ b/osquery/tables/system/BUCK
@@ -316,7 +316,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/expected:expected"),
         osquery_target("osquery/utils/system:filepath"),
-        osquery_target("osquery/utils/system:system"),
+        osquery_target("osquery/utils/system:system_utils"),
         osquery_target("osquery/utils/system:time"),
         osquery_target("osquery/utils/system:uptime"),
         osquery_target("specs:tables_processes_row"),

--- a/osquery/tables/utility/BUCK
+++ b/osquery/tables/utility/BUCK
@@ -23,7 +23,7 @@ osquery_cxx_library(
         osquery_target("osquery/filesystem:osquery_filesystem"),
         osquery_target("osquery/process:process"),
         osquery_target("osquery/utils/macros:macros"),
-        osquery_target("osquery/utils/system:system"),
+        osquery_target("osquery/utils/system:system_utils"),
         osquery_tp_target("boost"),
     ],
 )

--- a/osquery/utils/json/BUCK
+++ b/osquery/utils/json/BUCK
@@ -27,7 +27,7 @@ osquery_cxx_library(
         osquery_target("osquery/utils:utils"),
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/status:status"),
-        osquery_target("osquery/utils/system:system"),
+        osquery_target("osquery/utils/system:system_utils"),
         osquery_tp_target("rapidjson"),
     ],
 )

--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -181,7 +181,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_library(
-    name = "system",
+    name = "system_utils",
     header_namespace = "osquery/utils/system",
     exported_platform_headers = [
         (
@@ -241,6 +241,6 @@ osquery_cxx_library(
     ],
     visibility = ["PUBLIC"],
     deps = [
-        ":system",
+        ":system_utils",
     ],
 )

--- a/tools/build_defs/oss/osquery/cxx.bzl
+++ b/tools/build_defs/oss/osquery/cxx.bzl
@@ -4,6 +4,7 @@ load(
     _osquery_cxx_binary = "osquery_cxx_binary",
     _osquery_cxx_library = "osquery_cxx_library",
     _osquery_cxx_test = "osquery_cxx_test",
+    _osquery_native = "osquery_native",
     _osquery_prebuilt_cxx_library = "osquery_prebuilt_cxx_library",
     _osquery_prebuilt_cxx_library_group = "osquery_prebuilt_cxx_library_group",
 )
@@ -119,7 +120,13 @@ def osquery_cxx_binary(external = False, **kwargs):
     _ignore = [external]
     _osquery_set_generic_kwargs(kwargs)
     _osquery_set_preprocessor_kwargs(kwargs, external)
-    _osquery_cxx_binary(**kwargs)
+    if host_info().os.is_macos:
+        not_supported_key = "platforms"
+        if not_supported_key in kwargs:
+            kwargs.pop(not_supported_key)
+        _osquery_native.apple_binary(**kwargs)
+    else:
+        _osquery_cxx_binary(**kwargs)
 
 def osquery_cxx_test(external = False, **kwargs):
     _ignore = [external]


### PR DESCRIPTION
Summary: It is better supported and also allows us to generate Xcode project

Differential Revision: D13761638
