### PR TITLE
tables: extend python_packages and npm_packages to cover modern package managers

### DIFF
--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -40,7 +40,22 @@ const std::set<std::string> kNodeModulesPath = {
     "/home/%/.npm-global/lib",
     "/home/%/.nvm/versions/node/%/lib",
     "/Users/%/.npm-global/lib",
-    "/Users/%/.nvm/versions/node/%/lib"
+    "/Users/%/.nvm/versions/node/%/lib",
+    // asdf nodejs
+    "/home/%/.asdf/installs/nodejs/%/lib",
+    "/Users/%/.asdf/installs/nodejs/%/lib",
+    // fnm (Linux)
+    "/home/%/.local/share/fnm/node-versions/%/installation/lib",
+    // fnm (macOS default)
+    "/Users/%/Library/Application Support/fnm/node-versions/%/installation/lib",
+    // fnm (macOS XDG_DATA_HOME)
+    "/Users/%/.local/share/fnm/node-versions/%/installation/lib",
+    // mise nodejs
+    "/home/%/.local/share/mise/installs/node/%/lib",
+    "/Users/%/.local/share/mise/installs/node/%/lib",
+    // Volta
+    "/home/%/.volta/tools/image/node/%/lib",
+    "/Users/%/.volta/tools/image/node/%/lib"
 #endif
 };
 

--- a/osquery/tables/system/python_packages.cpp
+++ b/osquery/tables/system/python_packages.cpp
@@ -43,6 +43,11 @@ const std::set<std::string> kPythonPath = {
     "/usr/lib/python%/dist-packages",
     "/usr/lib/python%/site-packages",
     "/Library/Python/%/site-packages",
+    // conda (system-level)
+    "/opt/conda/lib/python%/dist-packages",
+    "/opt/conda/lib/python%/site-packages",
+    "/opt/miniconda3/lib/python%/site-packages",
+    "/opt/anaconda3/lib/python%/site-packages",
 };
 
 // clang-format off
@@ -55,10 +60,40 @@ const std::set<std::string> kDarwinPythonPath = {
 const std::set<std::string> kUserDirectoryPaths = {
     ".pyenv/versions",
     ".local/lib/python%",
+    // asdf
+    ".asdf/installs/python",
+    // uv (uv tool install)
+    ".local/share/uv/tools",
+    // mise
+    ".local/share/mise/installs/python",
+    // pipx (v1.2+)
+    ".local/share/pipx/venvs",
+    // pipx legacy (pre-v1.2, macOS)
+    ".local/pipx/venvs",
+    // Poetry (Linux XDG)
+    ".cache/pypoetry/virtualenvs",
+    // conda/miniforge base envs
+    "miniforge3/lib/python%",
+    "miniconda3/lib/python%",
+    "anaconda3/lib/python%",
+    "mambaforge/lib/python%",
+    // conda/miniforge named envs
+    "miniforge3/envs",
+    "miniconda3/envs",
+    "anaconda3/envs",
+    "mambaforge/envs",
+    // virtualenvwrapper
+    ".virtualenvs",
+    // pew (Linux XDG)
+    ".local/share/virtualenvs",
 };
 
 const std::set<std::string> kDarwinUserDirectoryPaths = {
     "Library/Python",
+    // Poetry (macOS)
+    "Library/Caches/pypoetry/virtualenvs",
+    // pew (macOS)
+    "Library/Application Support/virtualenvs",
 };
 
 const std::string kWinPythonInstallKey =


### PR DESCRIPTION
## What

This PR extends the default filesystem path lists used by the `python_packages` and `npm_packages` tables to include the installation locations of widely-used modern package and version managers: `uv`, `mise`, `pipx`, `poetry`, `conda`, `asdf`, `fnm`, and `volta`.

### Scope notes

This PR does not include detection of packages installed in arbitrary project-level virtual environments (e.g `.venv`).   Those can exist anywhere in the filesystem.

Currently the code uses known-path expansion. Scanning them would require a paradigm change with an unbounded tree walk (which could be resource-intensive.)

Therefore, only virtual environments created under well-known, predictable locations (managed by the tools listed above) are in scope.

## Why

`python_packages` and `npm_packages` discover installed packages by scanning a hardcoded list of filesystem paths. Any path not in the list is silently skipped, making packages invisible to osquery.

Today's most popular package and version managers (pipx, uv, mise, poetry, asdf for Python; fnm, volta, mise, asdf for Node) are all absent from that list. This means both direct packages and their transitive dependencies go unreported, which matters for vulnerability scanning and inventory.

### Example of queries to check specific package presence

Admitting we want to check if `litellm` version `1.82.8`is installed on a machine

#### Before the PR

The only working approach **requires knowing the exact path** (including the username, the tool that installed the package, and the Python version)

<details> <summary> Version 1 - hardcoded path (single user)</summary>

```sql
SELECT name, version, directory FROM python_packages
  WHERE name = 'litellm' AND version = '1.82.8'
    AND directory = '/home/johndoe/.local/pipx/venvs/litellm/lib/python3.13/site-packages';
```

</details>

<details> <summary>Version 2 - enumerate all users (still requires hardcoding the tool and Python version)</summary>

```sql
  SELECT p.name, p.version, p.directory
  FROM python_packages p
  WHERE p.name = 'litellm' AND p.version = '1.82.8'
    AND p.directory IN (
      -- pipx, python 3.13
      SELECT directory || '/.local/pipx/venvs/litellm/lib/python3.13/site-packages' FROM users
      UNION SELECT directory || '/.local/share/pipx/venvs/litellm/lib/python3.13/site-packages' FROM users
      -- pipx, python 3.12
      UNION SELECT directory || '/.local/pipx/venvs/litellm/lib/python3.12/site-packages' FROM users
      UNION SELECT directory || '/.local/share/pipx/venvs/litellm/lib/python3.12/site-packages' FROM users
      -- uv, python 3.13
      UNION SELECT directory || '/.local/share/uv/tools/litellm/lib/python3.13/site-packages' FROM users
      -- uv, python 3.12
      UNION SELECT directory || '/.local/share/uv/tools/litellm/lib/python3.12/site-packages' FROM users
      -- mise, python 3.13
      UNION SELECT directory || '/.local/share/mise/installs/python/3.13.0/lib/python3.13/site-packages' FROM users
      -- mise, python 3.12
      UNION SELECT directory || '/.local/share/mise/installs/python/3.12.7/lib/python3.12/site-packages' FROM users
      -- ... and so on for every tool × every Python version
    );
```
</details>

***Notes:*** Even this is incomplete: it assumes `litellm` is the tool name in the venv path, which is only true if it was installed directly. If it is a transitive dependency of another tool, the venv name  is not the tool's name (hard to know it upfront)


#### After the PR

```sql
  SELECT name, version, directory FROM python_packages
  WHERE name = 'litellm' AND version = '1.82.8';
```


**This PR adds those paths to the default scan list so packages installed via these tools are found automatically without having to know username, python version, the instalaltion tool**

## Changes

### `python_packages.cpp`

**`kUserDirectoryPaths`** (searched under each user's home directory):

| Tool | New path pattern |
|------|-----------------|
| asdf | `.asdf/installs/python` |
| uv (`uv tool install`) | `.local/share/uv/tools` |
| mise | `.local/share/mise/installs/python` |
| pipx (v1.2+) | `.local/share/pipx/venvs` |
| pipx legacy / macOS (reverted in v1.5) | `.local/pipx/venvs` |
| Poetry (Linux XDG) | `.cache/pypoetry/virtualenvs` |
| Conda base env | `miniforge3/lib/python%`, `miniconda3/lib/python%`, `anaconda3/lib/python%`, `mambaforge/lib/python%` |
| Conda named envs | `miniforge3/envs`, `miniconda3/envs`, `anaconda3/envs`, `mambaforge/envs` |

**`kDarwinUserDirectoryPaths`** (macOS only):

| Tool | New path pattern |
|------|-----------------|
| Poetry (macOS) | `Library/Caches/pypoetry/virtualenvs` |

**`kPythonPath`** (system-wide):

| Tool | New path pattern |
|------|-----------------|
| System conda | `/opt/conda/lib/python%/[dist\|site]-packages`, `/opt/miniconda3/lib/python%/site-packages`, `/opt/anaconda3/lib/python%/site-packages` |

### `npm_packages.cpp`

**`kNodeModulesPath`**:

| Tool | New path pattern |
|------|-----------------|
| asdf nodejs | `/home/%/.asdf/installs/nodejs/%/lib`, `/Users/%/.asdf/installs/nodejs/%/lib` |
| fnm (Linux) | `/home/%/.local/share/fnm/node-versions/%/installation/lib` |
| fnm (macOS default) | `/Users/%/Library/Application Support/fnm/node-versions/%/installation/lib` |
| fnm (macOS with XDG_DATA_HOME) | `/Users/%/.local/share/fnm/node-versions/%/installation/lib` |
| mise | `/home/%/.local/share/mise/installs/node/%/lib`, `/Users/%/.local/share/mise/installs/node/%/lib` |
| Volta | `/home/%/.volta/tools/image/node/%/lib`, `/Users/%/.volta/tools/image/node/%/lib` |

## Path verification

All paths verified against official documentation or upstream source code — none are guessed:

- **uv**: https://docs.astral.sh/uv/concepts/tools/
- **mise**: https://mise.jdx.dev/getting-started.html
- **pipx**: https://pipx.pypa.io/latest/docs/ + macOS revert: https://github.com/pypa/pipx/issues/1198
- **Poetry**: https://python-poetry.org/docs/configuration/
- **conda**: https://docs.conda.io/projects/conda/en/stable/user-guide/install/linux.html
- **fnm**: https://github.com/Schniz/fnm/blob/master/docs/configuration.md
- **Volta**: https://github.com/volta-cli/volta/issues/1639

## Tests

No new unit tests are added. This change modifies only static path constant arrays (`kPythonPath`, `kUserDirectoryPaths`, `kDarwinUserDirectoryPaths`, `kNodeModulesPath`). Hence, there is no new logic to test. The parsing logic exercised by these paths is already covered by:

- `osquery/tables/system/tests/npm_packages_tests.cpp` — unit tests for `genNodeSiteDirectories`
- `tests/integration/tables/python_packages.cpp` and `tests/integration/tables/npm_packages.cpp` — schema sanity checks

This follows the same approach as #8529, which added new paths to `python_packages` without adding tests.

## Manual verification

Two properties can be verified with an unmodified osquery binary.

### 1. Auto-discovery works without knowing the username, Python version, or install tool

A plain query (no filter) already auto-discovers packages across all users and Python versions for the paths currently in the scan list:

```
$ osqueryd -S --line "SELECT name, version, directory FROM python_packages;" 2>/dev/null \
    | grep "directory ="  | sort -u

directory = /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/site-packages/
directory = /opt/homebrew/lib/python3.11/site-packages/
directory = /opt/homebrew/lib/python3.12/site-packages/
directory = /opt/homebrew/lib/python3.13/site-packages/
directory = /Users/me/Library/Python/3.8/lib/python/site-packages/
directory = /Users/me/Library/Python/3.9/lib/python/site-packages/
directory = /Users/me/Library/Python/3.11/lib/python/site-packages/
```

No username, Python version, or install tool was specified (osquery found them all). 

This PR extends this same auto-discovery to pipx, uv, mise, poetry, asdf, and conda. After the PR, their paths will appear in the scan list and here automatically.

### 2. Transitive dependencies are caught

`python_packages` scans site-packages directories recursively, so it finds all packages present: whether installed directly or pulled in as a dependency.

We can take the example of a `kubernetes` package installed via `pipx`. Querying its venv directly returns all 18 packages inside, including `urllib3` which is a transitive dependency:

```
$ osqueryd -S --line \
    "SELECT name, version FROM python_packages \
     WHERE directory = '/Users/me/.local/pipx/venvs/kubernetes/lib/python3.13/site-packages';" 2>/dev/null

   name = kubernetes
   name = urllib3
   name = requests
   name = certifi
   name = charset-normalizer
   name = idna
   name = oauthlib
   name = requests-oauthlib
   name = google-auth
   name = cachetools
   name = pyasn1
   name = pyasn1_modules
   name = rsa
   name = PyYAML
   name = python-dateutil
   name = six
   name = durationpy
   name = websocket-client
```

Today, a plain `SELECT name, version FROM python_packages WHERE name = 'urllib3'` won't return the pipx install. 

After the PR, `~/.local/pipx/venvs` is in the scan list. The `kubernetes` venv is discovered automatically, and all 18 packages, including `urllib3`, appear in a plain query with no filter.
