### PR TITLE
Patch environment file path in initd and systemd scripts during DEB packaging

### DIFF
--- a/cmake/CPackConfig.cmake.in
+++ b/cmake/CPackConfig.cmake.in
@@ -14,6 +14,16 @@ if("${CPACK_GENERATOR}" STREQUAL "DEB")
        "/etc/init.d/osqueryd\n"
        "/etc/default/osqueryd\n")
 
+  # Patch the EnvironmentFile in the systemd unit
+  file(READ "@CMAKE_BINARY_DIR@/package/linux/osqueryd.service" osqueryd_service_file)
+  string(REPLACE "/etc/sysconfig/osqueryd" "/etc/default/osqueryd" osqueryd_service_file "${osqueryd_service_file}")
+  file(WRITE "@CMAKE_BINARY_DIR@/package/linux/osqueryd.service" "${osqueryd_service_file}")
+
+  # Patch /etc/sysconfig to /etc/default in the initd script
+  file(READ "@CMAKE_BINARY_DIR@/package/linux/osqueryd.initd" osqueryd_initd_file)
+  string(REPLACE "/etc/sysconfig" "/etc/default" osqueryd_initd_file "${osqueryd_initd_file}")
+  file(WRITE "@CMAKE_BINARY_DIR@/package/linux/osqueryd.initd" "${osqueryd_initd_file}")
+
   set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "@CMAKE_BINARY_DIR@/package/deb/conffiles;@CMAKE_BINARY_DIR@/package/deb/postinst")
 elseif("${CPACK_GENERATOR}" STREQUAL "productbuild")
 	set(CPACK_SET_DESTDIR ON)

--- a/tools/deployment/osqueryd.service
+++ b/tools/deployment/osqueryd.service
@@ -5,6 +5,7 @@ After=network.service syslog.service
 [Service]
 TimeoutStartSec=0
 EnvironmentFile=/etc/sysconfig/osqueryd
+ExecStartPre=/bin/sh -c "if [ ! -f $CONFIG_FILE ]; then touch $CONFIG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ ! -f $FLAG_FILE ]; then touch $FLAG_FILE; fi"
 ExecStartPre=/bin/sh -c "if [ -f $LOCAL_PIDFILE ]; then mv $LOCAL_PIDFILE $PIDFILE; fi"
 ExecStart=/usr/bin/osqueryd \


### PR DESCRIPTION
Also add a check to systemd script to create and empty config file,
if this is missing.

Co-authored-by: seph <seph@directionless.org>