### PR TITLE
Hash function for enum classes

### DIFF
--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -18,6 +18,8 @@
 #include <osquery/numeric_monitoring/pre_aggregation_cache.h>
 #include <osquery/registry_factory.h>
 
+#include <osquery/utils/enum_class_hash.h>
+
 namespace osquery {
 
 FLAG(bool,
@@ -45,18 +47,6 @@ inline auto reverseMap(
   }
   return reversed;
 }
-
-/**
- * This is just a ad-hoc fix up to handle libc++ and libstdc++ bug:
- * http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2148
- * Eventually it will be removed.
- */
-struct EnumClassHash {
-  template <typename EnumClassType>
-  std::size_t operator()(EnumClassType t) const {
-    return static_cast<std::size_t>(t);
-  }
-};
 
 const auto& getAggregationTypeToStringTable() {
   const auto static table =

--- a/osquery/utils/BUCK
+++ b/osquery/utils/BUCK
@@ -21,6 +21,7 @@ osquery_cxx_library(
         "attribute.h",
         "base64.h",
         "chars.h",
+        "enum_class_hash.h",
         "map_take.h",
         "mutex.h",
         "only_movable.h",

--- a/osquery/utils/enum_class_hash.h
+++ b/osquery/utils/enum_class_hash.h
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed as defined on the LICENSE file found in the
+ *  root directory of this source tree.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace osquery {
+
+/**
+ * This is just a ad-hoc fix up to handle libc++ and libstdc++ bug:
+ * http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2148
+ * Eventually it will be removed.
+ */
+struct EnumClassHash {
+  template <typename EnumClassType>
+  typename std::enable_if<std::is_enum<EnumClassType>::value, std::size_t>::type
+  operator()(EnumClassType t) const {
+    return static_cast<std::size_t>(t);
+  }
+};
+
+} // namespace osquery


### PR DESCRIPTION
Summary:
This is just a ad-hoc fix up to handle libc++ and libstdc++ bug:
http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2148
Eventually it will be removed.

Reviewed By: guliashvili

Differential Revision: D13896844
