### PR TITLE
Pass kwargs to osquery_tp_prebuilt_cxx_library

### DIFF
--- a/third-party/augeas/BUCK
+++ b/third-party/augeas/BUCK
@@ -40,4 +40,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.9.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/aws-sdk-cpp/BUCK
+++ b/third-party/aws-sdk-cpp/BUCK
@@ -57,4 +57,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.4.55",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/berkeley-db/BUCK
+++ b/third-party/berkeley-db/BUCK
@@ -42,4 +42,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "5.3.28",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/boost/BUCK
+++ b/third-party/boost/BUCK
@@ -61,4 +61,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.66.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/bzip2/BUCK
+++ b/third-party/bzip2/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.0.6",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/gflags/BUCK
+++ b/third-party/gflags/BUCK
@@ -45,4 +45,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.2.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/glog/BUCK
+++ b/third-party/glog/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.3.5",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libarchive/BUCK
+++ b/third-party/libarchive/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "3.3.2",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libaudit/BUCK
+++ b/third-party/libaudit/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.4.2",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libcryptsetup/BUCK
+++ b/third-party/libcryptsetup/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.7.5",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libdevmapper/BUCK
+++ b/third-party/libdevmapper/BUCK
@@ -36,4 +36,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.2.02.173",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libdpkg/BUCK
+++ b/third-party/libdpkg/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.19.0.5",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libelfin/BUCK
+++ b/third-party/libelfin/BUCK
@@ -50,4 +50,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.3",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libgcrypt/BUCK
+++ b/third-party/libgcrypt/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.8.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libgpg-error/BUCK
+++ b/third-party/libgpg-error/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.27",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libiptables/BUCK
+++ b/third-party/libiptables/BUCK
@@ -35,4 +35,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.8.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libmagic/BUCK
+++ b/third-party/libmagic/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "5.32",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/librdkafka/BUCK
+++ b/third-party/librdkafka/BUCK
@@ -40,4 +40,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.11.3",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/librpm/BUCK
+++ b/third-party/librpm/BUCK
@@ -42,4 +42,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "4.14.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libudev/BUCK
+++ b/third-party/libudev/BUCK
@@ -33,4 +33,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "173",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/libxml2/BUCK
+++ b/third-party/libxml2/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.9.7",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/linenoise-ng/BUCK
+++ b/third-party/linenoise-ng/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.0.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/lldpd/BUCK
+++ b/third-party/lldpd/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.9.6",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/openssl/BUCK
+++ b/third-party/openssl/BUCK
@@ -62,4 +62,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.0.2o",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/popt/BUCK
+++ b/third-party/popt/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.16",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/rapidjson/BUCK
+++ b/third-party/rapidjson/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.1.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/rocksdb/BUCK
+++ b/third-party/rocksdb/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "5.7.2",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/sleuthkit/BUCK
+++ b/third-party/sleuthkit/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "4.6.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/smartmontools/BUCK
+++ b/third-party/smartmontools/BUCK
@@ -46,4 +46,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.3.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/ssdeep-cpp/BUCK
+++ b/third-party/ssdeep-cpp/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.14.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/thrift/BUCK
+++ b/third-party/thrift/BUCK
@@ -47,4 +47,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "0.11.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/util-linux/BUCK
+++ b/third-party/util-linux/BUCK
@@ -37,4 +37,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "2.27.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/yara/BUCK
+++ b/third-party/yara/BUCK
@@ -38,4 +38,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "3.7.1",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/zlib/BUCK
+++ b/third-party/zlib/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.2.11",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/third-party/zstd/BUCK
+++ b/third-party/zstd/BUCK
@@ -43,4 +43,5 @@ osquery_tp_prebuilt_cxx_library(
     ],
     version = "1.2.0",
     build = "0",
+    visibility = ["PUBLIC"],
 )

--- a/tools/build_defs/oss/osquery/third_party.bzl
+++ b/tools/build_defs/oss/osquery/third_party.bzl
@@ -236,8 +236,8 @@ def osquery_tp_prebuilt_cxx_library(
         static_libs = None,
         platform_static_libs = None,
         linker_flags = None,
-        deps = None):
-    platform_prebuilt_library_targets = []
+        deps = None,
+        **kwargs):
     for platform in platforms:
         archive_target = _osquery_tp_prebuilt_cxx_archive(
             name = name,
@@ -300,8 +300,11 @@ def osquery_tp_prebuilt_cxx_library(
             static_lib_targets,
         )
 
+        if "platform_deps" not in kwargs:
+            kwargs["platform_deps"] = []
+
         for effective_platform in _PLATFORM_MAP[platform]:
-            platform_prebuilt_library_targets.append((
+            kwargs["platform_deps"].append((
                 effective_platform,
                 [":{}".format(prebuilt_library_target)],
             ))
@@ -309,8 +312,7 @@ def osquery_tp_prebuilt_cxx_library(
     _osquery_cxx_library(
         name = name,
         external = True,
-        platform_deps = platform_prebuilt_library_targets,
-        visibility = ["PUBLIC"],
+        **kwargs
     )
 
 def osquery_tp_prebuilt_python_library(


### PR DESCRIPTION
Summary: This way we can specify extra arguments that are going to be added to the library, like exported_preprocessor_flags which is required by some libraries.

Differential Revision: D14220787
