### PR TITLE
Test case for `apt_sources` using DEB822 style entries with underscore

### DIFF
--- a/osquery/tables/system/tests/linux/apt_sources_tests.cpp
+++ b/osquery/tables/system/tests/linux/apt_sources_tests.cpp
@@ -205,6 +205,14 @@ Signed-By: /usr/share/keyrings/osquery-archive-keyring.gpg",
        "ftp://pkg.osquery.io",
        "pkg.osquery.io noble",
        "pkg.osquery.io_dists_noble"},
+      // URIs with underscores in domain and path (issue #8624)
+      {"Types: deb \n\
+URIs: http://example.test_server.com/test_repo/deb \n\
+Suites: noble \n\
+Components: main",
+       "http://example.test_server.com/test_repo/deb",
+       "example.test_server.com/test_repo/deb noble",
+       "example.test_server.com_test_repo_deb_dists_noble"},
   };
 
   for (const auto& test_case : test_cases) {


### PR DESCRIPTION
Closes: #8624 

I'm not sure the diagnostic in #8624 is correct, so let's see what a test case says