### PR TITLE
Add flipType, isTypeEnter, isTypeExit for the systemcall event types

### DIFF
--- a/osquery/events/linux/probes/syscall_event.h
+++ b/osquery/events/linux/probes/syscall_event.h
@@ -22,6 +22,8 @@ enum class Type : __s32 {
   Unknown = 0,
   KillEnter = 1,
   KillExit = -KillEnter,
+  SetuidEnter = 2,
+  SetuidExit = -SetuidEnter,
 };
 
 static constexpr std::size_t kCommSize = 16u;
@@ -45,6 +47,16 @@ struct Event {
       /*  -8 */ __u32 uid;
       /*  -4 */ __u32 gid;
     } kill_enter;
+
+    struct SetuidEnter {
+      /* -40 type */
+      /* -36 pid */
+      /* -32 tgid */
+      /* -28 */ char comm[kCommSize];
+      /* -12 */ __s32 arg_uid;
+      /*  -8 */ __u32 uid;
+      /*  -4 */ __u32 gid;
+    } setuid_enter;
 
     struct Exit {
       /* -16 type */

--- a/osquery/events/linux/probes/syscall_event.h
+++ b/osquery/events/linux/probes/syscall_event.h
@@ -28,6 +28,19 @@ enum class Type : __s32 {
 
 static constexpr std::size_t kCommSize = 16u;
 
+constexpr Type flipType(Type const type) noexcept {
+  return static_cast<Type>(
+      -static_cast<std::underlying_type<Type>::type>(type));
+}
+
+constexpr bool isTypeExit(Type const type) noexcept {
+  return static_cast<std::underlying_type<Type>::type>(type) < 0;
+}
+
+constexpr bool isTypeEnter(Type const type) noexcept {
+  return 0 < static_cast<std::underlying_type<Type>::type>(type);
+}
+
 struct Event {
   // Common part for all events whether Enter or Exit
   Type type;

--- a/osquery/events/linux/probes/syscalls_programs.cpp
+++ b/osquery/events/linux/probes/syscalls_programs.cpp
@@ -107,6 +107,65 @@ Expected<ebpf::Program, ebpf::Program::Error> genLinuxKillEnterProgram(
   // clang-format on
 }
 
+Expected<ebpf::Program, ebpf::Program::Error> genLinuxSetuidEnterProgram(
+    enum bpf_prog_type prog_type, PerfEventCpuMap const& cpu_map) {
+  constexpr int kSetuidEnterSize = 40;
+  static_assert(sizeof(syscall::Type) + sizeof(syscall::Event::pid) +
+                        sizeof(syscall::Event::tgid) +
+                        sizeof(syscall::Event::Body::SetuidEnter) ==
+                    kSetuidEnterSize,
+                "A program below relies on certain size of output struct");
+  static_assert(static_cast<__s32>(syscall::Type::SetuidEnter) ==
+                    -static_cast<__s32>(syscall::Type::SetuidExit),
+                "Enter and Exit codes must be convertible to each other by "
+                "multiplying to -1");
+  // clang-format off
+  return ebpf::Program::load({
+    //                      code ,  dst reg ,  src reg , offset , immediate constant(k)
+    {BPF_ALU64 | BPF_X | BPF_MOV , BPF_REG_6, BPF_REG_1,     0,  0}, // r6 = r1
+    {BPF_ALU64 | BPF_K | BPF_MOV , BPF_REG_1,         0,     0,  0}, // r1 = 0
+
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_1,  -28,  0},
+    {BPF_STX | BPF_DW | BPF_MEM  , BPF_REG_10, BPF_REG_1,  -24,  0},
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_1,  -16,  0},
+
+    // Event.type = SyscallEvent::Type::SetuidEnter
+    {BPF_ST  | BPF_W | BPF_MEM   , BPF_REG_10,         0,  -kSetuidEnterSize,  static_cast<__s32>(syscall::Type::SetuidEnter)},
+
+    {BPF_JMP | BPF_K | BPF_CALL  ,          0,         0,    0,  BPF_FUNC_get_current_uid_gid},
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_0,   -8,  0}, // Event.uid
+    {BPF_ALU64 | BPF_K | BPF_RSH ,          0,         0,    0,  32},
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_0,   -4,  0}, // Event.gid
+
+    {BPF_JMP | BPF_K | BPF_CALL  ,          0,         0,    0,  BPF_FUNC_get_current_pid_tgid},
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_0,  -36,  0}, // Event.body.pid
+    {BPF_ALU64 | BPF_K | BPF_RSH ,          0,         0,    0,  32},
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_0,  -32,  0}, // Event.body.tgid
+
+    {BPF_ALU64 | BPF_X | BPF_MOV , BPF_REG_1, BPF_REG_10,    0,  0}, // r1 = r10
+    {BPF_ALU64 | BPF_K | BPF_ADD , BPF_REG_1,          0,    0,  -28}, // r1 += -36
+    {BPF_ALU64 | BPF_K | BPF_MOV , BPF_REG_2,          0,    0, syscall::kCommSize},   // r2 = SyscallEvent::kCommSize
+    {BPF_JMP | BPF_K | BPF_CALL  ,         0,          0,    0, BPF_FUNC_get_current_comm}, // call
+
+    {BPF_LDX | BPF_DW | BPF_MEM  , BPF_REG_7,  BPF_REG_6,   16,  0}, // see format: arg uid
+    {BPF_STX | BPF_W | BPF_MEM   , BPF_REG_10, BPF_REG_7,  -12,  0}, // Event.body.arg_uid
+
+    {BPF_ALU64 | BPF_X | BPF_MOV , BPF_REG_4, BPF_REG_10,    0,  0}, // r4 = r10
+    {BPF_ALU64 | BPF_K | BPF_ADD , BPF_REG_4,          0,    0,  -kSetuidEnterSize}, // r4 += -kSetuidEnterSize
+    {BPF_ALU64 | BPF_X | BPF_MOV , BPF_REG_1,  BPF_REG_6,    0,  0}, // r1 = r6
+    {BPF_LD | BPF_DW | BPF_IMM   , BPF_REG_2, BPF_PSEUDO_MAP_FD, 0, cpu_map.fd()},
+    {BPF_LD | BPF_W | BPF_IMM    ,         0,          0,    0,  0}, // imm is 32, but we loading 64, so this is yet another "smart" trick
+    {BPF_LD | BPF_DW | BPF_IMM   , BPF_REG_3,          0,    0, -1}, // r2 = -1 -> CPU
+    {BPF_LD | BPF_W | BPF_IMM    ,         0,          0,    0,  0}, // imm is 32, but we loading 64, so this is yet another "smart" trick
+    {BPF_ALU64 | BPF_K | BPF_MOV , BPF_REG_5,          0,    0, kSetuidEnterSize}, // r5 = kSetuidEnterSize
+    {BPF_JMP | BPF_K | BPF_CALL  ,         0,          0,    0, BPF_FUNC_perf_event_output}, // call
+    {BPF_ALU64 | BPF_K | BPF_MOV , BPF_REG_0,          0,    0,  0}, // r0 = 0
+    {BPF_JMP | BPF_K | BPF_EXIT  ,         0,          0,    0,  0}, // exit
+
+  }, BPF_PROG_TYPE_TRACEPOINT, kIsDebug);
+  // clang-format on
+}
+
 Expected<ebpf::Program, ebpf::Program::Error> genLinuxExitProgram(
     enum bpf_prog_type prog_type,
     PerfEventCpuMap const& cpu_map,

--- a/osquery/events/linux/probes/syscalls_programs.h
+++ b/osquery/events/linux/probes/syscalls_programs.h
@@ -24,6 +24,9 @@ using PerfEventCpuMap = ebpf::Map<int, int, BPF_MAP_TYPE_PERF_EVENT_ARRAY>;
 Expected<ebpf::Program, ebpf::Program::Error> genLinuxKillEnterProgram(
     enum bpf_prog_type prog_type, PerfEventCpuMap const& cpu_map);
 
+Expected<ebpf::Program, ebpf::Program::Error> genLinuxSetuidEnterProgram(
+    enum bpf_prog_type prog_type, PerfEventCpuMap const& cpu_map);
+
 Expected<ebpf::Program, ebpf::Program::Error> genLinuxExitProgram(
     enum bpf_prog_type prog_type,
     PerfEventCpuMap const& cpu_map,

--- a/osquery/events/linux/probes/tests/BUCK
+++ b/osquery/events/linux/probes/tests/BUCK
@@ -20,6 +20,7 @@ osquery_cxx_test(
             LINUX,
             [
                 "ebpf_tracepoint.cpp",
+                "syscall_event.cpp",
             ],
         ),
     ],

--- a/osquery/events/linux/probes/tests/syscall_event.cpp
+++ b/osquery/events/linux/probes/tests/syscall_event.cpp
@@ -1,0 +1,71 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under both the Apache 2.0 license (found in the
+ *  LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ *  in the COPYING file in the root directory of this source tree).
+ *  You may select, at your option, one of the above-listed licenses.
+ */
+
+#include <gtest/gtest.h>
+
+#include <osquery/events/linux/probes/syscall_event.h>
+
+namespace osquery {
+namespace {
+
+class SyscallsTracepointTests : public testing::Test {};
+
+template <events::syscall::Type enter, events::syscall::Type exit>
+void checkEventPair() {
+  static_assert(enter == events::syscall::flipType(exit),
+                "flipType have to flip Exit to Enter");
+  static_assert(exit == events::syscall::flipType(enter),
+                "flipType have to flip Enter to Exit");
+  static_assert(
+      enter == events::syscall::flipType(events::syscall::flipType(enter)),
+      "flipType applied twice to Enter have to return exactly the same Enter");
+  static_assert(
+      exit == events::syscall::flipType(events::syscall::flipType(exit)),
+      "flipType applied twice to Exit have to return exactly the same Exit");
+}
+
+TEST_F(SyscallsTracepointTests, SyscallEvent_flipType) {
+  checkEventPair<events::syscall::Type::KillEnter,
+                 events::syscall::Type::KillExit>();
+  checkEventPair<events::syscall::Type::SetuidEnter,
+                 events::syscall::Type::SetuidExit>();
+  static_assert(events::syscall::Type::Unknown ==
+                    events::syscall::flipType(events::syscall::Type::Unknown),
+                "syscall::Type::Unknown could not be fliped");
+}
+
+TEST_F(SyscallsTracepointTests, SyscallEvent_isTypeExit) {
+  static_assert(events::syscall::isTypeExit(events::syscall::Type::KillExit),
+                "");
+  static_assert(events::syscall::isTypeExit(events::syscall::Type::SetuidExit),
+                "");
+  static_assert(!events::syscall::isTypeExit(events::syscall::Type::Unknown),
+                "");
+  static_assert(
+      !events::syscall::isTypeExit(events::syscall::Type::SetuidEnter), "");
+  static_assert(
+      !events::syscall::isTypeExit(events::syscall::Type::SetuidEnter), "");
+}
+
+TEST_F(SyscallsTracepointTests, SyscallEvent_isTypeEnter) {
+  static_assert(!events::syscall::isTypeEnter(events::syscall::Type::KillExit),
+                "");
+  static_assert(
+      !events::syscall::isTypeEnter(events::syscall::Type::SetuidExit), "");
+  static_assert(!events::syscall::isTypeEnter(events::syscall::Type::Unknown),
+                "");
+  static_assert(
+      events::syscall::isTypeEnter(events::syscall::Type::SetuidEnter), "");
+  static_assert(
+      events::syscall::isTypeEnter(events::syscall::Type::SetuidEnter), "");
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
To able to invert type from enter to exit and determine if type is exit or enter.

Part of a linux  tracing system, blueprint: [#5218](https://github.com/facebook/osquery/issues/5218)

Reviewed By: SAlexandru

Differential Revision: D13761673
