### PR TITLE
Fix stringFromCFData

### DIFF
--- a/osquery/utils/conversions/darwin/cfdata.cpp
+++ b/osquery/utils/conversions/darwin/cfdata.cpp
@@ -9,27 +9,24 @@
 
 #include "cfdata.h"
 
-#include <iomanip>
-#include <sstream>
-
 namespace osquery {
 
 std::string stringFromCFData(const CFDataRef& cf_data) {
-    const std::string kHexDigitsLowercase = "0123456789abcdef";
-    const uint8_t * src = cf_dataGetBytePtr(cf_data);
-    const auto len = cf_dataGetLength(cf_data);
-    const uint8_t * end = src + len;
-    auto lenOfCharacters = len * 2;
-    std::string output;
-    while( src < end && lenOfCharacters >= 2)
-    {
-        uint8_t b = *src;
-        ++src;
-        output.push_back(kHexDigitsLowercase.at(b >> 4));
-        output.push_back(kHexDigitsLowercase.at(b & 0xF));
-        lenOfCharacters = lenOfCharacters - 2;
-    }
-    return output;
+  const std::string kHexDigitsLowercase = "0123456789abcdef";
+  const uint8_t* src = CFDataGetBytePtr(cf_data);
+  const auto len = CFDataGetLength(cf_data);
+  const uint8_t* end = src + len;
+  auto lenOfCharacters = len * 2;
+  std::string output;
+  while (src < end && lenOfCharacters >= 2) {
+    uint8_t b = *src;
+    ++src;
+    output.push_back(kHexDigitsLowercase.at(b >> 4));
+    output.push_back(kHexDigitsLowercase.at(b & 0xF));
+    lenOfCharacters = lenOfCharacters - 2;
+  }
+  return output;
 }
+
 
 }

--- a/osquery/utils/conversions/darwin/cfdata.cpp
+++ b/osquery/utils/conversions/darwin/cfdata.cpp
@@ -15,32 +15,21 @@
 namespace osquery {
 
 std::string stringFromCFData(const CFDataRef& cf_data) {
-  CFRange range = CFRangeMake(0, CFDataGetLength(cf_data));
-
-  char* buffer = (char*)malloc(range.length + 1);
-  if (buffer == nullptr) {
-    return "";
-  }
-  memset(buffer, 0, range.length + 1);
-
-  std::stringstream result;
-  CFDataGetBytes(cf_data, range, (UInt8*)buffer);
-  for (CFIndex i = 0; i < range.length; ++i) {
-    uint8_t byte = buffer[i];
-    if (isprint(byte)) {
-      result << byte;
-    } else if (range.length > 1 && buffer[i] == 0) {
-      result << ' ';
-    } else {
-      result << '%' << std::setfill('0') << std::setw(2) << std::hex
-             << (int)byte;
+    const std::string kHexDigitsLowercase = "0123456789abcdef";
+    const uint8_t * src = cf_dataGetBytePtr(cf_data);
+    const auto len = cf_dataGetLength(cf_data);
+    const uint8_t * end = src + len;
+    auto lenOfCharacters = len * 2;
+    std::string output;
+    while( src < end && lenOfCharacters >= 2)
+    {
+        uint8_t b = *src;
+        ++src;
+        output.push_back(kHexDigitsLowercase.at(b >> 4));
+        output.push_back(kHexDigitsLowercase.at(b & 0xF));
+        lenOfCharacters = lenOfCharacters - 2;
     }
-  }
-
-  // Cleanup allocations.
-  free(buffer);
-  return result.str();
+    return output;
 }
-
 
 }


### PR DESCRIPTION
I am building a binary for OSX that reports the details of devices that are physically connected to the Mac.
I used your implementation of stringFromCFData in order to convert the "USB device signature" which is of type **Data** (bytes) into a string. However I saw that the output is a random unrelated string. 
I created my own implementation and called both implementations one after the other in order to compare results:
![Calling both functions](https://github.com/osquery/osquery/assets/93097769/fd16e0eb-faf3-4f67-ac93-3f60c20fd06b)

Here are the results, screenshotted from my XCode debugging session:
![First disk](https://github.com/osquery/osquery/assets/93097769/2d37564a-ad1f-4cdf-8bf4-a95822c62761)
![Second disk](https://github.com/osquery/osquery/assets/93097769/545f8685-220e-45d3-9b6a-c110e6056240)
On the left is an **ioRegistryExplorer window** showing the device "USB device signature", on the right are the results strings.
As you can see the current OSquery implementation is getting it wrong both times. 

I even created a unit test locally in order to double check. This time I used a C-style byte array, as this is what "Data" really is. 
![UnitTest](https://github.com/osquery/osquery/assets/93097769/1c060344-bb89-4992-be3a-19310be0910f)
As you can see the current implementation gets it wring again.
