### PR TITLE
feat: add CLI arguments for customizing profiling thresholds in profile.py

### DIFF
--- a/tools/analysis/profile.py
+++ b/tools/analysis/profile.py
@@ -336,6 +336,17 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Validate threshold arguments: ensure v1 < v2 < v3
+    def validate_thresholds(name, values):
+        if not (values[0] < values[1] < values[2]):
+            parser.error(f"{name} thresholds must be in increasing order: v1 < v2 < v3 (got {values})")
+
+    validate_thresholds("Utilization", args.utilization)
+    validate_thresholds("CPU time", args.cpu_time)
+    validate_thresholds("Memory", args.memory)
+    validate_thresholds("File descriptors", args.fds)
+    validate_thresholds("Duration", args.duration)
+
     # Update RANGES with argparse values
     RANGES.update({
         "utilization": args.utilization,


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->

This PR adds command-line arguments to customize profiling thresholds when using `tools/analysis/profile.py`.

Includes support for: 
* specifying utilization, CPU time, memory, etc.
* Includes argument validation. This ensures thresholds are specified in increasing order.

Defaults threshold values that are currently found in the `RANGES` dictionary [found here](https://github.com/osquery/osquery/blob/de827738df3e10ebe96a17fac62b5ba7c42e9b41/tools/analysis/profile.py#L28-L35) remain unchanged ensuring compatibility with existing tooling.



<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
