### PR TITLE
Quit carving when sending a block fails

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -352,9 +352,8 @@ Status Carver::postCarve(const boost::filesystem::path& path) {
     // TODO: Error sending files.
     status = contRequest.call(params);
     if (!status.ok()) {
-      VLOG(1) << "Post of carved block " << i
-              << " failed: " << status.getMessage();
-      continue;
+      return Status::failure("Failed to post carved block: " +
+                             status.getMessage());
     }
   }
 


### PR DESCRIPTION
Currently we log (only in --verbose) an error and then continue sending blocks. But there's not really much point in continuing to send blocks if the server failed a block because it won't be able to piece the archive back together. What we really need is a refactor to allow proper retries, but this at least makes the current behavior more clear and removes inefficient continued block sends that won't lead to a successful carve.