### PR TITLE
rocksdb: Remove use of OptimizeForSmallDB in rocksdb plugin

### DIFF
--- a/plugins/database/rocksdb.cpp
+++ b/plugins/database/rocksdb.cpp
@@ -79,7 +79,6 @@ Status RocksDBDatabasePlugin::setUp() {
 
   if (!initialized_) {
     initialized_ = true;
-    options_.OptimizeForSmallDb();
 
     // Set meta-data (mostly) handling options.
     options_.create_if_missing = true;


### PR DESCRIPTION
This fixes the crash in #5793.

The fix was attempted in a31d7582 but it did not include the existing plugin implementation.