### PR TITLE
[osquery] Introduce events stream registry

### DIFF
--- a/osquery/experimental/events_stream/BUCK
+++ b/osquery/experimental/events_stream/BUCK
@@ -1,0 +1,45 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "events_stream_registry",
+    srcs = [
+        "events_stream_registry.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream_registry.h",
+    ],
+    link_whole = True,
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)
+
+osquery_cxx_library(
+    name = "events_stream",
+    srcs = [
+        "events_stream.cpp",
+    ],
+    header_namespace = "osquery/experimental/events_stream",
+    exported_headers = [
+        "events_stream.h",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/utils:utils"),
+        osquery_tp_target("boost"),
+    ],
+)

--- a/osquery/experimental/events_stream/events_stream.cpp
+++ b/osquery/experimental/events_stream/events_stream.cpp
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream.h>
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+#include <osquery/registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+namespace osquery {
+
+DEFINE_string(events_streaming_plugin,
+              "",
+              "Experimental events streaming plugin");
+
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& serialized_event) {
+  if (FLAGS_events_streaming_plugin.empty()) {
+    LOG(INFO) << "New event: " << serialized_event;
+    return;
+  }
+  auto status = Registry::call(streamRegistryName(),
+                               FLAGS_events_streaming_plugin,
+                               {
+                                   {"event", serialized_event},
+                               });
+  if (!status.ok()) {
+    LOG(ERROR) << "Data loss. Event " << boost::io::quoted(serialized_event)
+               << " dispatch failed because " << status.what();
+  }
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream.h
+++ b/osquery/experimental/events_stream/events_stream.h
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace osquery {
+namespace experimental {
+namespace events {
+
+void dispatchSerializedEvent(const std::string& event);
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.cpp
+++ b/osquery/experimental/events_stream/events_stream_registry.cpp
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/events_stream/events_stream_registry.h>
+
+#include <boost/io/detail/quoted_manip.hpp>
+
+#include <osquery/registry_factory.h>
+
+namespace osquery {
+
+CREATE_REGISTRY(EventsStreamPlugin, experimental::events::streamRegistryName());
+
+Status EventsStreamPlugin::call(const PluginRequest& request,
+                                PluginResponse& response) {
+  // should be implemented in plugins
+  return Status::success();
+}
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName() {
+  return "osquery_events_stream";
+}
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/events_stream/events_stream_registry.h
+++ b/osquery/experimental/events_stream/events_stream_registry.h
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/plugins/plugin.h>
+#include <osquery/query.h>
+#include <osquery/utils/expected/expected.h>
+
+#include <osquery/numeric_monitoring.h>
+
+namespace osquery {
+
+class EventsStreamPlugin : public Plugin {
+ public:
+  Status call(const PluginRequest& request, PluginResponse& response) override;
+};
+
+namespace experimental {
+namespace events {
+
+char const* streamRegistryName();
+
+} // namespace events
+} // namespace experimental
+} // namespace osquery

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -70,6 +70,7 @@ osquery_cxx_library(
         osquery_target("osquery/database:database"),
         osquery_target("osquery/devtools:devtools"),
         osquery_target("osquery/dispatcher:dispatcher"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/extensions:impl_thrift"),
         osquery_target("osquery/killswitch:killswitch"),

--- a/osquery/sdk/BUCK
+++ b/osquery/sdk/BUCK
@@ -27,6 +27,7 @@ osquery_cxx_library(
         osquery_target("osquery/config:config"),
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/events:events_registry"),
+        osquery_target("osquery/experimental/events_stream:events_stream_registry"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/killswitch:killswitch"),
         osquery_target("osquery/numeric_monitoring:numeric_monitoring"),

--- a/osquery/sdk/tests/registry_tests.cpp
+++ b/osquery/sdk/tests/registry_tests.cpp
@@ -42,6 +42,9 @@ auto const mandatory_registries_ = std::vector<std::string>{
     "numeric_monitoring",
     "sql",
     "table",
+
+    // experimental
+    "osquery_events_stream",
 };
 
 TEST_F(PluginSdkRegistryTests, whether_all_mandatory_registries_are_in_sdk) {


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5516 [osquery] Introduce osquery/experimental directory&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14404652/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#5517 [osquery] Introduce events stream registry**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14404665/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5518 [osquery] make poll timeout mamber of the class&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14406162/)

It is experimental registry to stream events from osquery. It is separated from logger registry, which is semantically very similar, on purpose.

Firstly, because we are still not sure about exact way to process, filter, deliver events. I think the best way to test things is to implement pipeline for the events separately from the logger for now and may be merge them later. It's easier to merge things than split them.

Secondary, current implementation of logger is not very performant with plenty of additional functionality. Since we going to evaluate performance hit of new type of events (linux syscall tracing) it is not a good idea to connect it to sophisticated system with well known performance problems.

Differential Revision: [D14404665](https://our.internmc.facebook.com/intern/diff/D14404665/)