### PR TITLE
schemer formatters: json deserializer

### DIFF
--- a/osquery/utils/schemer/json/schemer_json_error.h
+++ b/osquery/utils/schemer/json/schemer_json_error.h
@@ -13,6 +13,9 @@ namespace schemer {
 
 enum class JsonError {
   Syntax = 1,
+  TypeMismatch = 2,
+  MissedKey = 3,
+  IncorrectFormat = 4,
 };
 
 } // namespace schemer

--- a/osquery/utils/schemer/json/schemer_json_impl.h
+++ b/osquery/utils/schemer/json/schemer_json_impl.h
@@ -103,6 +103,99 @@ class JsonWriter final {
   WriterType& writer_;
 };
 
+class JsonReader final {
+ public:
+  explicit JsonReader(rapidjson::Value const& jObject) : jObject_(jObject) {
+    status.ignoreResult();
+  }
+
+  template <typename KeyType, typename ValueType>
+  void record(const KeyType& key, ValueType& value) {
+    if (status.isError()) {
+      return;
+    }
+    auto const it = jObject_.FindMember(key);
+    if (it == jObject_.MemberEnd()) {
+      status = createError(JsonError::MissedKey)
+               << "Missed mandatory key " << key;
+    } else {
+      copyValueFromJValue(key, value, it->value);
+    }
+  }
+
+  static inline std::string jValueToStringForErrorMessage(
+      rapidjson::Value const& jObject) {
+    auto buf = rapidjson::StringBuffer{};
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+    jObject.Accept(writer);
+    // make sure string representation of value is not too long
+    std::size_t const kMaxLength = 22u;
+    if (buf.GetSize() < kMaxLength) {
+      return std::string{buf.GetString(), buf.GetSize()};
+    } else {
+      return std::string{buf.GetString(), kMaxLength - 3} + "...";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_same<ValueType, std::string>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.IsString()) {
+      value.assign(jValue.GetString(), jValue.GetStringLength());
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected string";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_floating_point<ValueType>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.IsNumber()) {
+      value = jValue.GetDouble();
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected floating point number";
+    }
+  }
+
+  template <typename KeyType,
+            typename ValueType,
+            typename std::enable_if<std::is_integral<ValueType>::value,
+                                    int>::type = 0>
+  void copyValueFromJValue(const KeyType& key,
+                           ValueType& value,
+                           rapidjson::Value const& jValue) {
+    if (jValue.template Is<ValueType>()) {
+      value = jValue.template Get<ValueType>();
+    } else {
+      status = createError(JsonError::TypeMismatch)
+               << "Wrong type of value in pair {\"" << key
+               << "\":" << jValueToStringForErrorMessage(jValue)
+               << "}, expected "
+               << boost::core::demangle(typeid(ValueType).name());
+    }
+  }
+
+ public:
+  ExpectedSuccess<JsonError> status = Success{};
+
+ private:
+  rapidjson::Value const& jObject_;
+};
+
 } // namespace impl
 } // namespace schemer
 } // namespace osquery


### PR DESCRIPTION
Summary:
This is a JSON deserializing formatter for schemer. It parse C++ object from
JSON object according to defined in C++ class schema. The implementation based
on rapidjson library.

Two methods with the same name: `osquery::schemer::fromJson`

Differential Revision: D14664162
