### PR TITLE
windows/logged_in_users: Add sid, hive columns

### DIFF
--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -108,7 +108,6 @@ QueryData genLoggedInUsers(QueryContext& context) {
     }
 
     r["pid"] = INTEGER(-1);
-    results.push_back(r);
 
     if (clientInfo != nullptr) {
       WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, clientInfo, count);
@@ -148,6 +147,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
     }
 
     r["sid"] = TEXT(sidStr);
+    results.push_back(r);
 
     LocalFree(sidStr);
   }

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -118,7 +118,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
       sessionInfo = nullptr;
     }
 
-    HANDLE hToken;
+    HANDLE hToken = nullptr;
     res = WTSQueryUserToken(pSessionInfo[i].SessionId, &hToken);
     if (res == 0) {
       VLOG(1) << "Error querying user token (" << GetLastError() << ")";
@@ -136,9 +136,12 @@ QueryData genLoggedInUsers(QueryContext& context) {
       continue;
     }
 
-    CloseHandle(hToken);
+    if (hToken != nullptr) {
+      CloseHandle(hToken);
+      hToken = nullptr;
+    }
 
-    char* sidStr;
+    char* sidStr = nullptr;
     res = ConvertSidToStringSidA(userToken.User.Sid, &sidStr);
     if (res == 0) {
       VLOG(1) << "Error stringifying user SID (" << GetLastError() << ")";
@@ -149,7 +152,10 @@ QueryData genLoggedInUsers(QueryContext& context) {
     r["sid"] = TEXT(sidStr);
     results.push_back(r);
 
-    LocalFree(sidStr);
+    if (sidStr != nullptr) {
+      LocalFree(sidStr);
+      sidStr = nullptr;
+    }
   }
 
   if (pSessionInfo != nullptr) {

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -66,7 +66,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
               << ")";
       continue;
     }
-    auto wtsSession = (PWTSINFO)sessionInfo;
+    auto wtsSession = reinterpret_cast<WTSINFOA*>(sessionInfo);
     r["user"] = SQL_TEXT(wtsSession->UserName);
     r["type"] = SQL_TEXT(kSessionStates.at(pSessionInfo[i].State));
     r["tty"] = pSessionInfo[i].pSessionName == nullptr
@@ -95,7 +95,8 @@ QueryData genLoggedInUsers(QueryContext& context) {
       results.push_back(r);
       continue;
     }
-    auto wtsClient = (PWTSCLIENT)clientInfo;
+
+    auto wtsClient = reinterpret_cast<WTSCLIENTA*>(clientInfo);
     if (wtsClient->ClientAddressFamily == AF_INET) {
       r["host"] = std::to_string(wtsClient->ClientAddress[0]) + "." +
                   std::to_string(wtsClient->ClientAddress[1]) + "." +
@@ -149,7 +150,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
       continue;
     }
 
-    r["sid"] = TEXT(sidStr);
+    r["sid"] = SQL_TEXT(sidStr);
     results.push_back(r);
 
     if (sidStr != nullptr) {

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -134,6 +134,10 @@ QueryData genLoggedInUsers(QueryContext& context) {
 
     const auto sidStr = psidToString(reinterpret_cast<SID*>(sidBuf.get()));
     r["sid"] = SQL_TEXT(sidStr);
+
+    const auto hivePath = "HKEY_USERS\\" + sidStr;
+    r["hive"] = SQL_TEXT(hivePath);
+
     results.push_back(r);
   }
 

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -136,7 +136,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
     r["sid"] = SQL_TEXT(sidStr);
 
     const auto hivePath = "HKEY_USERS\\" + sidStr;
-    r["hive"] = SQL_TEXT(hivePath);
+    r["registry_hive"] = SQL_TEXT(hivePath);
 
     results.push_back(r);
   }

--- a/osquery/tables/system/windows/logged_in_users.cpp
+++ b/osquery/tables/system/windows/logged_in_users.cpp
@@ -67,7 +67,7 @@ QueryData genLoggedInUsers(QueryContext& context) {
               << ")";
       continue;
     }
-    auto wtsSession = reinterpret_cast<WTSINFOA*>(sessionInfo);
+    const auto wtsSession = reinterpret_cast<WTSINFOA*>(sessionInfo);
     r["user"] = SQL_TEXT(wtsSession->UserName);
     r["type"] = SQL_TEXT(kSessionStates.at(pSessionInfo[i].State));
     r["tty"] = pSessionInfo[i].pSessionName == nullptr
@@ -123,7 +123,6 @@ QueryData genLoggedInUsers(QueryContext& context) {
     if (sessionInfo != nullptr) {
       WTSFreeMemoryEx(WTSTypeSessionInfoLevel1, sessionInfo, count);
       sessionInfo = nullptr;
-      wtsSession = nullptr;
     }
 
     if (sidBuf == nullptr) {

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -10,6 +10,7 @@ schema([
 ])
 extended_schema(WINDOWS, [
     Column("sid", TEXT, "User security identifier"),
+    Column("hive", TEXT, "HKEY_USERS registry hive"),
 ])
 attributes(cacheable=True)
 implementation("logged_in_users@genLoggedInUsers")

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -10,7 +10,7 @@ schema([
 ])
 extended_schema(WINDOWS, [
     Column("sid", TEXT, "User security identifier"),
-    Column("hive", TEXT, "HKEY_USERS registry hive"),
+    Column("registry_hive", TEXT, "HKEY_USERS registry hive"),
 ])
 attributes(cacheable=True)
 implementation("logged_in_users@genLoggedInUsers")

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -8,5 +8,8 @@ schema([
     Column("time", INTEGER, "Time entry was made"),
     Column("pid", INTEGER, "Process (or thread) ID"),
 ])
+extended_schema(WINDOWS, [
+    Column("sid", TEXT, "User security identifier"),
+])
 attributes(cacheable=True)
 implementation("logged_in_users@genLoggedInUsers")

--- a/specs/logged_in_users.table
+++ b/specs/logged_in_users.table
@@ -9,7 +9,7 @@ schema([
     Column("pid", INTEGER, "Process (or thread) ID"),
 ])
 extended_schema(WINDOWS, [
-    Column("sid", TEXT, "User security identifier"),
+    Column("sid", TEXT, "The user's unique security identifier"),
     Column("registry_hive", TEXT, "HKEY_USERS registry hive"),
 ])
 attributes(cacheable=True)

--- a/tests/integration/tables/logged_in_users.cpp
+++ b/tests/integration/tables/logged_in_users.cpp
@@ -33,7 +33,7 @@ TEST_F(LoggedInUsersTest, sanity) {
       {"pid", NonNegativeOrErrorInt},
 #ifdef OSQUERY_WINDOWS
       {"sid", NormalType},
-      {"hive", NormalType},
+      {"registry_hive", NormalType},
 #endif
   };
   validate_rows(rows, row_map);

--- a/tests/integration/tables/logged_in_users.cpp
+++ b/tests/integration/tables/logged_in_users.cpp
@@ -31,6 +31,10 @@ TEST_F(LoggedInUsersTest, sanity) {
       {"host", NormalType},
       {"time", NonNegativeInt},
       {"pid", NonNegativeOrErrorInt},
+#ifdef OSQUERY_WINDOWS
+      {"sid", NormalType},
+      {"hive", NormalType},
+#endif
   };
   validate_rows(rows, row_map);
 }


### PR DESCRIPTION
This introduces two new (Windows-only) columns to the `logged_in_users` table:

* `sid` corresponds to the logged in user's security identifier, used to uniquely identify the user and their permissions on the local system.
* `registry_hive` corresponds to the user's HKU registry hive, used to look up per-user configuration information.

I've updated the integration tests to test for these columns on Windows only. Please let me know if there's anything else I can do!