### PR TITLE
Populate path correctly in Firefox addons

### DIFF
--- a/osquery/tables/applications/posix/browser_firefox.cpp
+++ b/osquery/tables/applications/posix/browser_firefox.cpp
@@ -46,7 +46,7 @@ const std::map<std::string, std::string> kFirefoxAddonKeys = {
     {"applyBackgroundUpdates", "autoupdate"},
     {"hasBinaryComponents", "native"},
     {"location", "location"},
-    {"descriptor", "path"},
+    {"path", "path"},
 };
 
 void genFirefoxAddonsFromExtensions(const std::string& uid,


### PR DESCRIPTION
In my testing of Osquery, I noticed the `path` field for `firefox_addons` is always blank. After inspecting the structure of the JSON and the code in Osquery, I believe the key to look up path should be renamed from `descriptor` to `path`.