### PR TITLE
Add machine-wide provisioned MSIX packages to programs table (#8001)

### DIFF
--- a/osquery/tables/system/windows/programs.cpp
+++ b/osquery/tables/system/windows/programs.cpp
@@ -350,12 +350,13 @@ void genMsixPrograms(const std::string& key,
           installDir = installDir.substr(0, pos);
         }
         // For bundles, strip the extra AppxMetadata directory.
-        if (installDir.size() >= 13 &&
-            installDir.compare(
-                installDir.size() - 13, 13, "\\AppxMetadata") == 0) {
-          installDir = installDir.substr(0, installDir.size() - 13);
+        const std::string kAppxMetadataSuffix = "\\AppxMetadata";
+        auto suffixPos = installDir.rfind(kAppxMetadataSuffix);
+        if (suffixPos != std::string::npos &&
+            suffixPos == installDir.size() - kAppxMetadataSuffix.size()) {
+          installDir = installDir.substr(0, suffixPos);
         }
-        // e.g. C:\Program Files\WindowsApps\Microsoft.Paint_11.0.0_neutral_~_8wekyb3d8bbwe
+        // e.g. C:\...\Microsoft.Paint_11.0_neutral_~_8wekyb3d8bbwe
         result["install_location"] = installDir;
         break;
       }


### PR DESCRIPTION
Resolves #8001 

Reviewer, please disable whitespace diffs when reviewing.

Enumerate provisioned MSIX packages from HKLM AppxAllUserStore (Applications and InboxApplications) in addition to per-user packages. Per-user entries take precedence via deduplication on package family name.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
