### PR TITLE
Remove test_older_macos job in GitHub Actions because runner has been removed

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -798,20 +798,6 @@ jobs:
         name: macos_unsigned_release_package_data_${{ matrix.architecture }}
         path: ${{ steps.packages.outputs.REL_UNSIGNED_RELEASE_PACKAGE_DATA_PATH }}
 
-    - name: Package the tests for older x86_64 macOS workers
-      if: matrix.architecture == 'x86_64' && matrix.os == 'macos-14'
-      working-directory: ${{ github.workspace }}/workspace
-      run: |
-        mkdir macos_tests_${{ matrix.build_type }}
-        ${{ steps.build_paths.outputs.SOURCE }}/tools/ci/scripts/macos/package_tests.sh build macos_tests_${{ matrix.build_type }} ${{ matrix.architecture }}
-
-    - name: Store the packaged tests for older x86_64 macOS workers
-      if: matrix.architecture == 'x86_64' && matrix.os == 'macos-14'
-      uses: actions/upload-artifact@v4.4.0
-      with:
-        name: macos_tests_${{ matrix.build_type }}
-        path: workspace/macos_tests_${{ matrix.build_type }}.tar.gz
-
     # Before we terminate this job, delete the build folder. The cache
     # actions will require the disk space to create the archives.
     - name: Reclaim disk space


### PR DESCRIPTION
macos-13 runner has been removed: https://github.com/actions/runner-images/issues/13046
