### PR TITLE
[Fix #5341] addressing deadlock regression in windows dispatcher threads

### DIFF
--- a/osquery/remote/http_client.h
+++ b/osquery/remote/http_client.h
@@ -201,7 +201,13 @@ class Client {
 
  public:
   Client(Options const& opts = Options())
-      : client_options_(opts), r_(ios_), sock_(ios_), timer_(ios_) {}
+      : client_options_(opts), r_(ios_), sock_(ios_), timer_(ios_) {
+// Fix #4235, #5341: Boost on Windows requires notification that it should
+// let windows manage thread cleanup. *Do not remove this on Windows*
+#ifdef WIN32
+    boost::asio::detail::win_thread::set_terminate_threads(true);
+#endif
+  }
 
   void setOptions(Options const& opts) {
     new_client_options_ = !(client_options_ == opts);


### PR DESCRIPTION
This addresses a slight regression to ensure that we set `set_terminate_threads` on Windows. Without this flag being set, Windows threads will deadlock on exit as the boost managed io service threads never receive termination notifications.

I'm opening this PR up against the old master as I feel we should likely cut a 3.3.3, and I'm happy to re-open this PR against the upstream experimental as well, but we'll want a fix for this released as quickly as possible to Windows deployments.