### PR TITLE
Add Windows product version information to file table

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -90,6 +90,7 @@ typedef struct win_stat {
   std::string type;
   std::string attributes;
   std::string volume_serial;
+  std::string product_version;
 
 } WINDOWS_STAT;
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1820,6 +1820,8 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
   (!ret) ? wfile_stat->ctime = -1
          : wfile_stat->ctime = longIntToUnixtime(basic_info.ChangeTime);
 
+  windowsGetFileVersion(path.string(), wfile_stat->product_version);
+
   CloseHandle(file_handle);
 
   return Status();

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -124,6 +124,7 @@ void genFileInfo(const fs::path& path,
   r["attributes"] = TEXT(file_stat.attributes);
   r["file_id"] = TEXT(file_stat.file_id);
   r["volume_serial"] = TEXT(file_stat.volume_serial);
+  r["product_version"] = TEXT(file_stat.product_version);
 
 #endif
 

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -23,6 +23,7 @@ extended_schema(WINDOWS, [
     Column("attributes", TEXT, "File attrib string. See: https://ss64.com/nt/attrib.html"),
     Column("volume_serial", TEXT, "Volume serial number"),
     Column("file_id", TEXT, "file ID"),
+    Column("product_version", TEXT, "File product version"),
 ])
 attributes(utility=True)
 implementation("utility/file@genFile")

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -70,6 +70,7 @@ TEST_F(FileTests, test_sanity) {
   row_map["attributes"] = NormalType;
   row_map["volume_serial"] = NormalType;
   row_map["file_id"] = NormalType;
+  row_map["product_version"] = NormalType;
 #endif
 
   validate_rows(data, row_map);


### PR DESCRIPTION
Hi! This PR adds a new column called `product_version` to the file table, which is only
populated when queries are done on Windows. It is a very minimal PR that uses an existing helper function (`windowsGetFileVersion`) to populate the column.

The column is not named `file_version`, despite the name of the helper function because the underlying data retrieved by that helper function is actually the `dwProductVersion*` fields of the `VS_FIXEDFILEINFO` struct. In the future, if we want to add a column that _actually_ contains the results of the `dwFileVersion*` fields, we can add a new column called `file_version` without modifying existing functionality.
