### PR TITLE
Add Facebook copyright message

### DIFF
--- a/mode/system.py
+++ b/mode/system.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python2
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 import sys
 import argparse


### PR DESCRIPTION
Summary: We recently added a Facebook copyright header to many files in the osquery repository. Unfortunately we missed this one in the first diff.

Differential Revision: D14140835
