### PR TITLE
[osquery] Rename system:cpu target to system:cpu_topology

### DIFF
--- a/osquery/utils/system/BUCK
+++ b/osquery/utils/system/BUCK
@@ -106,7 +106,7 @@ osquery_cxx_test(
 )
 
 osquery_cxx_library(
-    name = "cpu",
+    name = "cpu_topology",
     header_namespace = "osquery/utils/system",
     exported_platform_headers = [
         (
@@ -133,7 +133,7 @@ osquery_cxx_library(
 )
 
 osquery_cxx_test(
-    name = "cpu_tests",
+    name = "cpu_topology_tests",
     srcs = [
         "tests/cpu.cpp",
     ],
@@ -147,7 +147,7 @@ osquery_cxx_test(
     ],
     visibility = ["PUBLIC"],
     deps = [
-        ":cpu",
+        ":cpu_topology",
     ],
 )
 

--- a/osquery/utils/system/linux/ebpf/BUCK
+++ b/osquery/utils/system/linux/ebpf/BUCK
@@ -41,7 +41,7 @@ osquery_cxx_library(
     deps = [
         osquery_target("osquery/utils/conversions:conversions"),
         osquery_target("osquery/utils/system/linux/perf_event:perf_event"),
-        osquery_target("osquery/utils/system:cpu"),
+        osquery_target("osquery/utils/system:cpu_topology"),
         osquery_target("osquery/utils/expected:expected"),
         osquery_target("osquery/utils/versioning:semantic"),
         osquery_target("osquery/utils/system:errno"),


### PR DESCRIPTION
Stack:
&nbsp;&nbsp;&nbsp;&nbsp;:black_circle:&nbsp; **#5527 [osquery] Rename system:cpu target to system:cpu_topology**&nbsp;&nbsp;[:yellow_heart:](https://our.internmc.facebook.com/intern/diff/D14455350/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5519 [osquery] Implement even producer to trace syscalls {kill, setuid} and dump them to experimental events streaming registry&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14406173/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5520 [osquery] Helper function to read process cmdline from `/proc/<pid>/cmdline` on linux by PID&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14421472/)
&nbsp;&nbsp;&nbsp;&nbsp;:white_circle:&nbsp; #5521 [osquery] Simple LRU cache implementation&nbsp;&nbsp;[:green_heart:](https://our.internmc.facebook.com/intern/diff/D14424352/)

for the sake of xCode, because it doesn't tolerate duplicated target names

Differential Revision: [D14455350](https://our.internmc.facebook.com/intern/diff/D14455350/)