### PR TITLE
to<std::string>() conversion template for c++ enums

### DIFF
--- a/osquery/utils/conversions/BUCK
+++ b/osquery/utils/conversions/BUCK
@@ -60,9 +60,23 @@ osquery_cxx_library(
     tests = [":conversions_tests"],
     visibility = ["PUBLIC"],
     deps = [
+        ":to",
         osquery_target("osquery/utils/expected:expected"),
         osquery_tp_target("boost"),
         osquery_tp_target("glog"),
+    ],
+)
+
+osquery_cxx_library(
+    name = "to",
+    header_namespace = "osquery/utils/conversions",
+    exported_headers = [
+        "to.h",
+    ],
+    tests = [":conversions_tests"],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_tp_target("boost"),
     ],
 )
 
@@ -76,5 +90,16 @@ osquery_cxx_test(
     visibility = ["PUBLIC"],
     deps = [
         ":conversions",
+    ],
+)
+
+osquery_cxx_test(
+    name = "to_tests",
+    srcs = [
+        "tests/to.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":to",
     ],
 )

--- a/osquery/utils/conversions/tests/to.cpp
+++ b/osquery/utils/conversions/tests/to.cpp
@@ -1,0 +1,55 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include <osquery/utils/conversions/to.h>
+
+namespace osquery {
+
+class NonFailingConversionsTests : public testing::Test {};
+
+enum class TestGreenColor {
+  Green,
+  Pine,
+  Fern,
+  Olive,
+};
+
+TEST_F(NonFailingConversionsTests, to_string_from_enum_class) {
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestGreenColor::Green).find("TestGreenColor[0]"));
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestGreenColor::Pine).find("TestGreenColor[1]"));
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestGreenColor::Fern).find("TestGreenColor[2]"));
+}
+
+enum class TestOrangeColor {
+  Orange,
+  Fire,
+  Clay,
+  Cider,
+};
+
+TEST_F(NonFailingConversionsTests, to_string_from_old_enum) {
+  EXPECT_NE(
+      std::string::npos,
+      to<std::string>(TestOrangeColor::Orange).find("TestOrangeColor[0]"));
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestOrangeColor::Fire).find("TestOrangeColor[1]"));
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestOrangeColor::Clay).find("TestOrangeColor[2]"));
+  EXPECT_NE(std::string::npos,
+            to<std::string>(TestOrangeColor::Cider).find("TestOrangeColor[3]"));
+}
+
+} // namespace osquery

--- a/osquery/utils/conversions/to.h
+++ b/osquery/utils/conversions/to.h
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#pragma once
+
+#include <boost/core/demangle.hpp>
+#include <type_traits>
+
+namespace osquery {
+/**
+ * Non failing conversion functions
+ */
+
+/**
+ * Conversion either scoped or unscoped enum value to std::string
+ * of human readable representation.
+ *
+ * enum class En {
+ *  First = 1,
+ * };
+ * to<std::string>(En::First) -> "En::First[1]"
+ */
+template <typename ToType, typename FromType>
+inline typename std::enable_if<std::is_enum<FromType>::value &&
+                                   std::is_same<ToType, std::string>::value,
+                               ToType>::type
+to(FromType from) noexcept {
+  auto str = ToType{boost::core::demangle(typeid(from).name())};
+  str.append("[");
+  str.append(std::to_string(
+      static_cast<typename std::underlying_type<FromType>::type>(from)));
+  str.append("]");
+  return str;
+}
+
+} // namespace osquery

--- a/osquery/utils/error/BUCK
+++ b/osquery/utils/error/BUCK
@@ -6,7 +6,6 @@
 
 load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library", "osquery_cxx_test")
 load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
-load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
 
 osquery_cxx_library(
     name = "error",
@@ -17,7 +16,7 @@ osquery_cxx_library(
     tests = [":error_tests"],
     visibility = ["PUBLIC"],
     deps = [
-        osquery_tp_target("boost"),
+        osquery_target("osquery/utils/conversions:to"),
         osquery_target("osquery/utils:attribute"),
     ],
 )

--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <osquery/utils/attribute.h>
+#include <osquery/utils/conversions/to.h>
 
-#include <boost/core/demangle.hpp>
 #include <memory>
 #include <new>
 #include <sstream>
@@ -32,11 +32,6 @@ class ErrorBase {
 
 template <typename ErrorCodeEnumType>
 class Error final : public ErrorBase {
- private:
-  static std::string getErrorTypeName() {
-    return boost::core::demangle(typeid(ErrorCodeEnumType).name());
-  }
-
  public:
   using SelfType = Error<ErrorCodeEnumType>;
 
@@ -72,8 +67,7 @@ class Error final : public ErrorBase {
   }
 
   std::string getShortMessage() const override {
-    return getErrorTypeName() + " " +
-           std::to_string(static_cast<int>(errorCode_));
+    return to<std::string>(errorCode_);
   }
 
   std::string getFullMessage() const override {

--- a/osquery/utils/error/tests/error.cpp
+++ b/osquery/utils/error/tests/error.cpp
@@ -25,10 +25,10 @@ GTEST_TEST(ErrorTest, initialization) {
   EXPECT_TRUE(error == TestError::SomeError);
 
   auto shortMsg = error.getShortMessageRecursive();
-  EXPECT_NE(std::string::npos, shortMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError[1]"));
 
   auto fullMsg = error.getFullMessageRecursive();
-  EXPECT_NE(std::string::npos, fullMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError[1]"));
   EXPECT_NE(std::string::npos, fullMsg.find("TestMessage"));
 }
 
@@ -40,13 +40,13 @@ GTEST_TEST(ErrorTest, recursive) {
   EXPECT_TRUE(error.hasUnderlyingError());
 
   auto shortMsg = error.getShortMessageRecursive();
-  EXPECT_NE(std::string::npos, shortMsg.find("TestError 1"));
-  EXPECT_NE(std::string::npos, shortMsg.find("TestError 2"));
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError[1]"));
+  EXPECT_NE(std::string::npos, shortMsg.find("TestError[2]"));
 
   auto fullMsg = error.getFullMessageRecursive();
-  EXPECT_NE(std::string::npos, fullMsg.find("TestError 1"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError[1]"));
   EXPECT_NE(std::string::npos, fullMsg.find("SuperTestMessage"));
-  EXPECT_NE(std::string::npos, fullMsg.find("TestError 2"));
+  EXPECT_NE(std::string::npos, fullMsg.find("TestError[2]"));
   EXPECT_NE(std::string::npos, fullMsg.find("TestMessage"));
 }
 


### PR DESCRIPTION
Summary:
Move out c++ enums to std::string conversion function from
osquery/utils/error.h to separate module. To be able to use it somewhere else.

Reviewed By: guliashvili

Differential Revision: D13896772
