### PR TITLE
Move out to plugins/ registration of enroll:tls plugin in registry

### DIFF
--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -94,6 +94,7 @@ osquery_cxx_library(
         osquery_target("plugins/logger:tls_logger"),
         osquery_target("plugins/killswitch:killswitch_filesystem"),
         osquery_target("plugins/killswitch:killswitch_tls"),
+        osquery_target("plugins/remote/enroll:tls_enroll_plugin"),
         osquery_target("specs:tables"),
         osquery_tp_target("boost"),
     ],

--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -55,8 +55,6 @@ HIDDEN_FLAG(string,
             "enroll_secret",
             "Override the TLS enroll secret key name");
 
-REGISTER(TLSEnrollPlugin, "enroll", "tls");
-
 std::string TLSEnrollPlugin::enroll() {
   // If no node secret has been negotiated, try a TLS request.
   auto uri = "https://" + FLAGS_tls_hostname + FLAGS_enroll_tls_endpoint;

--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -30,7 +30,12 @@ namespace osquery {
 
 DECLARE_string(enroll_secret_path);
 DECLARE_bool(disable_enrollment);
-DECLARE_uint64(config_tls_max_attempts);
+
+CLI_FLAG(uint64,
+         tls_enroll_max_attempts,
+         3,
+         "Number of attempts to retry a TLS enroll request, it used to be the "
+         "same as [config_tls_max_attempts]");
 
 /// Enrollment TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,
@@ -62,9 +67,9 @@ std::string TLSEnrollPlugin::enroll() {
 
   std::string node_key;
   VLOG(1) << "TLSEnrollPlugin requesting a node enroll key from: " << uri;
-  for (size_t i = 1; i <= FLAGS_config_tls_max_attempts; i++) {
+  for (size_t i = 1; i <= FLAGS_tls_enroll_max_attempts; i++) {
     auto status = requestKey(uri, node_key);
-    if (status.ok() || i == FLAGS_config_tls_max_attempts) {
+    if (status.ok() || i == FLAGS_tls_enroll_max_attempts) {
       break;
     }
 

--- a/plugins/config/tls_config.cpp
+++ b/plugins/config/tls_config.cpp
@@ -31,7 +31,7 @@ namespace osquery {
 CLI_FLAG(uint64,
          config_tls_max_attempts,
          3,
-         "Number of attempts to retry a TLS config/enroll request");
+         "Number of attempts to retry a TLS config request");
 
 /// Config retrieval TLS endpoint (path) using TLS hostname.
 CLI_FLAG(string,

--- a/plugins/remote/enroll/BUCK
+++ b/plugins/remote/enroll/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_library(
+    name = "tls_enroll_plugin",
+    srcs = [
+        "tls_enroll_plugin.cpp",
+    ],
+    link_whole = True,
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/remote/enroll:tls_enroll"),
+    ],
+)

--- a/plugins/remote/enroll/tls_enroll_plugin.cpp
+++ b/plugins/remote/enroll/tls_enroll_plugin.cpp
@@ -1,0 +1,16 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/registry_factory.h>
+#include <osquery/remote/enroll/tls_enroll.h>
+
+namespace osquery {
+
+REGISTER(TLSEnrollPlugin, "enroll", "tls");
+
+}

--- a/sdk/BUCK
+++ b/sdk/BUCK
@@ -39,6 +39,5 @@ osquery_cxx_library(
         osquery_target("osquery/utils:attribute"),
         osquery_target("osquery/utils:utils"),
         osquery_target("osquery:headers"),
-        osquery_target("plugins/config:tls_config"),
     ],
 )


### PR DESCRIPTION
Summary:
to be able to exclude dependency on enroll:tls plugin from plugins_sdk.
Only plugin registration was moved by now. The actual plugin code will be moved a bit later.

Reviewed By: guliashvili

Differential Revision: D14241687
