### PR TITLE
deployment: updating osquery installation path on Windows

### DIFF
--- a/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyBeforeModify.ps1
@@ -3,13 +3,11 @@
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-. "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
+# This library file contains constant definitions and helper functions
 
-$serviceName = 'osqueryd'
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData "osquery"
-$daemonFolder = Join-Path $targetFolder $serviceName
-$extensionsFolder = Join-Path $targetFolder 'extensions'
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
 
 # Ensure the service is stopped and processes are not running if exists.
 if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
@@ -17,7 +15,7 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
   Stop-Service $serviceName
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 }

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -3,17 +3,13 @@
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-. "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\\osquery_utils.ps1"
 
-$serviceName = 'osqueryd'
-$serviceDescription = 'osquery daemon service'
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData 'osquery'
-$daemonFolder = Join-Path $targetFolder 'osqueryd'
-$extensionsFolder = Join-Path $targetFolder 'extensions'
-$logFolder = Join-Path $targetFolder 'log'
-$targetDaemonBin = Join-Path $targetFolder 'osqueryd.exe'
-$destDaemonBin = Join-Path $daemonFolder 'osqueryd.exe'
+# This library file contains constant definitions and helper functions
+
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
+
 $packageParameters = $env:chocolateyPackageParameters
 $arguments = @{}
 
@@ -23,7 +19,7 @@ if ((Get-Service $serviceName -ErrorAction SilentlyContinue) -and `
   Stop-Service $serviceName
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 }
@@ -74,7 +70,17 @@ if ($installService) {
     Write-Debug 'Installing osquery daemon service.'
     # If the 'install' parameter is passed, we create a Windows service with
     # the flag file in the default location in \ProgramData\osquery\
-    New-Service -Name $serviceName -BinaryPathName "$destDaemonBin --flagfile=\ProgramData\osquery\osquery.flags" -DisplayName $serviceName -Description $serviceDescription -StartupType Automatic
+    # the flag file in the default location in Program Files
+    $cmd = '"{0}" --flagfile="C:\Program Files\osquery\osquery.flags"' -f $destDaemonBin
+
+    $svcArgs = @{
+      Name = $serviceName
+      BinaryPathName = $cmd
+      DisplayName = $serviceName
+      Description = $serviceDescription
+      StartupType = "Automatic"
+    }
+    New-Service @svcArgs
 
     # If the osquery.flags file doesn't exist, we create a blank one.
     if (-not (Test-Path "$targetFolder\osquery.flags")) {

--- a/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyuninstall.ps1
@@ -3,9 +3,12 @@
 #
 #  This source code is licensed in accordance with the terms specified in
 #  the LICENSE file found in the root directory of this source tree.
-$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
-$targetFolder = Join-Path $progData "osquery"
-$serviceName = 'osqueryd'
+
+# This library file contains constant definitions and helper functions
+
+#Requires -Version 3.0
+
+. "$PSScriptRoot\\osquery_utils.ps1"
 
 # Remove the osquery path from the System PATH variable. Note: Here
 # we don't make use of our local vars, as Regex requires escaping the '\'
@@ -17,10 +20,10 @@ if ($oldPath -imatch [regex]::escape($targetFolder)) {
 
 if ((Get-Service $serviceName -ErrorAction SilentlyContinue)) {
   Stop-Service $serviceName
-  
+
   # If we find zombie processes, ensure they're termintated
   $proc = Get-Process | Where-Object { $_.ProcessName -eq 'osqueryd' }
-  if ($proc -ne $null) {
+  if ($null -ne $proc) {
     Stop-Process -Force $proc -ErrorAction SilentlyContinue
   }
 

--- a/tools/provision/chocolatey/osquery_utils.ps1
+++ b/tools/provision/chocolatey/osquery_utils.ps1
@@ -7,6 +7,27 @@
 # Force Powershell to use TLS 1.2
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
+# The osquery installation happens in Program Files
+$progFiles =  [System.Environment]::GetEnvironmentVariable('ProgramFiles')
+$targetFolder = Join-Path $progFiles 'osquery'
+
+# Maintain the daemon and extension folders for "safe" permissions management
+$daemonFolder = Join-Path $targetFolder 'osqueryd'
+$extensionsFolder = Join-Path $targetFolder 'extensions'
+$logFolder = Join-Path $targetFolder 'log'
+
+# Maintain the binary paths for creating the system service and extraction
+$targetDaemonBin = Join-Path $targetFolder "osqueryd.exe"
+$destDaemonBin = Join-Path $daemonFolder "osqueryd.exe"
+
+# Meta data for the system service installation
+$serviceName = 'osqueryd'
+$serviceDescription = 'osquery daemon service'
+
+# Track the old installation paths for removal
+$progData = [System.Environment]::GetEnvironmentVariable('ProgramData')
+$legacyInstall = Join-Path $progData "osquery"
+
 # Helper function to add an explicit Deny-Write ACE for the Everyone group
 function Set-DenyWriteAcl {
   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "Medium")]
@@ -267,7 +288,7 @@ function Invoke-VcVarsAll {
     } else {
       $vcvarsall = Join-Path $vcvarsall 'vcvarsall.bat'
     }
-  
+
     # Lastly invoke the environment provisioning script
     $null = Invoke-BatchFile "$vcvarsall" "amd64"
     return $true


### PR DESCRIPTION
CVE-2019-3567: This vulnerability affects osquery versions <= 3.3.2

osquery as it stands is vulnerable to a privilege escalation attack, if a malicious attacker is able to inject a new executable path into the extensions.load file, and hard link a parent folder of a malicious binary to a folder with known 'safe' permissions, osquery will load said malicious executable with SYSTEM permissions. This can be mitigated by migrating our installation to the 'Program Files' directory on windows which restricts unprivileged write access.

Test Plan: I built and installed this package locally
* Build the chocolatey package, we have to manually do this, but we can use our generation scripts :
```
PS C:\open\fbsource\xplat\osquery\oss\build\chocolatey\osquery> choco pack
Chocolatey v0.10.11
Attempting to build package from 'osquery.nuspec'.
Successfully created package 'C:\open\fbsource\xplat\osquery\oss\build\chocolatey\osquery\osquery.3.3.2.nupkg'
PS C:\open\fbsource\xplat\osquery\oss\build\chocolatey\osquery> ls


    Directory: C:\open\fbsource\xplat\osquery\oss\build\chocolatey\osquery


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----         5/7/2019   1:41 PM                tools
-a----         5/7/2019   1:43 PM        8938792 osquery.3.3.2.nupkg
-a----         5/7/2019   1:42 PM           1951 osquery.nuspec
```
* Installing the package locally:
```
PS C:\Users\thor\Desktop> choco install -s . -yf --version 3.3.2 osquery --params='/InstallService'
Chocolatey v0.10.11
Installing the following packages:
osquery
By installing you accept licenses for the packages.

osquery v3.3.2 (forced)
osquery package files install completed. Performing other installation steps.
C:\Program Files\osquery\osqueryd
C:\Program Files\osquery\log
Extracting C:\ProgramData\chocolatey\lib\osquery\tools\\bin\\osquery.zip to C:\Program Files\osquery...
C:\Program Files\osquery
True
osqueryd
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
 The install of osquery was successful.
  Software installed to 'C:\Program Files\osquery'

Chocolatey installed 1/1 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
PS C:\Users\thor\Desktop> sc.exe qc osqueryd
[SC] QueryServiceConfig SUCCESS

SERVICE_NAME: osqueryd
        TYPE               : 10  WIN32_OWN_PROCESS
        START_TYPE         : 2   AUTO_START
        ERROR_CONTROL      : 1   NORMAL
        BINARY_PATH_NAME   : "C:\Program Files\osquery\osqueryd\osqueryd.exe" --flagfile="C:\Program Files\osquery\osquery.flags"
        LOAD_ORDER_GROUP   :
        TAG                : 0
        DISPLAY_NAME       : osqueryd
        DEPENDENCIES       :
        SERVICE_START_NAME : LocalSystem
PS C:\Users\thor\Desktop>
```