### PR TITLE
[osquery] Implement even producer to trace syscalls {kill, setuid} and dump them to experimental events streaming registry

### DIFF
--- a/osquery/experimental/tracing/BUCK
+++ b/osquery/experimental/tracing/BUCK
@@ -1,0 +1,46 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:platforms.bzl", "LINUX")
+
+osquery_cxx_library(
+    name = "syscalls_tracing",
+    srcs = [
+        "syscalls_tracing.cpp",
+    ],
+    header_namespace = "osquery/experimental/tracing",
+    exported_headers = [
+        "syscalls_tracing.h",
+    ],
+    platform_headers = [
+        (
+            LINUX,
+            [
+                "syscalls_tracing_impl.h",
+            ],
+        ),
+    ],
+    platform_srcs = [
+        (
+            LINUX,
+            [
+                "syscalls_tracing_impl.cpp",
+            ],
+        ),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/core:core"),
+        osquery_target("osquery/dispatcher:dispatcher"),
+        osquery_target("osquery/events/linux/probes:probes_events"),
+        osquery_target("osquery/experimental/events_stream:events_stream"),
+        osquery_target("osquery/utils/conversions:conversions"),
+        osquery_target("osquery/utils/json:json"),
+        osquery_target("osquery/utils/system:time"),
+    ],
+)

--- a/osquery/experimental/tracing/syscalls_tracing.cpp
+++ b/osquery/experimental/tracing/syscalls_tracing.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <osquery/experimental/tracing/syscalls_tracing.h>
-#ifdef POSIX
+#ifdef LINUX
 #include <osquery/experimental/tracing/syscalls_tracing_impl.h>
 #endif
 
@@ -24,7 +24,7 @@ namespace experimental {
 namespace tracing {
 
 void init() {
-#ifdef POSIX
+#ifdef LINUX
   if (FLAGS_enable_experimental_tracing) {
     LOG(INFO) << "Experimental syscall tracing is enabled";
     impl::runService();

--- a/osquery/experimental/tracing/syscalls_tracing.cpp
+++ b/osquery/experimental/tracing/syscalls_tracing.cpp
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/tracing/syscalls_tracing.h>
+#ifdef POSIX
+#include <osquery/experimental/tracing/syscalls_tracing_impl.h>
+#endif
+
+#include <osquery/flags.h>
+#include <osquery/logger.h>
+
+namespace osquery {
+
+DEFINE_bool(enable_experimental_tracing,
+            false,
+            "Experimental syscalls tracing");
+
+namespace experimental {
+namespace tracing {
+
+void init() {
+#ifdef POSIX
+  if (FLAGS_enable_experimental_tracing) {
+    LOG(INFO) << "Experimental syscall tracing is enabled";
+    impl::runService();
+  }
+#endif
+}
+
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/tracing/syscalls_tracing.h
+++ b/osquery/experimental/tracing/syscalls_tracing.h
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace experimental {
+namespace tracing {
+
+void init();
+
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/tracing/syscalls_tracing_impl.cpp
+++ b/osquery/experimental/tracing/syscalls_tracing_impl.cpp
@@ -1,0 +1,129 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/experimental/tracing/syscalls_tracing_impl.h>
+
+#include <osquery/events/linux/probes/probes.h>
+#include <osquery/experimental/events_stream/events_stream.h>
+
+#include <osquery/dispatcher.h>
+#include <osquery/logger.h>
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/system/time.h>
+
+namespace osquery {
+namespace experimental {
+namespace tracing {
+
+namespace {
+
+enum class Error {
+  InitialisationProblem = 1,
+  RuntimeProblem = 2,
+  DeinitializationProblem = 3,
+};
+
+ExpectedSuccess<Error> runSyscallTracing() {
+  auto probes_exp = ::osquery::events::LinuxProbesControl::spawn();
+  if (probes_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "linux probes control spawn failed",
+                       probes_exp.takeError());
+  }
+  auto probes = probes_exp.take();
+  auto kill_trace_on_exp = probes.traceKill();
+  if (kill_trace_on_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "kill tracing initialisation failed",
+                       kill_trace_on_exp.takeError());
+  }
+  auto setuid_trace_on_exp = probes.traceSetuid();
+  if (setuid_trace_on_exp.isError()) {
+    return createError(Error::InitialisationProblem,
+                       "setuid tracing initialisation failed",
+                       setuid_trace_on_exp.takeError());
+  }
+  auto output_batch = ebpf::PerfOutputsPoll<
+      ::osquery::events::syscall::Event>::MessageBatchType{};
+  auto event_joiner = ::osquery::events::syscall::EnterExitJoiner{};
+  while (true) {
+    auto status = probes.getReader().read(output_batch);
+    if (status.isError()) {
+      return createError(
+          Error::RuntimeProblem, "event read failed", status.takeError());
+    }
+    for (const auto& event : output_batch) {
+      auto final_event = event_joiner.join(event);
+      if (final_event) {
+        auto event_json = JSON{};
+        auto event_str = std::string{};
+        event_json.add("time", getUnixTime());
+        event_json.add("pid", final_event->pid);
+        event_json.add("tgid", final_event->tgid);
+        event_json.add("return", final_event->return_value);
+        if (final_event->type ==
+            ::osquery::events::syscall::EventType::KillEnter) {
+          event_json.add("type", "kill");
+          event_json.add("uid", final_event->body.kill_enter.uid);
+          event_json.add("gid", final_event->body.kill_enter.gid);
+          event_json.add("comm", final_event->body.kill_enter.comm);
+          event_json.add("arg_pid", final_event->body.kill_enter.arg_pid);
+          event_json.add("arg_sig", final_event->body.kill_enter.arg_sig);
+        } else if (final_event->type ==
+                   ::osquery::events::syscall::EventType::SetuidEnter) {
+          event_json.add("type", "setuid");
+          event_json.add("uid", final_event->body.setuid_enter.uid);
+          event_json.add("gid", final_event->body.setuid_enter.gid);
+          event_json.add("comm", final_event->body.setuid_enter.comm);
+          event_json.add("arg_uid", final_event->body.setuid_enter.arg_uid);
+        } else {
+          event_json.add("type", "unknown");
+        }
+        auto status_json_to_string = event_json.toString(event_str);
+        if (status_json_to_string.ok()) {
+          osquery::experimental::events::dispatchSerializedEvent(event_str);
+        } else {
+          LOG(ERROR) << "Event serialisation failed: "
+                     << status_json_to_string.what();
+        }
+      }
+    }
+  }
+  return Success{};
+}
+
+class SyscallTracingRannable : public ::osquery::InternalRunnable {
+ public:
+  explicit SyscallTracingRannable()
+      : ::osquery::InternalRunnable("SyscallTracingRannable") {}
+
+  void start() override {
+    auto ret = runSyscallTracing();
+    if (ret.isError()) {
+      LOG(ERROR) << "Experimental syscall tracing failed: "
+                 << ret.getError().getMessage();
+    }
+  }
+
+  void stop() override {}
+};
+
+} // namespace
+
+namespace impl {
+
+void runService() {
+  Dispatcher::addService(std::make_shared<SyscallTracingRannable>());
+}
+
+} // namespace impl
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/experimental/tracing/syscalls_tracing_impl.h
+++ b/osquery/experimental/tracing/syscalls_tracing_impl.h
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace experimental {
+namespace tracing {
+
+namespace impl {
+void runService();
+}
+
+} // namespace tracing
+} // namespace experimental
+} // namespace osquery

--- a/osquery/main/BUCK
+++ b/osquery/main/BUCK
@@ -71,6 +71,7 @@ osquery_cxx_library(
         osquery_target("osquery/devtools:devtools"),
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/experimental/events_stream:events_stream_registry"),
+        osquery_target("osquery/experimental/tracing:syscalls_tracing"),
         osquery_target("osquery/extensions:extensions"),
         osquery_target("osquery/extensions:impl_thrift"),
         osquery_target("osquery/killswitch:killswitch"),

--- a/osquery/main/main.cpp
+++ b/osquery/main/main.cpp
@@ -33,6 +33,8 @@
 #include <osquery/sql/sqlite_util.h>
 #include <osquery/system.h>
 
+#include <osquery/experimental/tracing/syscalls_tracing.h>
+
 namespace fs = boost::filesystem;
 
 namespace osquery {
@@ -107,6 +109,8 @@ int startDaemon(Initializer& runner) {
 
   // Begin the schedule runloop.
   startScheduler();
+
+  osquery::experimental::tracing::init();
 
   // Finally wait for a signal / interrupt to shutdown.
   runner.waitForShutdown();


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5527 [osquery] Rename system:cpu target to system:cpu_topology&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14455350/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#5519 [osquery] Implement even producer to trace syscalls {kill, setuid} and dump them to experimental events streaming registry**&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14406173/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5520 [osquery] Helper function to read process cmdline from `/proc/<pid>/cmdline` on linux by PID&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14421472/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5521 [osquery] Simple LRU cache implementation&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14424352/)

This is very simple usage of system calls {kill, setuid} tracing. Enable it if cli flag `--enable_experimental_tracing` is specified.
All received events from the kernel will be serialised to JSON string and sent to experimental events streaming registry. Without any preprocessing or filtering.

I'm going to use this prototype to estimate performance hit of this subsystem in small fraction of our deployment.

Differential Revision: [D14406173](https://our.internmc.facebook.com/intern/diff/D14406173/)