### PR TITLE
Remove unnecessary internal header definition from core/plugins/BUCK and core/sql/BUCK

### DIFF
--- a/osquery/core/plugins/BUCK
+++ b/osquery/core/plugins/BUCK
@@ -10,7 +10,6 @@ load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
 osquery_cxx_library(
     name = "plugins",
     srcs = glob(["*.cpp"]),
-    headers = glob(["*.h"]),
     header_namespace = "osquery/plugins",
     exported_headers = glob(["*.h"]),
     visibility = ["PUBLIC"],

--- a/osquery/core/sql/BUCK
+++ b/osquery/core/sql/BUCK
@@ -11,7 +11,6 @@ load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
 osquery_cxx_library(
     name = "core_sql",
     srcs = glob(["*.cpp"]),
-    headers = glob(["*.h"]),
     header_namespace = "osquery/core/sql",
     exported_headers = glob(["*.h"]),
     visibility = ["PUBLIC"],


### PR DESCRIPTION
Summary: They duplicate exported_headers and cause failures in cpp_library target definition

Differential Revision: D14164702
