### PR TITLE
Fix memory leak in macos extended_attributes

### DIFF
--- a/osquery/tables/system/darwin/extended_attributes.cpp
+++ b/osquery/tables/system/darwin/extended_attributes.cpp
@@ -80,6 +80,7 @@ std::vector<std::string> parseExtendedAttributeList(const std::string& path) {
 
   ssize_t ret = listxattr(path.c_str(), content, value, 0);
   if (ret == 0) {
+    free(content);
     return attributes;
   }
 


### PR DESCRIPTION
Summary: This bug was found using the OSS version of infer with default options.

Reviewed By: guliashvili

Differential Revision: D14567925
