### PR TITLE
Use Status::success and Status::failure throughout osquery

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -503,7 +503,7 @@ Status Config::refresh() {
       }
       // Don't force because the config plugin may have started services.
       Initializer::requestShutdown();
-      return Status();
+      return Status::success();
     }
     status = update(response[0]);
   }
@@ -661,7 +661,7 @@ Status Config::updateSource(const std::string& source,
   }
 
   applyParsers(source, doc.doc(), false);
-  return Status();
+  return Status::success();
 }
 
 Status Config::genPack(const std::string& name,
@@ -681,7 +681,7 @@ Status Config::genPack(const std::string& name,
   auto clone = response[0][name];
   if (clone.empty()) {
     LOG(WARNING) << "Error reading the query pack named: " << name;
-    return Status();
+    return Status::success();
   }
 
   stripConfigComments(clone);
@@ -692,7 +692,7 @@ Status Config::genPack(const std::string& name,
     addPack(name, source, doc.doc());
   }
 
-  return Status();
+  return Status::success();
 }
 
 void Config::applyParsers(const std::string& source,
@@ -1090,7 +1090,7 @@ Status ConfigPlugin::call(const PluginRequest& request,
 
     response.push_back(
         {{"name", name->second}, {"value", Flag::getValue(name->second)}});
-    return Status();
+    return Status::success();
   }
   return Status(1, "Config plugin action unknown: " + action->second);
 }
@@ -1100,7 +1100,7 @@ Status ConfigParserPlugin::setUp() {
     auto obj = data_.getObject();
     data_.add(key, obj);
   }
-  return Status();
+  return Status::success();
 }
 
 void ConfigRefreshRunner::start() {

--- a/osquery/config/tests/config_tests.cpp
+++ b/osquery/config/tests/config_tests.cpp
@@ -123,7 +123,7 @@ class TestConfigPlugin : public ConfigPlugin {
                  std::string& pack) override {
     gen_pack_count_++;
     getUnrestrictedPack().toString(pack);
-    return Status();
+    return Status::success();
   }
 
  public:
@@ -411,7 +411,7 @@ class TestConfigParserPlugin : public ConfigParserPlugin {
     auto obj2 = data_.getObject();
     data_.addRef("key2", "value2", obj2);
     data_.add("dictionary3", obj2, data_.doc());
-    return Status();
+    return Status::success();
   }
 
   // Flag tracking that the update method was called.
@@ -452,7 +452,7 @@ class PlaceboConfigParserPlugin : public ConfigParserPlugin {
     return {};
   }
   Status update(const std::string&, const ParserConfig&) override {
-    return Status();
+    return Status::success();
   }
 
   /// Make sure configure is called.

--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -189,7 +189,7 @@ Status deserializeDiffResults(const rj::Value& doc, DiffResults& dr) {
       return status;
     }
   }
-  return Status();
+  return Status::success();
 }
 
 inline void addLegacyFieldsAndDecorations(const QueryLogItem& item,
@@ -260,7 +260,7 @@ Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc) {
   }
 
   addLegacyFieldsAndDecorations(item, doc, doc.doc());
-  return Status();
+  return Status::success();
 }
 
 Status serializeEvent(const QueryLogItem& item,
@@ -306,7 +306,7 @@ Status serializeQueryLogItemAsEvents(const QueryLogItem& item, JSON& doc) {
       doc.push(obj);
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json) {
@@ -334,7 +334,7 @@ Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& item,
     event.Accept(writer);
     items.push_back(sb.GetString());
   }
-  return Status();
+  return Status::success();
 }
 
 }

--- a/osquery/core/sql/diff_results.cpp
+++ b/osquery/core/sql/diff_results.cpp
@@ -33,7 +33,7 @@ Status serializeDiffResults(const DiffResults& d,
     return status;
   }
   doc.add("added", added_arr, obj);
-  return Status();
+  return Status::success();
 }
 
 Status serializeDiffResultsJSON(const DiffResults& d,

--- a/osquery/core/sql/query_data.cpp
+++ b/osquery/core/sql/query_data.cpp
@@ -24,7 +24,7 @@ Status serializeQueryData(const QueryData& q,
     }
     doc.push(row_obj, arr);
   }
-  return Status();
+  return Status::success();
 }
 
 Status serializeQueryData(const QueryDataTyped& q,
@@ -39,7 +39,7 @@ Status serializeQueryData(const QueryDataTyped& q,
     }
     doc.push(row_obj, arr);
   }
-  return Status();
+  return Status::success();
 }
 
 Status serializeQueryDataJSON(const QueryData& q, std::string& json) {
@@ -78,7 +78,7 @@ Status deserializeQueryData(const rj::Value& arr, QueryData& qd) {
     }
     qd.push_back(r);
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeQueryData(const rj::Value& arr, QueryDataTyped& qd) {
@@ -94,7 +94,7 @@ Status deserializeQueryData(const rj::Value& arr, QueryDataTyped& qd) {
     }
     qd.push_back(r);
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeQueryData(const rj::Value& v, QueryDataSet& qd) {
@@ -110,7 +110,7 @@ Status deserializeQueryData(const rj::Value& v, QueryDataSet& qd) {
     }
     qd.insert(std::move(r));
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeQueryDataJSON(const std::string& json, QueryData& qd) {

--- a/osquery/core/sql/row.cpp
+++ b/osquery/core/sql/row.cpp
@@ -30,7 +30,7 @@ Status serializeRow(const Row& r,
     }
   }
 
-  return Status();
+  return Status::success();
 }
 
 class DocAppenderVisitor : public boost::static_visitor<> {
@@ -67,7 +67,7 @@ Status serializeRow(const RowTyped& r,
       doc.addRef(i.first, castVariant(i.second), obj);
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status serializeRowJSON(const RowTyped& r, std::string& json, bool asNumeric) {
@@ -102,7 +102,7 @@ Status deserializeRow(const rj::Value& doc, Row& r) {
       r[name] = i.value.GetString();
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeRow(const rj::Value& doc, RowTyped& r) {
@@ -123,7 +123,7 @@ Status deserializeRow(const rj::Value& doc, RowTyped& r) {
       }
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeRowJSON(const std::string& json, Row& r) {

--- a/osquery/core/sql/table_rows.cpp
+++ b/osquery/core/sql/table_rows.cpp
@@ -21,7 +21,7 @@ Status serializeTableRows(const TableRows& rows, JSON& doc, rj::Document& arr) {
     }
     doc.push(row_obj, arr);
   }
-  return Status();
+  return Status::success();
 }
 
 Status serializeTableRowsJSON(const TableRows& rows, std::string& json) {

--- a/osquery/core/windows/handle.cpp
+++ b/osquery/core/windows/handle.cpp
@@ -67,7 +67,7 @@ Status Handle::openSymLinkObj(const std::wstring& strName) {
     return Status(ntStatus, "NtOpenSymbolicLinkObject returned failure");
   }
 
-  return Status();
+  return Status::success();
 }
 
 Status Handle::openDirObj(const std::wstring& strName) {
@@ -107,6 +107,6 @@ Status Handle::openDirObj(const std::wstring& strName) {
     return Status(ntStatus, "NtOpenDirecotryObject returned failure");
   }
 
-  return Status();
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -481,7 +481,7 @@ Status ptreeToRapidJSON(const std::string& in, std::string& out) {
 
   json.toString(out);
 
-  return Status();
+  return Status::success();
 }
 
 static Status migrateV0V1(void) {
@@ -519,7 +519,7 @@ static Status migrateV0V1(void) {
     }
   }
 
-  return Status();
+  return Status::success();
 }
 
 static Status migrateV1V2(void) {
@@ -629,6 +629,6 @@ Status upgradeDatabase(int to_version) {
     db_version++;
   }
 
-  return Status();
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/distributed/distributed.cpp
+++ b/osquery/distributed/distributed.cpp
@@ -229,7 +229,7 @@ Status Distributed::acceptWork(const std::string& work) {
       VLOG(1) << "Falied to Accelerate: Timeframe is not an integer";
     }
   }
-  return Status();
+  return Status::success();
 }
 
 DistributedQueryRequest Distributed::popRequest() {
@@ -260,7 +260,7 @@ Status serializeDistributedQueryRequest(const DistributedQueryRequest& r,
   assert(obj.IsObject());
   doc.addCopy("query", r.query, obj);
   doc.addCopy("id", r.id, obj);
-  return Status();
+  return Status::success();
 }
 
 Status serializeDistributedQueryRequestJSON(const DistributedQueryRequest& r,
@@ -283,7 +283,7 @@ Status deserializeDistributedQueryRequest(const rj::Value& obj,
 
   r.query = obj["query"].GetString();
   r.id = obj["id"].GetString();
-  return Status();
+  return Status::success();
 }
 
 Status deserializeDistributedQueryRequestJSON(const std::string& json,
@@ -312,7 +312,7 @@ Status serializeDistributedQueryResult(const DistributedQueryResult& r,
 
   doc.add("request", request_obj);
   doc.add("results", results_arr);
-  return Status();
+  return Status::success();
 }
 
 Status serializeDistributedQueryResultJSON(const DistributedQueryResult& r,
@@ -343,7 +343,7 @@ Status deserializeDistributedQueryResult(const rj::Value& obj,
   r.request = request;
   r.results = results;
 
-  return Status();
+  return Status::success();
 }
 
 Status deserializeDistributedQueryResultJSON(const std::string& json,

--- a/osquery/extensions/impl_thrift.cpp
+++ b/osquery/extensions/impl_thrift.cpp
@@ -436,7 +436,7 @@ Status ExtensionManagerClient::query(const std::string& sql, QueryData& qd) {
     qd.push_back(row);
   }
 
-  return Status();
+  return Status::success();
 }
 
 Status ExtensionManagerClient::getQueryColumns(const std::string& sql,

--- a/osquery/extensions/interface.cpp
+++ b/osquery/extensions/interface.cpp
@@ -119,7 +119,7 @@ Status ExtensionManagerInterface::registerExtension(
 
   WriteLock lock(extensions_mutex_);
   extensions_[uuid] = info;
-  return Status();
+  return Status::success();
 }
 
 Status ExtensionManagerInterface::query(const std::string& sql, QueryData& qd) {
@@ -139,7 +139,7 @@ Status ExtensionManagerInterface::deregisterExtension(RouteUUID uuid) {
 
   WriteLock lock(extensions_mutex_);
   extensions_.erase(uuid);
-  return Status();
+  return Status::success();
 }
 
 Status ExtensionManagerInterface::getQueryColumns(const std::string& sql,

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -112,7 +112,7 @@ Status windowsShortPathToLongPath(const std::string& shortPath,
     return Status(GetLastError(), "Failed to convert short path to long path");
   }
   rLongPath = std::string(longPath);
-  return Status();
+  return Status::success();
 }
 
 Status windowsGetFileVersion(const std::string& path, std::string& rVersion) {
@@ -138,7 +138,7 @@ Status windowsGetFileVersion(const std::string& path, std::string& rVersion) {
       std::to_string((pFileInfo->dwProductVersionMS >> 0 & 0xffff)) + "." +
       std::to_string((pFileInfo->dwProductVersionLS >> 16 & 0xffff)) + "." +
       std::to_string((pFileInfo->dwProductVersionLS >> 0 & 0xffff));
-  return Status();
+  return Status::success();
 }
 
 static bool hasGlobBraces(const std::string& glob) {
@@ -340,7 +340,7 @@ static Status checkAccessWithSD(PSECURITY_DESCRIPTOR sd, mode_t mode) {
   }
 
   if (access_status) {
-    return Status();
+    return Status::success();
   }
 
   return Status(1, "Bad mode for file");
@@ -659,7 +659,7 @@ static Status isUserCurrentUser(PSID user) {
   /// Determine if the current user SID matches that of the specified user
   PTOKEN_USER ptu = reinterpret_cast<PTOKEN_USER>(tuBuff.data());
   if (EqualSid(user, ptu->User.Sid)) {
-    return Status();
+    return Status::success();
   }
 
   return Status(1, "User not current user");
@@ -701,7 +701,7 @@ Status PlatformFile::isOwnerRoot() const {
   }
 
   if (EqualSid(owner, admins_sid) || EqualSid(owner, system_sid)) {
-    return Status();
+    return Status::success();
   }
 
   return Status(1, "Owner is not in Administrators group or Local System");
@@ -786,7 +786,7 @@ static Status lowPrivWriteDenied(PACL acl) {
 
       // A Deny-Write on Everyone supersedes other allow writes
       if (EqualSid(&denied_ace->SidStart, world_sid)) {
-        return Status();
+        return Status::success();
       }
 
       // Stash the Deny-Write ACE to check against future user Allow ACEs
@@ -827,7 +827,7 @@ static Status lowPrivWriteDenied(PACL acl) {
       }
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status PlatformFile::hasSafePermissions() const {
@@ -1493,13 +1493,13 @@ Status platformIsTmpDir(const fs::path& dir) {
   if (!dirPathsAreEqual(dir, fs::temp_directory_path(ec))) {
     return Status(1, "Not temp directory");
   }
-  return Status();
+  return Status::success();
 }
 
 Status platformIsFileAccessible(const fs::path& path) {
   boost::system::error_code ec;
   if (fs::is_regular_file(path, ec) && ec.value() == errc::success) {
-    return Status();
+    return Status::success();
   }
   return Status(1, "Not accessible file");
 }
@@ -1824,7 +1824,7 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
 
   CloseHandle(file_handle);
 
-  return Status();
+  return Status::success();
 }
 
 fs::path getSystemRoot() {

--- a/osquery/numeric_monitoring/plugin_interface.cpp
+++ b/osquery/numeric_monitoring/plugin_interface.cpp
@@ -58,7 +58,7 @@ const HostIdentifierKeys& hostIdentifierKeys() {
 Status NumericMonitoringPlugin::call(const PluginRequest& request,
                                      PluginResponse& response) {
   // should be implemented in plugins
-  return Status();
+  return Status::success();
 }
 
 } // namespace osquery

--- a/osquery/sql/dynamic_table_row.cpp
+++ b/osquery/sql/dynamic_table_row.cpp
@@ -39,7 +39,7 @@ Status deserializeTableRows(const rj::Value& arr, TableRows& rows) {
     }
     rows.push_back(std::move(r));
   }
-  return Status();
+  return Status::success();
 }
 
 Status deserializeTableRowsJSON(const std::string& json, TableRows& rows) {
@@ -62,7 +62,7 @@ Status deserializeRow(const rj::Value& doc, DynamicTableRowHolder& r) {
       r[name] = i.value.GetString();
     }
   }
-  return Status();
+  return Status::success();
 }
 
 int DynamicTableRow::get_rowid(sqlite_int64 default_value,
@@ -148,7 +148,7 @@ Status DynamicTableRow::serialize(JSON& doc, rj::Value& obj) const {
     doc.addRef(i.first, i.second, obj);
   }
 
-  return Status();
+  return Status::success();
 }
 
 TableRowHolder DynamicTableRow::clone() const {

--- a/osquery/sql/virtual_sqlite_table.cpp
+++ b/osquery/sql/virtual_sqlite_table.cpp
@@ -65,7 +65,7 @@ Status genSqliteTableRow(sqlite3_stmt* stmt,
     r["path"] = sqlite_db.string();
   }
   qd.push_back(std::move(r));
-  return Status();
+  return Status::success();
 }
 
 Status genTableRowsForSqliteTable(const fs::path& sqlite_db,

--- a/osquery/tables/events/windows/powershell_events.cpp
+++ b/osquery/tables/events/windows/powershell_events.cpp
@@ -60,7 +60,7 @@ class PowershellEventSubscriber
     wc->sources.insert(kPowershellEventsChannel);
 
     subscribe(&PowershellEventSubscriber::Callback, wc);
-    return Status();
+    return Status::success();
   }
 
   Status Callback(const ECRef& ec, const SCRef& sc);
@@ -134,7 +134,7 @@ Status PowershellEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   // For script block logging we only care about events with script blocks
   auto eid = ec->eventRecord.get("Event.System.EventID", -1);
   if (eid != kScriptBlockLoggingEid) {
-    return Status();
+    return Status::success();
   }
 
   Row results;
@@ -155,7 +155,7 @@ Status PowershellEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   // If there's only one script block no reassembly is needed
   if (results["MessageTotal"] == "1") {
     addScriptResult(results);
-    return Status();
+    return Status::success();
   }
 
   // Add the script content to the DB for later reassembly
@@ -170,7 +170,7 @@ Status PowershellEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
 
   // If we expect more blocks bail out early
   if (results["MessageNumber"] != results["MessageTotal"]) {
-    return Status();
+    return Status::success();
   }
 
   // Otherwise all script blocks should be accounted for so reconstruct
@@ -203,6 +203,6 @@ Status PowershellEventSubscriber::Callback(const ECRef& ec, const SCRef& sc) {
   results["ScriptBlockText"] = powershell_script;
   addScriptResult(results);
 
-  return Status();
+  return Status::success();
 }
 } // namespace osquery

--- a/osquery/tables/networking/curl.cpp
+++ b/osquery/tables/networking/curl.cpp
@@ -51,7 +51,7 @@ Status processRequest(Row& r) {
     return Status(1, e.what());
   }
 
-  return Status();
+  return Status::success();
 }
 
 QueryData genCurl(QueryContext& context) {

--- a/osquery/tables/networking/curl_certificate.cpp
+++ b/osquery/tables/networking/curl_certificate.cpp
@@ -201,7 +201,7 @@ Status getTLSCertificate(std::string hostname, QueryData& results) {
   r["hostname"] = hostname;
   fillRow(r, cert.get());
   results.push_back(r);
-  return Status();
+  return Status::success();
 }
 
 QueryData genTLSCertificate(QueryContext& context) {

--- a/osquery/tables/system/windows/chocolatey_packages.cpp
+++ b/osquery/tables/system/windows/chocolatey_packages.cpp
@@ -47,7 +47,7 @@ Status genPackage(const fs::path& nuspec, Row& r) {
   r["author"] = propTree.get("package.metadata.authors", "");
   r["license"] = propTree.get("package.metadata.licenseUrl", "");
 
-  return Status();
+  return Status::success();
 }
 
 QueryData genChocolateyPackages(QueryContext& context) {

--- a/osquery/tables/system/windows/drivers.cpp
+++ b/osquery/tables/system/windows/drivers.cpp
@@ -111,7 +111,7 @@ Status getDeviceList(const device_infoset_t& infoset,
     return Status::failure("Failed to enumerate installed devices with " +
                            std::to_string(GetLastError()));
   }
-  return Status();
+  return Status::success();
 }
 
 Status getDeviceProperty(const device_infoset_t& infoset,
@@ -124,7 +124,7 @@ Status getDeviceProperty(const device_infoset_t& infoset,
       infoset.get(), &device, &prop, &dev_prop_type, nullptr, 0, &buff_size, 0);
   auto err = GetLastError();
   if (err == ERROR_NOT_FOUND) {
-    return Status();
+    return Status::success();
   }
   if (err != ERROR_INSUFFICIENT_BUFFER) {
     return Status::failure(
@@ -164,7 +164,7 @@ Status getDeviceProperty(const device_infoset_t& infoset,
                            std::to_string(dev_prop_type));
   }
 
-  return Status();
+  return Status::success();
 }
 
 std::string getDriverImagePath(const std::string& service_key) {
@@ -202,7 +202,7 @@ Status genServiceKeyMap(
     }
     services_image_map[key_it->second] = kNormalizeImage(data_it->second);
   }
-  return Status();
+  return Status::success();
 }
 
 QueryData genDrivers(QueryContext& context) {

--- a/osquery/tables/system/windows/ie_extensions.cpp
+++ b/osquery/tables/system/windows/ie_extensions.cpp
@@ -86,7 +86,7 @@ static inline Status getBHOs(QueryData& results) {
       results.push_back(r);
     }
   }
-  return Status();
+  return Status::success();
 }
 QueryData genIEExtensions(QueryContext& context) {
   QueryData results;

--- a/osquery/tables/system/windows/objects.cpp
+++ b/osquery/tables/system/windows/objects.cpp
@@ -113,7 +113,7 @@ Status enumerateObjectNamespace(const std::wstring& directory,
     objects.push_back(object);
   }
 
-  return Status();
+  return Status::success();
 }
 
 // enumerate all objects in a given windows terminal services session

--- a/osquery/tables/system/windows/registry.cpp
+++ b/osquery/tables/system/windows/registry.cpp
@@ -132,7 +132,7 @@ Status queryMultipleRegistryKeys(const std::vector<std::string>& regexes,
     return Status(1,
                   "Failed to finalize statement with " + std::to_string(ret));
   }
-  return Status();
+  return Status::success();
 }
 
 Status getClassName(const std::string& clsId, std::string& rClsName) {
@@ -155,7 +155,7 @@ Status getClassName(const std::string& clsId, std::string& rClsName) {
   for (const auto& row : regQueryResults) {
     if (!row.at("data").empty()) {
       rClsName = row.at("data");
-      return Status();
+      return Status::success();
     }
   }
 
@@ -185,7 +185,7 @@ Status getClassExecutables(const std::string& clsId,
       results.push_back(r.at("data"));
     }
   }
-  return Status();
+  return Status::success();
 }
 
 Status getUsernameFromKey(const std::string& key, std::string& rUsername) {
@@ -239,7 +239,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
   explodeRegistryPath(keyPath, hive, key);
 
   if (kRegistryHives.count(hive) != 1) {
-    return Status();
+    return Status::success();
   }
 
   HKEY hkey;
@@ -304,7 +304,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
   }
 
   if (cValues <= 0) {
-    return Status();
+    return Status::success();
   }
 
   DWORD cchValue = maxKeyLength;
@@ -425,7 +425,7 @@ Status queryKey(const std::string& keyPath, QueryData& results) {
     }
     results.push_back(r);
   }
-  return Status();
+  return Status::success();
 }
 
 static inline void populateDefaultKeys(std::set<std::string>& rKeys) {
@@ -453,7 +453,7 @@ static inline Status populateSubkeys(std::set<std::string>& rKeys,
     }
   }
   rKeys = std::move(newKeys);
-  return Status();
+  return Status::success();
 }
 
 static inline void appendSubkeyToKeys(const std::string& subkey,
@@ -485,14 +485,14 @@ static inline Status populateAllKeysRecursive(
     }
   }
 
-  return Status();
+  return Status::success();
 }
 
 Status expandRegistryGlobs(const std::string& pattern,
                            std::set<std::string>& results) {
   auto pathElems = osquery::split(pattern, kRegSep);
   if (pathElems.size() == 0) {
-    return Status();
+    return Status::success();
   }
 
   /*
@@ -530,7 +530,7 @@ Status expandRegistryGlobs(const std::string& pattern,
       appendSubkeyToKeys(*elem, results);
     }
   }
-  return Status();
+  return Status::success();
 }
 
 static inline void maybeWarnLocalUsers(const std::set<std::string>& rKeys) {

--- a/osquery/tables/system/windows/services.cpp
+++ b/osquery/tables/system/windows/services.cpp
@@ -133,7 +133,7 @@ static inline Status getService(const SC_HANDLE& scmHandle,
   }
 
   results.push_back(r);
-  return Status();
+  return Status::success();
 }
 
 static inline Status getServices(QueryData& results) {
@@ -188,7 +188,7 @@ static inline Status getServices(QueryData& results) {
     }
   }
 
-  return Status();
+  return Status::success();
 }
 
 QueryData genServices(QueryContext& context) {

--- a/osquery/tables/system/windows/windows_crashes.cpp
+++ b/osquery/tables/system/windows/windows_crashes.cpp
@@ -201,7 +201,7 @@ Status logExceptionInfo(IDebugControl5* control, Row& r) {
     r["exception_message"] = errorMsg.str();
   }
 
-  return Status();
+  return Status::success();
 }
 
 Status logPIDAndTID(IDebugSystemObjects2* system, Row& r) {
@@ -216,14 +216,14 @@ Status logPIDAndTID(IDebugSystemObjects2* system, Row& r) {
 
   r["pid"] = BIGINT(procID);
   r["tid"] = BIGINT(threadID);
-  return Status();
+  return Status::success();
 }
 
 Status logProcessUptime(IDebugSystemObjects2* system, Row& r) {
   unsigned long uptime = 0;
   if (system->GetCurrentProcessUpTime(&uptime) == S_OK) {
     r["process_uptime"] = BIGINT(uptime);
-    return Status();
+    return Status::success();
   }
   return Status(1);
 }
@@ -240,7 +240,7 @@ Status logDumpTime(IDebugControl5* control, Row& r) {
   std::stringstream dumpTimestamp;
   dumpTimestamp << std::put_time(&gmt, "%Y-%m-%d %H:%M:%S UTC");
   r["datetime"] = dumpTimestamp.str();
-  return Status();
+  return Status::success();
 }
 
 Status logOSVersion(IDebugControl5* control, Row& r) {
@@ -255,7 +255,7 @@ Status logOSVersion(IDebugControl5* control, Row& r) {
     r["major_version"] = INTEGER(majorVersion);
     r["minor_version"] = INTEGER(minorVersion);
     r["build_number"] = INTEGER(buildNumber);
-    return Status();
+    return Status::success();
   }
   return Status(1);
 }
@@ -274,7 +274,7 @@ Status logDumpType(IDebugControl5* control, Row& r) {
     }
   }
   r["type"] = osquery::join(activeFlags, ",");
-  return Status();
+  return Status::success();
 }
 
 // Note: appears to only detect unmanaged stack frames.
@@ -314,7 +314,7 @@ Status logStackTrace(IDebugControl5* control, IDebugSymbols3* symbols, Row& r) {
     stackTrace.str("");
   }
   r["stack_trace"] = osquery::join(stackTraces, ",");
-  return Status();
+  return Status::success();
 }
 
 Status logRegisters(IDebugClient5* client,
@@ -366,7 +366,7 @@ Status logPEPathAndVersion(IDebugSymbols3* symbols, Row& r) {
                << ((version.dwFileVersionLS >> 16) & 0xffff) << "."
                << ((version.dwFileVersionLS >> 0) & 0xffff);
     r["version"] = versionStr.str();
-    return Status();
+    return Status::success();
   }
   return Status(1);
 }
@@ -386,7 +386,7 @@ Status logModulePath(IDebugSymbols3* symbols, Row& r) {
            DEBUG_MODNAME_IMAGE, modIndex, 0, modPath, MAX_PATH + 1, nullptr) ==
        S_OK)) {
     r["module"] = modPath;
-    return Status();
+    return Status::success();
   }
   return Status(1);
 }
@@ -510,7 +510,7 @@ Status logPEBInfo(IDebugClient5* client,
         envBufferAddr, sizeof(env), env, UNICODE_STRING_MAX_BYTES, &bytesRead);
   }
 
-  return Status();
+  return Status::success();
 }
 
 void debugEngineCleanup(IDebugClient5* client,

--- a/osquery/tables/yara/yara_utils.cpp
+++ b/osquery/tables/yara/yara_utils.cpp
@@ -252,7 +252,7 @@ Status YARAConfigParserPlugin::setUp() {
     return Status(1, "Unable to initialize YARA");
   }
 
-  return Status();
+  return Status::success();
 }
 
 Status YARAConfigParserPlugin::update(const std::string& source,
@@ -305,7 +305,7 @@ Status YARAConfigParserPlugin::update(const std::string& source,
       VLOG(1) << "YARA file_paths key is invalid";
     }
   }
-  return Status();
+  return Status::success();
 }
 
 /// Call the simple YARA ConfigParserPlugin "yara".

--- a/osquery/utils/json/json.cpp
+++ b/osquery/utils/json/json.cpp
@@ -283,7 +283,7 @@ Status JSON::toString(std::string& str) const {
   rj::Writer<rj::StringBuffer> writer(sb);
   doc_.Accept(writer);
   str = sb.GetString();
-  return Status();
+  return Status::success();
 }
 
 Status JSON::fromString(const std::string& str) {
@@ -295,7 +295,7 @@ Status JSON::fromString(const std::string& str) {
     message += std::to_string(pr.Offset());
     return Status(1, message);
   }
-  return Status();
+  return Status::success();
 }
 
 void JSON::mergeObject(rj::Value& target_obj, rj::Value& source_obj) {


### PR DESCRIPTION
Summary:
We replace deprecated calls to the Status class with newer ones. This will stop Lint from nagging me every time I open these files. There should be no change to functionality.

Specifically, we use a codemod on `.cpp` files to replace any instance of `return Status();` with `return Status::success();`. We then manually change some instances where we return error status. There is one case, in `query.cpp::325`, where we add an error message to a new call to `Status::failure`.

Reviewed By: guliashvili

Differential Revision: D14652922
