### PR TITLE
Add Facebook Copyright message to Facebook owned, open-source osquery files

### DIFF
--- a/osquery/core/plugins/sql.cpp
+++ b/osquery/core/plugins/sql.cpp
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  * @brief The osquery SQL implementation is managed as a plugin.
  *
  * The osquery RegistryFactory creates a Registry type called "sql", then

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  * @brief The osquery SQL implementation is managed as a plugin.
  *
  * The osquery RegistryFactory creates a Registry type called "sql", then

--- a/osquery/extensions/thrift/osquery.thrift
+++ b/osquery/extensions/thrift/osquery.thrift
@@ -1,3 +1,5 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 namespace cpp osquery.extensions
 
 /// Registry operations use a registry name, plugin name, request/response.

--- a/osquery/sql/tests/sql_test_utils.cpp
+++ b/osquery/sql/tests/sql_test_utils.cpp
@@ -1,3 +1,4 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #include <osquery/sql/tests/sql_test_utils.h>
 
 namespace osquery {

--- a/osquery/sql/tests/sql_test_utils.h
+++ b/osquery/sql/tests/sql_test_utils.h
@@ -1,3 +1,4 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 #include <osquery/core.h>
 #include <osquery/registry_interface.h>
 #include <osquery/sql.h>

--- a/tools/analysis/analyze.bat
+++ b/tools/analysis/analyze.bat
@@ -1,3 +1,4 @@
 @echo off
+REM Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 "C:\Program Files\Cppcheck\cppcheck.exe" --quiet -i .\build\ .
 "C:\Program Files\Cppcheck\cppcheck.exe" --quiet --project=.\build\windows10\OSQUERY.sln

--- a/tools/build_defs/oss/osquery/codegen.bzl
+++ b/tools/build_defs/oss/osquery/codegen.bzl
@@ -1,4 +1,5 @@
 """Implementation of osquery code generation targets"""
+"""Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved"""
 
 load(
     "//tools/build_defs/oss/osquery:cxx.bzl",

--- a/tools/codegen/gentargets.py
+++ b/tools/codegen/gentargets.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import argparse
 import json

--- a/tools/codegen/genwebsitejson.py
+++ b/tools/codegen/genwebsitejson.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-"""Generate a complete table specification for the website
+"""
+Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+Generate a complete table specification for the website
 
 This script will generate JSON output as expected by the osquery website given
 a directory of osquery schema specifications. Results will be printer to stdout.

--- a/tools/codegen/genwebsitemetadata.py
+++ b/tools/codegen/genwebsitemetadata.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-"""Generate a new website version metadata file based on a new release version
+"""
+Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+Generate a new website version metadata file based on a new release version
 
 Usage:
     python tools/codegen/genwebsitemetadata.py --file=~/osquery-site/src/data/osquery_metadata.json

--- a/tools/deployment/linux_postinstall.sh
+++ b/tools/deployment/linux_postinstall.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 # Could be called by DPKG or RPM.
 # Handle the cases we want to hook or silently claim success.

--- a/tools/generate_xcode_project.sh
+++ b/tools/generate_xcode_project.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
 set -e
 
 BUILD_DIR=$1
@@ -9,5 +11,5 @@ rm -rf ${BUILD_DIR}
 mkdir -p ${BUILD_DIR}
 
 echo "Generating xcode project using cmake: $CMAKE_COMMAND"
-cd ${BUILD_DIR} 
+cd ${BUILD_DIR}
 eval ${CMAKE_COMMAND}

--- a/tools/hooks/pre-commit.py
+++ b/tools/hooks/pre-commit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import os
 import subprocess
@@ -10,7 +11,7 @@ def main():
     my_env["PATH"] = "/urs/local/osquery/bin/" + os.pathsep + my_env["PATH"]
     cmd = ["python", "tools/formatting/git-clang-format.py", "--diff", "--commit", "master", "--style=file"]
     p = subprocess.Popen(" ".join(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, env=my_env)
-    out, err = p.communicate() 
+    out, err = p.communicate()
 
     if not (out.startswith("no modified files to format") or
             out.startswith("clang-format did not modify any files")):

--- a/tools/make-win64-binaries.bat
+++ b/tools/make-win64-binaries.bat
@@ -1,8 +1,9 @@
 @echo off & setlocal
+REM Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 REM command chcp returns string: "Active code page: ..."
 for /F "tokens=*"  %%i in ('chcp') do SET t=%%i
 
-REM Get the last substring (codepage) from "t" and assign it to "CodePage" 
+REM Get the last substring (codepage) from "t" and assign it to "CodePage"
 :loop
 for /f "tokens=1*" %%a in ("%t%") do (
     set CodePage=%%a

--- a/tools/make-win64-dev-env.bat
+++ b/tools/make-win64-dev-env.bat
@@ -1,5 +1,5 @@
 @echo off
+REM Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 %SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass .\tools\provision.ps1
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 %ALLUSERSPROFILE%\chocolatey\bin\refreshenv.cmd
-


### PR DESCRIPTION
Summary:
This diff adds a Facebook copyright header to files in the osquery open source repository which:
* Facebook owns
* Do not currently have a Facebook copyright header

Differential Revision: D14122845
