### PR TITLE
log(config): append status.getMessage() to error logs in restoreConfi…

### DIFF
--- a/osquery/config/config.cpp
+++ b/osquery/config/config.cpp
@@ -647,7 +647,8 @@ Expected<ConfigMap, Config::RestoreConfigError> Config::restoreConfigBackup() {
     if (!status.ok()) {
       LOG(ERROR)
           << "restoreConfigBackup database failed to retrieve config for key "
-          << key;
+          << key << " (error: " << status.getMessage() << ")";
+          
       return createError(Config::RestoreConfigError::DatabaseError)
              << "Could not retrieve value for the key: " << key;
     }
@@ -965,7 +966,8 @@ Status Config::update(const ConfigMap& config) {
 
     if (!status.ok()) {
       LOG(ERROR) << "updateSource failed to parse config, of source: "
-                 << source.first << " and content: " << source.second;
+                 << source.first << " and content: " << source.second
+                 << " (error: " << status.getMessage() << ")";
       return status;
     }
     // If a source was updated and the content has changed, then the registry


### PR DESCRIPTION
…gBackup() and Config::update()

### What
This PR improves error logging in `config.cpp`:
1. `restoreConfigBackup()` now logs `status.getMessage()` when DB retrieval fails.
2. `Config::update()` now logs `status.getMessage()` when `updateSource()` fails.

### Why
Previously, operators had no visibility into the underlying error message when these functions failed.  
This change makes the log messages consistent and more actionable.

### Risk
Low: only log messages are updated, no functional changes.

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
