### PR TITLE
Handle bad fds in md_tables

### DIFF
--- a/osquery/events/linux/syslog.cpp
+++ b/osquery/events/linux/syslog.cpp
@@ -132,6 +132,7 @@ Status SyslogEventPublisher::lockPipe(const std::string& path) {
         1, "Error in open for locking pipe: " + std::string(strerror(errno)));
   }
   if (flock(lockFd_, LOCK_EX | LOCK_NB) != 0) {
+    close(lockFd_);
     lockFd_ = -1;
     return Status(
         1, "Unable to acquire pipe lock: " + std::string(strerror(errno)));
@@ -144,6 +145,8 @@ void SyslogEventPublisher::unlockPipe() {
     if (flock(lockFd_, LOCK_UN) != 0) {
       LOG(WARNING) << "Error unlocking pipe: " << std::string(strerror(errno));
     }
+    close(lockFd_);
+    lockFd_ = -1;
   }
 }
 


### PR DESCRIPTION
Summary:
Infer flagged this use of `unique_ptr` as potentially leaking the FD. I do not think this is the case but there is a missing check for a failed `open`. I am unsure of what the `ioctl` would do in this case.

I removed the custom decl to make the logic in this table easier (opinion).

Reviewed By: guliashvili

Differential Revision: D14700412
