### PR TITLE
"schemer" serialisation framework

### DIFF
--- a/osquery/utils/schemer/BUCK
+++ b/osquery/utils/schemer/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_library(
+    name = "schemer",
+    header_namespace = "osquery/utils/schemer",
+    exported_headers = [
+        "schemer.h",
+    ],
+    tests = [
+        osquery_target("osquery/utils/schemer/tests:schemer_tests"),
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/osquery/utils/schemer/schemer.h
+++ b/osquery/utils/schemer/schemer.h
@@ -1,0 +1,68 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace schemer {
+
+/**
+ * @brief Serialization framework
+ *
+ * @details This is a framework to declare a serialization and deserialization
+ * schema for C++ classes. The schema can be used by different implementations
+ * to represent C++ object as data-interchange format or to parse an object from
+ * formatted representation.
+ *
+ * It works without macro or any verbose transformation code. All you need to
+ * do to be able to serialize and deserialize some C++ class is to define a
+ * template static method discloseSchema in the class. Which describe all
+ * members that have to be read by serializer and written by deserializer.
+ * Everything else is a job of schemer formatters.
+ *
+ * Support of specific types, including nested types support depends on the
+ * formatter implementation.
+ *
+ * Why:
+ *  - One place to describe class members instead of two different methods for
+ * serializer and deserializer.
+ *  - One way do describe schema for many formatters (JSON, TOML, hasher, etc).
+ *  - Schemer also sets the order of elements of class, therefore even binary
+ * formatters can use it, just ignoring the names.
+ *  - It is simple - just one method, nothing more. Therefore there is zero
+ * dependencies. Everything is in formatters.
+ *
+ * @code{.cpp}
+ * class JudgmentDay {
+ *  public:
+ *   template <typename Archive, typename ValueType>
+ *   static inline void discloseSchema(Archive& a, ValueType& value) {
+ *     schemer::record(a, "Year", value.year_);
+ *     schemer::record(a, "Month", value.month_);
+ *     schemer::record(a, "Day", value.day_);
+ *   }
+ *  private:
+ *   int year_ = 1997;
+ *   std::string month_ = "August";
+ *   unsigned short day_ = 29;
+ * };
+ * @endcode
+ *
+ * For more descriptive example see `schemer/tests/schemer.cpp`
+ */
+
+/**
+ * @brief Declare member of a class serializable
+ */
+template <typename Archive, typename KeyType, typename ValueType>
+inline void record(Archive& a, KeyType const& key, ValueType& value) {
+  a.template record<KeyType, ValueType>(key, value);
+};
+
+} // namespace schemer
+} // namespace osquery

--- a/osquery/utils/schemer/tests/BUCK
+++ b/osquery/utils/schemer/tests/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_test(
+    name = "schemer_tests",
+    srcs = [
+        "schemer.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/conversions:to"),
+        osquery_target("osquery/utils/schemer:schemer"),
+    ],
+)

--- a/osquery/utils/schemer/tests/schemer.cpp
+++ b/osquery/utils/schemer/tests/schemer.cpp
@@ -1,0 +1,110 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/schemer/schemer.h>
+
+#include <osquery/utils/conversions/to.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace osquery {
+namespace {
+
+class SchemerTests : public testing::Test {};
+
+class TestArchiveReader {
+ private:
+  template <typename ValueType>
+  ValueType getValue() const;
+
+ public:
+  template <typename KeyType, typename ValueType>
+  void record(KeyType const& key, ValueType& value) {
+    if (key == "Alpha") {
+      value = getValue<ValueType>();
+    } else if (key == "Bravo") {
+      value = getValue<ValueType>();
+    } else if (key == "Charlie") {
+      value = getValue<ValueType>() + getValue<ValueType>();
+    }
+  }
+};
+
+template <>
+int TestArchiveReader::getValue<int>() const {
+  return 1234;
+}
+
+template <>
+std::string TestArchiveReader::getValue<std::string>() const {
+  return "water under the bridge";
+}
+
+class TestArchiveWriter {
+ public:
+  template <typename KeyType, typename ValueType>
+  void record(KeyType const& key, ValueType& value) {
+    auto ostr = std::ostringstream{};
+    ostr << key << ':' << value << ' ';
+    text += ostr.str();
+  }
+
+ public:
+  std::string text;
+};
+
+class Alpha {
+ public:
+  template <typename Archive, typename ValueType>
+  static void discloseSchema(Archive& a, ValueType& value) {
+    schemer::record(a, "Alpha", value.alpha_);
+    schemer::record(a, "Bravo", value.bravo_);
+    schemer::record(a, "Charlie", value.charlie_);
+  }
+
+  auto const& getAlpha() const {
+    return alpha_;
+  }
+
+  auto const& getBravo() const {
+    return bravo_;
+  }
+
+  auto const& getCharlie() const {
+    return charlie_;
+  }
+
+ private:
+  // let's declare everything as private to make sure that even private members
+  // can be serialized and deserialized by schemers
+  int alpha_ = 712;
+  std::string bravo_ = "Richard";
+  int charlie_ = 413;
+};
+
+TEST_F(SchemerTests, serializing) {
+  auto const alpha = Alpha{};
+  auto writer = TestArchiveWriter{};
+  Alpha::discloseSchema(writer, alpha);
+  ASSERT_EQ(writer.text, "Alpha:712 Bravo:Richard Charlie:413 ");
+}
+
+TEST_F(SchemerTests, deserializing) {
+  auto alpha = Alpha{};
+  auto reader = TestArchiveReader{};
+  Alpha::discloseSchema(reader, alpha);
+  EXPECT_EQ(alpha.getAlpha(), 1234);
+  EXPECT_EQ(alpha.getBravo(), "water under the bridge");
+  EXPECT_EQ(alpha.getCharlie(), 1234 + 1234);
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
This is a framework to declare a serialization and deserialization
 schema for C++ classes. The schema can be used by different implementations
 to represent C++ object as data-interchange format or to parse an object from
 formatted representation.

 It works without macro or any verbose transformation code. All you need to
 do to be able to serialize and deserialize some C++ class is to define a
 template static method `discloseSchema` in the class. Which describe all
 members that have to be read by serializer and written by deserializer.
 Everything else is a job of schemer formatters.

 Support of specific types, including nested types support depends on the formatter implementation.

   1. One place to describe class members instead of two different methods for serializer and deserializer.
   2. One way do describe schema for many formatters (JSON, TOML, hasher, etc).
   3. Schemer also sets the order of elements of class, therefore even binary formatters can use it, just ignoring the names.
   4. It is simple - just one method, nothing more. Therefore there is zero dependencies. Everything is in formatters.

  - JSON serializer/deserializer.
  - Hasher - it helps to impelement transformation of osquery events in hash form for probabilistic filters.

Differential Revision: D14663949
