### PR TITLE
Helper function to read process cmdline from `/proc/<pid>/cmdline` on linux by PID

### DIFF
--- a/osquery/experimental/README.md
+++ b/osquery/experimental/README.md
@@ -1,0 +1,5 @@
+## Here be dragons
+
+### Disclaimer
+
+The code in this directory is only for experimental purposes. It could be unreliable or unstable, could be not well tested or could fail. There is no guarantee about the future of the code here, it wether could be removed or utterly changed. It exists here for the beta testing purposes or discussions. Should something from here be used in the non-experimental code it will be moved outside of experimental directory.

--- a/osquery/experimental/events_stream/BUCK
+++ b/osquery/experimental/events_stream/BUCK
@@ -1,0 +1,45 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "events_stream_registry",
+    srcs = [
+        "events_stream_registry.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream_registry.h",
+    ],
+    link_whole = True,
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)
+
+osquery_cxx_library(
+    name = "events_stream",
+    srcs = [
+        "events_stream.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream.h",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/experimental/events_stream/events_stream.cpp
+++ b/osquery/experimental/events_stream/events_stream.cpp
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream.h>
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+namespace osquery {
+
+DEFINE_string(events_streaming_plugin,
+              "",
+              "Experimental events streaming plugin");
+
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& serialized_event) {
+  if (FLAGS_events_streaming_plugin.empty()) {
+    LOG(INFO) << "New event: " << serialized_event;
+    return;
+  }
+  auto status = Registry::call(streamRegistryName(),
+                               FLAGS_events_streaming_plugin,
+                               {
+                                   {"event", serialized_event},
+                               });
+  if (!status.ok()) {
+    LOG(ERROR) << "Data loss. Event " << boost::io::quoted(serialized_event)
+               << " dispatch failed because " << status.what();
+  }
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream.h
+++ b/osquery/experimental/events_stream/events_stream.h
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace osquery {
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& event);
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.cpp
+++ b/osquery/experimental/events_stream/events_stream_registry.cpp
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <osquery/registry_factory.h>
+
+namespace osquery {
+
+CREATE_REGISTRY(EventsStreamPlugin, experimental::events::streamRegistryName());
+
+Status EventsStreamPlugin::call(const PluginRequest& request,
+                                PluginResponse& response) {
+  // should be implemented in plugins
+  return Status::success();
+}
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName() {
+  return "osquery_events_stream";
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.h
+++ b/osquery/experimental/events_stream/events_stream_registry.h
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/plugins/plugin.h>
+#include <osquery/query.h>
+#include <osquery/utils/expected/expected.h>
+
+#include <osquery/numeric_monitoring.h>
+
+namespace osquery {
+
+class EventsStreamPlugin : public Plugin {
+ public:
+  Status call(const PluginRequest& request, PluginResponse& response) override;
+};
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName();
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/tracing/BUCK
+++ b/osquery/experimental/tracing/BUCK
@@ -1,0 +1,35 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+
+osquery_cxx_library(
+    name = "syscalls_tracing",
+    header_namespace = "osquery/experimental/tracing",
+    exported_headers = [
+        "syscalls_tracing.h",
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "syscalls_tracing.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/dispatcher:dispatcher"),
+        osquery_target("osquery/events/linux/probes:probes_events"),
+        osquery_target("osquery/experimental/events_stream:events_stream"),
+        osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("osquery/utils/json:json"),
+        osquery_target("osquery/utils/system:time"),
+    ],
+)

--- a/osquery/experimental/tracing/syscalls_tracing.cpp
+++ b/osquery/experimental/tracing/syscalls_tracing.cpp
@@ -1,0 +1,138 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/tracing/syscalls_tracing.h>
+
+#include <osquery/experimental/events_stream/events_stream.h>
+
+#include <osquery/events/linux/probes/probes.h>
+
+#include <osquery/dispatcher.h>
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/system/time.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+namespace osquery {
+
+DEFINE_bool(enable_experimental_tracing,
+            false,
+            "Experimental syscalls tracing");
+
+namespace experimental {
+namespace tracing {
+
+namespace {
+
+enum class Error {
+  InitialisationProblem = 1,
+  RuntimeProblem = 2,
+  DeinitializationProblem = 3,
+};
+
+ExpectedSuccess<Error> runSyscallTracing() {
+  auto probes_exp = ::osquery::events::LinuxProbesControl::spawn();
+  if (probes_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "linux probes control spawn failed",
+                       probes_exp.takeError());
+  }
+  auto probes = probes_exp.take();
+  auto kill_trace_on_exp = probes.traceKill();
+  if (kill_trace_on_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "kill tracing initialisation failed",
+                       kill_trace_on_exp.takeError());
+  }
+  auto setuid_trace_on_exp = probes.traceSetuid();
+  if (setuid_trace_on_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "setuid tracing initialisation failed",
+                       setuid_trace_on_exp.takeError());
+  }
+  auto output_batch = ebpf::PerfOutputsPoll<
+      ::osquery::events::syscall::Event>::MessageBatchType{};
+  auto event_joiner = ::osquery::events::syscall::EnterExitJoiner{};
+  while (true) {
+    auto status = probes.getReader().read(output_batch);
+    if (status.isError()) {
+      return createError(
+          Error::RuntimeProblem, "event read failed", status.takeError());
+    }
+    for (const auto& event : output_batch) {
+      auto final_event = event_joiner.join(event);
+      if (final_event) {
+        auto event_json = JSON{};
+        auto event_str = std::string{};
+        event_json.add("time", getUnixTime());
+        event_json.add("pid", final_event->pid);
+        event_json.add("tgid", final_event->tgid);
+        event_json.add("return", final_event->return_value);
+        if (final_event->type ==
+            ::osquery::events::syscall::EventType::KillEnter) {
+          event_json.add("type", "kill");
+          event_json.add("uid", final_event->body.kill_enter.uid);
+          event_json.add("gid", final_event->body.kill_enter.gid);
+          event_json.add("comm", final_event->body.kill_enter.comm);
+          event_json.add("arg_pid", final_event->body.kill_enter.arg_pid);
+          event_json.add("arg_sig", final_event->body.kill_enter.arg_sig);
+        } else if (final_event->type ==
+                   ::osquery::events::syscall::EventType::SetuidEnter) {
+          event_json.add("type", "setuid");
+          event_json.add("uid", final_event->body.setuid_enter.uid);
+          event_json.add("gid", final_event->body.setuid_enter.gid);
+          event_json.add("comm", final_event->body.setuid_enter.comm);
+          event_json.add("arg_uid", final_event->body.setuid_enter.arg_uid);
+        } else {
+          event_json.add("type", "unknown");
+        }
+        auto status_json_to_string = event_json.toString(event_str);
+        if (status_json_to_string.ok()) {
+          osquery::experimental::events::dispatchSerializedEvent(event_str);
+        } else {
+          LOG(ERROR) << "Event serialisation failed: "
+                     << status_json_to_string.what();
+        }
+      }
+    }
+  }
+  return Success{};
+}
+
+class SyscallTracingRannable : public ::osquery::InternalRunnable {
+ public:
+  explicit SyscallTracingRannable()
+      : ::osquery::InternalRunnable("SyscallTracingRannable") {}
+
+  void start() override {
+    auto ret = runSyscallTracing();
+    if (ret.isError()) {
+      LOG(ERROR) << "Experimental syscall tracing failed: "
+                 << ret.getError().getMessage();
+    }
+  }
+
+  void stop() override {}
+};
+
+} // namespace
+
+void init() {
+  if (FLAGS_enable_experimental_tracing) {
+    LOG(INFO) << "Experimental syscall tracing is enabled";
+    Dispatcher::addService(std::make_shared<SyscallTracingRannable>());
+  }
+}
+
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/tracing/syscalls_tracing.h
+++ b/osquery/experimental/tracing/syscalls_tracing.h
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace experimental {
+namespace tracing {
+
+void init();
+
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -71,6 +71,7 @@ osquery_cxx_library(
         osquery_target("osquery/devtools:devtools"),
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/experimental/events_stream:events_stream_registry"),
+        osquery_target("osquery/experimental/tracing:syscalls_tracing"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/extensions:impl_thrift"),
         osquery_target("osquery/killswitch:killswitch"),

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -70,6 +70,7 @@ osquery_cxx_library(
         osquery_target("osquery/database:database"),
         osquery_target("osquery/devtools:devtools"),
         osquery_target("osquery/dispatcher:dispatcher"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/extensions:impl_thrift"),
         osquery_target("osquery/killswitch:killswitch"),

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -33,6 +33,8 @@
 #include <osquery/sql/sqlite_util.h>
 #include <osquery/system.h>
 
+#include <osquery/experimental/tracing/syscalls_tracing.h>
+
 namespace fs = boost::filesystem;
 
 namespace osquery {
@@ -107,6 +109,8 @@ int startDaemon(Initializer& runner) {
 
   // Begin the schedule runloop.
   startScheduler();
+
+  osquery::experimental::tracing::init();
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();

--- a/osquery/sdk/BUCK
+++ b/osquery/sdk/BUCK
@@ -27,6 +27,7 @@ osquery_cxx_library(
         osquery_target("osquery/config:config"),
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/events:events_registry"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/killswitch:killswitch"),
         osquery_target("osquery/numeric_monitoring:numeric_monitoring"),

--- a/osquery/sdk/tests/registry_tests.cpp
+++ b/osquery/sdk/tests/registry_tests.cpp
@@ -42,6 +42,9 @@ auto const mandatory_registries_ = std::vector<std::string>{
     "numeric_monitoring",
     "sql",
     "table",
+
+    // experimental
+    "osquery_events_stream",
 };
 
 TEST_F(PluginSdkRegistryTests, whether_all_mandatory_registries_are_in_sdk) {

--- a/osquery/utils/system/linux/ebpf/perf_output.h
+++ b/osquery/utils/system/linux/ebpf/perf_output.h
@@ -86,7 +86,7 @@ class PerfOutput final {
 template <typename MessageType>
 class PerfOutputsPoll final {
  public:
-  explicit PerfOutputsPoll() noexcept = default;
+  explicit PerfOutputsPoll() = default;
 
   PerfOutputsPoll(PerfOutputsPoll&&);
   PerfOutputsPoll& operator=(PerfOutputsPoll&&);
@@ -109,12 +109,9 @@ class PerfOutputsPoll final {
   ExpectedSuccess<PerfOutputError> read(MessageBatchType& batch);
 
  private:
-  static constexpr std::chrono::milliseconds kPollTimeout =
-      std::chrono::seconds{2};
-
- private:
   std::vector<PerfOutput<MessageType>> outputs_;
   std::vector<struct pollfd> fds_;
+  const std::chrono::milliseconds poll_timeout_ = std::chrono::seconds{2};
 };
 
 } // namespace ebpf

--- a/osquery/utils/system/linux/ebpf/perf_output_impl.h
+++ b/osquery/utils/system/linux/ebpf/perf_output_impl.h
@@ -290,7 +290,7 @@ template <typename MessageType>
 ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
     PerfOutputsPoll<MessageType>::MessageBatchType& batch) {
   while (true) {
-    int ret = ::poll(fds_.data(), fds_.size(), kPollTimeout.count());
+    int ret = ::poll(fds_.data(), fds_.size(), poll_timeout_.count());
     if (ret < 0) {
       return createError(PerfOutputError::SystemError,
                          "perf output polling failed")

--- a/osquery/utils/system/linux/proc/BUCK
+++ b/osquery/utils/system/linux/proc/BUCK
@@ -1,0 +1,38 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "proc",
+    header_namespace = "osquery/utils/system/linux/proc",
+    exported_platform_headers = [
+        (
+            LINUX,
+            [
+                "proc.h",
+            ],
+        ),
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "proc.cpp",
+            ],
+        ),
+    ],
+    tests = [
+        osquery_target("osquery/utils/system/linux/proc/tests:proc_tests"),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/utils/system/linux/proc/proc.cpp
+++ b/osquery/utils/system/linux/proc/proc.cpp
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/system/linux/proc/proc.h>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+
+namespace osquery {
+namespace proc {
+
+namespace fs = boost::filesystem;
+
+namespace {
+
+inline fs::path attrPath(const std::string& pid, char const* attr) {
+  auto attr_path = fs::path("/proc");
+  attr_path /= pid;
+  attr_path /= attr;
+  return attr_path;
+}
+
+inline fs::path attrPath(pid_t pid, char const* attr) {
+  return attrPath(std::to_string(pid), attr);
+}
+
+} // namespace
+
+std::string cmdline(pid_t const pid) {
+  auto attr_path = attrPath(pid, "cmdline");
+  auto ifs = std::ifstream(attr_path.c_str(),
+                           std::ios_base::in | std::ios_base::binary);
+  using iter = std::istreambuf_iterator<std::string::value_type>;
+  auto content = std::string{iter(ifs), iter{}};
+  std::replace(content.begin(), content.end(), '\0', ' ');
+  boost::algorithm::trim_right(content);
+  return content;
+}
+
+} // namespace proc
+} // namespace osquery

--- a/osquery/utils/system/linux/proc/proc.h
+++ b/osquery/utils/system/linux/proc/proc.h
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2018-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <boost/filesystem/path.hpp>
+
+#include <string>
+
+namespace osquery {
+namespace proc {
+
+std::string cmdline(pid_t pid);
+
+} // namespace proc
+} // namespace osquery

--- a/osquery/utils/system/linux/proc/tests/BUCK
+++ b/osquery/utils/system/linux/proc/tests/BUCK
@@ -1,0 +1,28 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed as defined on the LICENSE file found in the
+#  root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+
+osquery_cxx_test(
+    name = "proc_tests",
+    srcs = [
+        "empty.cpp",
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "proc.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/system/linux/proc:proc"),
+    ],
+)

--- a/osquery/utils/system/linux/proc/tests/empty.cpp
+++ b/osquery/utils/system/linux/proc/tests/empty.cpp
@@ -1,0 +1,7 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */

--- a/osquery/utils/system/linux/proc/tests/proc.cpp
+++ b/osquery/utils/system/linux/proc/tests/proc.cpp
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/system/linux/proc/proc.h>
+
+#include <gtest/gtest.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace osquery {
+namespace {
+
+class LinuxProcTests : public testing::Test {};
+
+TEST_F(LinuxProcTests, cmdline_1) {
+  auto line = proc::cmdline(1);
+  ASSERT_FALSE(line.empty());
+}
+
+TEST_F(LinuxProcTests, cmdline_self) {
+  auto line = proc::cmdline(getpid());
+  ASSERT_NE(line.find("osquery/utils/system/linux/proc/tests/proc_tests"),
+            std::string::npos);
+}
+
+TEST_F(LinuxProcTests, cmdline_not_existing_pid) {
+  ASSERT_TRUE(proc::cmdline(-1).empty());
+  ASSERT_TRUE(proc::cmdline(0).empty());
+  ASSERT_TRUE(proc::cmdline(-12).empty());
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
I need it to add cmdline attribute to the syscall tracing events. I think it
could be useful somewhere else in osquery (for instance in implementation of
table `processess`), so I made it in `osquery/utils`.

Differential Revision: D14421472
