### PR TITLE
Remove folly initialisation routine from osquery/core/init.cpp

### DIFF
--- a/osquery/core/init.cpp
+++ b/osquery/core/init.cpp
@@ -29,10 +29,6 @@
 #include <sys/resource.h>
 #endif
 
-#ifdef FBTHRIFT
-#include <folly/init/Init.h>
-#endif
-
 #include <boost/filesystem.hpp>
 
 #include "osquery/utils/config/default_paths.h"
@@ -266,7 +262,10 @@ static inline void printUsage(const std::string& binary, ToolType tool) {
   fprintf(stdout, EPILOG);
 }
 
-Initializer::Initializer(int& argc, char**& argv, ToolType tool)
+Initializer::Initializer(int& argc,
+                         char**& argv,
+                         ToolType tool,
+                         bool const init_glog)
     : argc_(&argc), argv_(&argv) {
   // Initialize random number generated based on time.
   std::srand(static_cast<unsigned int>(
@@ -358,12 +357,6 @@ Initializer::Initializer(int& argc, char**& argv, ToolType tool)
 
   // Let gflags parse the non-help options/flags.
   GFLAGS_NAMESPACE::ParseCommandLineFlags(argc_, argv_, isShell());
-
-  bool init_glog = true;
-#ifdef FBTHRIFT
-  init_glog = false;
-  ::folly::init(&argc, &argv, false);
-#endif
 
   // Initialize registries and plugins
   registryAndPluginInit();

--- a/osquery/extensions/thrift/osquery.thrift
+++ b/osquery/extensions/thrift/osquery.thrift
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
 namespace cpp osquery.extensions
-namespace py osquery.osquery
+namespace py osquery.extensions
 
 /// Registry operations use a registry name, plugin name, request/response.
 typedef map<string, string> ExtensionPluginRequest

--- a/osquery/include/osquery/system.h
+++ b/osquery/include/osquery/system.h
@@ -47,8 +47,13 @@ class Initializer : private boost::noncopyable {
    * @param argc the number of elements in argv
    * @param argv the command-line arguments passed to `main()`
    * @param tool the type of osquery main (daemon, shell, test, extension).
+   * @param init_glog whether to start google logging module (it can be
+   * initialized at most once)
    */
-  Initializer(int& argc, char**& argv, ToolType tool = ToolType::TEST);
+  Initializer(int& argc,
+              char**& argv,
+              ToolType tool = ToolType::TEST,
+              bool init_glog = true);
 
   /**
    * @brief Sets up the process as an osquery daemon.

--- a/osquery/main/tests.cpp
+++ b/osquery/main/tests.cpp
@@ -16,10 +16,6 @@
 
 #include <gtest/gtest.h>
 
-#ifdef FBTHRIFT
-#include <folly/init/Init.h>
-#endif
-
 #include <osquery/logger.h>
 #include <osquery/process/process.h>
 
@@ -126,10 +122,6 @@ int main(int argc, char* argv[]) {
   osquery::kProcessTestExecPath = argv[0];
   osquery::kExpectedExtensionArgs[0] = argv[0];
   osquery::kExpectedWorkerArgs[0] = argv[0];
-
-#ifdef FBTHRIFT
-  ::folly::init(&argc, &argv, false);
-#endif
 
   if (auto val = osquery::getEnvVar("OSQUERY_WORKER")) {
     return workerMain(argc, argv);


### PR DESCRIPTION
Summary: osquery build doesn't use folly for now so this facebook specific routine is dead and should be removed or moved to another place.

Differential Revision: D14242160
