### PR TITLE
Fix integration test for certificate_trust_settings

### DIFF
--- a/tests/integration/tables/certificate_trust_settings.cpp
+++ b/tests/integration/tables/certificate_trust_settings.cpp
@@ -25,7 +25,18 @@ class certificateTrustSettings : public testing::Test {
 TEST_F(certificateTrustSettings, test_sanity) {
   auto const all_data =
       execute_query("select * from certificate_trust_settings");
-  ASSERT_EQ(all_data.size(), 0ul);
+  ValidationMap row_map = {
+      {"common_name", NormalType},
+      {"serial", NormalType},
+      {"trust_domain", NormalType},
+      {"trust_policy_name", NormalType},
+      {"trust_policy_data", NormalType},
+      {"trust_allowed_error", NormalType},
+      {"trust_key_usage", NormalType},
+      {"trust_result", NormalType},
+  };
+
+  validate_rows(all_data, row_map);
 }
 } // namespace table_tests
 } // namespace osquery


### PR DESCRIPTION
The previous test would fail any time the table returned results. It passed on CI because there are no results given the system configuration.
