### PR TITLE
Replace Status(0) calls with Status::success() to appease Lint

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -232,7 +232,7 @@ Status Carver::carve(const boost::filesystem::path& path) {
     }
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 };
 
 Status Carver::postCarve(const boost::filesystem::path& path) {
@@ -305,7 +305,7 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
   }
 
   updateCarveValue(carveGuid_, "status", "SUCCESS");
-  return Status(0, "Ok");
+  return Status::success();
 };
 
 Status carvePaths(const std::set<std::string>& paths) {

--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -813,7 +813,7 @@ Status Config::update(const ConfigMap& config) {
     backupConfig(config);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void Config::purge() {
@@ -1010,7 +1010,7 @@ Status Config::genHash(std::string& hash) const {
   new_hash.update(buffer.data(), buffer.size());
   hash = new_hash.digest();
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::string Config::getHash(const std::string& source) const {

--- a/osquery/config/config.h
+++ b/osquery/config/config.h
@@ -405,7 +405,7 @@ class Config : private boost::noncopyable {
  *    public:
  *     virtual Status genConfig(std::map<std::string, std::string>& config) {
  *       config["my_source"] = "{}";
- *       return Status(0, "OK");
+ *       return Status::success();
  *     }
  *   };
  *

--- a/osquery/core/flags.cpp
+++ b/osquery/core/flags.cpp
@@ -54,7 +54,7 @@ Status Flag::getDefaultValue(const std::string& name, std::string& value) {
   }
 
   value = info.default_value;
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool Flag::isDefault(const std::string& name) {
@@ -117,12 +117,12 @@ std::string Flag::getDescription(const std::string& name) {
 Status Flag::updateValue(const std::string& name, const std::string& value) {
   if (instance().flags_.count(name) > 0) {
     flags::SetCommandLineOption(name.c_str(), value.c_str());
-    return Status(0, "OK");
+    return Status::success();
   } else if (instance().aliases_.count(name) > 0) {
     // Updating a flag by an alias name.
     auto& real_name = instance().aliases_.at(name).description;
     flags::SetCommandLineOption(real_name.c_str(), value.c_str());
-    return Status(0, "OK");
+    return Status::success();
   } else if (name.find("custom_") == 0) {
     instance().custom_[name] = value;
   }

--- a/osquery/core/plugins/plugin.h
+++ b/osquery/core/plugins/plugin.h
@@ -44,7 +44,7 @@ class Plugin : private boost::noncopyable {
  public:
   /// The plugin may perform some initialization, not required.
   virtual Status setUp() {
-    return Status(0, "Not used");
+    return Status::success();
   }
 
   /// The plugin may perform some tear down, release, not required.
@@ -97,7 +97,7 @@ class Plugin : private boost::noncopyable {
                             const PluginResponse& info) {
     (void)name;
     (void)info;
-    return Status(0, "Not used");
+    return Status::success();
   }
 
   /// Allow a specialized plugin type to act when an external plugin is removed.

--- a/osquery/core/plugins/sql.h
+++ b/osquery/core/plugins/sql.h
@@ -49,7 +49,7 @@ class SQLPlugin : public Plugin {
    * managed, tables are enumerated and attached during initialization.
    */
   virtual Status attach(const std::string& /*name*/) {
-    return Status(0, "Not used");
+    return Status::success();
   }
 
   /// Tables may be detached by name.

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -58,7 +58,7 @@ Status Query::getPreviousQueryResults(QueryDataSet& results) const {
   if (!status.ok()) {
     return status;
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::vector<std::string> Query::getStoredQueryNames() {
@@ -162,7 +162,7 @@ Status Query::addNewResults(QueryData current_qd,
       return status;
     }
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 
@@ -267,7 +267,7 @@ Status serializeEvent(const QueryLogItem& item,
   }
 
   doc.add("columns", columns_obj, obj);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status serializeQueryLogItemAsEvents(const QueryLogItem& item, JSON& doc) {

--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -241,7 +241,7 @@ Status getEphemeralUUID(std::string& ident) {
   if (ident.size() == 0) {
     ident = osquery::generateNewUUID();
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status getHostUUID(std::string& ident) {
@@ -260,7 +260,7 @@ Status getSpecifiedUUID(std::string& ident) {
     return Status(1, "No specified identifier for host");
   }
   ident = FLAGS_specified_identifier;
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::string getHostIdentifier() {
@@ -297,7 +297,7 @@ Status checkStalePid(const std::string& content) {
   try {
     pid = boost::lexical_cast<int>(content);
   } catch (const boost::bad_lexical_cast& /* e */) {
-    return Status(0, "Could not parse pid from existing pidfile");
+    return Status::success();
   }
 
   PlatformProcess target(pid);
@@ -330,7 +330,7 @@ Status checkStalePid(const std::string& content) {
     VLOG(1) << "Found stale process for osqueryd (" << content << ")";
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status createPidFile() {

--- a/osquery/core/tables.cpp
+++ b/osquery/core/tables.cpp
@@ -161,7 +161,7 @@ Status TablePlugin::call(const PluginRequest& request,
     return Status(1, "Unknown table plugin action: " + action);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::string TablePlugin::columnDefinition(bool is_extension) const {

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -120,7 +120,7 @@ Status DatabasePlugin::scan(const std::string& domain,
                             std::vector<std::string>& results,
                             const std::string& prefix,
                             size_t max) const {
-  return Status(0, "Not used");
+  return Status::success();
 }
 
 Status DatabasePlugin::call(const PluginRequest& request,

--- a/osquery/database/plugins/ephemeral.cpp
+++ b/osquery/database/plugins/ephemeral.cpp
@@ -83,7 +83,7 @@ Status EphemeralDatabasePlugin::putBatch(const std::string& domain,
     setValue(domain, key, value);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void EphemeralDatabasePlugin::dumpDatabase() const {

--- a/osquery/database/plugins/rocksdb.cpp
+++ b/osquery/database/plugins/rocksdb.cpp
@@ -274,7 +274,7 @@ Status RocksDBDatabasePlugin::put(const std::string& domain,
 Status RocksDBDatabasePlugin::putBatch(const std::string& domain,
                                        const DatabaseStringValueList& data) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   auto cfh = getHandleForColumnFamily(domain);
@@ -323,7 +323,7 @@ void RocksDBDatabasePlugin::dumpDatabase() const {}
 Status RocksDBDatabasePlugin::remove(const std::string& domain,
                                      const std::string& key) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   auto cfh = getHandleForColumnFamily(domain);
@@ -345,7 +345,7 @@ Status RocksDBDatabasePlugin::removeRange(const std::string& domain,
                                           const std::string& low,
                                           const std::string& high) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   auto cfh = getHandleForColumnFamily(domain);
@@ -397,6 +397,6 @@ Status RocksDBDatabasePlugin::scan(const std::string& domain,
     }
   }
   delete it;
-  return Status(0, "OK");
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/database/plugins/sqlite.cpp
+++ b/osquery/database/plugins/sqlite.cpp
@@ -187,7 +187,7 @@ Status SQLiteDatabasePlugin::put(const std::string& domain,
 Status SQLiteDatabasePlugin::putBatch(const std::string& domain,
                                       const DatabaseStringValueList& data) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   // Prepare the query, adding placeholders for all the rows we have in `data`
@@ -235,13 +235,13 @@ Status SQLiteDatabasePlugin::putBatch(const std::string& domain,
     tryVacuum(db_);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status SQLiteDatabasePlugin::remove(const std::string& domain,
                                     const std::string& key) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   sqlite3_stmt* stmt = nullptr;
@@ -267,7 +267,7 @@ Status SQLiteDatabasePlugin::removeRange(const std::string& domain,
                                          const std::string& low,
                                          const std::string& high) {
   if (read_only_) {
-    return Status(0, "Database in readonly mode");
+    return Status::success();
   }
 
   sqlite3_stmt* stmt = nullptr;
@@ -310,6 +310,6 @@ Status SQLiteDatabasePlugin::scan(const std::string& domain,
     results.push_back(std::move(r["key"]));
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/dispatcher/dispatcher.cpp
+++ b/osquery/dispatcher/dispatcher.cpp
@@ -83,7 +83,7 @@ Status Dispatcher::addService(InternalRunnableRef service) {
     self.service_threads_.push_back(std::move(thread));
     self.services_.push_back(std::move(service));
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void Dispatcher::removeService(const InternalRunnable* service) {

--- a/osquery/dispatcher/distributed_runner.cpp
+++ b/osquery/dispatcher/distributed_runner.cpp
@@ -54,7 +54,7 @@ void DistributedRunner::start() {
 Status startDistributed() {
   if (!FLAGS_disable_distributed) {
     Dispatcher::addService(std::make_shared<DistributedRunner>());
-    return Status(0, "OK");
+    return Status::success();
   } else {
     return Status(1, "Distributed query service not enabled.");
   }

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -47,7 +47,7 @@ Status DistributedPlugin::call(const PluginRequest& request,
     std::string queries;
     getQueries(queries);
     response.push_back({{"results", queries}});
-    return Status(0, "OK");
+    return Status::success();
   } else if (action == "writeResults") {
     if (request.count("results") == 0) {
       return Status(1, "Missing results field");
@@ -75,7 +75,7 @@ Status Distributed::pullUpdates() {
     return acceptWork(response[0]["results"]);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 size_t Distributed::getPendingQueryCount() {
@@ -135,7 +135,7 @@ Status Distributed::runQueries() {
 
 Status Distributed::flushCompleted() {
   if (getCompletedCount() == 0) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   auto distributed_plugin = RegistryFactory::get().getActive("distributed");

--- a/osquery/events/benchmarks/events_benchmarks.cpp
+++ b/osquery/events/benchmarks/events_benchmarks.cpp
@@ -50,7 +50,7 @@ class BenchmarkEventSubscriber
   }
 
   Status Callback(const ECRef& ec, const SCRef& sc) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   void benchmarkInit() {

--- a/osquery/events/darwin/diskarbitration.cpp
+++ b/osquery/events/darwin/diskarbitration.cpp
@@ -54,7 +54,7 @@ void DiskArbitrationEventPublisher::restart() {
 Status DiskArbitrationEventPublisher::run() {
   restart();
   CFRunLoopRun();
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void DiskArbitrationEventPublisher::stop() {

--- a/osquery/events/darwin/fsevents.cpp
+++ b/osquery/events/darwin/fsevents.cpp
@@ -248,7 +248,7 @@ Status FSEventsEventPublisher::run() {
 
   // Start the run loop, it may be removed with a tearDown.
   CFRunLoopRun();
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void FSEventsEventPublisher::Callback(

--- a/osquery/events/darwin/iokit.cpp
+++ b/osquery/events/darwin/iokit.cpp
@@ -205,7 +205,7 @@ Status IOKitEventPublisher::run() {
 
   // Start the run loop, it may be removed with a tearDown.
   CFRunLoopRun();
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool IOKitEventPublisher::shouldFire(const IOKitSubscriptionContextRef& sc,

--- a/osquery/events/darwin/scnetwork.cpp
+++ b/osquery/events/darwin/scnetwork.cpp
@@ -178,6 +178,6 @@ Status SCNetworkEventPublisher::run() {
 
   // Start the run loop, it may be removed with a tearDown.
   CFRunLoopRun();
-  return Status(0, "OK");
+  return Status::success();
 }
 };

--- a/osquery/events/events.cpp
+++ b/osquery/events/events.cpp
@@ -760,7 +760,7 @@ void EventFactory::configUpdate() {
 
 Status EventFactory::run(const std::string& type_id) {
   if (FLAGS_disable_events) {
-    return Status(0, "Events disabled");
+    return Status::success();
   }
 
   // An interesting take on an event dispatched entrypoint.
@@ -810,7 +810,7 @@ Status EventFactory::run(const std::string& type_id) {
   // If the event factory's `end` method was called these publishers will be
   // cleaned up after their thread context is removed; otherwise, a removed
   // thread context and failed publisher will remain available for stats.
-  return Status(0, "OK");
+  return Status::success();
 }
 
 // There's no reason for the event factory to keep multiple instances.
@@ -830,7 +830,7 @@ Status EventFactory::registerEventPublisher(const PluginRef& pub) {
   }
 
   if (specialized_pub == nullptr || specialized_pub.get() == nullptr) {
-    return Status(0, "Invalid publisher");
+    return Status::success();
   }
 
   auto type_id = specialized_pub->type();
@@ -867,7 +867,7 @@ Status EventFactory::registerEventPublisher(const PluginRef& pub) {
     }
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
@@ -947,7 +947,7 @@ Status EventFactory::registerEventSubscriber(const PluginRef& sub) {
     specialized_sub->state(EventState::EVENT_FAILED);
     return Status(1, status.getMessage());
   } else {
-    return Status(0, "OK");
+    return Status::success();
   }
 }
 
@@ -1031,7 +1031,7 @@ Status EventFactory::deregisterEventPublisher(const std::string& type_id) {
       publisher->stop();
     }
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status EventFactory::deregisterEventSubscriber(const std::string& sub) {

--- a/osquery/events/linux/auditeventpublisher.cpp
+++ b/osquery/events/linux/auditeventpublisher.cpp
@@ -56,7 +56,7 @@ Status AuditEventPublisher::setUp() {
     executable_path_ = buffer;
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void AuditEventPublisher::configure() {
@@ -96,7 +96,7 @@ Status AuditEventPublisher::run() {
     fire(event_context);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void AuditEventPublisher::ProcessEvents(

--- a/osquery/events/linux/inotify.cpp
+++ b/osquery/events/linux/inotify.cpp
@@ -63,7 +63,7 @@ Status INotifyEventPublisher::setUp() {
   if (scratch_ == nullptr) {
     return Status(1, "Could not allocate scratch space");
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool INotifyEventPublisher::needMonitoring(const std::string& path,
@@ -224,7 +224,7 @@ Status INotifyEventPublisher::run() {
   int selector = ::poll(fds, 1, 1000);
   if (selector == -1) {
     if (errno == EINTR) {
-      return Status(0, "inotify poll interrupted");
+      return Status::success();
     }
     LOG(WARNING) << "Could not read inotify handle";
     return Status(1, "inotify poll failed");
@@ -232,11 +232,11 @@ Status INotifyEventPublisher::run() {
 
   if (selector == 0) {
     // Read timeout.
-    return Status(0, "Continue");
+    return Status::success();
   }
 
   if (!(fds[0].revents & POLLIN)) {
-    return Status(0, "Invalid poll response");
+    return Status::success();
   }
 
   WriteLock lock(scratch_mutex_);
@@ -271,7 +271,7 @@ Status INotifyEventPublisher::run() {
     p += (sizeof(struct inotify_event)) + event->len;
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 INotifyEventContextRef INotifyEventPublisher::createEventContextFrom(

--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -96,7 +96,7 @@ Status SyslogEventPublisher::setUp() {
   VLOG(1) << "Successfully opened pipe for syslog ingestion: "
           << FLAGS_syslog_pipe_path;
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status SyslogEventPublisher::createPipe(const std::string& path) {
@@ -115,14 +115,14 @@ Status SyslogEventPublisher::createPipe(const std::string& path) {
   if (group == nullptr) {
     VLOG(1) << "No group " << kPipeGroupName
             << " found. Not changing group for the pipe.";
-    return Status(0, "OK");
+    return Status::success();
   }
   if (chown(FLAGS_syslog_pipe_path.c_str(), -1, group->gr_gid) == -1) {
     return Status(1,
                   "Error in chown to group " + kPipeGroupName + ": " +
                       std::string(strerror(errno)));
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status SyslogEventPublisher::lockPipe(const std::string& path) {
@@ -136,7 +136,7 @@ Status SyslogEventPublisher::lockPipe(const std::string& path) {
     return Status(
         1, "Unable to acquire pipe lock: " + std::string(strerror(errno)));
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void SyslogEventPublisher::unlockPipe() {
@@ -157,7 +157,7 @@ Status SyslogEventPublisher::run() {
       // If there is no pending data, we have flushed everything and can wait
       // until the next time EventFactory calls run(). This also allows the
       // thread to join when it is stopped by EventFactory.
-      return Status(0, "OK");
+      return Status::success();
     }
     std::string line;
     std::getline(readStream_, line);
@@ -176,7 +176,7 @@ Status SyslogEventPublisher::run() {
       }
     }
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void SyslogEventPublisher::tearDown() {
@@ -205,7 +205,7 @@ Status SyslogEventPublisher::populateEventContext(const std::string& line,
   }
 
   if (key == kCsvFields.end()) {
-    return Status(0, "OK");
+    return Status::success();
   } else {
     return Status(1, "Received fewer fields than expected");
   }

--- a/osquery/events/linux/udev.cpp
+++ b/osquery/events/linux/udev.cpp
@@ -41,7 +41,7 @@ Status UdevEventPublisher::setUp() {
   }
 
   udev_monitor_enable_receiving(monitor_);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void UdevEventPublisher::tearDown() {
@@ -81,7 +81,7 @@ Status UdevEventPublisher::run() {
 
     if (selector == 0 || !(fds[0].revents & POLLIN)) {
       // Read timeout.
-      return Status(0, "Finished");
+      return Status::success();
     }
 
     struct udev_device* device = udev_monitor_receive_device(monitor_);
@@ -97,7 +97,7 @@ Status UdevEventPublisher::run() {
   }
 
   pause(std::chrono::milliseconds(kUdevMLatency));
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::string UdevEventPublisher::getValue(struct udev_device* device,

--- a/osquery/events/tests/darwin/fsevents_tests.cpp
+++ b/osquery/events/tests/darwin/fsevents_tests.cpp
@@ -227,7 +227,7 @@ class TestFSEventsEventSubscriber
 
   Status init() override {
     callback_count_ = 0;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   SCRef GetSubscription(const std::string& path, uint32_t mask = 0) {
@@ -240,7 +240,7 @@ class TestFSEventsEventSubscriber
   Status SimpleCallback(const ECRef& ec, const SCRef& sc) {
     WriteLock lock(mutex_);
     callback_count_ += 1;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status Callback(const ECRef& ec, const SCRef& sc) {
@@ -253,7 +253,7 @@ class TestFSEventsEventSubscriber
     WriteLock lock(mutex_);
     actions_.push_back(ec->action);
     callback_count_ += 1;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   void WaitForEvents(int max, int initial = 0) {

--- a/osquery/events/tests/events_tests.cpp
+++ b/osquery/events/tests/events_tests.cpp
@@ -230,7 +230,7 @@ class TestEventPublisher
  public:
   Status setUp() override {
     smallest_ever_ += 1;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   void configure() override {
@@ -344,7 +344,7 @@ static int kBellHathTolled = 0;
 Status TestTheeCallback(const EventContextRef& ec,
                         const SubscriptionContextRef& sc) {
   kBellHathTolled += 1;
-  return Status(0, "OK");
+  return Status::success();
 }
 
 class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
@@ -371,7 +371,7 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
   Status Callback(const ECRef& ec, const SCRef& sc) {
     // We don't care about the subscription or the event contexts.
     bellHathTolled = true;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status SpecialCallback(const ECRef& ec, const SCRef& sc) {
@@ -379,7 +379,7 @@ class FakeEventSubscriber : public EventSubscriber<FakeEventPublisher> {
     if (ec->required_value == 42) {
       contextBellHathTolled = true;
     }
-    return Status(0, "OK");
+    return Status::success();
   }
 
   void lateInit() {

--- a/osquery/events/tests/linux/inotify_tests.cpp
+++ b/osquery/events/tests/linux/inotify_tests.cpp
@@ -284,12 +284,12 @@ class TestINotifyEventSubscriber
 
   Status init() override {
     callback_count_ = 0;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status SimpleCallback(const ECRef& ec, const SCRef& sc) {
     callback_count_ += 1;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status Callback(const ECRef& ec, const SCRef& sc) {
@@ -303,7 +303,7 @@ class TestINotifyEventSubscriber
 
     WriteLock lock(actions_lock_);
     actions_.push_back(ec->action);
-    return Status(0, "OK");
+    return Status::success();
   }
 
   SCRef GetSubscription(const std::string& path,

--- a/osquery/events/windows/windows_event_log.cpp
+++ b/osquery/events/windows/windows_event_log.cpp
@@ -61,7 +61,7 @@ void WindowsEventLogEventPublisher::configure() {
 
 Status WindowsEventLogEventPublisher::run() {
   pause(std::chrono::milliseconds(100));
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void WindowsEventLogEventPublisher::stop() {

--- a/osquery/examples/example_extension.cpp
+++ b/osquery/examples/example_extension.cpp
@@ -15,12 +15,12 @@ class ExampleConfigPlugin : public ConfigPlugin {
  public:
   Status setUp() {
     LOG(WARNING) << "ExampleConfigPlugin setting up";
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status genConfig(std::map<std::string, std::string>& config) {
     config["data"] = "{\"queries\":{}}";
-    return Status(0, "OK");
+    return Status::success();
   }
 };
 

--- a/osquery/examples/example_writable_table.cpp
+++ b/osquery/examples/example_writable_table.cpp
@@ -80,7 +80,7 @@ class WritableTable : public TablePlugin {
     const auto& rowid = row.at("rowid");
     rowid_to_primary_key.insert({rowid, primary_key});
 
-    return Status(0, "OK");
+    return Status::success();
   }
 
   /// Expands a value list returned by osquery into a Row (without the rowid
@@ -102,7 +102,7 @@ class WritableTable : public TablePlugin {
     row["integer"] =
         std::to_string(document[1].IsNull() ? 0 : document[1].GetInt());
 
-    return Status(0, "OK");
+    return Status::success();
   }
 
  public:

--- a/osquery/extensions/extensions.cpp
+++ b/osquery/extensions/extensions.cpp
@@ -168,7 +168,7 @@ Status extensionPathActive(const std::string& path, bool use_timeout = false) {
         // Create a client with a 10-second receive timeout.
         ExtensionManagerClient client(path, 10 * 1000);
         auto status = client.ping();
-        return Status(0, "OK");
+        return Status::success();
       } catch (const std::exception& /* e */) {
         // Path might exist without a connected extension or extension manager.
       }
@@ -430,7 +430,7 @@ Status loadExtensions(const std::string& loadfile) {
     // forking and executing the extension binary.
     Watcher::get().addExtensionPath(binary);
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status startExtension(const std::string& name, const std::string& version) {
@@ -626,7 +626,7 @@ Status getExtensions(const std::string& manager_path,
                              ext.second.sdk_version};
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status callExtension(const RouteUUID uuid,
@@ -674,7 +674,7 @@ Status startExtensionWatcher(const std::string& manager_path,
   // Start a extension watcher, if the manager dies, so should we.
   Dispatcher::addService(
       std::make_shared<ExtensionWatcher>(manager_path, interval, fatal));
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status startExtensionManager() {
@@ -733,6 +733,6 @@ Status startExtensionManager(const std::string& manager_path) {
     }
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/extensions/tests/extensions.cpp
+++ b/osquery/extensions/tests/extensions.cpp
@@ -186,7 +186,7 @@ class ExtensionPlugin : public Plugin {
     for (const auto& request_item : request) {
       response.push_back({{request_item.first, request_item.second}});
     }
-    return Status(0, "Test success");
+    return Status::success();
   }
 };
 

--- a/osquery/filesystem/file_compression.cpp
+++ b/osquery/filesystem/file_compression.cpp
@@ -196,6 +196,6 @@ Status archive(const std::set<boost::filesystem::path>& paths,
     archive_entry_free(entry);
   }
   archive_write_free(arch);
-  return Status(0, "Ok");
+  return Status::success();
 };
 } // namespace osquery

--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -69,7 +69,7 @@ Status writeTextFile(const fs::path& path,
     return Status(1, "Failed to write contents to file: " + path.string());
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 struct OpenReadableFile : private boost::noncopyable {
@@ -167,7 +167,7 @@ Status readFile(const fs::path& path,
   if (preserve_time && !FLAGS_disable_forensic) {
     handle.fd->setFileTimes(times);
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status readFile(const fs::path& path,
@@ -212,7 +212,7 @@ Status isWritable(const fs::path& path, bool effective) {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_WRITE);
     return Status(fd.isValid() ? 0 : 1);
   } else if (platformAccess(path.string(), W_OK) == 0) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "Path is not writable: " + path.string());
@@ -228,7 +228,7 @@ Status isReadable(const fs::path& path, bool effective) {
     PlatformFile fd(path, PF_OPEN_EXISTING | PF_READ);
     return Status(fd.isValid() ? 0 : 1);
   } else if (platformAccess(path.string(), R_OK) == 0) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "Path is not readable: " + path.string());
@@ -244,7 +244,7 @@ Status pathExists(const fs::path& path) {
   if (!fs::exists(path, ec) || ec.value() != errc::success) {
     return Status(1, ec.message());
   }
-  return Status(0, "1");
+  return Status::success();
 }
 
 Status movePath(const fs::path& from, const fs::path& to) {
@@ -347,7 +347,7 @@ Status resolveFilePattern(const fs::path& fs_path,
                           std::vector<std::string>& results,
                           GlobLimits setting) {
   genGlobs(fs_path.string(), results, setting);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 inline void replaceGlobWildcards(std::string& pattern, GlobLimits limits) {
@@ -405,7 +405,7 @@ inline Status listInAbsoluteDirectory(const fs::path& path,
   }
 
   genGlobs(path.string(), results, limits);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status listFilesInDirectory(const fs::path& path,
@@ -425,7 +425,7 @@ Status listDirectoriesInDirectory(const fs::path& path,
 Status isDirectory(const fs::path& path) {
   boost::system::error_code ec;
   if (fs::is_directory(path, ec)) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   // The success error code is returned for as a failure (undefined error)
@@ -584,6 +584,6 @@ Status parseJSONContent(const std::string& content, pt::ptree& tree) {
   } catch (const pt::json_parser::json_parser_error& /* e */) {
     return Status(1, "Could not parse JSON from file");
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/filesystem/linux/mem.cpp
+++ b/osquery/filesystem/linux/mem.cpp
@@ -50,7 +50,7 @@ Status readMem(int fd, size_t base, size_t length, uint8_t* buffer) {
     return Status(1, "Read incorrect number of bytes");
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status readRawMem(size_t base, size_t length, void** buffer) {
@@ -106,6 +106,6 @@ Status readRawMem(size_t base, size_t length, void** buffer) {
   }
 
   close(fd);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/filesystem/linux/proc.cpp
+++ b/osquery/filesystem/linux/proc.cpp
@@ -54,7 +54,7 @@ Status procGetNamespaceInode(ino_t& inode,
     return Status(1, "Invalid inode value in descriptor for namespace " + path);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status procGetProcessNamespaces(const std::string& process_id,
@@ -79,7 +79,7 @@ Status procGetProcessNamespaces(const std::string& process_id,
     namespace_list[namespace_name] = namespace_inode;
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 std::string procDecodeAddressFromHex(const std::string& encoded_address,

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -119,7 +119,7 @@ Status PlatformFile::isOwnerRoot() const {
   }
 
   if (owner_id == 0) {
-    return Status(0, "OK");
+    return Status::success();
   }
   return Status(1, "Owner is not root");
 }
@@ -135,7 +135,7 @@ Status PlatformFile::isOwnerCurrentUser() const {
   }
 
   if (owner_id == ::getuid()) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "Owner is not current user");
@@ -148,7 +148,7 @@ Status PlatformFile::isExecutable() const {
   }
 
   if ((file_stat.st_mode & S_IXUSR) == S_IXUSR) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "Not executable");
@@ -163,7 +163,7 @@ Status PlatformFile::hasSafePermissions() const {
   // We allow user write for now, since our main threat is external
   // modification by other users
   if ((file.st_mode & S_IWOTH) == 0) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "Writable");
@@ -313,7 +313,7 @@ Status platformIsTmpDir(const fs::path& dir) {
   }
 
   if (dir_stat.st_mode & (1 << 9)) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return Status(1, "");
@@ -325,7 +325,7 @@ Status platformIsFileAccessible(const fs::path& path) {
   if (::lstat(path.c_str(), &link_stat) < 0) {
     return Status(1, "File is not acccessible");
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool platformIsatty(FILE* f) {

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -883,7 +883,7 @@ Status PlatformFile::hasSafePermissions() const {
   if (!s.ok()) {
     return Status(1, "Write ACE was found on the parent directory");
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool PlatformFile::getFileTimes(PlatformTime& times) {
@@ -1547,7 +1547,7 @@ Status socketExists(const fs::path& path, bool remove_socket) {
       return Status(1, "Named pipe does not exist");
     }
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 LONGLONG filetimeToUnixtime(const FILETIME& ft) {

--- a/osquery/include/osquery/events.h
+++ b/osquery/include/osquery/events.h
@@ -239,7 +239,7 @@ class EventPublisherPlugin : public Plugin,
    * started, immediately following registration.
    */
   Status setUp() override {
-    return Status(0, "Not used");
+    return Status::success();
   }
 
   /**
@@ -641,7 +641,7 @@ class EventSubscriberPlugin : public Plugin, public Eventer {
 
  private:
   Status setUp() override {
-    return Status(0, "Setup never used");
+    return Status::success();
   }
 
  private:

--- a/osquery/include/osquery/extensions.h
+++ b/osquery/include/osquery/extensions.h
@@ -53,7 +53,7 @@ class ExternalSQLPlugin : public SQLPlugin {
                         std::vector<std::string>& tables) const override {
     static_cast<void>(query);
     static_cast<void>(tables);
-    return Status(0, "Not used");
+    return Status::success();
   }
 
   Status getQueryColumns(const std::string& query,

--- a/osquery/logger/logger.cpp
+++ b/osquery/logger/logger.cpp
@@ -371,7 +371,7 @@ Status logString(const std::string& message,
                  const std::string& category,
                  const std::string& receiver) {
   if (FLAGS_disable_logging) {
-    return Status(0, "Logging disabled");
+    return Status::success();
   }
 
   Status status;
@@ -399,7 +399,7 @@ Status logQueryLogItem(const QueryLogItem& results) {
 Status logQueryLogItem(const QueryLogItem& results,
                        const std::string& receiver) {
   if (FLAGS_disable_logging) {
-    return Status(0, "Logging disabled");
+    return Status::success();
   }
 
   if (Killswitch::get().isTotalQueryCounterMonitorEnabled()) {
@@ -428,7 +428,7 @@ Status logQueryLogItem(const QueryLogItem& results,
 
 Status logSnapshotQuery(const QueryLogItem& item) {
   if (FLAGS_disable_logging) {
-    return Status(0, "Logging disabled");
+    return Status::success();
   }
 
   if (Killswitch::get().isTotalQueryCounterMonitorEnabled()) {

--- a/osquery/logger/tests/logger.cpp
+++ b/osquery/logger/tests/logger.cpp
@@ -99,7 +99,7 @@ class TestLoggerPlugin : public LoggerPlugin {
 
   Status logEvent(const std::string& e) override {
     LoggerTests::events_logged++;
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status logString(const std::string& s) override {
@@ -114,13 +114,13 @@ class TestLoggerPlugin : public LoggerPlugin {
 
   Status logStatus(const std::vector<StatusLogLine>& log) override {
     placeStatuses(log);
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status logSnapshot(const std::string& s) override {
     LoggerTests::snapshot_rows_added += 1;
     LoggerTests::snapshot_rows_removed += 0;
-    return Status(0, "OK");
+    return Status::success();
   }
 
  public:
@@ -299,7 +299,7 @@ class SecondTestLoggerPlugin : public LoggerPlugin {
 
   Status logStatus(const std::vector<StatusLogLine>& log) override {
     placeStatuses(log);
-    return Status(0, "OK");
+    return Status::success();
   }
 
   bool usesLogStatus() override {
@@ -398,11 +398,11 @@ class RecursiveLoggerPlugin : public LoggerPlugin {
       }
       statuses++;
     }
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status logSnapshot(const std::string& s) override {
-    return Status(0, "OK");
+    return Status::success();
   }
 
  public:

--- a/osquery/registry/registry_factory.cpp
+++ b/osquery/registry/registry_factory.cpp
@@ -136,7 +136,7 @@ Status RegistryFactory::removeBroadcast(const RouteUUID& uuid) {
 
   WriteLock lock(mutex_);
   extensions_.erase(uuid);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 /// Adds an alias for an internal registry item. This registry will only

--- a/osquery/registry/registry_interface.cpp
+++ b/osquery/registry/registry_interface.cpp
@@ -266,7 +266,7 @@ Status RegistryInterface::addExternal(const RouteUUID& uuid,
     }
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 /// Remove all the routes for a given uuid.

--- a/osquery/registry/tests/registry.cpp
+++ b/osquery/registry/tests/registry.cpp
@@ -63,7 +63,7 @@ class HouseCat : public CatPlugin {
   Status setUp() {
     // Make sure the Plugin implementation's init is called.
     some_value_ = 9000;
-    return Status(0, "OK");
+    return Status::success();
   }
 };
 
@@ -196,7 +196,7 @@ Status SpecialWidget::call(const PluginRequest& request,
   response.push_back(request);
   response[0]["from"] = name_;
   response[0]["secret_power"] = secretPower(request);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 #define UNUSED(x) (void)(x)

--- a/osquery/remote/enroll/enroll.cpp
+++ b/osquery/remote/enroll/enroll.cpp
@@ -123,7 +123,7 @@ void EnrollPlugin::genHostDetails(JSON& host_details) {
 Status EnrollPlugin::call(const PluginRequest& request,
                           PluginResponse& response) {
   if (FLAGS_disable_enrollment) {
-    return Status(0, "Enrollment disabled");
+    return Status::success();
   }
 
   // Only support the 'enroll' action.
@@ -137,7 +137,7 @@ Status EnrollPlugin::call(const PluginRequest& request,
   if (node_key.size() == 0) {
     return Status(1, "No enrollment key found/retrieved");
   } else {
-    return Status(0, "OK");
+    return Status::success();
   }
 }
 }

--- a/osquery/remote/enroll/tls_enroll.cpp
+++ b/osquery/remote/enroll/tls_enroll.cpp
@@ -120,6 +120,6 @@ Status TLSEnrollPlugin::requestKey(const std::string& uri,
   if (node_key.empty()) {
     return Status(1, "No node key returned from TLS enroll plugin");
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/remote/serializers/json.cpp
+++ b/osquery/remote/serializers/json.cpp
@@ -22,7 +22,7 @@ Status JSONSerializer::deserialize(const std::string& serialized, JSON& json) {
     // payload, but doesn't respond with anything. This has been seen in the
     // wild, for example with Sumo Logic.
     json = JSON();
-    return Status(0, "OK");
+    return Status::success();
   }
 
   return json.fromString(serialized);

--- a/osquery/remote/tests/requests_tests.cpp
+++ b/osquery/remote/tests/requests_tests.cpp
@@ -42,11 +42,11 @@ class MockSerializer : public Serializer {
   }
 
   Status serialize(const JSON& params, std::string& serialized) {
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status deserialize(const std::string& serialized, JSON& params) {
-    return Status(0, "OK");
+    return Status::success();
   }
 };
 
@@ -125,11 +125,11 @@ class CopySerializer : public Serializer {
                       ? it->value.GetString()
                       : "");
 
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status deserialize(const std::string& serialized, JSON& params) {
-    return Status(0, "OK");
+    return Status::success();
   }
 };
 

--- a/osquery/remote/utility.h
+++ b/osquery/remote/utility.h
@@ -174,7 +174,7 @@ class TLSRequestHelper : private boost::noncopyable {
       return Status(1, message);
     }
 
-    return Status(0, "OK");
+    return Status::success();
   }
 
   /**

--- a/osquery/sql/sql.cpp
+++ b/osquery/sql/sql.cpp
@@ -168,7 +168,7 @@ Status SQLPlugin::call(const PluginRequest& request, PluginResponse& response) {
     return this->attach(request.at("table"));
   } else if (request.at("action") == "detach") {
     this->detach(request.at("table"));
-    return Status(0, "OK");
+    return Status::success();
   } else if (request.at("action") == "tables") {
     std::vector<std::string> tables;
     auto status = this->getQueryTables(request.at("query"), tables);

--- a/osquery/tables/events/darwin/disk_events.cpp
+++ b/osquery/tables/events/darwin/disk_events.cpp
@@ -33,7 +33,7 @@ Status DiskEventSubscriber::init() {
   subscription->physical_disks = false;
 
   subscribe(&DiskEventSubscriber::Callback, subscription);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status DiskEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -60,6 +60,6 @@ Status DiskEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   }
 
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/events/darwin/file_events.cpp
+++ b/osquery/tables/events/darwin/file_events.cpp
@@ -104,6 +104,6 @@ Status FileEventSubscriber::Callback(const FSEventsEventContextRef& ec,
       ec->path, (ec->action == "CREATED" || ec->action == "UPDATED"), r);
 
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/events/darwin/hardware_events.cpp
+++ b/osquery/tables/events/darwin/hardware_events.cpp
@@ -30,7 +30,7 @@ Status HardwareEventSubscriber::init() {
   auto subscription = createSubscriptionContext();
   subscribe(&HardwareEventSubscriber::Callback, subscription);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status HardwareEventSubscriber::Callback(
@@ -53,6 +53,6 @@ Status HardwareEventSubscriber::Callback(
   r["serial"] = ec->serial;
   r["revision"] = ec->version;
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/events/darwin/openbsm_events.cpp
+++ b/osquery/tables/events/darwin/openbsm_events.cpp
@@ -199,7 +199,7 @@ Status OpenBSMProcEvSubscriber::handleExec(const OpenBSMEventContextRef& ec) {
   /* If mapping doesn't exist no fork was captured. Not fatal. Ignoring. */
 
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status OpenBSMProcEvSubscriber::handleFork(const OpenBSMEventContextRef& ec) {

--- a/osquery/tables/events/linux/file_events.cpp
+++ b/osquery/tables/events/linux/file_events.cpp
@@ -121,6 +121,6 @@ Status FileEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   // A callback is somewhat useless unless it changes the EventSubscriber
   // state or calls `add` to store a marked up event.
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/events/linux/hardware_events.cpp
+++ b/osquery/tables/events/linux/hardware_events.cpp
@@ -39,7 +39,7 @@ Status HardwareEventSubscriber::init() {
   subscription->action = UDEV_EVENT_ACTION_ALL;
 
   subscribe(&HardwareEventSubscriber::Callback, subscription);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -47,15 +47,15 @@ Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   if (ec->devtype.empty()) {
     // Superfluous hardware event.
-    return Status(0, "Missing type.");
+    return Status::success();
   } else if (ec->devnode.empty() && ec->driver.empty()) {
-    return Status(0, "Missing node and driver.");
+    return Status::success();
   }
 
   struct udev_device* device = ec->device;
   r["type"] = ec->devtype;
   if (FLAGS_hardware_disabled_types.find(r.at("type")) != std::string::npos) {
-    return Status(0, "Disabled type.");
+    return Status::success();
   }
 
   r["action"] = ec->action_string;
@@ -66,7 +66,7 @@ Status HardwareEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   r["model"] = UdevEventPublisher::getValue(device, "ID_MODEL_FROM_DATABASE");
   if (r["path"].empty() && r["model"].empty()) {
     // Don't emit mising path/model combos.
-    return Status(0, "Missing path and model.");
+    return Status::success();
   }
 
   r["model_id"] = INTEGER(UdevEventPublisher::getValue(device, "ID_MODEL_ID"));

--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -32,7 +32,7 @@ Status AuditProcessEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&AuditProcessEventSubscriber::Callback, sc);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status AuditProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -43,7 +43,7 @@ Status AuditProcessEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   }
 
   addBatch(emitted_row_list);
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status AuditProcessEventSubscriber::ProcessEvents(
@@ -165,7 +165,7 @@ Status AuditProcessEventSubscriber::ProcessEvents(
     emitted_row_list.push_back(row);
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 const std::set<int>& AuditProcessEventSubscriber::GetSyscallSet() noexcept {

--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -1139,7 +1139,7 @@ Status ProcessFileEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&ProcessFileEventSubscriber::Callback, sc);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void ProcessFileEventSubscriber::configure() {
@@ -1286,7 +1286,7 @@ Status ProcessFileEventSubscriber::ProcessEvents(
     }
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 const std::set<int>& ProcessFileEventSubscriber::GetSyscallSet() noexcept {

--- a/osquery/tables/events/linux/selinux_events.cpp
+++ b/osquery/tables/events/linux/selinux_events.cpp
@@ -32,7 +32,7 @@ Status SELinuxEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&SELinuxEventSubscriber::Callback, sc);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status SELinuxEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -46,7 +46,7 @@ Status SELinuxEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
     add(row);
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status SELinuxEventSubscriber::ProcessEvents(
@@ -75,7 +75,7 @@ Status SELinuxEventSubscriber::ProcessEvents(
     }
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 const std::set<int>& SELinuxEventSubscriber::GetEventSet() noexcept {

--- a/osquery/tables/events/linux/socket_events.cpp
+++ b/osquery/tables/events/linux/socket_events.cpp
@@ -108,7 +108,7 @@ Status SocketEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&SocketEventSubscriber::Callback, sc);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -119,7 +119,7 @@ Status SocketEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   }
 
   addBatch(emitted_row_list);
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status SocketEventSubscriber::ProcessEvents(
@@ -203,7 +203,7 @@ Status SocketEventSubscriber::ProcessEvents(
     emitted_row_list.push_back(row);
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 const std::set<int>& SocketEventSubscriber::GetSyscallSet() noexcept {

--- a/osquery/tables/events/linux/syslog_events.cpp
+++ b/osquery/tables/events/linux/syslog_events.cpp
@@ -33,7 +33,7 @@ class SyslogEventSubscriber : public EventSubscriber<SyslogEventPublisher> {
   Status init() override {
     SyslogSubscriptionContextRef sc = createSubscriptionContext();
     subscribe(&SyslogEventSubscriber::Callback, sc);
-    return Status(0, "OK");
+    return Status::success();
   }
 
   size_t getEventsExpiry() override {
@@ -52,6 +52,6 @@ REGISTER(SyslogEventSubscriber, "event_subscriber", "syslog_events");
 Status SyslogEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   Row r(ec->fields);
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/events/linux/user_events.cpp
+++ b/osquery/tables/events/linux/user_events.cpp
@@ -43,7 +43,7 @@ Status UserEventSubscriber::init() {
   auto sc = createSubscriptionContext();
   subscribe(&UserEventSubscriber::Callback, sc);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status UserEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
@@ -54,7 +54,7 @@ Status UserEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   }
 
   addBatch(emitted_row_list);
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status UserEventSubscriber::ProcessEvents(
@@ -98,6 +98,6 @@ Status UserEventSubscriber::ProcessEvents(
     }
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/tables/events/windows/windows_events.cpp
+++ b/osquery/tables/events/windows/windows_events.cpp
@@ -57,7 +57,7 @@ class WindowsEventSubscriber
       wc->sources.insert(stringToWstring(chan));
     }
     subscribe(&WindowsEventSubscriber::Callback, wc);
-    return Status(0, "OK");
+    return Status::success();
   }
 
   Status Callback(const ECRef& ec, const SCRef& sc);
@@ -138,6 +138,6 @@ Status WindowsEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   r["data"] = s;
 
   add(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -103,7 +103,7 @@ Status genRoute(const struct rt_msghdr *route,
   // Fields not supported by OSX routes:
   r["source"] = "";
   r["metric"] = "0";
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status genArp(const struct rt_msghdr *route,
@@ -130,7 +130,7 @@ Status genArp(const struct rt_msghdr *route,
     r["permanent"] = "0";
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {

--- a/osquery/tables/networking/freebsd/routes.cpp
+++ b/osquery/tables/networking/freebsd/routes.cpp
@@ -104,7 +104,7 @@ Status genRoute(const struct rt_msghdr* route,
   // Fields not supported by OSX routes:
   r["source"] = "";
   r["metric"] = "0";
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status genArp(const struct rt_msghdr* route,
@@ -131,7 +131,7 @@ Status genArp(const struct rt_msghdr* route,
     r["permanent"] = "0";
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData& results) {

--- a/osquery/tables/networking/linux/routes.cpp
+++ b/osquery/tables/networking/linux/routes.cpp
@@ -104,7 +104,7 @@ Status readNetlink(int socket_fd, int seq, char* output, size_t* size) {
            static_cast<pid_t>(nl_hdr->nlmsg_pid) != getpid());
 
   *size = message_size;
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void genNetlinkRoutes(const struct nlmsghdr* netlink_msg, QueryData& results) {

--- a/osquery/tables/system/cpuid.cpp
+++ b/osquery/tables/system/cpuid.cpp
@@ -177,7 +177,7 @@ inline Status genStrings(QueryData& results) {
   r["input_eax"] = "1,3";
   results.push_back(r);
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 inline void genFamily(QueryData& results) {

--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -87,7 +87,7 @@ Status getHomebrewCellar(fs::path& cellarPath) {
   }
 
   cellarPath = path;
-  return Status(0, "OK");
+  return Status::success();
 }
 
 QueryData genHomebrewPackages(QueryContext& context) {

--- a/osquery/tables/system/darwin/keychain_acl.cpp
+++ b/osquery/tables/system/darwin/keychain_acl.cpp
@@ -121,7 +121,7 @@ Status parseKeychainItemACLEntry(SecACLRef acl,
   }
 
   acls.push_back(acl_data);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status parseKeychainItemACL(SecAccessRef access,
@@ -147,7 +147,7 @@ Status parseKeychainItemACL(SecAccessRef access,
   }
 
   CFRelease(acl_list);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 static std::string attributeBufferToString(const void* data, UInt32 length) {
@@ -263,7 +263,7 @@ Status genKeychainACLAppsForEntry(SecKeychainRef keychain,
     }
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 Status genKeychainACLApps(const std::string& path, QueryData& results) {
@@ -307,7 +307,7 @@ Status genKeychainACLApps(const std::string& path, QueryData& results) {
 
   CFRelease(keychain);
   CFRelease(search);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 QueryData genKeychainACLApps(QueryContext& context) {

--- a/osquery/tables/system/darwin/sip_config.cpp
+++ b/osquery/tables/system/darwin/sip_config.cpp
@@ -82,7 +82,7 @@ Status genCsrConfigFromNvram(uint32_t& config) {
   } else {
     CFRelease(properties);
     // The case where csr-active-config is cleared or not set is not an error
-    return Status(0, "csr-active-config key not found");
+    return Status::success();
   }
 }
 

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -114,7 +114,7 @@ Status deletedMatchesInode(const std::string& path, const std::string& pid) {
 
   // If the inodes match, the binary name actually ends with " (deleted)"
   if (std::to_string(st.st_ino) == inode) {
-    return Status(0, "Inodes match");
+    return Status::success();
   } else {
     return Status(1, "Inodes do not match");
   }

--- a/osquery/tables/system/posix/suid_bin.cpp
+++ b/osquery/tables/system/posix/suid_bin.cpp
@@ -67,7 +67,7 @@ Status genBin(const fs::path& path, int perms, QueryData& results) {
   }
 
   results.push_back(r);
-  return Status(0, "OK");
+  return Status::success();
 }
 
 bool isSuidBin(const fs::path& path, int perms) {

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -205,7 +205,7 @@ Status verifySignature(SignatureInformation::Result& result,
     return Status(1, "Failed to verify the file signature");
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status getOriginalProgramName(SignatureInformation& signature_info,
@@ -256,7 +256,7 @@ Status getOriginalProgramName(SignatureInformation& signature_info,
         wstringToString(publisher_info_blob_ptr->pwszProgramName);
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status getCertificateInformation(SignatureInformation& signature_info,
@@ -312,7 +312,7 @@ Status getCertificateInformation(SignatureInformation& signature_info,
     return Status::failure("Failed to retrieve the subject name");
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status getSignatureInformation(SignatureInformation& signature_info,
@@ -395,7 +395,7 @@ Status getSignatureInformation(SignatureInformation& signature_info,
     return status;
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 Status querySignatureInformation(SignatureInformation& signature_info,
@@ -415,7 +415,7 @@ Status querySignatureInformation(SignatureInformation& signature_info,
   }
 
   if (signature_info.result == SignatureInformation::Result::Missing) {
-    return Status(0, "Ok");
+    return Status::success();
   }
 
   status = getSignatureInformation(signature_info, utf16_path);
@@ -423,7 +423,7 @@ Status querySignatureInformation(SignatureInformation& signature_info,
     return status;
   }
 
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 namespace tables {
@@ -442,7 +442,7 @@ Status generateRow(Row& r, const std::string& path) {
   }
 
   generateRow(r, signature_info);
-  return Status(0, "Ok");
+  return Status::success();
 }
 
 QueryData genAuthenticode(QueryContext& context) {

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -220,7 +220,7 @@ Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
       rUsername = std::move(wstringToString(accntName));
     }
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 inline void explodeRegistryPath(const std::string& path,

--- a/osquery/tables/yara/yara_events.cpp
+++ b/osquery/tables/yara/yara_events.cpp
@@ -188,6 +188,6 @@ Status YARAEventSubscriber::Callback(const FileEventContextRef& ec,
     add(r);
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 }

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -97,7 +97,7 @@ Status compileSingleFile(const std::string& file, YR_RULES** rules) {
     compiler = nullptr;
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 /**
@@ -193,7 +193,7 @@ Status handleRuleFiles(const std::string& category,
     compiler = nullptr;
   }
 
-  return Status(0, "OK");
+  return Status::success();
 }
 
 /**
@@ -259,7 +259,7 @@ Status YARAConfigParserPlugin::update(const std::string& source,
                                       const ParserConfig& config) {
   // The YARA config parser requested the "yara" top-level key in the config.
   if (config.count("yara") == 0) {
-    return Status(0, "No Yara Configuration");
+    return Status::success();
   }
   const auto& yara_config = config.at("yara").doc();
 

--- a/osquery/utils/aws/aws_util.cpp
+++ b/osquery/utils/aws/aws_util.cpp
@@ -505,7 +505,7 @@ Status appendLogTypeToJson(const std::string& log_type, std::string& log) {
   if (!log.empty()) {
     log.pop_back();
   }
-  return Status(0, "OK");
+  return Status::success();
 }
 
 void setAWSProxy(Aws::Client::ClientConfiguration& config) {


### PR DESCRIPTION
Summary:
I got tired of Lint telling me to update the calls to the Status class, so I wrote some codemods to update the vast majority of them:

  $ cd ~/fbsource
  $ codemod -d xplat/osquery/oss/osquery --extensions cpp,h "return Status\(0\, \".*\"\);" "return Status::success();"

**Blindly accepted all changes**.

FWIW, I tried to do something similar with the failure return values, but the unit tests were failing afterward.

Differential Revision: D14278739
