### PR TITLE
Change dependency for macOS universal binary in CI workflow

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -872,7 +872,7 @@ jobs:
 
   # This job builds the universal macOS artifacts
   build_universal_macos_artifacts:
-    needs: test_older_macos
+    needs: build_macos
 
     runs-on: macos-14
 


### PR DESCRIPTION
After `build_macos` completes, all the artifacts are available for this step.

Right now I'm waiting for the `test_older_macos` job to complete in order to be able to kick off code signing. Will be more convenient to have this go sooner.
