### PR TITLE
Adding Host field to HTTPS header

### DIFF
--- a/osquery/remote/http/http_client.cpp
+++ b/osquery/remote/http/http_client.cpp
@@ -192,7 +192,8 @@ void Client::sendRequest(STREAM_TYPE& stream,
     if (client_options_.ssl_connection_ &&
         (kHTTPSDefaultPort != *client_options_.remote_port_)) {
       host_header_value += ':' + *client_options_.remote_port_;
-    } else if (kHTTPDefaultPort != *client_options_.remote_port_) {
+    } else if (!client_options_.ssl_connection_ &&
+        kHTTPDefaultPort != *client_options_.remote_port_) {
       host_header_value += ':' + *client_options_.remote_port_;
     }
     req.set(beast_http::field::host, host_header_value);

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -228,6 +228,8 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     // Later, when posting/putting, the data will be optionally compressed.
     r << http::Request::Header("Content-Encoding", "gzip");
   }
+  
+  r << http::Request::Header("Host", FLAGS_tls_hostname);
 
   // Allow request calls to override the default HTTP POST verb.
   HTTPVerb verb;

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -228,7 +228,7 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     // Later, when posting/putting, the data will be optionally compressed.
     r << http::Request::Header("Content-Encoding", "gzip");
   }
-  
+ 
   // Allow request calls to override the default HTTP POST verb.
   HTTPVerb verb;
   auto it = options_.doc().FindMember("_verb");

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -229,8 +229,6 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     r << http::Request::Header("Content-Encoding", "gzip");
   }
   
-  r << http::Request::Header("Host", FLAGS_tls_hostname);
-
   // Allow request calls to override the default HTTP POST verb.
   HTTPVerb verb;
   auto it = options_.doc().FindMember("_verb");


### PR DESCRIPTION
We were having issues connecting to a remote server (Fleet) because our requests are routed based off of the Host field of the HTTP request. I'm not sure if this was omitted for any particular reason, but would love to discuss.

We figured this out because Curl requests were able to be routed correctly, since Curl automatically uses the domain name for the Host field.