### PR TITLE
windows/logical_drives: Refactor

### DIFF
--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,11 +22,11 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    uint64_t freeSpace = -1;
+    uint64_t freeSpace = -1, driveSize = -1;
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
     logicalDisk.GetUnsignedLongLong("FreeSpace", freeSpace);
-    logicalDisk.GetString("Size", r["size"]);
+    logicalDisk.GetUnsignedLongLong("Size", driveSize);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
     // NOTE(ww): Previous versions of this table used the type
@@ -35,7 +35,8 @@ QueryData genLogicalDrives(QueryContext& context) {
     // return "Unknown". That behavior is preserved here.
     r["type"] = "Unknown";
     r["device_id"] = deviceId;
-    r["free_space"] = BIGINT(freeSpace);
+    r["free_space"] = UNSIGNED_BIGINT(freeSpace);
+    r["size"] = UNSIGNED_BIGINT(driveSize);
     r["boot_partition"] = INTEGER(0);
 
     std::string assocQuery =

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,12 +22,17 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    r["free_space"] = r["size"] = "-1";
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
-    logicalDisk.GetString("FreeSpace", r["free_space"]);
-    logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
+
+    if (!logicalDisk.GetString("FreeSpace", r["free_space"]).ok()) {
+      r["free_space"] = "-1";
+    }
+
+    if (!logicalDisk.GetString("Size", r["size"]).ok()) {
+      r["free_space"] = "-1";
+    }
 
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,9 +22,10 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
+    uint64_t freeSpace = -1;
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
-    logicalDisk.GetString("FreeSpace", r["free_space"]);
+    logicalDisk.GetUnsignedLongLong("FreeSpace", freeSpace);
     logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
@@ -34,6 +35,7 @@ QueryData genLogicalDrives(QueryContext& context) {
     // return "Unknown". That behavior is preserved here.
     r["type"] = "Unknown";
     r["device_id"] = deviceId;
+    r["free_space"] = BIGINT(freeSpace);
     r["boot_partition"] = INTEGER(0);
 
     std::string assocQuery =

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,6 +22,7 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
+    r["free_space"] = r["size"] = "-1";
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
     logicalDisk.GetString("FreeSpace", r["free_space"]);

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -18,15 +18,15 @@ QueryData genLogicalDrives(QueryContext& context) {
   const WmiRequest wmiLogicalDiskReq(
       "select DeviceID, Description, FreeSpace, Size, FileSystem from "
       "Win32_LogicalDisk");
-  auto const& wmiResults = wmiLogicalDiskReq.results();
-  for (unsigned int i = 0; i < wmiResults.size(); ++i) {
+  auto const& logicalDisks = wmiLogicalDiskReq.results();
+  for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    wmiResults[i].GetString("DeviceID", deviceId);
-    wmiResults[i].GetString("Description", r["type"]);
-    wmiResults[i].GetString("FreeSpace", r["free_space"]);
-    wmiResults[i].GetString("Size", r["size"]);
-    wmiResults[i].GetString("FileSystem", r["file_system"]);
+    logicalDisk.GetString("DeviceID", deviceId);
+    logicalDisk.GetString("Description", r["type"]);
+    logicalDisk.GetString("FreeSpace", r["free_space"]);
+    logicalDisk.GetString("Size", r["size"]);
+    logicalDisk.GetString("FileSystem", r["file_system"]);
 
     r["device_id"] = deviceId;
     r["boot_partition"] = INTEGER(0);

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,11 +22,11 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    uint64_t freeSpace = -1, driveSize = -1;
+    uint64_t freeSpace = -1;
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
     logicalDisk.GetUnsignedLongLong("FreeSpace", freeSpace);
-    logicalDisk.GetUnsignedLongLong("Size", driveSize);
+    logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
     // NOTE(ww): Previous versions of this table used the type
@@ -35,8 +35,7 @@ QueryData genLogicalDrives(QueryContext& context) {
     // return "Unknown". That behavior is preserved here.
     r["type"] = "Unknown";
     r["device_id"] = deviceId;
-    r["free_space"] = UNSIGNED_BIGINT(freeSpace);
-    r["size"] = UNSIGNED_BIGINT(driveSize);
+    r["free_space"] = BIGINT(freeSpace);
     r["boot_partition"] = INTEGER(0);
 
     std::string assocQuery =

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,7 +22,6 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    r["free_space"] = r["size"] = "-1";
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
     logicalDisk.GetString("FreeSpace", r["free_space"]);

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -52,8 +52,7 @@ QueryData genLogicalDrives(QueryContext& context) {
             "SELECT BootPartition FROM Win32_DiskPartition WHERE DeviceID='") +
         partitionDeviceId + '\'';
     const WmiRequest wmiPartitionReq(partitionQuery);
-    auto const& wmiPartitionResults =
-        wmiPartitionReq.results();
+    auto const& wmiPartitionResults = wmiPartitionReq.results();
 
     if (wmiPartitionResults.empty()) {
       results.push_back(r);

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,17 +22,12 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
+    r["free_space"] = r["size"] = "-1";
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
+    logicalDisk.GetString("FreeSpace", r["free_space"]);
+    logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
-
-    if (!logicalDisk.GetString("FreeSpace", r["free_space"]).ok()) {
-      r["free_space"] = "-1";
-    }
-
-    if (!logicalDisk.GetString("Size", r["size"]).ok()) {
-      r["free_space"] = "-1";
-    }
 
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -29,6 +29,14 @@ QueryData genLogicalDrives(QueryContext& context) {
     logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
+    if (r["free_space"].empty()) {
+      r["free_space"] = "-1";
+    }
+
+    if (r["size"].empty()) {
+      r["size"] = "-1";
+    }
+
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.
     // However, a bug in WMI marshalling caused the type to always

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -22,10 +22,9 @@ QueryData genLogicalDrives(QueryContext& context) {
   for (const auto& logicalDisk : logicalDisks) {
     Row r;
     std::string deviceId;
-    uint64_t freeSpace = -1;
     logicalDisk.GetString("DeviceID", deviceId);
     logicalDisk.GetString("Description", r["description"]);
-    logicalDisk.GetUnsignedLongLong("FreeSpace", freeSpace);
+    logicalDisk.GetString("FreeSpace", r["free_space"]);
     logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
@@ -35,7 +34,6 @@ QueryData genLogicalDrives(QueryContext& context) {
     // return "Unknown". That behavior is preserved here.
     r["type"] = "Unknown";
     r["device_id"] = deviceId;
-    r["free_space"] = BIGINT(freeSpace);
     r["boot_partition"] = INTEGER(0);
 
     std::string assocQuery =

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -23,11 +23,16 @@ QueryData genLogicalDrives(QueryContext& context) {
     Row r;
     std::string deviceId;
     logicalDisk.GetString("DeviceID", deviceId);
-    logicalDisk.GetString("Description", r["type"]);
+    logicalDisk.GetString("Description", r["description"]);
     logicalDisk.GetString("FreeSpace", r["free_space"]);
     logicalDisk.GetString("Size", r["size"]);
     logicalDisk.GetString("FileSystem", r["file_system"]);
 
+    // NOTE(ww): Previous versions of this table used the type
+    // column to provide a non-canonical description of the drive.
+    // However, a bug in WMI marshalling caused the type to always
+    // return "Unknown". That behavior is preserved here.
+    r["type"] = "Unknown";
     r["device_id"] = deviceId;
     r["boot_partition"] = INTEGER(0);
 

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -4,8 +4,8 @@ schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
     Column("type", TEXT, "Deprecated."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
-    Column("free_space", BIGINT, "The amount of free space, in bytes, on the drive (-1 on failure)."),
-    Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
+    Column("free_space", UNSIGNED_BIGINT, "The amount of free space, in bytes, on the drive."),
+    Column("size", UNSIGNED_BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),
     Column("boot_partition", INTEGER, "True if Windows booted from this drive."),
 ])

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -4,8 +4,8 @@ schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
     Column("type", TEXT, "Deprecated."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
-    Column("free_space", UNSIGNED_BIGINT, "The amount of free space, in bytes, on the drive."),
-    Column("size", UNSIGNED_BIGINT, "The total amount of space, in bytes, of the drive."),
+    Column("free_space", BIGINT, "The amount of free space, in bytes, on the drive (-1 on failure)."),
+    Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),
     Column("boot_partition", INTEGER, "True if Windows booted from this drive."),
 ])

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -4,7 +4,7 @@ schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
     Column("type", TEXT, "Deprecated."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
-    Column("free_space", BIGINT, "The amount of free space, in bytes, on the drive (-1 on failure)."),
+    Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),
     Column("boot_partition", INTEGER, "True if Windows booted from this drive."),

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -4,8 +4,8 @@ schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
     Column("type", TEXT, "Deprecated."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
-    Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
-    Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
+    Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive (-1 on failure)."),
+    Column("size", BIGINT, "The total amount of space, in bytes, of the drive (-1 on failure)."),
     Column("file_system", TEXT, "The file system of the drive."),
     Column("boot_partition", INTEGER, "True if Windows booted from this drive."),
 ])

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -2,7 +2,7 @@ table_name("logical_drives")
 description("Details for logical drives on the system. A logical drive generally represents a single partition.")
 schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
-    Column("type", TEXT, "The type of disk drive this logical drive represents."),
+    Column("type", TEXT, "The type of disk drive this logical drive represents, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
     Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -2,7 +2,7 @@ table_name("logical_drives")
 description("Details for logical drives on the system. A logical drive generally represents a single partition.")
 schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
-    Column("type", TEXT, "Deprecated."),
+    Column("type", TEXT, "Deprecated (always 'Unknown')."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
     Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive (-1 on failure)."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive (-1 on failure)."),

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -2,7 +2,8 @@ table_name("logical_drives")
 description("Details for logical drives on the system. A logical drive generally represents a single partition.")
 schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
-    Column("type", TEXT, "The type of disk drive this logical drive represents, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
+    Column("type", TEXT, "Deprecated."),
+    Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
     Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),

--- a/specs/windows/logical_drives.table
+++ b/specs/windows/logical_drives.table
@@ -4,7 +4,7 @@ schema([
     Column("device_id", TEXT, "The drive id, usually the drive name, e.g., 'C:'."),
     Column("type", TEXT, "Deprecated."),
     Column("description", TEXT, "The canonical description of the drive, e.g. 'Logical Fixed Disk', 'CD-ROM Disk'."),
-    Column("free_space", BIGINT, "The amount of free space, in bytes, of the drive."),
+    Column("free_space", BIGINT, "The amount of free space, in bytes, on the drive (-1 on failure)."),
     Column("size", BIGINT, "The total amount of space, in bytes, of the drive."),
     Column("file_system", TEXT, "The file system of the drive."),
     Column("boot_partition", INTEGER, "True if Windows booted from this drive."),

--- a/tests/integration/tables/logical_drives.cpp
+++ b/tests/integration/tables/logical_drives.cpp
@@ -29,6 +29,7 @@ TEST_F(logicalDrives, test_sanity) {
   ValidatatioMap row_map = {
       {"device_id", NormalType},
       {"type", NormalType},
+      {"description", NormalType},
       {"free_space", IntType},
       {"size", IntType},
       {"file_system", NormalType},

--- a/tests/integration/tables/logical_drives.cpp
+++ b/tests/integration/tables/logical_drives.cpp
@@ -23,25 +23,19 @@ class logicalDrives : public testing::Test {
 };
 
 TEST_F(logicalDrives, test_sanity) {
-  // 1. Query data
   auto const data = execute_query("select * from logical_drives");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for avaialbe flags
-  // Or use custom DataCheck object
-  // ValidatatioMap row_map = {
-  //      {"device_id", NormalType}
-  //      {"type", NormalType}
-  //      {"free_space", IntType}
-  //      {"size", IntType}
-  //      {"file_system", NormalType}
-  //      {"boot_partition", IntType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+  ASSERT_GE(data.size(), 1ul);
+
+  ValidatatioMap row_map = {
+      {"device_id", NormalType},
+      {"type", NormalType},
+      {"free_space", IntType},
+      {"size", IntType},
+      {"file_system", NormalType},
+      {"boot_partition", IntType},
+  };
+
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests


### PR DESCRIPTION
This generally refactors the `logical_drives` table on Windows to conform more closely to C++11 idioms. It also enables the integration test for `logical_drives`.

See #5367. I'll open a PR for the boot partition fixes once this is merged.

cc @akindyakov @guliashvili 