### PR TITLE
[osquery] Add "cmdline" attribute for every event along with PID

### DIFF
--- a/osquery/experimental/tracing/BUCK
+++ b/osquery/experimental/tracing/BUCK
@@ -39,8 +39,10 @@ osquery_cxx_library(
         osquery_target("osquery/dispatcher:dispatcher"),
         osquery_target("osquery/events/linux/probes:probes_events"),
         osquery_target("osquery/experimental/events_stream:events_stream"),
+        osquery_target("osquery/utils/caches:lru"),
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/json:json"),
+        osquery_target("osquery/utils/system/linux/proc:proc"),
         osquery_target("osquery/utils/system:time"),
     ],
 )


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5519 [osquery] Implement even producer to trace syscalls {kill, setuid} and dump them to experimental events streaming registry&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14406173/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5520 [osquery] Helper function to read process cmdline from `/proc/<pid>/cmdline` on linux by PID&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14421472/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5521 [osquery] Simple LRU cache implementation&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14424352/)
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#5522 [osquery] Add "cmdline" attribute for every event along with PID**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14426129/)

Add "cmdline" attribute for every event along with PID of observable process. 

**Why cache**? I did that with a LRU caching because we expect receiving events so often, that so slow operation as reading a file is going to slow everything down.

**Why we should retrieve `cmdline` at the moment of receiving event**? It's is important to retrieve anything about process at the moment of receiving event. Because process can exit at any moment and system drops process metainformation shortly after it. Which means osquery will never get that information.

**Why only `cmdline`**? Because it is important and we need it already. Should we provide more information about process, like parent or start time, we just add it easily.

Differential Revision: [D14426129](https://our.internmc.facebook.com/intern/diff/D14426129/)