### PR TITLE
Fix memory leak in macos keychain_items

### DIFF
--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -299,12 +299,12 @@ CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
   auto status = SecItemCopyMatching(query, (CFTypeRef*)&keychain_certs);
   CFRelease(query);
 
+  // Release each keychain search path.
+  CFRelease(keychains);
+
   if (status != errSecSuccess) {
     return nullptr;
   }
-
-  // Release each keychain search path.
-  CFRelease(keychains);
 
   return keychain_certs;
 }


### PR DESCRIPTION
Summary: This fixes a potential memory leak in keychain_items similar to D14567925. This leak was identified with the default options for OSS infer.

Reviewed By: guliashvili

Differential Revision: D14641455
