### PR TITLE
Yet another overload of `createError()`

### DIFF
--- a/osquery/core/database/rocksdb_database.cpp
+++ b/osquery/core/database/rocksdb_database.cpp
@@ -239,8 +239,7 @@ Expected<std::string, DatabaseError> RocksdbDatabase::getRawBytesInternal(
     in_panic_ = true;
     auto corruption_error =
         createError(RocksdbError::DatabaseIsCorrupted, status.ToString());
-    auto error =
-        createError(DatabaseError::Panic, "", std::move(corruption_error));
+    auto error = createError(DatabaseError::Panic, std::move(corruption_error));
     panic(error);
     return std::move(error);
   }
@@ -294,7 +293,7 @@ Expected<std::string, DatabaseError> RocksdbDatabase::getString(
                                     "Fetching string as integer");
       LOG(ERROR) << type_error.getMessage().c_str();
       assert(false);
-      return createError(DatabaseError::KeyNotFound, "", std::move(type_error));
+      return createError(DatabaseError::KeyNotFound, std::move(type_error));
     }
     return result_str;
   }
@@ -324,7 +323,7 @@ Expected<int32_t, DatabaseError> RocksdbDatabase::getInt32(
       auto type_error = createError(RocksdbError::UnexpectedValueType,
                                     "Fetching string as integer");
       auto error =
-          createError(DatabaseError::KeyNotFound, "", std::move(type_error));
+          createError(DatabaseError::KeyNotFound, std::move(type_error));
       assert(false && error.getMessage().c_str());
       LOG(ERROR) << error.getMessage();
       debug_only::fail(error.getMessage().c_str());

--- a/osquery/ev2/manager.cpp
+++ b/osquery/ev2/manager.cpp
@@ -22,17 +22,15 @@ ExpectedSuccess<EventManager::Error> EventManager::bind(
   if (it != publishers_.end()) {
     auto ret = it->second->subscribe(std::move(sub));
     if (ret.isError()) {
-      return createError(Error::PublisherError,
-                         "Calling subscribe() on publisher '" +
-                             it->second->name() +
-                             "' for subscription from request from '" +
-                             sub->subscriber() + "' returned an error.",
-                         ret.takeError());
+      return createError(Error::PublisherError, ret.takeError())
+             << "Calling subscribe() on publisher '" << it->second->name()
+             << "' for subscription from request from '" << sub->subscriber()
+             << "' returned an error.";
     }
   } else {
-    return createError(Error::UnknownPublisher,
-                       "No registered publisher for bind request from '" +
-                           sub->subscriber() + "'");
+    return createError(Error::UnknownPublisher)
+           << "No registered publisher for bind request from '"
+           << sub->subscriber() << "'";
   }
 
   return Success();

--- a/osquery/events/linux/probes/syscalls_programs.cpp
+++ b/osquery/events/linux/probes/syscalls_programs.cpp
@@ -221,11 +221,10 @@ Expected<ebpf::Program, ebpf::Program::Error> genLinuxProgram(
   } else if (syscall::EventType::SetuidEnter == type) {
     return genLinuxSetuidEnterProgram(prog_type, cpu_map);
   } else {
-    return createError(ebpf::Program::Error::Unknown,
-                       "There is no program for type(")
-           << static_cast<int>(type) << ") system call "
-           << boost::core::demangle(typeid(type).name()) << "("
-           << static_cast<int>(type) << ")";
+    return createError(ebpf::Program::Error::Unknown)
+           << "There is no program for type(" << static_cast<int>(type)
+           << ") system call " << boost::core::demangle(typeid(type).name())
+           << "(" << static_cast<int>(type) << ")";
   }
 }
 

--- a/osquery/profiler/posix/code_profiler.cpp
+++ b/osquery/profiler/posix/code_profiler.cpp
@@ -62,7 +62,7 @@ static Expected<struct rusage, RusageError> callRusage() {
   if (rusage_status != -1) {
     return stats;
   } else {
-    return createError(RusageError::FatalError, "")
+    return createError(RusageError::FatalError)
            << "Linux query profiling failed. error code: " << rusage_status
            << " message: " << boost::io::quoted(strerror(errno));
   }

--- a/osquery/utils/error/error.h
+++ b/osquery/utils/error/error.h
@@ -40,6 +40,10 @@ class Error final : public ErrorBase {
         message_(std::move(message)),
         underlyingError_(std::move(underlying_error)) {}
 
+  explicit Error(ErrorCodeEnumType error_code,
+                 std::unique_ptr<ErrorBase> underlying_error = nullptr)
+      : errorCode_(error_code), underlyingError_(std::move(underlying_error)) {}
+
   virtual ~Error() = default;
 
   Error(Error&& other) = default;
@@ -139,6 +143,22 @@ OSQUERY_NODISCARD Error<ErrorCodeEnumType> createError(
       std::move(message),
       std::make_unique<Error<OtherErrorCodeEnumType>>(
           std::move(underlying_error)));
+}
+
+template <typename ErrorCodeEnumType, typename OtherErrorCodeEnumType>
+OSQUERY_NODISCARD Error<ErrorCodeEnumType> createError(
+    ErrorCodeEnumType error_code,
+    Error<OtherErrorCodeEnumType> underlying_error) {
+  return Error<ErrorCodeEnumType>(
+      error_code,
+      std::make_unique<Error<OtherErrorCodeEnumType>>(
+          std::move(underlying_error)));
+}
+
+template <typename ErrorCodeEnumType>
+OSQUERY_NODISCARD Error<ErrorCodeEnumType> createError(
+    ErrorCodeEnumType error_code) {
+  return Error<ErrorCodeEnumType>(error_code);
 }
 
 template <typename ErrorType,

--- a/osquery/utils/system/linux/cpu.cpp
+++ b/osquery/utils/system/linux/cpu.cpp
@@ -32,7 +32,7 @@ Expected<std::string, Error> readSysCpuFile(char const* path) {
 Expected<std::size_t, Error> decodeCpuNumber(const std::string& str) {
   auto exp = tryTo<std::size_t>(str);
   if (exp.isError()) {
-    return createError(Error::IncorrectRange, "", exp.takeError())
+    return createError(Error::IncorrectRange, exp.takeError())
            << "Incorrect CPU number representation " << boost::io::quoted(str);
   }
   return exp.take();
@@ -60,7 +60,7 @@ Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str) {
       if (num_exp.get() < mask.size()) {
         mask.set(num_exp.get());
       } else {
-        return createError(Error::IncorrectRange, "")
+        return createError(Error::IncorrectRange)
                << "CPU number " << num_exp.get() << " out of bound [0,"
                << mask.size() << ")";
       }
@@ -79,7 +79,7 @@ Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str) {
                << boost::io::quoted(interval);
       }
       if (to_exp.get() >= mask.size()) {
-        return createError(Error::IncorrectRange, "")
+        return createError(Error::IncorrectRange)
                << "CPU number " << to_exp.get() << " out of bound [0,"
                << mask.size() << ")";
       }


### PR DESCRIPTION
Summary:
There is unnecessary redundancy of how error message now is created.

It could be with string argument:
```
return createError(ConversionError::InvalidArgument,
                   "Wrong string representation of boolean ",
                   prop_exp.takeError())
       << boost::io::quoted(from);
```

And it could be without it:
```
return createError(ConversionError::InvalidArgument, prop_exp.takeError())
       << "Wrong string representation of boolean "
       << boost::io::quoted(from);
```

So, my suggestion is to make it uniform - use only second option and form error
string only with `operator<<`. This diff introduce function overload without
message within argument list and some usage examples. If everyone ok with it,
I'll remove all cases of 3 args form usage in next diff.

Differential Revision: D14405326
