### PR TITLE
Remove centos and linux from platform checks

### DIFF
--- a/osquery/core/system.cpp
+++ b/osquery/core/system.cpp
@@ -578,6 +578,9 @@ bool checkPlatform(const std::string& platform) {
     return true;
   }
 
+  // Technically "centos" and "ubuntu" are no longer supported. We have never
+  // differentiated between Linux distributions, but rather execute all Linux
+  // based queries on any Linux system.
   auto linux_type = (platform.find("linux") != std::string::npos ||
                      platform.find("ubuntu") != std::string::npos ||
                      platform.find("centos") != std::string::npos);


### PR DESCRIPTION
Summary: This diff removes checks for the query platform values `centos` and `ubuntu`. Previously we supported these values, but didn't actually respect them. That is, we executed queries specified to run on `centos` or `ubuntu` on any Linux system. From now on, any query specified to run on either of these platforms *will not be executed*. Queries should be updated to have a platform value of `linux` instead.

Differential Revision: D14430282
