### PR TITLE
plugin SDK tests: registry should contain only optional plugins and some mandatory registries

### DIFF
--- a/sdk/BUCK
+++ b/sdk/BUCK
@@ -17,6 +17,9 @@ osquery_cxx_library(
         "plugin_sdk.h",
     ],
     link_whole = True,
+    tests = [
+        osquery_target("sdk/tests:plugin_sdk_tests"),
+    ],
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/config:config"),

--- a/sdk/BUCK
+++ b/sdk/BUCK
@@ -9,10 +9,14 @@ load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
 
 osquery_cxx_library(
     name = "plugin_sdk",
+    srcs = [
+        "empty_register_foreign_tables.cpp",
+    ],
     header_namespace = "osquery/sdk",
     exported_headers = [
         "plugin_sdk.h",
     ],
+    link_whole = True,
     visibility = ["PUBLIC"],
     deps = [
         osquery_target("osquery/config:config"),

--- a/sdk/empty_register_foreign_tables.cpp
+++ b/sdk/empty_register_foreign_tables.cpp
@@ -1,0 +1,15 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+namespace osquery {
+
+void registerForeignTables() {
+  // this is a hacky way to avoid including all tables to plugin_sdk library
+}
+
+} // namespace osquery

--- a/sdk/tests/BUCK
+++ b/sdk/tests/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_test(
+    name = "plugin_sdk_tests",
+    srcs = [
+        "registry_tests.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/extensions:impl_thrift"),
+        osquery_target("sdk:plugin_sdk"),
+    ],
+)

--- a/sdk/tests/registry_tests.cpp
+++ b/sdk/tests/registry_tests.cpp
@@ -1,0 +1,61 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/registry.h>
+
+#include <gtest/gtest.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <unordered_set>
+#include <vector>
+
+namespace osquery {
+namespace {
+
+class PluginSdkRegistryTests : public testing::Test {};
+
+TEST_F(PluginSdkRegistryTests, there_is_no_registered_plugin_in_sdk) {
+  for (auto const& ptr : AutoRegisterInterface::plugins()) {
+    EXPECT_TRUE(ptr->optional_)
+        << " unexpected non internal plugin in sdk:"
+        << " (type: " << boost::io::quoted(ptr->type_)
+        << ", name: " << boost::io::quoted(ptr->name_) << ")";
+  }
+}
+
+auto const mandatory_registries_ = std::vector<std::string>{
+    "config",
+    "config_parser",
+    "database",
+    "distributed",
+    "enroll",
+    "event_publisher",
+    "event_subscriber",
+    "killswitch",
+    "logger",
+    "numeric_monitoring",
+    "sql",
+    "table",
+};
+
+TEST_F(PluginSdkRegistryTests, whether_all_mandatory_registries_are_in_sdk) {
+  auto known_registries = std::unordered_set<std::string>{};
+  for (auto const& ptr : AutoRegisterInterface::registries()) {
+    EXPECT_FALSE(known_registries.count(ptr->name_))
+        << " duplicated registry " << boost::io::quoted(ptr->name_);
+    known_registries.emplace(ptr->name_);
+  }
+  for (auto const& name : mandatory_registries_) {
+    EXPECT_TRUE(known_registries.count(name))
+        << " missing mandatory registry " << boost::io::quoted(name);
+  }
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
osquery registries is big part of SDK interface and it is important to make
sure SDK include them all.

Need of tests for non optional plugins can be not so obvious. All non-optional
plugins should not be included to SDK library. Because it causes to double
plugin registration when extensions process connects to `osqueryd`. That leads
to the crash of extensions process.

Unfortunatelly there is no explisit list of plugins included to SDK and there is
no way to check them at compile time. Thankfully it can be done at
runtime and we can make a test for it.

Differential Revision: D14261046
