### PR TITLE
Force buck to produce short file paths on windows

### DIFF
--- a/tools/buckconfigs/windows-x86_64/base.bcfg
+++ b/tools/buckconfigs/windows-x86_64/base.bcfg
@@ -5,6 +5,7 @@
   preprocess_mode = combined
   sandbox_sources = true
   use_arg_file = true
+  filepath_length_limited = true
 
 [cxx_base]
   cppflags = \


### PR DESCRIPTION
Summary: by using config option `cxx.filepath_length_limited=true`. Because unfortunately there is very low limit for file path length on windows up to win10 (260 chars).

Differential Revision: D14460635
