### PR TITLE
Fix typo in winbaseobj.table description

### DIFF
--- a/specs/windows/winbaseobj.table
+++ b/specs/windows/winbaseobj.table
@@ -1,5 +1,5 @@
 table_name("winbaseobj")
-description("Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows ojbect types include Mutexes, Events, Jobs and Semaphors.")
+description("Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows object types include Mutexes, Events, Jobs and Semaphors.")
 schema([
     Column("session_id", INTEGER, "Terminal Services Session Id"),
     Column("object_name", TEXT, "Object Name"),


### PR DESCRIPTION
<!-- Thank you for contributing to osquery! -->
<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
