### PR TITLE
[build][linux] Add dependency for pthread in osquery/core

### DIFF
--- a/osquery/core/BUCK
+++ b/osquery/core/BUCK
@@ -92,5 +92,6 @@ osquery_cxx_library(
         osquery_tp_target("gflags"),
         osquery_tp_target("glog"),
         osquery_tp_target("openssl", "crypto"),
+        osquery_tp_target("glibc", "pthread"),
     ],
 )


### PR DESCRIPTION
This fixes the linking error described in #5536.