### PR TITLE
Revert "Update Windows runner version in hosted_runners.yml (#8618)"

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -968,7 +968,7 @@ jobs:
       matrix:
         build_type: [Release]
         bitness: [64, arm64]
-        os: [windows-2022]
+        os: [windows-2019]
 
     steps:
     - name: Select the build job count
@@ -1181,7 +1181,7 @@ jobs:
         SCCACHE_CACHE_SIZE: "5G"
 
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
         @echo on
 
         set cross_compilation=
@@ -1259,7 +1259,7 @@ jobs:
         SCCACHE_CACHE_SIZE: "5G"
 
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
         @echo on
 
         cmake --build . -j ${{ steps.build_job_count.outputs.VALUE }}
@@ -1281,7 +1281,7 @@ jobs:
       working-directory: ${{ steps.build_paths.outputs.BINARY }}
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
         @echo on
         ctest --build-nocmake -C Release -V
 
@@ -1300,7 +1300,7 @@ jobs:
       shell: cmd
 
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ steps.vc_arch.outputs.VC_ARCH }}
         @echo on
 
         7z ^


### PR DESCRIPTION
This reverts commit 45411df1568a75901892fdf0119d817431fc34c1.

This fixes an issue in osquery 5.18.0 arm64 Windows executable not starting on Window arm64 VMs.

It crashes at startup running any kind of query.

5.18.0 osqueryi.exe:
```cmd
C:\Users\Lucas>.\osqueryi.exe -S --allow_unsafe --json "SELECT si.uuid, si.hardware_serial, si.hostname, si.computer_name, si.hardware_model, os.platform, os.version as os_version, oi.instance_id, oi.version as osquery_version FROM system_info si, os_version os, osquery_info oi"

C:\Users\Lucas>
```

Here's the crash report from Event Viewer: [Report.wer.txt](https://github.com/user-attachments/files/20840051/Report.wer.txt).
This was also reproduced by @dantecatalfamo.

This PR:
```cmd
C:\Users\Lucas>.\osqueryi.exe -S --allow_unsafe --json "SELECT si.uuid, si.hardware_serial, si.hostname, si.computer_name, si.hardware_model, os.platform, os.version as os_version, oi.instance_id, oi.version as osquery_version FROM system_info si, os_version os, osquery_info oi"
[
  {"computer_name":"WIN-85PHPP410L4","hardware_model":"QEMU Virtual Machine","hardware_serial":"","hostname":"WIN-85PHPP410L4","instance_id":"85ac589f-2181-4df2-9c3e-db851f42d020","os_version":"10.0.26100","osquery_version":"5.18.0-3-gea580a9f2","platform":"windows","uuid":"4BFBAB91-69AC-4AEE-84FE-82C9B8F16A3E"}
]
```