### PR TITLE
Fix build against libaudit >=4.1.1 by removing set_aumessage_mode call

### DIFF
--- a/osquery/events/linux/auditdnetlink.cpp
+++ b/osquery/events/linux/auditdnetlink.cpp
@@ -379,9 +379,6 @@ bool AuditdNetlinkReader::configureAuditService() noexcept {
   audit_set_backlog_limit(audit_netlink_handle_, FLAGS_audit_backlog_limit);
   audit_set_failure(audit_netlink_handle_, AUDIT_FAIL_SILENT);
 
-  // Request only the highest priority of audit status messages.
-  set_aumessage_mode(MSG_QUIET, DBG_NO);
-
   //
   // Audit rules
   //


### PR DESCRIPTION
The set_aumessage_mode function and its associated constants (MSG_QUIET, DBG_NO) were removed from libaudit in version 4.1.1, breaking the ABI and causing build failures.

This function call was redundant as it was setting the library's default behavior (only receiving highest priority audit status messages). Remove the obsolete call to restore compatibility with newer libaudit versions while maintaining identical functionality.

The change is backward compatible and will compile successfully with both older libaudit versions (that still contain the function) and newer versions (where it has been removed).

Fixes: https://github.com/osquery/osquery/issues/8665