### PR TITLE
std::getenv doesn't work for windows sometimes, let's use osquery::getEnvVar instead

### DIFF
--- a/osquery/config/tests/BUCK
+++ b/osquery/config/tests/BUCK
@@ -76,5 +76,6 @@ osquery_cxx_library(
     deps = [
         osquery_target("osquery/filesystem:osquery_filesystem"),
         osquery_target("osquery/utils/json:json"),
+        osquery_target("osquery/utils/system:env"),
     ],
 )

--- a/osquery/config/tests/test_utils.cpp
+++ b/osquery/config/tests/test_utils.cpp
@@ -10,6 +10,8 @@
 
 #include <osquery/filesystem/filesystem.h>
 
+#include <osquery/utils/system/env.h>
+
 #include <gtest/gtest.h>
 
 #include <boost/io/detail/quoted_manip.hpp>
@@ -22,11 +24,11 @@ namespace fs = boost::filesystem;
 
 fs::path getConfDirPathImpl() {
   char const* kEnvVarName = "TEST_CONF_FILES_DIR";
-  auto const value = std::getenv(kEnvVarName);
-  EXPECT_NE(value, nullptr)
+  auto const value_opt = osquery::getEnvVar(kEnvVarName);
+  EXPECT_TRUE(static_cast<bool>(value_opt))
       << "Env var " << boost::io::quoted(kEnvVarName) << " was not found, "
       << " looks like cxx_test argument 'env' is not set up.";
-  return fs::path(value);
+  return fs::path(value_opt.get());
 }
 
 }


### PR DESCRIPTION
Differential Revision: D14065193
