### PR TITLE
Add Facebook copyright header to bzl files

### DIFF
--- a/tools/build_defs/oss/osquery/cxx.bzl
+++ b/tools/build_defs/oss/osquery/cxx.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 load(
     "//tools/build_defs/oss/osquery:native_functions.bzl",
     _osquery_custom_set_generic_kwargs = "osquery_custom_set_generic_kwargs",

--- a/tools/build_defs/oss/osquery/defaults.bzl
+++ b/tools/build_defs/oss/osquery/defaults.bzl
@@ -1,4 +1,8 @@
 """osquery build defaults"""
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
 
 OSQUERY_THIRD_PARTY_PATH = "third-party"
 

--- a/tools/build_defs/oss/osquery/globs.bzl
+++ b/tools/build_defs/oss/osquery/globs.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 def _paths_join(path, *others):
     """Joins one or more path components intelligently.
 

--- a/tools/build_defs/oss/osquery/native.bzl
+++ b/tools/build_defs/oss/osquery/native.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 load(
     "//tools/build_defs/oss/osquery:defaults.bzl",
     _OSQUERY_ROOT_TARGET_PATH = "OSQUERY_ROOT_TARGET_PATH",

--- a/tools/build_defs/oss/osquery/native_functions.bzl
+++ b/tools/build_defs/oss/osquery/native_functions.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 osquery_native = native
 
 osquery_read_config = osquery_native.read_config

--- a/tools/build_defs/oss/osquery/platforms.bzl
+++ b/tools/build_defs/oss/osquery/platforms.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 LINUX = "linux-x86_64"
 
 MACOSX = "macosx-x86_64"

--- a/tools/build_defs/oss/osquery/python.bzl
+++ b/tools/build_defs/oss/osquery/python.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 load("//tools/build_defs/oss/osquery:native_functions.bzl", "osquery_native")
 
 def osquery_python_library(**kwargs):

--- a/tools/build_defs/oss/osquery/third_party.bzl
+++ b/tools/build_defs/oss/osquery/third_party.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 load(
     "//tools/build_defs/oss/osquery:cxx.bzl",
     _osquery_cxx_library = "osquery_cxx_library",

--- a/tools/build_defs/oss/osquery/third_party_archive.bzl
+++ b/tools/build_defs/oss/osquery/third_party_archive.bzl
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
 _S3_BASE_URL = "https://s3.amazonaws.com/osquery-packages"
 
 _S3_BASE_DIR = "third-party"


### PR DESCRIPTION
Summary: This diff adds a Facebook copyright header to the bzl files used in osquery. Ultimately we want to update the files in `tools/build_defs/oss/osquery/`, but those are generated files. This diff updates the source files which we use to generate those files.

Differential Revision: D14131483
