### PR TITLE
Relicense yara_utils to Facebook

### DIFF
--- a/osquery/tables/yara/yara_utils.h
+++ b/osquery/tables/yara/yara_utils.h
@@ -1,6 +1,5 @@
-/*
- *  Copyright (c) 2015, Welsey Shields
- *  All rights reserved.
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
  *  This source code is licensed as defined on the LICENSE file found in the
  *  root directory of this source tree.


### PR DESCRIPTION
Summary: This file was originally written by wxsBSD in 2015. He has since joined Facebook and has graciously agreed to re-license this file to Facebook. This diff formalizes the relicensing by changing the copyright notice on the file. Note that wxsBSD still retains a copyright to all previous versions of the file.

Reviewed By: wxsBSD

Differential Revision: D14131447
