### PR TITLE
Do not mess with namaspace which comes from thirdparty library (rapidjson)

### DIFF
--- a/osquery/utils/json/BUCK
+++ b/osquery/utils/json/BUCK
@@ -18,7 +18,6 @@ osquery_cxx_library(
         "json.h",
     ],
     exported_preprocessor_flags = [
-        "-DRAPIDJSON_NO_SIZETYPEDEFINE",
         "-DRAPIDJSON_HAS_STDSTRING=1",
     ],
     tests = [":json_tests"],

--- a/osquery/utils/json/json.h
+++ b/osquery/utils/json/json.h
@@ -19,10 +19,6 @@
 #pragma warning(disable : 4715)
 #endif
 
-namespace rapidjson {
-using SizeType = ::std::size_t;
-} // namespace rapidjson
-
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/stringbuffer.h>

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -73,7 +73,6 @@ TARGETS_POSTSCRIPT = """    ],
         "-DOSQUERY_PLATFORM_MASK=9",
         "-DFBTHRIFT",
         "-DRAPIDJSON_HAS_STDSTRING=1",
-        "-DRAPIDJSON_NO_SIZETYPEDEFINE",
     ],
     deps = [
         ":if-cpp2",


### PR DESCRIPTION
Summary: Let's use `SizeType` definition from rapidjson itself

Reviewed By: marekcirkos

Differential Revision: D13986840
