### PR TITLE
Support of nested type in schemer json formatter

### DIFF
--- a/osquery/utils/schemer/json/schemer_json_error.h
+++ b/osquery/utils/schemer/json/schemer_json_error.h
@@ -13,6 +13,9 @@ namespace schemer {
 
 enum class JsonError {
   Syntax = 1,
+  TypeMismatch = 2,
+  MissedKey = 3,
+  IncorrectFormat = 4,
 };
 
 } // namespace schemer

--- a/osquery/utils/schemer/json/schemer_json_impl.h
+++ b/osquery/utils/schemer/json/schemer_json_impl.h
@@ -103,6 +103,99 @@ class JsonWriter final {
   WriterType& writer_;
 };
 
+class JsonReader final {
+ public:
+  explicit JsonReader(rapidjson::Value const& jObject) : jObject_(jObject) {
+    status.ignoreResult();
+  }
+
+  template <typename KeyType, typename ValueType>
+  void record(const KeyType& key, ValueType& value) {
+    if (status.isError()) {
+      return;
+    }
+    auto const it = jObject_.FindMember(key);
+    if (it == jObject_.MemberEnd()) {
+      status = createError(JsonError::MissedKey)
+               << "Missed mandatory key " << key;
+    } else {
+      copyValueFromJValue(key, value, it->value);
+    }
+  }
+
+  static inline std::string jValueToStringForErrorMessage(
+      rapidjson::Value const& jObject) {
+    auto buf = rapidjson::StringBuffer{};
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    jObject.Accept(writer);
+    // make sure string representation of value is not too long
+    std::size_t const kMaxLength = 22u;
+    if (buf.GetSize() < kMaxLength) {
+      return std::string{buf.GetString(), buf.GetSize()};
+    } else {
+      return std::string{buf.GetString(), kMaxLength - 3} + "...";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_same<ValueType, std::string>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.IsString()) {
+      value.assign(jValue.GetString(), jValue.GetStringLength());
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected string";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_floating_point<ValueType>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.IsNumber()) {
+      value = jValue.GetDouble();
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected floating point number";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_integral<ValueType>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.template Is<ValueType>()) {
+      value = jValue.template Get<ValueType>();
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected "
+               << boost::core::demangle(typeid(ValueType).name());
+    }
+  }
+
+ public:
+  ExpectedSuccess<JsonError> status = Success{};
+
+ private:
+  rapidjson::Value const& jObject_;
+};
+
 } // namespace impl
 } // namespace schemer
 } // namespace osquery

--- a/osquery/utils/schemer/schemer.h
+++ b/osquery/utils/schemer/schemer.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 namespace osquery {
 namespace schemer {
 
@@ -62,6 +64,36 @@ namespace schemer {
 template <typename Archive, typename KeyType, typename ValueType>
 inline void record(Archive& a, KeyType const& key, ValueType& value) {
   a.template record<KeyType, ValueType>(key, value);
+};
+
+namespace impl {
+
+class DummyArchive {
+ public:
+  template <typename KeyType, typename ValueType>
+  void record(KeyType const& key, ValueType& value);
+};
+
+} // namespace impl
+
+/**
+ * @brief Type trait to check if a type has a defined schema
+ */
+template <typename Type>
+class has_schema {
+ private:
+  template <typename T>
+  static constexpr bool test(
+      decltype(&T::template discloseSchema<impl::DummyArchive, Type>)) {
+    return true;
+  }
+  template <typename T>
+  static constexpr bool test(...) {
+    return false;
+  }
+
+ public:
+  static constexpr bool value = test<Type>(nullptr);
 };
 
 } // namespace schemer

--- a/osquery/utils/schemer/tests/schemer.cpp
+++ b/osquery/utils/schemer/tests/schemer.cpp
@@ -106,5 +106,36 @@ TEST_F(SchemerTests, deserializing) {
   EXPECT_EQ(alpha.getCharlie(), 1234 + 1234);
 }
 
+class Beta {
+ public:
+  template <typename Archive, typename ValueType>
+  static void discloseSchema(Archive&, ValueType&) {}
+};
+
+class Gama {};
+
+TEST_F(SchemerTests, has_schema_static_go) {
+  static_assert(schemer::has_schema<Alpha>::value,
+                "expected true, class Alpha has defined schema");
+  static_assert(schemer::has_schema<Beta>::value,
+                "expected true, class Beta has defined schema");
+}
+
+TEST_F(SchemerTests, has_schema_static_no_go) {
+  static_assert(!schemer::has_schema<Gama>::value,
+                "expected false, there is no schema");
+  static_assert(!schemer::has_schema<int>::value,
+                "expected false, there is no schema for int as a basic type");
+  static_assert(
+      !schemer::has_schema<unsigned>::value,
+      "expected false, there is no schema for unsigned as a basic type");
+  static_assert(!schemer::has_schema<float>::value,
+                "expected false, there is no schema for float as a basic type");
+  static_assert(!schemer::has_schema<char const*>::value,
+                "expected false, there is no schema for c string");
+  static_assert(!schemer::has_schema<std::string>::value,
+                "expected false, there is no schema for std::string");
+}
+
 } // namespace
 } // namespace osquery


### PR DESCRIPTION
Summary:
Since this diff an object of a class with defined schema (see type trait
schemer::has_schema) are allowed as memebers of anoter class with schema.

Example. C++ classes:
```
class Simple {
  int alpha = 1;

 public:
  template <typename Archive, typename ValueType>
  static void discloseSchema(Archive& a, ValueType& value) {
    schemer::record(a, "alpha", value.alpha);
  }
};

class Nested {
  Frist beta;
  int gama = 2;

 public:
  template <typename Archive, typename ValueType>
  static void discloseSchema(Archive& a, ValueType& value) {
    schemer::record(a, "beta", value.beta);
    schemer::record(a, "gama", value.gama);
  }
};
```

Json representation of `Nested`:
```
{
  "beta": {
    "alpha": 1
  },
  "gama": 2
}
```

Differential Revision: D14683589
