### PR TITLE
Fix crash #7353 when osquery captures kill syscall when not subscribed to them

### DIFF
--- a/osquery/tables/events/linux/process_events.cpp
+++ b/osquery/tables/events/linux/process_events.cpp
@@ -149,11 +149,6 @@ Status AuditProcessEventSubscriber::ProcessEvents(
       continue;
     }
 
-    // Skip kill events if not subscribed to them
-    if (!FLAGS_audit_allow_kill_process_events && is_kill_syscall) {
-      continue;
-    }
-
     // Acquire the base syscall record, which is common to all the different
     // events we are handling here
     const AuditEventRecord* syscall_event_record =

--- a/osquery/tables/events/tests/linux/process_events_tests.cpp
+++ b/osquery/tables/events/tests/linux/process_events_tests.cpp
@@ -19,9 +19,6 @@
 #include <osquery/tables/events/linux/process_events.h>
 
 namespace osquery {
-
-DECLARE_bool(audit_allow_kill_process_events);
-
 namespace {
 using RawAuditEvent = const std::vector<std::pair<int, std::string>>;
 
@@ -204,8 +201,6 @@ TEST_F(ProcessEventsTests, kill_syscall_event_processing) {
   };
   // clang-format on
 
-  FLAGS_audit_allow_kill_process_events = true;
-
   Row event_row;
   GenerateEventRow(event_row, kSampleKillEvent);
 
@@ -263,8 +258,6 @@ TEST_F(ProcessEventsTests, kill_syscall_without_obj_pid_record) {
     { 1320, "audit(1588703361.452:26860): " }
   };
   // clang-format on
-
-  FLAGS_audit_allow_kill_process_events = true;
 
   Row event_row;
 


### PR DESCRIPTION
<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->

Fix for https://github.com/osquery/osquery/issues/7353

1. Add handle of absence of AUDIT_OBJ_PID record - use defaults if OBJ_PID record not found. Not sure if osquery should fill the fields by default values or skip them as it does in similar cases. All kill-related fields not even used as i can see in https://osquery.io/schema/5.0.1/#process_events, so not sure if it is still actual code.
2. Test for no crash in 1
2. Skip parsing kill syscall when `audit_allow_kill_process_events` is turned off


