### PR TITLE
deploy: updating MSI package to install to Program Files

### DIFF
--- a/tools/deployment/make_windows_package.ps1
+++ b/tools/deployment/make_windows_package.ps1
@@ -132,7 +132,7 @@ function New-MsiPackage() {
   # if no flags file specified, create a stub to run the service
   if ($flagsPath -eq '') {
     $flagspath = Join-Path $buildPath 'osquery.flags'
-    New-Item -ItemType file $flagspath
+    New-Item -Force -ItemType file $flagspath
   }
 
   # We take advantage of a trick with WiX to copy folders
@@ -166,7 +166,8 @@ $wix +=
       Description='osquery standalone installer'
       Comments='Facebooks opensource host intrusion detection agent'
       Manufacturer='Facebook'
-      InstallerVersion='100'
+      InstallerVersion='200'
+      Platform='x64'
       Languages='1033'
       Compressed='yes'
       SummaryCodepage='1252' />
@@ -191,7 +192,7 @@ $wix +=
     <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
 
     <Directory Id='TARGETDIR' Name='SourceDir'>
-      <Directory Id='CommonAppDataFolder'>
+      <Directory Id='ProgramFiles64Folder'>
         <Directory Id='INSTALLFOLDER' Name='osquery'>
           <Directory Id='DaemonFolder' Name='osqueryd'>
             <Component Id='osqueryd'
@@ -211,7 +212,7 @@ $wix +=
               <ServiceInstall Id='osqueryd'
                 Name='osqueryd'
                 Account='NT AUTHORITY\SYSTEM'
-                Arguments='--flagfile=C:\ProgramData\osquery\osquery.flags'
+                Arguments='--flagfile="C:\Program Files\osquery\osquery.flags"'
                 Start='auto'
                 Type='ownProcess'
                 Vital='yes'


### PR DESCRIPTION
This changes the deployment script to create an MSI binary which installs osquery to the Program Files folder, as per the latest security issues related to priv escalation in program data.