### PR TITLE
[osquery] make poll timeout mamber of the class

### DIFF
--- a/osquery/utils/system/linux/ebpf/perf_output.h
+++ b/osquery/utils/system/linux/ebpf/perf_output.h
@@ -86,7 +86,7 @@ class PerfOutput final {
 template <typename MessageType>
 class PerfOutputsPoll final {
  public:
-  explicit PerfOutputsPoll() noexcept = default;
+  explicit PerfOutputsPoll() = default;
 
   PerfOutputsPoll(PerfOutputsPoll&&);
   PerfOutputsPoll& operator=(PerfOutputsPoll&&);
@@ -109,12 +109,9 @@ class PerfOutputsPoll final {
   ExpectedSuccess<PerfOutputError> read(MessageBatchType& batch);
 
  private:
-  static constexpr std::chrono::milliseconds kPollTimeout =
-      std::chrono::seconds{2};
-
- private:
   std::vector<PerfOutput<MessageType>> outputs_;
   std::vector<struct pollfd> fds_;
+  const std::chrono::milliseconds poll_timeout_ = std::chrono::seconds{2};
 };
 
 } // namespace ebpf

--- a/osquery/utils/system/linux/ebpf/perf_output_impl.h
+++ b/osquery/utils/system/linux/ebpf/perf_output_impl.h
@@ -290,7 +290,7 @@ template <typename MessageType>
 ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
     PerfOutputsPoll<MessageType>::MessageBatchType& batch) {
   while (true) {
-    int ret = ::poll(fds_.data(), fds_.size(), kPollTimeout.count());
+    int ret = ::poll(fds_.data(), fds_.size(), poll_timeout_.count());
     if (ret < 0) {
       return createError(PerfOutputError::SystemError,
                          "perf output polling failed")


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5516 [osquery] Introduce osquery/experimental directory&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14404652/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5517 [osquery] Introduce events stream registry&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14404665/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#5518 [osquery] make poll timeout mamber of the class**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14406162/)

method count of `std::chrono::duration::count` is not a constexpr so that means `kPollTimeout` could not be constexpr either. Let's make it just const member of the class PerfOutputPoll.

Differential Revision: [D14406162](https://our.internmc.facebook.com/intern/diff/D14406162/)