### PR TITLE
Fix a bug in the counting uptime on Windows

### DIFF
--- a/osquery/tables/system/uptime.cpp
+++ b/osquery/tables/system/uptime.cpp
@@ -46,7 +46,7 @@ long getUptime() {
 
   return sys_info.uptime;
 #elif defined(WIN32)
-  return static_cast<long>(GetTickCount64()) / 1000;
+  return static_cast<long>(GetTickCount64() / 1000);
 #endif
 
   return -1;


### PR DESCRIPTION
osquery incorrectly calculated uptime on windows hosts, it has been fixed.
```
osquery> select * from uptime;
+------+-------+---------+---------+---------------+
| days | hours | minutes | seconds | total_seconds |
+------+-------+---------+---------+---------------+
| 14   | 6     | 48      | 0       | 1234080       |
+------+-------+---------+---------+---------------+
```
```
PS C:\Users\karmazin> $signature = @'
»
» [DllImport(@"kernel32.dll", SetLastError=true)]
» public static extern UInt64 GetTickCount64 ();
»
» '@
PS C:\Users\karmazin>  $type = Add-Type -MemberDefinition $signature -Name SystemTime -Namespace GetTickCount64 -PassThr
u
PS C:\Users\karmazin>
PS C:\Users\karmazin> [System.TimeSpan]::FromMilliseconds($type::GetTickCount64())


Days              : 63
Hours             : 23
Minutes           : 53
Seconds           : 34
Milliseconds      : 843
Ticks             : 55292148430000
TotalDays         : 63,9955421643518
TotalHours        : 1535,89301194444
TotalMinutes      : 92153,5807166667
TotalSeconds      : 5529214,843
TotalMilliseconds : 5529214843
```

