### PR TITLE
New cli flag [tls_enroll_max_attempts] instead of reusing [config_tls_max_attempts]

### DIFF
--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -30,7 +30,12 @@ namespace osquery {
 
 DECLARE_string(enroll_secret_path);
 DECLARE_bool(disable_enrollment);
-DECLARE_uint64(config_tls_max_attempts);
+
+CLI_FLAG(uint64,
+         tls_enroll_max_attempts,
+         3,
+         "Number of attempts to retry a TLS enroll request, it used to be the "
+         "same as [config_tls_max_attempts]");
 
 /// Enrollment TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,
@@ -62,9 +67,9 @@ std::string TLSEnrollPlugin::enroll() {
 
   std::string node_key;
   VLOG(1) << "TLSEnrollPlugin requesting a node enroll key from: " << uri;
-  for (size_t i = 1; i <= FLAGS_config_tls_max_attempts; i++) {
+  for (size_t i = 1; i <= FLAGS_tls_enroll_max_attempts; i++) {
     auto status = requestKey(uri, node_key);
-    if (status.ok() || i == FLAGS_config_tls_max_attempts) {
+    if (status.ok() || i == FLAGS_tls_enroll_max_attempts) {
       break;
     }
 

--- a/plugins/config/tls_config.cpp
+++ b/plugins/config/tls_config.cpp
@@ -31,7 +31,7 @@ namespace osquery {
 CLI_FLAG(uint64,
          config_tls_max_attempts,
          3,
-         "Number of attempts to retry a TLS config/enroll request");
+         "Number of attempts to retry a TLS config request");
 
 /// Config retrieval TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,

--- a/sdk/BUCK
+++ b/sdk/BUCK
@@ -39,6 +39,5 @@ osquery_cxx_library(
         osquery_target("osquery/utils:attribute"),
         osquery_target("osquery/utils:utils"),
         osquery_target("osquery:headers"),
-        osquery_target("plugins/config:tls_config"),
     ],
 )


### PR DESCRIPTION
Summary:
To get rid of dependency on `plugins/config:tls_config` from `osquery/remote/enroll/tls_enroll`.
To be able to remove dependency on `plugins/config:tls_config` from plugins_sdk.

Reviewed By: guliashvili

Differential Revision: D14241685
