### PR TITLE
Fix osquery mode to skip TLS verification in debug builds

### DIFF
--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -59,7 +59,7 @@ CLI_FLAG(uint32,
          3600,
          "TLS session keep alive timeout in seconds");
 
-#if defined(DEBUG)
+#ifndef NDEBUG
 HIDDEN_FLAG(bool,
             tls_allow_unsafe,
             false,
@@ -112,7 +112,16 @@ http::Client::Options TLSTransport::getOptions() {
       boost_system::error_code ec;
 
       auto status = fs::status(server_certificate_file_, ec);
-      options.openssl_verify_path(server_certificate_file_);
+
+#ifndef NDEBUG
+      if (!FLAGS_tls_allow_unsafe) {
+        // In unsafe mode we skip verification of the server's TLS details
+        // to allow people to connect to devservers
+#else
+      if (true) {
+#endif
+        options.openssl_verify_path(server_certificate_file_);
+      }
 
       // On Windows, we cannot set openssl_certificate to a directory
       if (isPlatform(PlatformType::TYPE_WINDOWS) &&
@@ -120,7 +129,13 @@ http::Client::Options TLSTransport::getOptions() {
         LOG(WARNING) << "Cannot set a non-regular file as a certificate: "
                      << server_certificate_file_;
       } else {
-        options.openssl_certificate(server_certificate_file_);
+#ifndef NDEBUG
+        if (!FLAGS_tls_allow_unsafe) {
+#else
+        if (true) {
+#endif
+          options.openssl_certificate(server_certificate_file_);
+        }
       }
     }
   }
@@ -145,7 +160,7 @@ http::Client::Options TLSTransport::getOptions() {
     options.openssl_sni_hostname(it->value.GetString());
   }
 
-#if defined(DEBUG)
+#ifndef NDEBUG
   // Configuration may allow unsafe TLS testing if compiled as a debug target.
   if (FLAGS_tls_allow_unsafe) {
     options.always_verify_peer(false);
@@ -188,7 +203,8 @@ static auto getClient() {
 
 Status TLSTransport::sendRequest() {
   if (destination_.find("https://") == std::string::npos) {
-    return Status(1, "Cannot create TLS request for non-HTTPS protocol URI");
+    return Status::failure(
+        "Cannot create TLS request for non-HTTPS protocol URI");
   }
 
   http::Request r(destination_);
@@ -208,15 +224,15 @@ Status TLSTransport::sendRequest() {
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
   } catch (const std::exception& e) {
-    return Status((tlsFailure(e.what())) ? 2 : 1,
-                  std::string("Request error: ") + e.what());
+    return Status::failure(std::string("Request error: ") + e.what());
   }
   return response_status_;
 }
 
 Status TLSTransport::sendRequest(const std::string& params, bool compress) {
   if (destination_.find("https://") == std::string::npos) {
-    return Status(1, "Cannot create TLS request for non-HTTPS protocol URI");
+    return Status::failure(
+        "Cannot create TLS request for non-HTTPS protocol URI");
   }
 
   http::Request r(destination_);
@@ -257,8 +273,7 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
   } catch (const std::exception& e) {
-    return Status((tlsFailure(e.what())) ? 2 : 1,
-                  std::string("Request error: ") + e.what());
+    return Status::failure(std::string("Request error: ") + e.what());
   }
   return response_status_;
 }


### PR DESCRIPTION
Summary:
We allow people using a debug build of osqueryd to skip verification of the server's TLS certificate. This allow people to connect to a devserver, for example, when testing the Graph API endpoints used by osquery.

This mode broke at some point when we stopped defining the `DEBUG` constant when building osqueryd in debug mode. This diff updates the code so that we use the constant `NDEBUG`, which is actually defined for release builds. For example, for OS X, see the build configs at https://fburl.com/ywr1tyuk and https://fburl.com/mte9ajvr.

We also update the code to ensure the command line option `--tls_allow_unsafe` allows a person to connect to a dev server.

Differential Revision: D14260226
