### PR TITLE
Remove the rest use cases of createError with message as an arg (#5524)

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -576,8 +576,8 @@ Expected<ConfigMap, Config::RestoreConfigError> Config::restoreConfigBackup() {
       LOG(ERROR)
           << "restoreConfigBackup database failed to retrieve config for key "
           << key;
-      return createError(Config::RestoreConfigError::DatabaseError,
-                         "Could not retrieve value for the key: " + key);
+      return createError(Config::RestoreConfigError::DatabaseError)
+             << "Could not retrieve value for the key: " << key;
     }
     config[key.substr(kConfigPersistencePrefix.length())] = std::move(value);
   }

--- a/osquery/core/database/database.cpp
+++ b/osquery/core/database/database.cpp
@@ -19,9 +19,8 @@ Expected<int32_t, DatabaseError> Database::getInt32(const std::string& domain,
     if (value) {
       return *value;
     } else {
-      return createError(DatabaseError::FailToReadData,
-                         "Failed to convert string to int",
-                         value.takeError());
+      return createError(DatabaseError::FailToReadData, value.takeError())
+             << "Failed to convert string to int";
     }
   } else {
     return string_value.takeError();

--- a/osquery/core/database/in_memory_database.cpp
+++ b/osquery/core/database/in_memory_database.cpp
@@ -40,8 +40,8 @@ Expected<StorageType, DatabaseError> InMemoryStorage<StorageType>::get(
   if (iter != storage_.end()) {
     return iter->second;
   }
-  return createError(DatabaseError::KeyNotFound, "Can't find value for key ")
-         << key;
+  return createError(DatabaseError::KeyNotFound)
+         << "Can't find value for key " << key;
 }
 
 void InMemoryDatabase::close() {
@@ -70,8 +70,8 @@ ExpectedSuccess<DatabaseError> InMemoryDatabase::open() {
 
 Error<DatabaseError> InMemoryDatabase::domainNotFoundError(
     const std::string& domain) const {
-  return createError(DatabaseError::DomainNotFound, "Can't find domain: ")
-         << domain;
+  return createError(DatabaseError::DomainNotFound)
+         << "Can't find domain: " << domain;
 }
 
 template <typename T>
@@ -79,7 +79,7 @@ Expected<T, DatabaseError> InMemoryDatabase::getValue(const std::string& domain,
                                                       const std::string& key) {
   debug_only::verifyTrue(is_open_, "database is not open");
   if (!is_open_) {
-    return createError(DatabaseError::DbIsNotOpen, "Database is closed");
+    return createError(DatabaseError::DbIsNotOpen) << "Database is closed";
   }
   auto storage_iter = storage_.find(domain);
   if (storage_iter == storage_.end()) {
@@ -92,10 +92,11 @@ Expected<T, DatabaseError> InMemoryDatabase::getValue(const std::string& domain,
     if (value.type() == typeid(T)) {
       return boost::get<T>(value);
     } else {
-      auto error =
-          createError(DatabaseError::KeyNotFound, "Requested wrong type for: ")
-          << domain << ":" << key << " stored type: " << value.type().name()
-          << " requested type " << boost::core::demangle(typeid(T).name());
+      auto error = createError(DatabaseError::KeyNotFound)
+                   << "Requested wrong type for: " << domain << ":" << key
+                   << " stored type: " << value.type().name()
+                   << " requested type "
+                   << boost::core::demangle(typeid(T).name());
       LOG(ERROR) << error.getMessage();
       debug_only::fail(error.getMessage().c_str());
       return std::move(error);
@@ -109,7 +110,7 @@ ExpectedSuccess<DatabaseError> InMemoryDatabase::putValue(
     const std::string& domain, const std::string& key, const T& value) {
   debug_only::verifyTrue(is_open_, "database is not open");
   if (!is_open_) {
-    return createError(DatabaseError::DbIsNotOpen, "Database is closed");
+    return createError(DatabaseError::DbIsNotOpen) << "Database is closed";
   }
   auto storage_iter = storage_.find(domain);
   if (storage_iter == storage_.end()) {

--- a/osquery/core/database/rocksdb_database.cpp
+++ b/osquery/core/database/rocksdb_database.cpp
@@ -233,18 +233,18 @@ Expected<std::string, DatabaseError> RocksdbDatabase::getRawBytesInternal(
   std::string value = "";
   auto status = db_->Get(default_read_options_, handle, key, &value);
   if (status.IsNotFound()) {
-    return createError(DatabaseError::KeyNotFound, "Value not found");
+    return createError(DatabaseError::KeyNotFound) << "Value not found";
   }
   if (status.IsCorruption()) {
     in_panic_ = true;
-    auto corruption_error =
-        createError(RocksdbError::DatabaseIsCorrupted, status.ToString());
+    auto corruption_error = createError(RocksdbError::DatabaseIsCorrupted)
+                            << status.ToString();
     auto error = createError(DatabaseError::Panic, std::move(corruption_error));
     panic(error);
     return std::move(error);
   }
   if (!status.ok()) {
-    return createError(DatabaseError::FailToReadData, status.ToString());
+    return createError(DatabaseError::FailToReadData) << status.ToString();
   }
   return value;
 }
@@ -253,7 +253,7 @@ ExpectedSuccess<DatabaseError> RocksdbDatabase::putRawBytesInternal(
     Handle* handle, const std::string& key, const std::string& value) {
   auto status = db_->Put(default_write_options_, handle, key, value);
   if (!status.ok()) {
-    return createError(DatabaseError::FailToWriteData, status.ToString());
+    return createError(DatabaseError::FailToWriteData) << status.ToString();
   }
   return Success();
 }
@@ -261,15 +261,15 @@ ExpectedSuccess<DatabaseError> RocksdbDatabase::putRawBytesInternal(
 Expected<RocksdbDatabase::HandleRef, DatabaseError> RocksdbDatabase::getHandle(
     const std::string& domain) {
   if (BOOST_UNLIKELY(in_panic_)) {
-    return createError(DatabaseError::Panic, "Database is in panic mode :(");
+    return createError(DatabaseError::Panic) << "Database is in panic mode :(";
   }
   if (BOOST_UNLIKELY(db_ == nullptr)) {
-    return createError(DatabaseError::DbIsNotOpen, "Database is closed");
+    return createError(DatabaseError::DbIsNotOpen) << "Database is closed";
   }
   auto handle = handles_map_.find(domain);
   if (BOOST_UNLIKELY(handle == handles_map_.end())) {
-    return createError(DatabaseError::DomainNotFound,
-                       "Unknown database domain");
+    return createError(DatabaseError::DomainNotFound)
+           << "Unknown database domain";
   }
   return handle->second;
 }
@@ -289,8 +289,8 @@ Expected<std::string, DatabaseError> RocksdbDatabase::getString(
   if (result) {
     std::string result_str = result.take();
     if (BOOST_UNLIKELY(validateInt32StorageBuffer(result_str))) {
-      auto type_error = createError(RocksdbError::UnexpectedValueType,
-                                    "Fetching string as integer");
+      auto type_error = createError(RocksdbError::UnexpectedValueType)
+                        << "Fetching string as integer";
       LOG(ERROR) << type_error.getMessage().c_str();
       assert(false);
       return createError(DatabaseError::KeyNotFound, std::move(type_error));
@@ -320,8 +320,8 @@ Expected<int32_t, DatabaseError> RocksdbDatabase::getInt32(
       int32_t result = *(reinterpret_cast<const int32_t*>(value.data()));
       return ntohl(result);
     } else {
-      auto type_error = createError(RocksdbError::UnexpectedValueType,
-                                    "Fetching string as integer");
+      auto type_error = createError(RocksdbError::UnexpectedValueType)
+                        << "Fetching string as integer";
       auto error =
           createError(DatabaseError::KeyNotFound, std::move(type_error));
       assert(false && error.getMessage().c_str());
@@ -355,16 +355,16 @@ ExpectedSuccess<DatabaseError> RocksdbDatabase::putStringsUnsafe(
     for (const auto& pair : data) {
       auto status = batch.Put(handle_ptr.get(), pair.first, pair.second);
       if (!status.ok()) {
-        auto batch_write_error =
-            createError(RocksdbError::BatchWriteFail, status.ToString());
+        auto batch_write_error = createError(RocksdbError::BatchWriteFail)
+                                 << status.ToString();
         return createError(DatabaseError::FailToWriteData,
-                           "Failed to write data",
-                           std::move(batch_write_error));
+                           std::move(batch_write_error))
+               << "Failed to write data";
       }
     }
     auto status = db_->Write(batch_write_options_, &batch);
     if (!status.ok()) {
-      return createError(DatabaseError::FailToWriteData, status.ToString());
+      return createError(DatabaseError::FailToWriteData) << status.ToString();
     }
   }
   return handle.takeError();

--- a/osquery/core/database/rocksdb_migration.cpp
+++ b/osquery/core/database/rocksdb_migration.cpp
@@ -126,9 +126,8 @@ ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::migrateFromVersion(
        version < kDatabaseSchemaVersionCurrent;) {
     auto iter = migration_map_.find(version);
     if (iter == migration_map_.end()) {
-      return createError(RocksdbMigrationError::NoMigrationFromCurrentVersion,
-                         "No migration logic from version: ")
-             << version;
+      return createError(RocksdbMigrationError::NoMigrationFromCurrentVersion)
+             << "No migration logic from version: " << version;
     }
     VLOG(1) << "Migrating from version: " << version
             << ". Src path: " << src_path << ". Dst path: " << dst_path;
@@ -137,9 +136,9 @@ ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::migrateFromVersion(
     if (migration_result) {
       int new_version = migration_result.take();
       if (new_version <= version) {
-        return createError(RocksdbMigrationError::MigrationLogicError,
-                           "New version(")
-               << version << ") is lower or same as old(" << new_version << ")";
+        return createError(RocksdbMigrationError::MigrationLogicError)
+               << "New version(" << version << ") is lower or same as old("
+               << new_version << ")";
       }
       version = new_version;
     } else {
@@ -174,16 +173,16 @@ ExpectedSuccess<RocksdbMigrationError> RocksdbMigration::moveDb(
     const std::string& src_path, const std::string& dst_path) {
   boost::system::error_code ec;
   if (fs::exists(fs::path(dst_path), ec)) {
-    return createError(RocksdbMigrationError::FailMoveDatabase,
-                       "Database at dst path already exists or path is not "
-                       "accessible. Path: ")
+    return createError(RocksdbMigrationError::FailMoveDatabase)
+           << "Database at dst path already exists or path is not accessible. "
+              "Path: "
            << dst_path << "Error: " << ec.value() << " " << ec.message();
   }
 
   fs::rename(src_path, dst_path, ec);
   if (!ec) {
-    return createError(RocksdbMigrationError::FailMoveDatabase, "Move failed: ")
-           << ec.value() << " " << ec.message();
+    return createError(RocksdbMigrationError::FailMoveDatabase)
+           << "Move failed: " << ec.value() << " " << ec.message();
   }
   return Success();
 }
@@ -210,11 +209,11 @@ RocksdbMigration::openDatabase(const std::string& path,
   auto status = rocksdb::DB::Open(
       handle.options, path, descriptors, &column_family_handles, &db);
   if (status.IsInvalidArgument()) {
-    return createError(RocksdbMigrationError::InvalidArgument,
-                       status.ToString());
+    return createError(RocksdbMigrationError::InvalidArgument)
+           << status.ToString();
   }
   if (!status.ok()) {
-    return createError(RocksdbMigrationError::FailToOpen, status.ToString());
+    return createError(RocksdbMigrationError::FailToOpen) << status.ToString();
   }
   handle.db_handle = std::unique_ptr<rocksdb::DB>(db);
   for (const auto& ptr : column_family_handles) {
@@ -251,18 +250,18 @@ Expected<int, RocksdbMigrationError> RocksdbMigration::getVersion(
       }
     }
     if (!status.ok()) {
-      return createError(RocksdbMigrationError::FailToGetVersion,
-                         status.ToString());
+      return createError(RocksdbMigrationError::FailToGetVersion)
+             << status.ToString();
     }
     auto result = tryTo<int>(version_str);
     if (result) {
       return *result;
     }
-    return createError(
-        RocksdbMigrationError::FailToGetVersion, "", result.takeError());
+    return createError(RocksdbMigrationError::FailToGetVersion,
+                       result.takeError());
   }
-  return createError(RocksdbMigrationError::FailToGetVersion,
-                     "Verion data is not found");
+  return createError(RocksdbMigrationError::FailToGetVersion)
+         << "Verion data is not found";
 }
 
 std::string RocksdbMigration::randomOutputPath() {

--- a/osquery/ev2/simple_publisher.h
+++ b/osquery/ev2/simple_publisher.h
@@ -54,9 +54,9 @@ class SimplePublisher : public Publisher {
       std::shared_ptr<Subscription> base_sub) final override {
     auto sub = std::dynamic_pointer_cast<SubscriptionT>(base_sub);
     if (!sub) {
-      return createError(Publisher::Error::InvalidSubscription,
-                         "SimplePublisher::subscribe() called with invalid "
-                         "subscription type.");
+      return createError(Publisher::Error::InvalidSubscription)
+             << "SimplePublisher::subscribe() called with invalid subscription "
+                "type.";
     }
 
     auto ret = reconfigure(sub);

--- a/osquery/events/linux/probes/ebpf_tracepoint.cpp
+++ b/osquery/events/linux/probes/ebpf_tracepoint.cpp
@@ -65,20 +65,19 @@ Expected<EbpfTracepoint, EbpfTracepoint::Error> EbpfTracepoint::load(
   auto fd_exp =
       perf_event_open::syscall(&trace_attr, pid, cpu, group_fd, flags);
   if (fd_exp.isError()) {
-    return createError(Error::SystemError,
-                       "Fail to create perf_event tracepoint",
-                       fd_exp.takeError());
+    return createError(Error::SystemError, fd_exp.takeError())
+           << "Fail to create perf_event tracepoint";
   }
   instance.fd_ = fd_exp.take();
 
   if (ioctl(instance.fd_, PERF_EVENT_IOC_SET_BPF, instance.program_.fd()) < 0) {
-    return createError(Error::SystemError,
-                       "Fail to attach perf event of EbpfTracepoint ")
+    return createError(Error::SystemError)
+           << "Fail to attach perf event of EbpfTracepoint "
            << boost::io::quoted(strerror(errno));
   }
   if (ioctl(instance.fd_, PERF_EVENT_IOC_ENABLE, 0) < 0) {
-    return createError(Error::SystemError,
-                       "Fail to enable perf event of EbpfTracepoint ")
+    return createError(Error::SystemError)
+           << "Fail to enable perf event of EbpfTracepoint "
            << boost::io::quoted(strerror(errno));
   }
   return std::move(instance);
@@ -106,8 +105,8 @@ ExpectedSuccess<EbpfTracepoint::Error> EbpfTracepoint::unload() {
   }
   fd_ = -1;
   if (failed) {
-    return createError(Error::SystemError, "EbpfTracepoint unload failed ")
-           << err_msg;
+    return createError(Error::SystemError)
+           << "EbpfTracepoint unload failed " << err_msg;
   }
   return Success{};
 }

--- a/osquery/killswitch/killswitch.cpp
+++ b/osquery/killswitch/killswitch.cpp
@@ -68,21 +68,20 @@ Expected<bool, Killswitch::IsEnabledError> Killswitch::isEnabled(
       {{Killswitch::action_, Killswitch::isEnabled_}, {Killswitch::key_, key}},
       response);
   if (!status.ok()) {
-    return createError(Killswitch::IsEnabledError::CallFailed,
-                       status.getMessage());
+    return createError(Killswitch::IsEnabledError::CallFailed)
+           << status.getMessage();
   }
 
   if (response.size() != 1) {
-    return createError(Killswitch::IsEnabledError::IncorrectResponseFormat,
-                       "Response size should be 1 but is ")
+    return createError(Killswitch::IsEnabledError::IncorrectResponseFormat)
+           << "Response size should be 1 but is "
            << std::to_string(response.size());
   }
   const auto& response_map = response[0];
   const auto& is_enabled_item = response_map.find(Killswitch::isEnabled_);
   if (is_enabled_item == response_map.end()) {
-    return createError(
-        Killswitch::IsEnabledError::IncorrectResponseFormat,
-        "isEnabled key missing in response of the action: isEnabled");
+    return createError(Killswitch::IsEnabledError::IncorrectResponseFormat)
+           << "isEnabled key missing in response of the action: isEnabled";
   }
 
   const auto& is_enabled_value = is_enabled_item->second;
@@ -91,8 +90,8 @@ Expected<bool, Killswitch::IsEnabledError> Killswitch::isEnabled(
   } else if (is_enabled_value == "0") {
     return false;
   } else {
-    return createError(Killswitch::IsEnabledError::IncorrectValue,
-                       "Unknown isEnabled value " + is_enabled_value);
+    return createError(Killswitch::IsEnabledError::IncorrectValue)
+           << "Unknown isEnabled value " << is_enabled_value;
   }
 }
 

--- a/osquery/killswitch/killswitch_plugin.cpp
+++ b/osquery/killswitch/killswitch_plugin.cpp
@@ -25,31 +25,30 @@ KillswitchPlugin::parseMapJSON(const std::string& content) {
   auto doc = JSON::newObject();
   if (!doc.fromString(content) || !doc.doc().IsObject()) {
     return createError(
-        KillswitchPlugin::ParseMapJSONError::UnknownParsingProblem,
-        "Error parsing the killswitch JSON. Content : " + content);
+               KillswitchPlugin::ParseMapJSONError::UnknownParsingProblem)
+           << "Error parsing the killswitch JSON. Content : " << content;
   }
 
   const auto table = doc.doc().FindMember("table");
   if (table == doc.doc().MemberEnd()) {
-    return createError(KillswitchPlugin::ParseMapJSONError::MissingKey,
-                       "Killswitch key table containing map was not found");
+    return createError(KillswitchPlugin::ParseMapJSONError::MissingKey)
+           << "Killswitch key table containing map was not found";
   }
   if (!table->value.IsObject()) {
-    return createError(KillswitchPlugin::ParseMapJSONError::IncorrectValueType,
-                       "Killswitch table value is not an object");
+    return createError(KillswitchPlugin::ParseMapJSONError::IncorrectValueType)
+           << "Killswitch table value is not an object";
   }
 
   for (const auto& keyValue : table->value.GetObject()) {
     if (!keyValue.name.IsString()) {
-      return createError(KillswitchPlugin::ParseMapJSONError::IncorrectKeyType,
-                         "Killswitch config key was not string");
+      return createError(KillswitchPlugin::ParseMapJSONError::IncorrectKeyType)
+             << "Killswitch config key was not string";
     }
     auto key = keyValue.name.GetString();
     if (!keyValue.value.IsBool()) {
       return createError(
-          KillswitchPlugin::ParseMapJSONError::IncorrectValueType,
-          std::string("At Killswitch config key: ") + key +
-              " value was not bool");
+                 KillswitchPlugin::ParseMapJSONError::IncorrectValueType)
+             << "At Killswitch config key: " << key << " value was not bool";
     }
     bool value = keyValue.value.GetBool();
     result[key] = value;
@@ -99,8 +98,8 @@ Expected<bool, KillswitchPlugin::IsEnabledError> KillswitchPlugin::isEnabled(
   if (killswitchMap_.find(key) != killswitchMap_.end()) {
     return killswitchMap_[key];
   } else {
-    return createError(KillswitchPlugin::IsEnabledError::NoKeyFound,
-                       "Could not find key " + key);
+    return createError(KillswitchPlugin::IsEnabledError::NoKeyFound)
+           << "Could not find key " << key;
   }
 }
 

--- a/osquery/numeric_monitoring/numeric_monitoring.cpp
+++ b/osquery/numeric_monitoring/numeric_monitoring.cpp
@@ -8,7 +8,7 @@
 
 #include <unordered_map>
 
-#include <boost/format.hpp>
+#include <boost/io/detail/quoted_manip.hpp>
 
 #include <osquery/dispatcher.h>
 #include <osquery/flags.h>
@@ -89,12 +89,9 @@ Expected<monitoring::PreAggregationType, ConversionError>
 tryTo<monitoring::PreAggregationType>(const std::string& from) {
   auto it = getStringToAggregationTypeTable().find(from);
   if (it == getStringToAggregationTypeTable().end()) {
-    return createError(
-        ConversionError::InvalidArgument,
-        boost::str(
-            boost::format(
-                "Wrong string representation of `PreAggregationType`: \"%s\"") %
-            from));
+    return createError(ConversionError::InvalidArgument)
+           << "Wrong string representation of `PreAggregationType`: "
+           << boost::io::quoted(from);
   }
   return it->second;
 }

--- a/osquery/utils/conversions/tryto.cpp
+++ b/osquery/utils/conversions/tryto.cpp
@@ -42,8 +42,8 @@ Expected<bool, ConversionError> stringToBool(std::string from) {
  }
  const auto it = table.find(from);
  if (it == table.end()) {
-   return createError(ConversionError::InvalidArgument,
-                      "Wrong string representation of boolean ")
+   return createError(ConversionError::InvalidArgument)
+          << "Wrong string representation of boolean "
           << boost::io::quoted(from);
  }
  return it->second;

--- a/osquery/utils/conversions/tryto.h
+++ b/osquery/utils/conversions/tryto.h
@@ -124,17 +124,16 @@ tryTo(const FromType& from, const int base = 10) noexcept {
   try {
     return impl::throwingStringToInt<ToType>(from, base);
   } catch (const std::invalid_argument& ia) {
-    return createError(ConversionError::InvalidArgument,
-                       "If no conversion could be performed. ")
-           << ia.what();
+    return createError(ConversionError::InvalidArgument)
+           << "If no conversion could be performed. " << ia.what();
   } catch (const std::out_of_range& oor) {
-    return createError(ConversionError::OutOfRange,
-                       "Value read is out of the range of representable values "
-                       "by an int. ")
+    return createError(ConversionError::OutOfRange)
+           << "Value read is out of the range of representable values by an "
+              "int. "
            << oor.what();
   } catch (...) {
-    return createError(ConversionError::Unknown,
-                       "Unknown error during conversion ")
+    return createError(ConversionError::Unknown)
+           << "Unknown error during conversion "
            << boost::core::demangle(typeid(FromType).name()) << " to "
            << boost::core::demangle(typeid(ToType).name()) << " base " << base;
   }

--- a/osquery/utils/error/tests/error.cpp
+++ b/osquery/utils/error/tests/error.cpp
@@ -57,7 +57,7 @@ bool stringContains(const std::string& where, const std::string& what) {
 GTEST_TEST(ErrorTest, createErrorSimple) {
   const auto msg = std::string{
       "\"!ab#c$d%e&f'g(h)i*j+k,l-m.n/o\" this is not a human readable text"};
-  auto err = osquery::createError(TestError::AnotherError, msg);
+  auto err = osquery::createError(TestError::AnotherError) << msg;
   EXPECT_EQ(TestError::AnotherError, err.getErrorCode());
   EXPECT_FALSE(err.hasUnderlyingError());
 
@@ -69,15 +69,16 @@ GTEST_TEST(ErrorTest, createErrorSimple) {
 GTEST_TEST(ErrorTest, createErrorFromOtherError) {
   const auto firstMsg = std::string{"2018-06-28 08:13 451014"};
 
-  auto firstErr = osquery::createError(TestError::SomeError, firstMsg);
+  auto firstErr = osquery::createError(TestError::SomeError) << firstMsg;
   EXPECT_EQ(TestError::SomeError, firstErr.getErrorCode());
   EXPECT_FALSE(firstErr.hasUnderlyingError());
 
   EXPECT_PRED2(stringContains, firstErr.getMessage(), firstMsg);
 
   const auto secondMsg = std::string{"what's wrong with the first message?!"};
-  auto secondErr = osquery::createError(
-      TestError::AnotherError, secondMsg, std::move(firstErr));
+  auto secondErr =
+      osquery::createError(TestError::AnotherError, std::move(firstErr))
+      << secondMsg;
   EXPECT_EQ(TestError::AnotherError, secondErr.getErrorCode());
   EXPECT_TRUE(secondErr.hasUnderlyingError());
   auto secondShortMsg = secondErr.getMessage();
@@ -88,8 +89,8 @@ GTEST_TEST(ErrorTest, createErrorFromOtherError) {
 
 GTEST_TEST(ErrorTest, createErrorAndStreamToIt) {
   const auto a4 = std::string{"A4"};
-  const auto err = osquery::createError(TestError::MusicError, "Do")
-                   << '-' << "Re"
+  const auto err = osquery::createError(TestError::MusicError)
+                   << "Do" << '-' << "Re"
                    << "-Mi"
                    << "-Fa"
                    << "-Sol"

--- a/osquery/utils/expected/expected.h
+++ b/osquery/utils/expected/expected.h
@@ -33,7 +33,7 @@
  *    if (first_error) {
  *      return Error<TestError>(TestError::SomeError, "some error message");
  *    } else {
- *      return createError(TestError::SomeError, "one more error message");
+ *      return createError(TestError::SomeError) << "one more error message";
  *    }
  *   }
  * }
@@ -43,7 +43,7 @@
  *   if (test) {
  *    return std::make_unique<PlatformProcess>(pid);
  *   } else {
- *    return createError(TestError::AnotherError, "something wrong");
+ *    return createError(TestError::AnotherError) << "something wrong";
  *   }
  * }
  *

--- a/osquery/utils/expected/tests/expected.cpp
+++ b/osquery/utils/expected/tests/expected.cpp
@@ -101,8 +101,8 @@ GTEST_TEST(ExpectedTest, createError_example) {
     if (valid) {
       return 50011971;
     }
-    return createError(TestError::Logical,
-                       "an error message is supposed to be here");
+    return createError(TestError::Logical)
+           << "an error message is supposed to be here";
   };
   auto v = giveMeDozen(true);
   EXPECT_TRUE(v);
@@ -135,12 +135,12 @@ GTEST_TEST(ExpectedTest, ExpectedSuccess_example) {
 GTEST_TEST(ExpectedTest, nested_errors_example) {
   const auto msg = std::string{"Write a good error message"};
   auto firstFailureSource = [&msg]() -> Expected<std::vector<int>, TestError> {
-    return createError(TestError::Semantic, msg);
+    return createError(TestError::Semantic) << msg;
   };
   auto giveMeNestedError = [&]() -> Expected<std::vector<int>, TestError> {
     auto ret = firstFailureSource();
     ret.isError();
-    return createError(TestError::Runtime, msg, ret.takeError());
+    return createError(TestError::Runtime, ret.takeError()) << msg;
   };
   auto ret = giveMeNestedError();
   EXPECT_FALSE(ret);
@@ -152,7 +152,7 @@ GTEST_TEST(ExpectedTest, nested_errors_example) {
 
 GTEST_TEST(ExpectedTest, error_handling_example) {
   auto failureSource = []() -> Expected<std::vector<int>, TestError> {
-    return createError(TestError::Runtime, "Test error message ()*+,-.");
+    return createError(TestError::Runtime) << "Test error message ()*+,-.";
   };
   auto ret = failureSource();
   if (ret.isError()) {
@@ -292,7 +292,7 @@ GTEST_TEST(ExpectedTest, error__takeOr_with_user_defined_class) {
     std::string text;
   };
   auto callable = []() -> Expected<SomeTestClass, TestError> {
-    return createError(TestError::Semantic, "error message");
+    return createError(TestError::Semantic) << "error message";
   };
   EXPECT_EQ(callable().takeOr(SomeTestClass("427 BC", "347 BC")).text,
             "427 BC - 347 BC");
@@ -308,7 +308,7 @@ GTEST_TEST(ExpectedTest, value_takeOr_with_rvalue_as_an_argument) {
 GTEST_TEST(ExpectedTest, error_takeOr_with_rvalue_as_an_argument) {
   auto value = int{312};
   auto callable = []() -> Expected<int, TestError> {
-    return createError(TestError::Logical, "error message");
+    return createError(TestError::Logical) << "error message";
   };
   value = callable().takeOr(value);
   EXPECT_EQ(value, 312);

--- a/osquery/utils/map_take.h
+++ b/osquery/utils/map_take.h
@@ -78,7 +78,7 @@ inline typename std::enable_if<impl::IsMap<MapType>::value,
 tryTake(MapType& table, const KeyType& key) {
   auto it = table.find(key);
   if (it == table.end()) {
-    return createError(MapTakeError::NoSuchKey, "no such key in the table");
+    return createError(MapTakeError::NoSuchKey) << "no such key in the table";
   }
   auto item = std::move(it->second);
   table.erase(it);
@@ -102,7 +102,7 @@ inline typename std::enable_if<impl::IsMap<MapType>::value,
 tryTakeCopy(MapType const& from, KeyType const& key) {
   auto const it = from.find(key);
   if (it == from.end()) {
-    return createError(MapTakeError::NoSuchKey, "no such key in the table");
+    return createError(MapTakeError::NoSuchKey) << "no such key in the table";
   }
   return it->second;
 }

--- a/osquery/utils/system/linux/cpu.cpp
+++ b/osquery/utils/system/linux/cpu.cpp
@@ -22,7 +22,8 @@ namespace {
 Expected<std::string, Error> readSysCpuFile(char const* path) {
   std::ifstream fin(path, std::ios_base::in | std::ios_base::binary);
   if (fin.fail() || fin.bad()) {
-    return createError(Error::IOError, "No access to the system file ") << path;
+    return createError(Error::IOError)
+           << "No access to the system file " << path;
   }
   auto data = std::string{};
   fin >> data;
@@ -74,8 +75,8 @@ Expected<Mask, Error> decodeMaskFromString(const std::string& encoded_str) {
         return to_exp.takeError();
       }
       if (to_exp.get() < from_exp.get()) {
-        return createError(Error::IncorrectRange,
-                           "Incorrect CPU number interval ")
+        return createError(Error::IncorrectRange)
+               << "Incorrect CPU number interval "
                << boost::io::quoted(interval);
       }
       if (to_exp.get() >= mask.size()) {

--- a/osquery/utils/system/linux/ebpf/ebpf.cpp
+++ b/osquery/utils/system/linux/ebpf/ebpf.cpp
@@ -40,15 +40,14 @@ constexpr int kMinimalLinuxVersionCode = KERNEL_VERSION(4, 9, 0);
 Expected<bool, PosixError> isSupportedBySystem() {
   struct utsname utsbuf;
   if (uname(&utsbuf) == -1) {
-    return createError(to<PosixError>(errno), "syscall uname() failed: ")
-           << boost::io::quoted(strerror(errno));
+    return createError(to<PosixError>(errno))
+           << "syscall uname() failed: " << boost::io::quoted(strerror(errno));
   }
   auto release_version_exp =
       tryTo<SemanticVersion>(std::string(utsbuf.release));
   if (release_version_exp.isError()) {
-    return createError(PosixError::Unknown,
-                       "uname() release field is malformed",
-                       release_version_exp.takeError())
+    return createError(PosixError::Unknown, release_version_exp.takeError())
+           << "uname() release field is malformed"
            << boost::io::quoted(utsbuf.release);
   }
   auto const version = release_version_exp.take();
@@ -59,8 +58,8 @@ Expected<bool, PosixError> isSupportedBySystem() {
 Expected<int, PosixError> syscall(int cmd, union bpf_attr* attr) {
   int const ret = ::syscall(__NR_bpf, cmd, attr, sizeof(union bpf_attr));
   if (ret < 0) {
-    return createError(to<PosixError>(errno), "bpf() syscall failed: ")
-           << boost::io::quoted(strerror(errno));
+    return createError(to<PosixError>(errno))
+           << "bpf() syscall failed: " << boost::io::quoted(strerror(errno));
   }
   return ret;
 }

--- a/osquery/utils/system/linux/ebpf/map.cpp
+++ b/osquery/utils/system/linux/ebpf/map.cpp
@@ -31,8 +31,8 @@ Expected<int, MapError> mapCreate(enum bpf_map_type map_type,
   attr.max_entries = static_cast<std::uint32_t>(max_entries);
   auto exp_bpf = syscall(BPF_MAP_CREATE, &attr);
   if (exp_bpf.isError()) {
-    return createError(
-        MapError::Unknown, "Creating eBPF map failed", exp_bpf.takeError());
+    return createError(MapError::Unknown, exp_bpf.takeError())
+           << "Creating eBPF map failed";
   }
   return exp_bpf.take();
 }
@@ -49,9 +49,8 @@ ExpectedSuccess<MapError> mapUpdateElement(const int fd,
   attr.flags = flags;
   auto exp_bpf = syscall(BPF_MAP_UPDATE_ELEM, &attr);
   if (exp_bpf.isError()) {
-    return createError(MapError::Unknown,
-                       "Updating value in eBPF map failed",
-                       exp_bpf.takeError());
+    return createError(MapError::Unknown, exp_bpf.takeError())
+           << "Updating value in eBPF map failed";
   }
   return Success{};
 }
@@ -67,12 +66,11 @@ ExpectedSuccess<MapError> mapLookupElement(const int fd,
   auto exp_bpf = syscall(BPF_MAP_LOOKUP_ELEM, &attr);
   if (exp_bpf.isError()) {
     if (exp_bpf.getErrorCode() == PosixError::NOENT) {
-      return createError(MapError::NoSuchKey,
-                         "No such key in the eBPF map",
-                         exp_bpf.takeError());
+      return createError(MapError::NoSuchKey, exp_bpf.takeError())
+             << "No such key in the eBPF map";
     }
-    return createError(
-        MapError::Unknown, "Look up in eBPF map failed", exp_bpf.takeError());
+    return createError(MapError::Unknown, exp_bpf.takeError())
+           << "Look up in eBPF map failed";
   }
   return Success{};
 }
@@ -85,13 +83,11 @@ ExpectedSuccess<MapError> mapDeleteElement(const int fd, void const* key) {
   auto exp_bpf = syscall(BPF_MAP_DELETE_ELEM, &attr);
   if (exp_bpf.isError()) {
     if (exp_bpf.getErrorCode() == PosixError::NOENT) {
-      return createError(MapError::NoSuchKey,
-                         "No such key in the eBPF map",
-                         exp_bpf.takeError());
+      return createError(MapError::NoSuchKey, exp_bpf.takeError())
+             << "No such key in the eBPF map";
     }
-    return createError(MapError::Unknown,
-                       "Deleting element from eBPF map failed",
-                       exp_bpf.takeError());
+    return createError(MapError::Unknown, exp_bpf.takeError())
+           << "Deleting element from eBPF map failed";
   }
   return Success{};
 }

--- a/osquery/utils/system/linux/ebpf/perf_output_impl.h
+++ b/osquery/utils/system/linux/ebpf/perf_output_impl.h
@@ -73,9 +73,8 @@ PerfOutput<MessageType>::load(std::size_t const cpu, std::size_t const size) {
   auto exp_fd = perf_event_open::syscall(
       &attr, pid, static_cast<int>(cpu), group_fd, flags);
   if (exp_fd.isError()) {
-    return createError(PerfOutputError::SystemError,
-                       "Fail to create perf_event output point",
-                       exp_fd.takeError());
+    return createError(PerfOutputError::SystemError, exp_fd.takeError())
+           << "Fail to create perf_event output point";
   }
   instance.fd_ = exp_fd.take();
 
@@ -87,13 +86,13 @@ PerfOutput<MessageType>::load(std::size_t const cpu, std::size_t const size) {
                             0);
   if (instance.data_ptr_ == MAP_FAILED) {
     instance.data_ptr_ = nullptr;
-    return createError(PerfOutputError::SystemError,
-                       "Fail to mmap memory for perf event of PerfOutput ")
+    return createError(PerfOutputError::SystemError)
+           << "Fail to mmap memory for perf event of PerfOutput "
            << boost::io::quoted(strerror(errno));
   }
   if (ioctl(instance.fd_, PERF_EVENT_IOC_ENABLE, 0) < 0) {
-    return createError(PerfOutputError::SystemError,
-                       "Fail to enable perf event of PerfOutput ")
+    return createError(PerfOutputError::SystemError)
+           << "Fail to enable perf event of PerfOutput "
            << boost::io::quoted(strerror(errno));
   }
   return Expected<PerfOutput<MessageType>, PerfOutputError>(
@@ -133,7 +132,7 @@ ExpectedSuccess<PerfOutputError> PerfOutput<MessageType>::unload() {
   }
   fd_ = -1;
   if (failed) {
-    return createError(PerfOutputError::SystemError, err_msg);
+    return createError(PerfOutputError::SystemError) << err_msg;
   }
   return Success{};
 }
@@ -233,8 +232,8 @@ ExpectedSuccess<PerfOutputError> PerfOutput<MessageType>::read(
                 "message type must be trivial, because it comes from ASM code "
                 "at the end");
   if (fd_ < 0) {
-    return createError(PerfOutputError::LogicError,
-                       "Attept to read from not loaded perf output");
+    return createError(PerfOutputError::LogicError)
+           << "Attept to read from not loaded perf output";
   }
   auto header = static_cast<struct perf_event_mmap_page*>(data_ptr_);
   if (header->data_head == header->data_tail) {
@@ -274,9 +273,9 @@ template <typename MessageType>
 ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::add(
     PerfOutput<MessageType> output) {
   if (outputs_.size() == cpu::kMaskSize) {
-    return createError(PerfOutputError::LogicError,
-                       "osquery support no more than ")
-           << cpu::kMaskSize << " cpu, change cpu::kMaskSize and recompile";
+    return createError(PerfOutputError::LogicError)
+           << "osquery support no more than " << cpu::kMaskSize
+           << " cpu, change cpu::kMaskSize and recompile";
   }
   struct pollfd pfd;
   pfd.fd = output.fd();
@@ -292,9 +291,8 @@ ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
   while (true) {
     int ret = ::poll(fds_.data(), fds_.size(), poll_timeout_.count());
     if (ret < 0) {
-      return createError(PerfOutputError::SystemError,
-                         "perf output polling failed")
-             << strerror(errno);
+      return createError(PerfOutputError::SystemError)
+             << "perf output polling failed" << strerror(errno);
     } else if (ret == 0) {
       // timeout; no event detected
     } else {
@@ -304,9 +302,8 @@ ExpectedSuccess<PerfOutputError> PerfOutputsPoll<MessageType>::read(
           fds_[index].revents = 0;
           auto status = outputs_[index].read(batch);
           if (status.isError()) {
-            return createError(PerfOutputError::LogicError,
-                               "read in perf output poll failed",
-                               status.takeError());
+            return createError(PerfOutputError::LogicError, status.takeError())
+                   << "read in perf output poll failed";
           }
         }
       }

--- a/osquery/utils/system/linux/ebpf/program.cpp
+++ b/osquery/utils/system/linux/ebpf/program.cpp
@@ -59,10 +59,9 @@ Expected<Program, Program::Error> Program::load(
   auto instance = Program{};
   auto fd_exp = syscall(BPF_PROG_LOAD, &attr);
   if (fd_exp.isError()) {
-    return createError(Program::Error::Unknown,
-                       "eBPF program load failed ",
-                       fd_exp.takeError())
-           << " bpf log: " << boost::io::quoted(bpf_log_buf.data());
+    return createError(Program::Error::Unknown, fd_exp.takeError())
+           << "eBPF program load failed, bpf log: "
+           << boost::io::quoted(bpf_log_buf.data());
   }
   instance.fd_ = fd_exp.take();
   return Expected<Program, Program::Error>(std::move(instance));

--- a/osquery/utils/system/linux/perf_event/perf_event.cpp
+++ b/osquery/utils/system/linux/perf_event/perf_event.cpp
@@ -39,7 +39,8 @@ Expected<int, PosixError> syscall(struct perf_event_attr* attr,
                                   unsigned long const flags) {
   auto ret = ::syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
   if (ret < 0) {
-    return createError(to<PosixError>(errno), "syscall perf_event_open failed ")
+    return createError(to<PosixError>(errno))
+           << "syscall perf_event_open failed "
            << boost::io::quoted(strerror(errno));
   }
   return ret;

--- a/osquery/utils/system/linux/tracing/native_event.cpp
+++ b/osquery/utils/system/linux/tracing/native_event.cpp
@@ -74,14 +74,14 @@ Expected<int, NativeEvent::Error> extractIdFromTheSystem(
     id_in >> id_str;
   }
   if (!id_in.is_open() || id_in.fail()) {
-    return createError(NativeEvent::Error::System,
-                       "Could not open linux event id file ")
+    return createError(NativeEvent::Error::System)
+           << "Could not open linux event id file "
            << boost::io::quoted(id_path.string());
   }
   auto id_exp = tryTo<SystemEventId>(id_str);
   if (id_exp.isError()) {
-    return createError(NativeEvent::Error::System,
-                       "Could not parse linux event id from the string ")
+    return createError(NativeEvent::Error::System)
+           << "Could not parse linux event id from the string "
            << boost::io::quoted(id_str);
   }
   return id_exp.get();
@@ -108,16 +108,16 @@ ExpectedSuccess<NativeEvent::Error> NativeEvent::enable(bool do_enable) {
   }
   if (!event_enable_out.is_open() || event_enable_out.fail()) {
     auto const action = do_enable ? "enable" : "disable";
-    return createError(Error::System, "Could not ")
-           << action << " system event, not sufficient rights to modify file "
+    return createError(Error::System)
+           << "Could not " << action
+           << " system event, not sufficient rights to modify file "
            << boost::io::quoted(event_enable_path.string());
   }
   if (do_enable) {
     auto id_exp = extractIdFromTheSystem(full_event_path);
     if (id_exp.isError()) {
-      return createError(Error::System,
-                         "Could not retrieve event id from the system",
-                         id_exp.takeError());
+      return createError(Error::System, id_exp.takeError())
+             << "Could not retrieve event id from the system";
     }
     id_ = id_exp.take();
   } else {

--- a/osquery/utils/versioning/semantic.cpp
+++ b/osquery/utils/versioning/semantic.cpp
@@ -20,16 +20,16 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
   auto const major_number_pos = str.find(SemanticVersion::separator);
   {
     if (major_number_pos == std::string::npos) {
-      return createError(ConversionError::InvalidArgument,
-                         "invalid format: expected 2 separators, found 0")
+      return createError(ConversionError::InvalidArgument)
+             << "invalid format: expected 2 separators, found 0 "
              << quoted(str);
     }
     auto major_exp = tryTo<unsigned>(str.substr(0, major_number_pos));
     if (major_exp.isError()) {
       return createError(ConversionError::InvalidArgument,
-                         "Invalid major version number, expected unsigned "
-                         "integer, found ",
                          major_exp.takeError())
+             << "Invalid major version number, expected unsigned integer, "
+                "found "
              << quoted(str);
     }
     version.major = major_exp.take();
@@ -38,17 +38,16 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
       str.find(SemanticVersion::separator, major_number_pos + 1);
   {
     if (minor_number_pos == std::string::npos) {
-      return createError(ConversionError::InvalidArgument,
-                         " there are must be 2 separators, found 1")
-             << quoted(str);
+      return createError(ConversionError::InvalidArgument)
+             << " there are must be 2 separators, found 1 " << quoted(str);
     }
     auto minor_exp = tryTo<unsigned>(
         str.substr(major_number_pos + 1, minor_number_pos - major_number_pos));
     if (minor_exp.isError()) {
       return createError(ConversionError::InvalidArgument,
-                         "Invalid minor version number, expected unsigned "
-                         "integer, found: ",
                          minor_exp.takeError())
+             << "Invalid minor version number, expected unsigned integer, "
+                "found: "
              << quoted(str);
     }
     version.minor = minor_exp.take();
@@ -59,9 +58,8 @@ Expected<SemanticVersion, ConversionError> SemanticVersion::tryFromString(
     auto patches_exp = tryTo<unsigned>(
         str.substr(minor_number_pos + 1, patch_number_pos - minor_number_pos));
     if (patches_exp.isError()) {
-      return createError(
-                 ConversionError::InvalidArgument,
-                 "Invalid patches number, expected unsigned integer, found: ")
+      return createError(ConversionError::InvalidArgument)
+             << "Invalid patches number, expected unsigned integer, found: "
              << quoted(str);
     }
     version.patches = patches_exp.take();

--- a/plugins/killswitch/killswitch_filesystem.cpp
+++ b/plugins/killswitch/killswitch_filesystem.cpp
@@ -41,8 +41,8 @@ KillswitchFilesystem::refresh() {
   if (!fs::is_regular_file(conf_path_, ec) || ec.value() != errc::success ||
       !readFile(conf_path_, content).ok()) {
     return createError(
-        KillswitchRefreshablePlugin::RefreshError::NoContentReached,
-        "Config file does not exist: " + conf_path_.string());
+               KillswitchRefreshablePlugin::RefreshError::NoContentReached)
+           << "Config file does not exist: " << conf_path_.string();
   }
 
   auto result = KillswitchPlugin::parseMapJSON(content);
@@ -50,8 +50,8 @@ KillswitchFilesystem::refresh() {
     setCache(*result);
     return Success();
   } else {
-    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
-                       result.getError().getMessage());
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError)
+           << result.getError().getMessage();
   }
 }
 

--- a/plugins/killswitch/killswitch_tls.cpp
+++ b/plugins/killswitch/killswitch_tls.cpp
@@ -66,27 +66,27 @@ TLSKillswitchPlugin::refresh() {
       uri_, params, content, FLAGS_killswitch_tls_max_attempts);
   if (!s.ok()) {
     return createError(
-        KillswitchRefreshablePlugin::RefreshError::NoContentReached,
-        "Could not retrieve config file from network");
+               KillswitchRefreshablePlugin::RefreshError::NoContentReached)
+           << "Could not retrieve config file from network";
   }
 
   JSON tree;
   Status parse_status = tree.fromString(content);
   if (!parse_status.ok()) {
-    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
-                       "Could not parse JSON from TLS killswitch node API");
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError)
+           << "Could not parse JSON from TLS killswitch node API";
   }
 
   // Extract config map from json
   auto it = tree.doc().FindMember("config");
   if (it == tree.doc().MemberEnd()) {
-    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
-                       "Killswitch member config is missing");
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError)
+           << "Killswitch member config is missing";
   }
 
   if (!it->value.IsString()) {
-    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
-                       "Killswitch member config is not a string");
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError)
+           << "Killswitch member config is not a string";
   }
 
   content = it->value.GetString();
@@ -96,8 +96,8 @@ TLSKillswitchPlugin::refresh() {
     setCache(*result);
     return Success();
   } else {
-    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError,
-                       result.getError().getMessage());
+    return createError(KillswitchRefreshablePlugin::RefreshError::ParsingError)
+           << result.getError().getMessage();
   }
 }
 } // namespace osquery


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/osquery/pull/5524

So let's get rid of the rest usecases of createError with message as an argument in order to remove it completely.

Reviewed By: jessek

Differential Revision: D14437933
