### PR TITLE
Fix systemd unit: use .target instead of .service

### DIFF
--- a/tools/deployment/linux_packaging/deb/osqueryd.service
+++ b/tools/deployment/linux_packaging/deb/osqueryd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The osquery daemon
+Description=osquery daemon
 After=network.target syslog.service
 
 [Service]

--- a/tools/deployment/linux_packaging/rpm/osqueryd.service
+++ b/tools/deployment/linux_packaging/rpm/osqueryd.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=The osquery daemon
+Description=osquery daemon
 After=network.target syslog.service
 
 [Service]


### PR DESCRIPTION
`network.target` is the systemd status of "the general network service has started"

(there is no generic "network.service")

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/systemd-network-targets-and-services_configuring-and-managing-networking

this updates the systemd file for both deb & rpm builds to correct this.

closes #8700 

