### PR TITLE
Make RockDB export ROCKSDB_LITE

### DIFF
--- a/third-party/rocksdb/BUCK
+++ b/third-party/rocksdb/BUCK
@@ -44,4 +44,7 @@ osquery_tp_prebuilt_cxx_library(
     version = "5.7.2",
     build = "0",
     visibility = ["PUBLIC"],
+    exported_preprocessor_flags = [
+        "-DROCKSDB_LITE=1",
+    ],
 )


### PR DESCRIPTION
Summary: Building without ROCKSDB_LITE causes osquery to crash due to a mismatch between the structs compiled into the pre-built library and the compiled osquery code.

Reviewed By: marekcirkos

Differential Revision: D14220786
