### PR TITLE
Fix hardware model and version on Lenovo

### DIFF
--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -121,6 +121,20 @@ QueryData genSystemInfo(QueryContext& context) {
           r["hardware_model"] = dmiString(textAddrs, address[0x05], maxlen);
           r["hardware_version"] = dmiString(textAddrs, address[0x06], maxlen);
           r["hardware_serial"] = dmiString(textAddrs, address[0x07], maxlen);
+
+          // Check if this is a Lenovo model.
+          std::string lcVendor = r["hardware_vendor"];
+          std::transform(
+              lcVendor.begin(), lcVendor.end(), lcVendor.begin(), ::tolower);
+          // Lenovo puts the model in the "Version" string and the product SKU
+          // in the "Model" string, so we'll switch them to be consistent with
+          // other vendors.
+          if (lcVendor == "lenovo") {
+            std::string version = r["hardware_model"];
+            r["hardware_model"] = r["hardware_version"];
+            r["hardware_version"] = version;
+          }
+
           return;
         }
 


### PR DESCRIPTION
From Fleet: https://github.com/fleetdm/fleet/issues/21648

This PR fixes an issue where Lenovo laptops report the hardware model and version incorrectly in the BIOS tables, resulting in incorrect values in the `hardware_model` and `hardware_version` columns of the `system_info` table.  This issue affects both Windows and Linux.  See https://github.com/fleetdm/fleet/issues/21648#issuecomment-2573866237 for examples of the undesirable output.

The fixes in this PR are:

* For Linux, swap the hardware_model and hardware_version values.  The reported version is something like `ThinkPad L15 Gen 3` which is consistent with the kind of value typically reported as `hardware_model` from other vendors.  The reported version is something like 21C8S3EA00 which appears to be a [product SKU](https://psref.lenovo.com/Detail/ThinkPad_L15_Gen_3_AMD?M=21C8S3EB00), which can serve as the "version" for this model.
* For Windows, retrieve the model name from the Win32_ComputerSystemProduct WMI class, and move the reported `hardware_model` into `hardware_version` as above.

Results:

<img width="596" alt="image" src="https://github.com/user-attachments/assets/08d2b2d3-50b4-4c74-b5b7-c69a33689bcb" />