### PR TITLE
windows: updating more references to osquery installation path

### DIFF
--- a/docs/wiki/deployment/configuration.md
+++ b/docs/wiki/deployment/configuration.md
@@ -29,7 +29,7 @@ The default config plugin, **filesystem**, reads from a file and optional
 directory ".d" based on the filename. The included initscripts set the default
 config path as follows:
 
-* Windows: **C:\ProgramData\osquery\osquery.conf**
+* Windows: **C:\Program Files\osquery\osquery.conf**
 * Linux: **/etc/osquery/osquery.conf** and **/etc/osquery/osquery.conf.d/**
 * MacOS: **/var/osquery/osquery.conf** and **/var/osquery/osquery.conf.d/**
 

--- a/docs/wiki/deployment/logging.md
+++ b/docs/wiki/deployment/logging.md
@@ -15,7 +15,7 @@ lrwxr-xr-x   1 root  wheel    77 Sep 30 17:37 osqueryd.INFO -> osqueryd.INFO.201
 -rw-------   1 root  wheel   388 Sep 30 17:37 osqueryd.results.log
 ```
 
-On Windows this directory defaults to `C:\ProgramData\osquery\log`.
+On Windows this directory defaults to `C:\Program Files\osquery\log`.
 
 ## Logger plugins
 

--- a/osquery/utils/config/default_paths.h
+++ b/osquery/utils/config/default_paths.h
@@ -27,7 +27,7 @@
 #define OSQUERY_LOG_HOME "/var/log/osquery/"
 #define OSQUERY_CERTS_HOME "/usr/share/osquery/certs/"
 #elif defined(WIN32)
-#define OSQUERY_HOME "\\ProgramData\\osquery\\"
+#define OSQUERY_HOME "\\Program Files\\osquery\\"
 #define OSQUERY_DB_HOME OSQUERY_HOME
 #define OSQUERY_SOCKET "\\\\.\\pipe\\"
 #define OSQUERY_PIDFILE OSQUERY_DB_HOME

--- a/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
+++ b/tools/deployment/chocolatey/tools/chocolateyinstall.ps1
@@ -69,7 +69,7 @@ if ($installService) {
   if (-not (Get-Service $serviceName -ErrorAction SilentlyContinue)) {
     Write-Debug 'Installing osquery daemon service.'
     # If the 'install' parameter is passed, we create a Windows service with
-    # the flag file in the default location in \ProgramData\osquery\
+    # the flag file in the default location in \Program Files\osquery\
     # the flag file in the default location in Program Files
     $cmd = '"{0}" --flagfile="C:\Program Files\osquery\osquery.flags"' -f $destDaemonBin
 

--- a/tools/deployment/osquery.example.conf
+++ b/tools/deployment/osquery.example.conf
@@ -69,8 +69,8 @@
     // "vuln-management": "/usr/share/osquery/packs/vuln-management.conf",
     // "hardware-monitoring": "/usr/share/osquery/packs/hardware-monitoring.conf",
     // "ossec-rootkit": "/usr/share/osquery/packs/ossec-rootkit.conf",
-    // "windows-hardening": "C:\\ProgramData\\osquery\\packs\\windows-hardening.conf",
-    // "windows-attacks": "C:\\ProgramData\\osquery\\packs\\windows-attacks.conf"
+    // "windows-hardening": "C:\\Program Files\\osquery\\packs\\windows-hardening.conf",
+    // "windows-attacks": "C:\\Program Files\\osquery\\packs\\windows-attacks.conf"
   },
 
   // Provides feature vectors for osquery to leverage in simple statistical 

--- a/tools/wel/osquery.man
+++ b/tools/wel/osquery.man
@@ -2,7 +2,7 @@
 <instrumentationManifest xsi:schemaLocation="http://schemas.microsoft.com/win/2004/08/events eventman.xsd" xmlns="http://schemas.microsoft.com/win/2004/08/events" xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:trace="http://schemas.microsoft.com/win/2004/08/events/trace">
 	<instrumentation>
 		<events>
-			<provider name="Facebook" guid="{F7740E18-3259-434F-9759-976319968900}" symbol="OsqueryWindowsEventLogProvider" resourceFileName="%systemdrive%\ProgramData\osquery\osqueryd\osqueryd.exe" messageFileName="%systemdrive%\ProgramData\osquery\osqueryd\osqueryd.exe">
+			<provider name="Facebook" guid="{F7740E18-3259-434F-9759-976319968900}" symbol="OsqueryWindowsEventLogProvider" resourceFileName="%systemdrive%\Program Files\osquery\osqueryd\osqueryd.exe" messageFileName="%systemdrive%\Program Files\osquery\osqueryd\osqueryd.exe">
 				<events>
 					<event symbol="DebugMessage" value="1" version="0" channel="osquery" level="win:Warning" task="LogMessage" opcode="MessageOpcode" template="_template_message" keywords="DebugWindowsEventLogMessage " message="$(string.osquery.event.1.message)"></event>
 					<event symbol="InfoMessage" value="2" version="0" channel="osquery" level="win:Informational" task="LogMessage" opcode="MessageOpcode" template="_template_message" keywords="InfoWindowsEventLogMessage " message="$(string.osquery.event.2.message)"></event>


### PR DESCRIPTION
This fixes a few additional incorrect references to the old ProgramData installation path.