### PR TITLE
Don't build etw tests if OSQUERY_BUILD_ETW is false

### DIFF
--- a/osquery/tables/events/tests/CMakeLists.txt
+++ b/osquery/tables/events/tests/CMakeLists.txt
@@ -20,7 +20,10 @@ function(osqueryTablesEventsTestsMain)
   elseif(DEFINED PLATFORM_WINDOWS)
     generateOsqueryTablesEventsTestsPowershelleventstestsTest()
     generateOsqueryTablesEventsTestsWindowseventstestsTest()
-    generateOsqueryTablesEventsTestsETWtestsTest()
+
+    if(OSQUERY_BUILD_ETW)
+      generateOsqueryTablesEventsTestsETWtestsTest()
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
## Summary
I ran into this bug while trying to build tests on windows.
- The cmake configuration tries to build etw tests without checking if OSQUERY_BUILD_ETW is true.
- This causes the build to error because it cannot find required header files.
- Simple fix was to add a check in CMakeLists.txt

