### PR TITLE
Fix sqlite API usage errors

### DIFF
--- a/osquery/sql/sqlite_filesystem.cpp
+++ b/osquery/sql/sqlite_filesystem.cpp
@@ -152,6 +152,11 @@ static void getParentDirectory(sqlite3_context* context,
     return;
   }
   const char* path = reinterpret_cast<const char*>(sqlite3_value_text(argv[0]));
+  if (path == nullptr) {
+    sqlite3_result_null(context);
+    return;
+  }
+
   int pos = 0;
   int last_slash_pos = -1;
 #if defined(OSQUERY_WINDOWS)

--- a/osquery/sql/sqlite_hashing.cpp
+++ b/osquery/sql/sqlite_hashing.cpp
@@ -36,6 +36,10 @@ static void hashSqliteValue(sqlite3_context* ctx,
   // Parse and verify the split input parameters.
   const char* input =
       reinterpret_cast<const char*>(sqlite3_value_text(argv[0]));
+  if (input == nullptr) {
+    sqlite3_result_null(ctx);
+    return;
+  }
 
   auto result = hashFromBuffer(ht, input, strlen(input));
   sqlite3_result_text(

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -50,6 +50,13 @@ bool isGateKeeperDevIdEnabled() {
       "SELECT disabled FROM authority WHERE label = 'Developer ID'";
   sqlite3_stmt* stmt = nullptr;
   rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr);
+  if (rc != SQLITE_OK) {
+    if (stmt != nullptr) {
+      sqlite3_finalize(stmt);
+    }
+    sqlite3_close(db);
+    return false;
+  }
 
   while ((sqlite3_step(stmt)) == SQLITE_ROW) {
     int value = sqlite3_column_int(stmt, 0);

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -299,12 +299,12 @@ CFArrayRef CreateKeychainItems(const std::set<std::string>& paths,
   auto status = SecItemCopyMatching(query, (CFTypeRef*)&keychain_certs);
   CFRelease(query);
 
+  // Release each keychain search path.
+  CFRelease(keychains);
+
   if (status != errSecSuccess) {
     return nullptr;
   }
-
-  // Release each keychain search path.
-  CFRelease(keychains);
 
   return keychain_certs;
 }


### PR DESCRIPTION
Summary: This handles exceptional error cases when using SQLite APIs in MacOS's Gatekeeper inspection and in osquery's added SQLite functions.

Reviewed By: marekcirkos

Differential Revision: D14641507
