### PR TITLE
tls: Disable TLS 1.0 and TLS 1.1

### DIFF
--- a/libraries/cmake/formula/openssl/CMakeLists.txt
+++ b/libraries/cmake/formula/openssl/CMakeLists.txt
@@ -11,6 +11,11 @@ function(opensslMain)
 
   set(common_options
     no-ssl3
+    no-ssl3-method
+    no-tls1
+    no-tls1-method
+    no-tls1_1
+    no-tls1_1-method
     no-asm
     no-shared
     no-weak-ssl-ciphers


### PR DESCRIPTION
- Disable support for TLS 1.0 and TLS 1.1 which are deprecated protocols.

- WIP: Should update Thrift to be able to compile