### PR TITLE
core/windows/wmi: Refactor to use smart pointers

### DIFF
--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -15,22 +15,6 @@
 
 namespace osquery {
 
-void free_IWbemClassObjectRef(IWbemClassObject *ptr) {
-  ptr->Release();
-}
-
-void free_IWbemLocatorRef(IWbemLocator *ptr) {
-  ptr->Release();
-}
-
-void free_IEnumWbemClassObjectRef(IEnumWbemClassObject *ptr) {
-  ptr->Release();
-}
-
-void free_IWbemServicesRef(IWbemServices *ptr) {
-  ptr->Release();
-}
-
 void WmiResultItem::PrintType(const std::string& name) const {
   std::wstring property_name = stringToWstring(name);
   VARIANT value;

--- a/osquery/core/windows/wmi.cpp
+++ b/osquery/core/windows/wmi.cpp
@@ -31,10 +31,6 @@ void free_IWbemServicesRef(IWbemServices *ptr) {
   ptr->Release();
 }
 
-WmiResultItem::WmiResultItem(WmiResultItem&& src) {
-  result_ = std::move(src.result_);
-}
-
 void WmiResultItem::PrintType(const std::string& name) const {
   std::wstring property_name = stringToWstring(name);
   VARIANT value;
@@ -344,12 +340,6 @@ WmiRequest::WmiRequest(const std::string& query, BSTR nspace) {
   }
 
   status_ = Status(0);
-}
-
-WmiRequest::WmiRequest(WmiRequest&& src) {
-  locator_ = std::move(src.locator_);
-  services_ = std::move(src.services_);
-  enum_ = std::move(src.enum_);
 }
 
 WmiRequest::~WmiRequest() {

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -48,7 +48,7 @@ class WmiResultItem {
     result_.reset(result);
   }
 
-  WmiResultItem(WmiResultItem&& src);
+  WmiResultItem(WmiResultItem&& src) = default;
 
   /**
   * @brief Windows WMI Helper function to print the type associated with results
@@ -164,7 +164,7 @@ class WmiRequest {
  public:
   explicit WmiRequest(const std::string& query,
                       BSTR nspace = (BSTR)L"ROOT\\CIMV2");
-  WmiRequest(WmiRequest&& src);
+  WmiRequest(WmiRequest&& src) = default;
   ~WmiRequest();
 
   const std::vector<WmiResultItem>& results() const {

--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -184,6 +184,6 @@ class WmiRequest {
 
   std::unique_ptr<IWbemLocator, decltype(impl::wmiObjectDeleter)> locator_{nullptr, impl::wmiObjectDeleter};
   std::unique_ptr<IEnumWbemClassObject, decltype(impl::wmiObjectDeleter)> enum_{nullptr, impl::wmiObjectDeleter};
-  std::shared_ptr<IWbemServices> services_{static_cast<IWbemServices*>(nullptr), impl::wmiObjectDeleter};
+  std::unique_ptr<IWbemServices, decltype(impl::wmiObjectDeleter)> services_{nullptr, impl::wmiObjectDeleter};
 };
 }


### PR DESCRIPTION
Hi!

This PR refactors the WmiRequest and WmiResultItem classes to use smart pointers to manage their WMI objects. Previously, this code used raw pointers for these objects. The destructors needed to ensure to free these objects, and the move constructors needed to manually transfer the pointer, and set the src pointer to `nullptr`.

Now, `unique_ptr`s are used for most of the objects. `shared_ptr` is used for the `IWbemServices` pointer in preparation for a future PR which will add an identical shared services pointer to the `WmiResultItem` class, for implementing some new functionality there. For reference, you can see that future PR here at https://github.com/trailofbits/osquery-pr/pull/8/.

Conversion to smart pointers for these types requires a custom deleter, so there are some extra `using` statements and custom deletion functions that you'll find. With smart pointers in place, the destructors can be simplified to completely remove the free'ing logic, and the move constructor can be simplified to simply use `std::move`.

Apart from these, the only other part of this PR is adjusting some of the logic in the `WmiRequest` constructor to adjust to these new smart pointers. Specifically, we introduce some locals which are use for the winapi calls, and then `reset` the smart pointers using those locals.

Thanks!