### PR TITLE
Reduce noisy logs from chrome extensions

### DIFF
--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -502,10 +502,10 @@ bool captureProfileSnapshotExtensionsFromPath(
 
     if (!status.ok()) {
       if (!isBuiltInChromeExtension(extension_path)) {
-        LOG(INFO) << "Failed to read the following manifest.json file: "
-                  << manifest_path.string()
-                  << ". The extension was referenced by the following profile: "
-                  << profile_path.value;
+        VLOG(1) << "Failed to read the following manifest.json file: "
+                << manifest_path.string()
+                << ". The extension was referenced by the following profile: "
+                << profile_path.value;
       }
 
       continue;
@@ -571,11 +571,10 @@ bool captureProfileSnapshotExtensionsFromPath(
 
       if (!status.ok()) {
         if (!isBuiltInChromeExtension(referenced_ext_path)) {
-          LOG(ERROR)
-              << "Failed to read the following manifest.json file: "
-              << manifest_path.string()
-              << ". The extension was referenced by the following profile: "
-              << profile_path.value;
+          VLOG(1) << "Failed to read the following manifest.json file: "
+                  << manifest_path.string()
+                  << ". The extension was referenced by the following profile: "
+                  << profile_path.value;
         }
 
         continue;
@@ -960,7 +959,7 @@ Status getExtensionFromSnapshot(
 
   status = localizeExtensionProperties(output);
   if (!status.ok()) {
-    LOG(ERROR) << "Failed to process the localization settngs for the "
+    LOG(ERROR) << "Failed to process the localization settings for the "
                   "following extension: "
                << output.path;
   }


### PR DESCRIPTION
Log sample to be logged only when verbose mode is ON: 
```
E0310 06:27:38.658774 1802252288 utils.cpp:574] Failed to read the following manifest.json file:
/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions/138.0.7204.100/Resources/network_speech_synthesis/mv3/manifest.json.
The extension was referenced by the following profile:
/Users/lucas/Library/Application Support/Google/Chrome/Default
```
It seems like a miss reference (points to an older non-existent version). 