### PR TITLE
Add missing tables to windows build.

### DIFF
--- a/specs/BUCK
+++ b/specs/BUCK
@@ -669,6 +669,14 @@ osquery_gentable_cxx_library(
             "linux,macos,windows",
         ),
         (
+            "windows/bitlocker_info.table",
+            "windows",
+        ),
+        (
+            "windows/logon_sessions.table",
+            "windows",
+        ),
+        (
             "windows/ntfs_acl_permissions.table",
             "windows",
         ),


### PR DESCRIPTION
Summary:
Some tables were forgotten during the port to Buck.

Checking missing tables:

```
diff <(find oss/specs -iname "*.table" -exec basename {} \; | sort) <(grep -e "[a-z0-9_]\+\.table\"," oss/specs/BUCK | sed -e 's: *"\([a-z]*/\)*\(.*\)",:\2:' | sort)
```

Reviewed By: guliashvili

Differential Revision: D14300038
