### PR TITLE
Fix incorrect example queries in table specs

### DIFF
--- a/specs/azure_instance_metadata.table
+++ b/specs/azure_instance_metadata.table
@@ -21,5 +21,5 @@ schema([
 attributes(cacheable=True)
 implementation("cloud/azure_metadata@genAzureMetadata")
 examples([
-    "select * from ec2_instance_metadata"
+    "select * from azure_instance_metadata"
 ])

--- a/specs/azure_instance_tags.table
+++ b/specs/azure_instance_tags.table
@@ -8,5 +8,5 @@ schema([
 attributes(cacheable=True)
 implementation("cloud/azure_metadata@genAzureTags")
 examples([
-    "select * from ec2_instance_tags"
+    "select * from azure_instance_tags"
 ])

--- a/specs/posix/docker_image_layers.table
+++ b/specs/posix/docker_image_layers.table
@@ -7,7 +7,7 @@ schema([
 ])
 implementation("applications/docker@genImageLayers")
 examples([
-  "select * from docker_images",
-  "select * from docker_images where id = '6a2f32de169d'",
-  "select * from docker_images where id = '6a2f32de169d14e6f8a84538eaa28f2629872d7d4f580a303b296c60db36fbd7'"
+  "select * from docker_image_layers",
+  "select * from docker_image_layers where id = '6a2f32de169d'",
+  "select * from docker_image_layers where id = '6a2f32de169d14e6f8a84538eaa28f2629872d7d4f580a303b296c60db36fbd7'"
 ])


### PR DESCRIPTION
This fixes a few copy/paste mistakes in example queries in table specs.