### PR TITLE
Remove dead code for deserializeQueryLogItem functions

### DIFF
--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -320,38 +320,6 @@ Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json) {
   return doc.toString(json);
 }
 
-Status deserializeQueryLogItem(const JSON& doc, QueryLogItem& item) {
-  if (!doc.doc().IsObject()) {
-    return Status(1);
-  }
-
-  if (doc.doc().HasMember("diffResults")) {
-    auto status =
-        deserializeDiffResults(doc.doc()["diffResults"], item.results);
-    if (!status.ok()) {
-      return status;
-    }
-  } else if (doc.doc().HasMember("snapshot")) {
-    auto status =
-        deserializeQueryData(doc.doc()["snapshot"], item.snapshot_results);
-    if (!status.ok()) {
-      return status;
-    }
-  }
-
-  getLegacyFieldsAndDecorations(doc, item);
-  return Status();
-}
-
-Status deserializeQueryLogItemJSON(const std::string& json,
-                                   QueryLogItem& item) {
-  auto doc = JSON::newObject();
-  if (!doc.fromString(json) || !doc.doc().IsObject()) {
-    return Status(1, "Cannot deserialize JSON");
-  }
-  return deserializeQueryLogItem(doc, item);
-}
-
 Status serializeQueryLogItemAsEventsJSON(const QueryLogItem& item,
                                          std::vector<std::string>& items) {
   auto doc = JSON::newArray();

--- a/osquery/database/tests/results.cpp
+++ b/osquery/database/tests/results.cpp
@@ -125,17 +125,6 @@ TEST_F(ResultsTests, test_serialize_query_log_item_json) {
   EXPECT_EQ(results.first, json);
 }
 
-TEST_F(ResultsTests, test_deserialize_query_log_item_json) {
-  auto results = getSerializedQueryLogItemJSON();
-
-  // Pull the serialized JSON back into a QueryLogItem output container.
-  QueryLogItem output;
-  auto s = deserializeQueryLogItemJSON(results.first, output);
-  EXPECT_TRUE(s.ok());
-  // The output container should match the input query data.
-  EXPECT_EQ(output, results.second);
-}
-
 TEST_F(ResultsTests, test_adding_duplicate_rows_to_query_data) {
   RowTyped r1, r2, r3;
   r1["foo"] = "bar";

--- a/osquery/include/osquery/query.h
+++ b/osquery/include/osquery/query.h
@@ -92,12 +92,6 @@ Status serializeQueryLogItem(const QueryLogItem& item, JSON& doc);
  */
 Status serializeQueryLogItemJSON(const QueryLogItem& item, std::string& json);
 
-/// Inverse of serializeQueryLogItem, convert JSON to QueryLogItem.
-Status deserializeQueryLogItem(const JSON& doc, QueryLogItem& item);
-
-/// Inverse of serializeQueryLogItem, convert a JSON string to QueryLogItem.
-Status deserializeQueryLogItemJSON(const std::string& json, QueryLogItem& item);
-
 /**
  * @brief Serialize a QueryLogItem object into a JSON document containing
  * events, a list of actions.


### PR DESCRIPTION
Summary: This diff removes two vestigial functions from the osquery core. There are no references to these functions except for the unit test, which we also update.

Differential Revision: D14664005
