### PR TITLE
fix magic table

### DIFF
--- a/osquery/tables/system/posix/magic.cpp
+++ b/osquery/tables/system/posix/magic.cpp
@@ -6,14 +6,26 @@
  *  root directory of this source tree.
  */
 
-#include <stdio.h>
 #include <magic.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/filesystem.hpp>
+#include <numeric>
 
 #include <osquery/logger.h>
 #include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
+
+namespace {
+
+constexpr std::array<const char*, 3> kMagicFiles = {
+    "/usr/share/misc/magic",
+    "/usr/share/misc/magic.mgc",
+    "/usr/share/file/magic/magic"};
+
+constexpr char* kMagicFileDBSep = ":";
+} // namespace
 
 QueryData genMagicData(QueryContext& context) {
   QueryData results;
@@ -26,10 +38,41 @@ QueryData genMagicData(QueryContext& context) {
     VLOG(1) << "Unable to initialize magic library";
     return results;
   }
-  if (magic_load(magic_cookie, nullptr) != 0) {
-    VLOG(1) << "Unable to load magic database : " << magic_error(magic_cookie);
-    magic_close(magic_cookie);
-    return results;
+
+  std::string magic_db_files;
+
+  if (context.hasConstraint("magic_db_files")) {
+    auto magic_files = context.constraints["magic_db_files"].getAll(EQUALS);
+    magic_db_files = boost::algorithm::join(magic_files, kMagicFileDBSep);
+  } else {
+    for (auto& file : kMagicFiles) {
+      if (boost::filesystem::exists(file)) {
+        magic_db_files = file;
+        break;
+      }
+    }
+  }
+
+  if (magic_db_files.empty()) {
+    VLOG(1) << "Will be loading magic with the default database ";
+    // because of how we compile this, unless you are a developer the default
+    // one will never work
+    if (magic_load(magic_cookie, nullptr) != 0) {
+      LOG(WARNING) << "Unable to load magic default database"
+                   << " because: " << magic_error(magic_cookie);
+      magic_close(magic_cookie);
+      return results;
+    }
+  } else {
+    // because of how we compile this, unless you are a developer the default
+    // one will never work
+    if (magic_load(magic_cookie, magic_db_files.c_str()) != 0) {
+      LOG(WARNING) << "Unable to load magic list of database: "
+                   << magic_db_files
+                   << " because: " << magic_error(magic_cookie);
+      magic_close(magic_cookie);
+      return results;
+    }
   }
 
   // Iterate through all the provided paths
@@ -37,6 +80,7 @@ QueryData genMagicData(QueryContext& context) {
   for (const auto& path_string : paths) {
     Row r;
     r["path"] = path_string;
+    r["magic_db_files"] = magic_db_files;
     r["data"] = magic_file(magic_cookie, path_string.c_str());
 
     // Retrieve MIME type

--- a/specs/posix/magic.table
+++ b/specs/posix/magic.table
@@ -1,7 +1,8 @@
 table_name("magic")
 description("Magic number recognition library table.")
 schema([
-    Column("path", TEXT, "Absolute path to target file", required=True),
+    Column("path", TEXT, "Absolute path to target file", required=True, index=True),
+    Column("magic_db_files", TEXT, "Colon(:) separated list of files where the magic db file can be found. By default one of the following is used: /usr/share/file/magic/magic, /usr/share/misc/magic or /usr/share/misc/magic.mgc", additional=True),
     Column("data", TEXT, "Magic number data from libmagic"),
     Column("mime_type", TEXT, "MIME type data from libmagic"),
     Column("mime_encoding", TEXT, "MIME encoding data from libmagic"),


### PR DESCRIPTION
Summary:
currently the magic table is broken. libmagic which is used to generate this information needs a database/configuration file that it usually auto-finds.
Our libmagic library tries to open the following file ```open("/usr/local/osquery/Cellar/libmagic/5.32_200/share/misc/magic.mgc", O_RDONLY) = -1 ENOENT (No such file or directory)``` (you can generate  this by using strace like ```trace -q -e trace=open ./buck-out/debug/gen/xplat/osquery/oss/osquery/osqueryd#gcc-5-glibc-2.23-clang -verbose -S "select * from magic where path = '/etc/passwd'"```).
How it auto-finds it I don't know 100%, but I guess it has something to with how the libmagic.so is actually build and installed. Basically this never works unless you are a developer on mac and used our previous build system.

I've updated the table to be able to specify the path to magic database file. If you don't specify it, I tried to check if one of the default files (files that should be present under /usr/share/ exists and use the first found). If all fail, I try the default one, but that most likely will fail.

Reviewed By: guliashvili

Differential Revision: D14066467
