### PR TITLE
Update osquery-toolchain to 1.2.0 (LLVM 11.0.0, zlib 1.2.13)

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -42,7 +42,7 @@ env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
   PACKAGING_COMMIT: c089fb2d3d796d976e3b2fbea7ee69a1616b9576
   SUBMODULE_CACHE_VERSION: 3
-  OSQUERY_TOOLCHAIN_VERSION: 1.1.0
+  OSQUERY_TOOLCHAIN_VERSION: 1.2.0
 
 # If the initial code sanity checks are passing, then one job
 # per [`platform` * `build_type`] will start, building osquery


### PR DESCRIPTION
- LLVM 9.0.1 -> 11.0.0
- zlib 1.2.11 -> 1.2.13

Builds tested on
- Ubuntu 16.04 (x86_64)
- Ubuntu 18.04 (x86_64, aarch64)
- Ubuntu 20.04 (x86_64, aarch64)
- Ubuntu 22.04 (x86_64, aarch64)
- Ubuntu 24.04 (x86_64, aarch64)
- CentOS 6 (x86_64)
- CentOS 7 (x86_64)
- CentOS 8 (x86_64)
- CentOS Stream 9 (x86_64, aarch64)
- CentOS Stream 10 (aarch64)