### PR TITLE
Include empty registerForeignTables() function to plugin_sdk library

### DIFF
--- a/sdk/BUCK
+++ b/sdk/BUCK
@@ -9,10 +9,14 @@ load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
 
 osquery_cxx_library(
     name = "plugin_sdk",
+    srcs = [
+        "empty_register_foreign_tables.cpp",
+    ],
     header_namespace = "osquery/sdk",
     exported_headers = [
         "plugin_sdk.h",
     ],
+    link_whole = True,
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/config:config"),

--- a/sdk/empty_register_foreign_tables.cpp
+++ b/sdk/empty_register_foreign_tables.cpp
@@ -1,0 +1,15 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+namespace osquery {
+
+void registerForeignTables() {
+  // this is a hacky way to avoid including all tables to plugin_sdk library
+}
+
+} // namespace osquery


### PR DESCRIPTION
Summary: as a hacky way to avoid including implementation of all tables to plugin sdk.

Differential Revision: D14261047
