### PR TITLE
Make poll timeout (kPollTimeout) member of the class

### DIFF
--- a/osquery/experimental/README.md
+++ b/osquery/experimental/README.md
@@ -1,0 +1,5 @@
+## Here be dragons
+
+### Disclaimer
+
+The code in this directory is only for experimental purposes. It could be unreliable or unstable, could be not well tested or could fail. There is no guarantee about the future of the code here, it wether could be removed or utterly changed. It exists here for the beta testing purposes or discussions. Should something from here be used in the non-experimental code it will be moved outside of experimental directory.

--- a/osquery/experimental/events_stream/BUCK
+++ b/osquery/experimental/events_stream/BUCK
@@ -1,0 +1,45 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "events_stream_registry",
+    srcs = [
+        "events_stream_registry.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream_registry.h",
+    ],
+    link_whole = True,
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)
+
+osquery_cxx_library(
+    name = "events_stream",
+    srcs = [
+        "events_stream.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream.h",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/experimental/events_stream/events_stream.cpp
+++ b/osquery/experimental/events_stream/events_stream.cpp
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream.h>
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+namespace osquery {
+
+DEFINE_string(events_streaming_plugin,
+              "",
+              "Experimental events streaming plugin");
+
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& serialized_event) {
+  if (FLAGS_events_streaming_plugin.empty()) {
+    LOG(INFO) << "New event: " << serialized_event;
+    return;
+  }
+  auto status = Registry::call(streamRegistryName(),
+                               FLAGS_events_streaming_plugin,
+                               {
+                                   {"event", serialized_event},
+                               });
+  if (!status.ok()) {
+    LOG(ERROR) << "Data loss. Event " << boost::io::quoted(serialized_event)
+               << " dispatch failed because " << status.what();
+  }
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream.h
+++ b/osquery/experimental/events_stream/events_stream.h
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace osquery {
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& event);
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.cpp
+++ b/osquery/experimental/events_stream/events_stream_registry.cpp
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <osquery/registry_factory.h>
+
+namespace osquery {
+
+CREATE_REGISTRY(EventsStreamPlugin, experimental::events::streamRegistryName());
+
+Status EventsStreamPlugin::call(const PluginRequest& request,
+                                PluginResponse& response) {
+  // should be implemented in plugins
+  return Status::success();
+}
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName() {
+  return "osquery_events_stream";
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.h
+++ b/osquery/experimental/events_stream/events_stream_registry.h
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/plugins/plugin.h>
+#include <osquery/query.h>
+#include <osquery/utils/expected/expected.h>
+
+#include <osquery/numeric_monitoring.h>
+
+namespace osquery {
+
+class EventsStreamPlugin : public Plugin {
+ public:
+  Status call(const PluginRequest& request, PluginResponse& response) override;
+};
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName();
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -70,6 +70,7 @@ osquery_cxx_library(
         osquery_target("osquery/database:database"),
         osquery_target("osquery/devtools:devtools"),
         osquery_target("osquery/dispatcher:dispatcher"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/extensions:impl_thrift"),
         osquery_target("osquery/killswitch:killswitch"),

--- a/osquery/sdk/BUCK
+++ b/osquery/sdk/BUCK
@@ -27,6 +27,7 @@ osquery_cxx_library(
         osquery_target("osquery/config:config"),
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/events:events_registry"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/killswitch:killswitch"),
         osquery_target("osquery/numeric_monitoring:numeric_monitoring"),

--- a/osquery/sdk/tests/registry_tests.cpp
+++ b/osquery/sdk/tests/registry_tests.cpp
@@ -42,6 +42,9 @@ auto const mandatory_registries_ = std::vector<std::string>{
     "numeric_monitoring",
     "sql",
     "table",
+
+    // experimental
+    "osquery_events_stream",
 };
 
 TEST_F(PluginSdkRegistryTests, whether_all_mandatory_registries_are_in_sdk) {

--- a/osquery/utils/system/linux/ebpf/perf_output.h
+++ b/osquery/utils/system/linux/ebpf/perf_output.h
@@ -86,7 +86,7 @@ class PerfOutput final {
 template <typename MessageType>
 class PerfOutputsPoll final {
  public:
-  explicit PerfOutputsPoll() noexcept = default;
+  explicit PerfOutputsPoll() = default;
 
   PerfOutputsPoll(PerfOutputsPoll&&);
   PerfOutputsPoll& operator=(PerfOutputsPoll&&);
@@ -109,12 +109,9 @@ class PerfOutputsPoll final {
   ExpectedSuccess<PerfOutputError> read(MessageBatchType& batch);
 
  private:
-  static constexpr std::chrono::milliseconds kPollTimeout =
-      std::chrono::seconds{2};
-
- private:
   std::vector<PerfOutput<MessageType>> outputs_;
   std::vector<struct pollfd> fds_;
+  const std::chrono::milliseconds poll_timeout_ = std::chrono::seconds{2};
 };
 
 } // namespace ebpf

--- a/osquery/utils/system/linux/ebpf/perf_output_impl.h
+++ b/osquery/utils/system/linux/ebpf/perf_output_impl.h
@@ -290,7 +290,7 @@ template <typename MessageType>
 ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
     PerfOutputsPoll<MessageType>::MessageBatchType& batch) {
   while (true) {
-    int ret = ::poll(fds_.data(), fds_.size(), kPollTimeout.count());
+    int ret = ::poll(fds_.data(), fds_.size(), poll_timeout_.count());
     if (ret < 0) {
       return createError(PerfOutputError::SystemError,
                          "perf output polling failed")


### PR DESCRIPTION
Summary: method count of `std::chrono::duration::count` is not a constexpr so that means `kPollTimeout` could not be constexpr either. Let's make it just const member of the class PerfOutputPoll.

Reviewed By: jessek

Differential Revision: D14406162
