### PR TITLE
schemer formatters: json serializer

### DIFF
--- a/osquery/utils/schemer/BUCK
+++ b/osquery/utils/schemer/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_library(
+    name = "schemer",
+    header_namespace = "osquery/utils/schemer",
+    exported_headers = [
+        "schemer.h",
+    ],
+    tests = [
+        osquery_target("osquery/utils/schemer/tests:schemer_tests"),
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/osquery/utils/schemer/json/BUCK
+++ b/osquery/utils/schemer/json/BUCK
@@ -1,0 +1,29 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_library")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+load("//tools/build_defs/oss/osquery:third_party.bzl", "osquery_tp_target")
+
+osquery_cxx_library(
+    name = "schemer_json",
+    header_namespace = "osquery/utils/schemer/json",
+    exported_headers = [
+        "schemer_json.h",
+        "schemer_json_error.h",
+        "schemer_json_impl.h",
+    ],
+    tests = [
+        osquery_target("osquery/utils/schemer/json/tests:schemer_json_tests"),
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/expected:expected"),
+        osquery_target("osquery/utils/json:json"),
+        osquery_target("osquery/utils/schemer:schemer"),
+        osquery_tp_target("rapidjson"),
+    ],
+)

--- a/osquery/utils/schemer/json/schemer_json.h
+++ b/osquery/utils/schemer/json/schemer_json.h
@@ -1,0 +1,68 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/utils/schemer/json/schemer_json_error.h>
+#include <osquery/utils/schemer/json/schemer_json_impl.h>
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/schemer/schemer.h>
+
+#include <string>
+
+namespace osquery {
+namespace schemer {
+
+/**
+ * @brief Schemer formatter implementing serialisation to JSON objects.
+ *
+ * Transform objects of a class with defined schema into JSON objects.
+ *
+ * Support only simple types as a members:
+ *  - boolean;
+ *  - integral types (int, short, long, long long, unsigned etc);
+ *  - floating point nubmers (float, double);
+ *  - std::string;
+ *  - C-string - only for serialisation.
+ *
+ * Not implemented yet, but comming soon:
+ *  - Nested types support
+ *  - Standard sontainers support
+ */
+
+/**
+ * @brief Serialize object of class with defined schema to JSON object printed
+ * to rapidjson stream
+ */
+template <typename Type, typename RapidJsonOutStream>
+ExpectedSuccess<JsonError> toJson(RapidJsonOutStream& os, Type const& value) {
+  rapidjson::Writer<RapidJsonOutStream> json_writer(os);
+  auto writer =
+      impl::JsonWriter<rapidjson::Writer<RapidJsonOutStream>>(json_writer);
+  Type::discloseSchema(writer, value);
+  return Success{};
+}
+
+/**
+ * @brief Serialize object of class with defined schema to JSON object printed
+ * to std::string
+ */
+template <typename Type>
+Expected<std::string, JsonError> toJson(Type const& value) {
+  auto buf = rapidjson::StringBuffer{};
+  auto exp = toJson(buf, value);
+  if (exp.isError()) {
+    return exp.takeError();
+  }
+  return std::string{buf.GetString(), buf.GetSize()};
+}
+
+} // namespace schemer
+} // namespace osquery

--- a/osquery/utils/schemer/json/schemer_json_error.h
+++ b/osquery/utils/schemer/json/schemer_json_error.h
@@ -1,0 +1,19 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace schemer {
+
+enum class JsonError {
+  Syntax = 1,
+};
+
+} // namespace schemer
+} // namespace osquery

--- a/osquery/utils/schemer/json/schemer_json_impl.h
+++ b/osquery/utils/schemer/json/schemer_json_impl.h
@@ -1,0 +1,108 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <osquery/utils/schemer/json/schemer_json_error.h>
+
+#include <osquery/utils/expected/expected.h>
+#include <osquery/utils/json/json.h>
+#include <osquery/utils/schemer/schemer.h>
+
+#include <string>
+
+namespace osquery {
+namespace schemer {
+namespace impl {
+
+template <typename WriterType,
+          typename ValueType,
+          typename std::enable_if<std::is_same<ValueType, bool>::value,
+                                  int>::type = 0>
+void writeValue(WriterType& writer, ValueType value) {
+  writer.Bool(value);
+}
+
+template <
+    typename WriterType,
+    typename ValueType,
+    typename std::enable_if<std::is_same<ValueType, std::int8_t>::value ||
+                                std::is_same<ValueType, std::int16_t>::value ||
+                                std::is_same<ValueType, std::int32_t>::value,
+                            int>::type = 0>
+void writeValue(WriterType& writer, ValueType value) {
+  writer.Int(value);
+}
+
+template <typename WriterType,
+          typename ValueType,
+          typename std::enable_if<std::is_same<ValueType, std::int64_t>::value,
+                                  int>::type = 0>
+void writeValue(WriterType& writer, ValueType const& value) {
+  writer.Int64(value);
+}
+
+template <
+    typename WriterType,
+    typename ValueType,
+    typename std::enable_if<std::is_same<ValueType, std::uint8_t>::value ||
+                                std::is_same<ValueType, std::uint16_t>::value ||
+                                std::is_same<ValueType, std::uint32_t>::value,
+                            int>::type = 0>
+void writeValue(WriterType& writer, ValueType value) {
+  writer.Uint(value);
+}
+
+template <typename WriterType,
+          typename ValueType,
+          typename std::enable_if<std::is_same<ValueType, std::uint64_t>::value,
+                                  int>::type = 0>
+void writeValue(WriterType& writer, ValueType const& value) {
+  writer.Uint64(value);
+}
+
+template <typename WriterType,
+          typename ValueType,
+          typename std::enable_if<std::is_floating_point<ValueType>::value,
+                                  int>::type = 0>
+void writeValue(WriterType& writer, ValueType const& value) {
+  writer.Double(value);
+}
+
+template <typename WriterType,
+          typename ValueType,
+          typename std::enable_if<std::is_same<ValueType, std::string>::value,
+                                  int>::type = 0>
+void writeValue(WriterType& writer, ValueType const& value) {
+  writer.String(value);
+}
+
+template <typename WriterType>
+class JsonWriter final {
+ public:
+  explicit JsonWriter(WriterType& writer) : writer_(writer) {
+    writer_.StartObject();
+  }
+
+  ~JsonWriter() {
+    writer_.EndObject();
+  }
+
+  template <typename KeyType, typename ValueType>
+  void record(const KeyType& key, ValueType const& value) {
+    writer_.Key(key);
+    writeValue(writer_, value);
+  }
+
+ private:
+  WriterType& writer_;
+};
+
+} // namespace impl
+} // namespace schemer
+} // namespace osquery

--- a/osquery/utils/schemer/json/tests/BUCK
+++ b/osquery/utils/schemer/json/tests/BUCK
@@ -1,0 +1,19 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_test(
+    name = "schemer_json_tests",
+    srcs = [
+        "schemer_json.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/schemer/json:schemer_json"),
+    ],
+)

--- a/osquery/utils/schemer/json/tests/schemer_json.cpp
+++ b/osquery/utils/schemer/json/tests/schemer_json.cpp
@@ -1,0 +1,60 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/schemer/json/schemer_json.h>
+
+#include <osquery/utils/conversions/to.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace osquery {
+namespace {
+
+class SchemerJsonTests : public testing::Test {};
+
+class TestClass {
+ public:
+  template <typename Archive, typename ValueType>
+  static void discloseSchema(Archive& a, ValueType& value) {
+    schemer::record(a, "Bravo", value.b_v_);
+    schemer::record(a, "India", value.i_v_);
+    schemer::record(a, "Uniform", value.ui_v_);
+    schemer::record(a, "Sierra", value.str_v_);
+  }
+
+ private:
+  bool b_v_ = true;
+  int i_v_ = -92374;
+  int ui_v_ = 64774;
+  std::string str_v_ = "What is Architecture?";
+};
+
+TEST_F(SchemerJsonTests, writer_to_stream) {
+  auto const v = TestClass{};
+  auto buf = rapidjson::StringBuffer{};
+  auto const retcode = schemer::toJson(buf, v);
+  EXPECT_TRUE(retcode) << retcode.getError().getMessage();
+  EXPECT_EQ(
+      std::string{buf.GetString()},
+      R"json({"Bravo":true,"India":-92374,"Uniform":64774,"Sierra":"What is Architecture?"})json");
+}
+
+TEST_F(SchemerJsonTests, writer_to_string) {
+  auto const v = TestClass{};
+  auto const exp = schemer::toJson(v);
+  EXPECT_TRUE(exp) << exp.getError().getMessage();
+  EXPECT_EQ(
+      exp.get(),
+      R"json({"Bravo":true,"India":-92374,"Uniform":64774,"Sierra":"What is Architecture?"})json");
+}
+
+} // namespace
+} // namespace osquery

--- a/osquery/utils/schemer/schemer.h
+++ b/osquery/utils/schemer/schemer.h
@@ -1,0 +1,68 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace osquery {
+namespace schemer {
+
+/**
+ * @brief Serialization framework
+ *
+ * @details This is a framework to declare a serialization and deserialization
+ * schema for C++ classes. The schema can be used by different implementations
+ * to represent C++ object as data-interchange format or to parse an object from
+ * formatted representation.
+ *
+ * It works without macro or any verbose transformation code. All you need to
+ * do to be able to serialize and deserialize some C++ class is to define a
+ * template static method discloseSchema in the class. Which describe all
+ * members that have to be read by serializer and written by deserializer.
+ * Everything else is a job of schemer formatters.
+ *
+ * Support of specific types, including nested types support depends on the
+ * formatter implementation.
+ *
+ * Why:
+ *  - One place to describe class members instead of two different methods for
+ * serializer and deserializer.
+ *  - One way do describe schema for many formatters (JSON, TOML, hasher, etc).
+ *  - Schemer also sets the order of elements of class, therefore even binary
+ * formatters can use it, just ignoring the names.
+ *  - It is simple - just one method, nothing more. Therefore there is zero
+ * dependencies. Everything is in formatters.
+ *
+ * @code{.cpp}
+ * class JudgmentDay {
+ *  public:
+ *   template <typename Archive, typename ValueType>
+ *   static inline void discloseSchema(Archive& a, ValueType& value) {
+ *     schemer::record(a, "Year", value.year_);
+ *     schemer::record(a, "Month", value.month_);
+ *     schemer::record(a, "Day", value.day_);
+ *   }
+ *  private:
+ *   int year_ = 1997;
+ *   std::string month_ = "August";
+ *   unsigned short day_ = 29;
+ * };
+ * @endcode
+ *
+ * For more descriptive example see `schemer/tests/schemer.cpp`
+ */
+
+/**
+ * @brief Declare member of a class serializable
+ */
+template <typename Archive, typename KeyType, typename ValueType>
+inline void record(Archive& a, KeyType const& key, ValueType& value) {
+  a.template record<KeyType, ValueType>(key, value);
+};
+
+} // namespace schemer
+} // namespace osquery

--- a/osquery/utils/schemer/tests/BUCK
+++ b/osquery/utils/schemer/tests/BUCK
@@ -1,0 +1,20 @@
+#  Copyright (c) 2014-present, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed in accordance with the terms specified in
+#  the LICENSE file found in the root directory of this source tree.
+
+load("//tools/build_defs/oss/osquery:cxx.bzl", "osquery_cxx_test")
+load("//tools/build_defs/oss/osquery:native.bzl", "osquery_target")
+
+osquery_cxx_test(
+    name = "schemer_tests",
+    srcs = [
+        "schemer.cpp",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        osquery_target("osquery/utils/conversions:to"),
+        osquery_target("osquery/utils/schemer:schemer"),
+    ],
+)

--- a/osquery/utils/schemer/tests/schemer.cpp
+++ b/osquery/utils/schemer/tests/schemer.cpp
@@ -1,0 +1,110 @@
+/**
+ *  Copyright (c) 2014-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed in accordance with the terms specified in
+ *  the LICENSE file found in the root directory of this source tree.
+ */
+
+#include <osquery/utils/schemer/schemer.h>
+
+#include <osquery/utils/conversions/to.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace osquery {
+namespace {
+
+class SchemerTests : public testing::Test {};
+
+class TestArchiveReader {
+ private:
+  template <typename ValueType>
+  ValueType getValue() const;
+
+ public:
+  template <typename KeyType, typename ValueType>
+  void record(KeyType const& key, ValueType& value) {
+    if (key == "Alpha") {
+      value = getValue<ValueType>();
+    } else if (key == "Bravo") {
+      value = getValue<ValueType>();
+    } else if (key == "Charlie") {
+      value = getValue<ValueType>() + getValue<ValueType>();
+    }
+  }
+};
+
+template <>
+int TestArchiveReader::getValue<int>() const {
+  return 1234;
+}
+
+template <>
+std::string TestArchiveReader::getValue<std::string>() const {
+  return "water under the bridge";
+}
+
+class TestArchiveWriter {
+ public:
+  template <typename KeyType, typename ValueType>
+  void record(KeyType const& key, ValueType& value) {
+    auto ostr = std::ostringstream{};
+    ostr << key << ':' << value << ' ';
+    text += ostr.str();
+  }
+
+ public:
+  std::string text;
+};
+
+class Alpha {
+ public:
+  template <typename Archive, typename ValueType>
+  static void discloseSchema(Archive& a, ValueType& value) {
+    schemer::record(a, "Alpha", value.alpha_);
+    schemer::record(a, "Bravo", value.bravo_);
+    schemer::record(a, "Charlie", value.charlie_);
+  }
+
+  auto const& getAlpha() const {
+    return alpha_;
+  }
+
+  auto const& getBravo() const {
+    return bravo_;
+  }
+
+  auto const& getCharlie() const {
+    return charlie_;
+  }
+
+ private:
+  // let's declare everything as private to make sure that even private members
+  // can be serialized and deserialized by schemers
+  int alpha_ = 712;
+  std::string bravo_ = "Richard";
+  int charlie_ = 413;
+};
+
+TEST_F(SchemerTests, serializing) {
+  auto const alpha = Alpha{};
+  auto writer = TestArchiveWriter{};
+  Alpha::discloseSchema(writer, alpha);
+  ASSERT_EQ(writer.text, "Alpha:712 Bravo:Richard Charlie:413 ");
+}
+
+TEST_F(SchemerTests, deserializing) {
+  auto alpha = Alpha{};
+  auto reader = TestArchiveReader{};
+  Alpha::discloseSchema(reader, alpha);
+  EXPECT_EQ(alpha.getAlpha(), 1234);
+  EXPECT_EQ(alpha.getBravo(), "water under the bridge");
+  EXPECT_EQ(alpha.getCharlie(), 1234 + 1234);
+}
+
+} // namespace
+} // namespace osquery


### PR DESCRIPTION
Summary:
This is a JSON serializing formatter for schemer. It represents C++ object as JSON object according to defined in C++ class schema. The implementation based on rapidjson library. It is very simple - just print all key:value pairs directly to rapidjson stream (it could be files stream or string stream). The second method of formatter converts C++ objects directly to JSON in string.

Two methods with the same name: `osquery::schemer::toJson`

Differential Revision: D14663996
