### PR TITLE
Define osquery version on base.cfg

### DIFF
--- a/osquery/utils/info/BUCK
+++ b/osquery/utils/info/BUCK
@@ -20,6 +20,15 @@ osquery_cxx_library(
         "tool_type.h",
         "version.h",
     ],
+    exported_preprocessor_flags = [
+        "-DOSQUERY_VERSION={}".format(read_config("osquery", "version")),
+        "-DOSQUERY_BUILD_VERSION={}".format(
+            read_config("osquery", "version"),
+        ),
+        "-DOSQUERY_BUILD_SDK_VERSION={}".format(
+            read_config("osquery", "version"),
+        ),
+    ],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/utils/conversions:conversions"),

--- a/tools/buckconfigs/base.bcfg
+++ b/tools/buckconfigs/base.bcfg
@@ -1,3 +1,6 @@
+[osquery]
+  version = 3.3.2
+
 [build]
   osquery = oss
 

--- a/tools/build_defs/oss/osquery/cxx.bzl
+++ b/tools/build_defs/oss/osquery/cxx.bzl
@@ -27,13 +27,6 @@ load(
 )
 
 # for osquery targets only
-_OSQUERY_PREPROCESSOR_FLAGS = [
-    "-DOSQUERY_VERSION=3.3.2",
-    "-DOSQUERY_BUILD_VERSION=3.3.2",
-    "-DOSQUERY_BUILD_SDK_VERSION=3.3.2",
-]
-
-# for osquery targets only
 _OSQUERY_PLATFORM_PREPROCESSOR_FLAGS = [
     (
         _LINUX,
@@ -100,9 +93,6 @@ def _osquery_set_generic_kwargs(kwargs):
 
 def _osquery_set_preprocessor_kwargs(kwargs, external):
     kwargs.setdefault("preprocessor_flags", [])
-    if not external:
-        kwargs["preprocessor_flags"] += _OSQUERY_PREPROCESSOR_FLAGS
-
     kwargs.setdefault("platform_preprocessor_flags", [])
     kwargs["platform_preprocessor_flags"] += _GLOBAL_PLATFORM_PREPROCESSOR_FLAGS
     if not external:


### PR DESCRIPTION
Summary:
This makes it easier to update the osquery version and simplifies cxx.bzl by removing osquery specific preprocessor flags.

This will also make rebuilding osquery after changing versions faster, since the flags are now only defined for the headers which need them.

Reviewed By: akindyakov

Differential Revision: D14183142
