### PR TITLE
build: suppress `enum-constexpr-conversion` error for boost mpl on macos

### DIFF
--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -146,6 +146,13 @@ function(importBoostInterfaceLibraries)
     BOOST_NO_CXX98_FUNCTION_BASE
   )
 
+  # silence enum constexpr conversion for MPL on Xcode 26
+  if(PLATFORM_MACOS)
+     target_compile_options(thirdparty_boost_mpl INTERFACE
+       -Wno-enum-constexpr-conversion
+      )
+  endif()
+
   # Additional settings for the libraries we just imported
   if(PLATFORM_LINUX)
     target_compile_definitions(thirdparty_boost_uuid INTERFACE


### PR DESCRIPTION
Until we can update boost and the osquery-toolchain, suppress the `enum-constexpr-conversion` error for boost MPL on macOS, to be able to build with Xcode 26. 

Fixes #8593 