### PR TITLE
windows/logical_drives: Fix boot partition detection

### DIFF
--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -50,17 +50,13 @@ QueryData genLogicalDrives(QueryContext& context) {
       r["size"] = "-1";
     }
 
-    // NOTE(ww): std::set::count is specified to only return {0, 1},
-    // so this narrowing operation is safe.
-    int bootPartition = static_cast<int>(bootDeviceIds.count(deviceId.at(0)));
-
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.
     // However, a bug in WMI marshalling caused the type to always
     // return "Unknown". That behavior is preserved here.
     r["type"] = "Unknown";
     r["device_id"] = deviceId;
-    r["boot_partition"] = INTEGER(bootPartition);
+    r["boot_partition"] = INTEGER(bootDeviceIds.count(deviceId.at(0)));
 
     results.push_back(std::move(r));
   }

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -6,8 +6,7 @@
  *  the LICENSE file found in the root directory of this source tree.
  */
 
-#include <Windows.h>
-#include <set>
+#include <unordered_set>
 
 #include "osquery/core/windows/wmi.h"
 #include <osquery/tables.h>
@@ -26,7 +25,7 @@ QueryData genLogicalDrives(QueryContext& context) {
   const WmiRequest wmiBootConfigurationReq(
       "select BootDirectory from Win32_BootConfiguration");
   auto const& bootConfigurations = wmiBootConfigurationReq.results();
-  std::set<char> bootDeviceIds;
+  std::unordered_set<char> bootDeviceIds;
 
   for (const auto& bootConfiguration : bootConfigurations) {
     std::string bootDirectory;

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -9,8 +9,8 @@
 #include <Windows.h>
 #include <set>
 
-#include <osquery/tables.h>
 #include "osquery/core/windows/wmi.h"
+#include <osquery/tables.h>
 
 namespace osquery {
 namespace tables {
@@ -26,12 +26,12 @@ QueryData genLogicalDrives(QueryContext& context) {
   const WmiRequest wmiBootConfigurationReq(
       "select BootDirectory from Win32_BootConfiguration");
   auto const& bootConfigurations = wmiBootConfigurationReq.results();
-  std::set<std::string> bootDirectories;
+  std::set<char> bootDeviceIds;
 
   for (const auto& bootConfiguration : bootConfigurations) {
     std::string bootDirectory;
     bootConfiguration.GetString("BootDirectory", bootDirectory);
-    bootDirectories.insert(std::move(bootDirectory));
+    bootDeviceIds.insert(bootDirectory.at(0));
   }
 
   for (const auto& logicalDisk : logicalDisks) {
@@ -51,10 +51,9 @@ QueryData genLogicalDrives(QueryContext& context) {
       r["size"] = "-1";
     }
 
-    std::string bootPath = deviceId + "\\Windows";
     // NOTE(ww): std::set::count is specified to only return {0, 1},
     // so this narrowing operation is safe.
-    int bootPartition = static_cast<int>(bootDirectories.count(bootPath));
+    int bootPartition = static_cast<int>(bootDeviceIds.count(deviceId.at(0)));
 
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.

--- a/osquery/tables/system/windows/logical_drives.cpp
+++ b/osquery/tables/system/windows/logical_drives.cpp
@@ -52,7 +52,9 @@ QueryData genLogicalDrives(QueryContext& context) {
     }
 
     std::string bootPath = deviceId + "\\Windows";
-    int bootPartition = bootDirectories.count(bootPath);
+    // NOTE(ww): std::set::count is specified to only return {0, 1},
+    // so this narrowing operation is safe.
+    int bootPartition = static_cast<int>(bootDirectories.count(bootPath));
 
     // NOTE(ww): Previous versions of this table used the type
     // column to provide a non-canonical description of the drive.


### PR DESCRIPTION
This is a follow-up to #5400, fixing the `boot_partition` column.

Previous versions of the table would consistently provide a false negative for bootable drives, thanks to a mismatch in format between `Win32_DiskPartition.DeviceID` and `Win32_LogicalDisk.DeviceID`. This change replaces the use of `Win32_DiskPartition` with `Win32_BootConfiguration` and moves the query to the top-level, fixing the bug and removing the need to make `N` WMI requests for `N` system drives.
