### PR TITLE
Added Changes to Pick ETW Changes from User History 

### DIFF
--- a/osquery/events/windows/etw/etw_user_session.cpp
+++ b/osquery/events/windows/etw/etw_user_session.cpp
@@ -16,6 +16,41 @@
 
 namespace osquery {
 
+namespace {
+
+
+bool queryExistingTraceSessionProperties(const std::string& sessionName,
+                                        EVENT_TRACE_PROPERTIES& out_properties) {
+  if (sessionName.empty()) {
+    return false;
+  }
+
+  struct QueryData {
+    EVENT_TRACE_PROPERTIES Properties;
+    CHAR LoggerName[MAX_PATH];
+    CHAR LogFileName[MAX_PATH];
+  };
+
+  QueryData query_data = {0};
+  query_data.Properties.Wnode.BufferSize = (ULONG)sizeof(QueryData);
+  query_data.Properties.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+  query_data.Properties.LoggerNameOffset = (ULONG)sizeof(EVENT_TRACE_PROPERTIES);
+  query_data.Properties.LogFileNameOffset =
+      query_data.Properties.LoggerNameOffset + MAX_PATH;
+
+  ULONG result = ControlTraceA(
+      NULL, sessionName.c_str(), &query_data.Properties, EVENT_TRACE_CONTROL_QUERY);
+
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+
+  out_properties = query_data.Properties;
+  return true;
+}
+
+} // namespace
+
 HIDDEN_FLAG(
     uint32,
     etw_userspace_trace_buffer_size,
@@ -165,11 +200,16 @@ void UserEtwSessionRunnable::initUserTraceSession(
 
   // Setting default trace session properties
   EVENT_TRACE_PROPERTIES session_properties = {0};
-  session_properties.BufferSize = FLAGS_etw_userspace_trace_buffer_size;
-  session_properties.MinimumBuffers = FLAGS_etw_userspace_trace_minimum_buffers;
-  session_properties.MaximumBuffers = FLAGS_etw_userspace_trace_maximum_buffers;
-  session_properties.FlushTimer = FLAGS_etw_userspace_trace_flush_timer;
-  session_properties.LogFileMode = kEventTraceLogFileMode;
+
+  if (!queryExistingTraceSessionProperties(sessionName, session_properties)) {
+    session_properties.BufferSize = FLAGS_etw_userspace_trace_buffer_size;
+    session_properties.MinimumBuffers =
+        FLAGS_etw_userspace_trace_minimum_buffers;
+    session_properties.MaximumBuffers =
+        FLAGS_etw_userspace_trace_maximum_buffers;
+    session_properties.FlushTimer = FLAGS_etw_userspace_trace_flush_timer;
+    session_properties.LogFileMode = kEventTraceLogFileMode;
+  }
   userTraceSession_->set_trace_properties(&session_properties);
 }
 


### PR DESCRIPTION
Added "use history" behavior: when initialising ETW sessions, we will try to query existing session properties and reuse them; if none exist, we fall back to current defaults. I'll implement this for both user and kernel ETW sessions.