### PR TITLE
Add recursion to `npm_packages`

### DIFF
--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -215,16 +215,13 @@ QueryData genNodePackagesImpl(QueryContext& context, Logger& logger) {
 
   // Read max_depth constraint, default to kDefaultMaxDepth (100)
   int max_depth = kDefaultMaxDepth;
-  if (context.constraints.count("max_depth") > 0 &&
-      context.constraints.at("max_depth").exists(EQUALS)) {
-    auto max_depth_set = context.constraints["max_depth"].getAll(EQUALS);
-    if (!max_depth_set.empty()) {
-      max_depth = tryTo<int>(*max_depth_set.begin()).takeOr(kDefaultMaxDepth);
-    }
+  if (context.hasConstraint("max_depth", EQUALS)) {
+    max_depth =
+        tryTo<int>(*context.constraints["max_depth"].getAll(EQUALS).begin())
+            .takeOr(kDefaultMaxDepth);
   }
 
-  if (context.constraints.count("directory") > 0 &&
-      context.constraints.at("directory").exists(EQUALS)) {
+  if (context.hasConstraint("directory", EQUALS)) {
     paths = context.constraints["directory"].getAll(EQUALS);
   } else {
     for (const auto& path : kNodeModulesPath) {

--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -11,6 +11,9 @@
 
 #include <stdlib.h>
 #include <string>
+#include <sys/stat.h>
+#include <unordered_set>
+#include <utility>
 
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
@@ -48,6 +51,33 @@ const std::vector<std::string> kPackageKeys{
     "name", "version", "description", "homepage"};
 
 const std::string kWinNodeInstallKey = "SOFTWARE\\Node.js\\InstallPath";
+
+const int kDefaultMaxDepth = 100;
+
+/**
+ * @brief Check if a directory has already been visited using inode tracking.
+ *
+ * This prevents infinite loops from symlinks pointing back up the directory
+ * tree. Uses platformLstat which doesn't follow symlinks.
+ *
+ * @param visited_inos Set of already-visited inodes
+ * @param path Directory path to check
+ * @return true if already visited, false if new
+ */
+static bool isDirVisited(std::unordered_set<int>& visited_inos,
+                         const std::string& path) {
+  if (path.empty()) {
+    return true;
+  }
+
+  struct stat d_stat;
+  if (!platformLstat(path, d_stat).ok()) {
+    return false;
+  }
+
+  auto [_, inserted] = visited_inos.emplace(d_stat.st_ino);
+  return !inserted;
+}
 
 void genNodePackage(const std::string& file, Row& r, Logger& logger) {
   std::string json;
@@ -107,30 +137,60 @@ void genNodePackage(const std::string& file, Row& r, Logger& logger) {
 
 void genNodeSiteDirectories(const std::string& site,
                             QueryData& results,
-                            Logger& logger) {
-  std::vector<std::string> manifest_paths;
+                            Logger& logger,
+                            int max_depth) {
+  // Queue of (directory_to_search, current_depth) pairs
+  std::vector<std::pair<std::string, int>> dirs_to_search;
+  std::unordered_set<int> visited_inos;
 
-  // Search for direct packages: node_modules/package/package.json
-  boost::filesystem::path pattern1("node_modules/%/package.json");
-  resolveFilePattern(site / pattern1, manifest_paths);
+  dirs_to_search.emplace_back(site, 0);
 
-  // Search for nested packages: node_modules/@scope/package/package.json
-  boost::filesystem::path pattern2("node_modules/@%/%/package.json");
-  resolveFilePattern(site / pattern2, manifest_paths);
+  while (!dirs_to_search.empty()) {
+    auto [current_dir, depth] = dirs_to_search.back();
+    dirs_to_search.pop_back();
 
-  for (const auto& path : manifest_paths) {
-    Row r;
-    genNodePackage(path, r, logger);
-    r["directory"] = site;
-    r["path"] = path;
-    r["pid_with_namespace"] = "0";
-    results.push_back(r);
+    // Skip if we've visited this directory already (symlink loop protection)
+    if (isDirVisited(visited_inos, current_dir)) {
+      continue;
+    }
+
+    std::vector<std::string> manifest_paths;
+
+    // Search for direct packages: node_modules/package/package.json
+    fs::path pattern1("node_modules/%/package.json");
+    resolveFilePattern(current_dir / pattern1, manifest_paths);
+
+    // Search for scoped packages: node_modules/@scope/package/package.json
+    fs::path pattern2("node_modules/@%/%/package.json");
+    resolveFilePattern(current_dir / pattern2, manifest_paths);
+
+    for (const auto& path : manifest_paths) {
+      Row r;
+      genNodePackage(path, r, logger);
+      r["directory"] = site;
+      r["path"] = path;
+      r["depth"] = INTEGER(depth);
+      r["max_depth"] = INTEGER(max_depth);
+      r["pid_with_namespace"] = "0";
+      results.push_back(r);
+
+      // Queue nested node_modules for searching if not at max depth
+      if (max_depth == -1 || depth < max_depth) {
+        fs::path pkg_dir = fs::path(path).parent_path();
+        fs::path nested_modules = pkg_dir / "node_modules";
+        boost::system::error_code ec;
+        if (fs::is_directory(nested_modules, ec)) {
+          dirs_to_search.emplace_back(pkg_dir.string(), depth + 1);
+        }
+      }
+    }
   }
 }
 
 void genWinNodePackages(const std::string& keyGlob,
                         QueryData& results,
-                        Logger& logger) {
+                        Logger& logger,
+                        int max_depth) {
 #ifdef WIN32
   std::set<std::string> installPathKeys;
   expandRegistryGlobs(keyGlob, installPathKeys);
@@ -141,7 +201,7 @@ void genWinNodePackages(const std::string& keyGlob,
       if (p.at("name") != "(Default)") {
         continue;
       }
-      genNodeSiteDirectories(p.at("data"), results, logger);
+      genNodeSiteDirectories(p.at("data"), results, logger, max_depth);
     }
     nodeInstallLocation.clear();
   }
@@ -151,6 +211,21 @@ void genWinNodePackages(const std::string& keyGlob,
 QueryData genNodePackagesImpl(QueryContext& context, Logger& logger) {
   QueryData results;
   std::set<std::string> paths;
+
+  // Read max_depth constraint, default to kDefaultMaxDepth (100)
+  int max_depth = kDefaultMaxDepth;
+  if (context.constraints.count("max_depth") > 0 &&
+      context.constraints.at("max_depth").exists(EQUALS)) {
+    auto max_depth_set = context.constraints["max_depth"].getAll(EQUALS);
+    if (!max_depth_set.empty()) {
+      try {
+        max_depth = std::stoi(*max_depth_set.begin());
+      } catch (const std::exception&) {
+        // Keep default on parse failure
+      }
+    }
+  }
+
   if (context.constraints.count("directory") > 0 &&
       context.constraints.at("directory").exists(EQUALS)) {
     paths = context.constraints["directory"].getAll(EQUALS);
@@ -165,15 +240,15 @@ QueryData genNodePackagesImpl(QueryContext& context, Logger& logger) {
     if (isPlatform(PlatformType::TYPE_WINDOWS)) {
       // Enumerate any system installed npm packages
       auto installPathKey = "HKEY_LOCAL_MACHINE\\" + kWinNodeInstallKey;
-      genWinNodePackages(installPathKey, results, logger);
+      genWinNodePackages(installPathKey, results, logger, max_depth);
 
       // Enumerate any user installed npm packages
       installPathKey = "HKEY_USERS\\%\\" + kWinNodeInstallKey;
-      genWinNodePackages(installPathKey, results, logger);
+      genWinNodePackages(installPathKey, results, logger, max_depth);
     }
   }
   for (const auto& key : paths) {
-    genNodeSiteDirectories(key, results, logger);
+    genNodeSiteDirectories(key, results, logger, max_depth);
   }
 
   return results;

--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -18,6 +18,7 @@
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/json/json.h>
 #include <osquery/worker/ipc/platform_table_container_ipc.h>
@@ -218,11 +219,7 @@ QueryData genNodePackagesImpl(QueryContext& context, Logger& logger) {
       context.constraints.at("max_depth").exists(EQUALS)) {
     auto max_depth_set = context.constraints["max_depth"].getAll(EQUALS);
     if (!max_depth_set.empty()) {
-      try {
-        max_depth = std::stoi(*max_depth_set.begin());
-      } catch (const std::exception&) {
-        // Keep default on parse failure
-      }
+      max_depth = tryTo<int>(*max_depth_set.begin()).takeOr(kDefaultMaxDepth);
     }
   }
 

--- a/osquery/tables/system/tests/npm_packages_tests.cpp
+++ b/osquery/tables/system/tests/npm_packages_tests.cpp
@@ -23,7 +23,8 @@ namespace tables {
 void genNodePackage(const std::string& file, Row& r, Logger& logger);
 void genNodeSiteDirectories(const std::string& site,
                             QueryData& results,
-                            Logger& logger);
+                            Logger& logger,
+                            int max_depth);
 
 } // namespace tables
 } // namespace osquery
@@ -83,6 +84,40 @@ class NpmPackagesUnitTest : public testing::Test {
     createPackageJson(package_path, package_json);
   }
 
+  // Helper to create a nested regular package (inside another package)
+  void createNestedRegularPackage(const fs::path& parent_pkg_path,
+                                  const std::string& package_name,
+                                  const std::string& version) {
+    auto package_path =
+        parent_pkg_path / "node_modules" / package_name / "package.json";
+    std::string package_json = R"({
+  "name": ")" + package_name + R"(",
+  "version": ")" + version + R"(",
+  "description": "Test nested package",
+  "author": "Nested Author",
+  "license": "ISC"
+})";
+    createPackageJson(package_path, package_json);
+  }
+
+  // Helper to create a nested scoped package (inside another package)
+  void createNestedScopedPackage(const fs::path& parent_pkg_path,
+                                 const std::string& scope,
+                                 const std::string& package_name,
+                                 const std::string& version) {
+    auto package_path = parent_pkg_path / "node_modules" / scope /
+                        package_name / "package.json";
+    std::string package_json = R"({
+  "name": ")" + scope + "/" + package_name +
+                               R"(",
+  "version": ")" + version + R"(",
+  "description": "Test nested scoped package",
+  "author": "Nested Author",
+  "license": "ISC"
+})";
+    createPackageJson(package_path, package_json);
+  }
+
   fs::path temp_dir_;
 };
 
@@ -102,7 +137,7 @@ TEST_F(NpmPackagesUnitTest, test_scoped_package_detection) {
   createScopedPackage("nested", "package", "3.2.1");
 
   QueryData results;
-  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger);
+  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger, 100);
 
   // We should find only 4 packages (2 scoped + 2 regular)
   // The nested/package should NOT be found
@@ -173,6 +208,164 @@ TEST_F(NpmPackagesUnitTest, test_scoped_package_detection) {
       << "Did not find @angular/core scoped package";
   EXPECT_TRUE(found_regular_express) << "Did not find express regular package";
   EXPECT_TRUE(found_regular_lodash) << "Did not find lodash regular package";
+}
+
+TEST_F(NpmPackagesUnitTest, test_nested_package_detection) {
+  GLOGLogger logger;
+
+  // Create a top-level package
+  createRegularPackage("express", "4.18.0");
+
+  // Create nested regular package inside express
+  auto express_path = temp_dir_ / "node_modules" / "express";
+  createNestedRegularPackage(express_path, "body-parser", "1.20.0");
+
+  // Create nested scoped package inside express
+  createNestedScopedPackage(express_path, "@types", "express", "4.17.0");
+
+  // Create deeply nested package (depth 2)
+  auto body_parser_path = express_path / "node_modules" / "body-parser";
+  createNestedRegularPackage(body_parser_path, "bytes", "3.1.0");
+
+  QueryData results;
+  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger, 100);
+
+  // Should find 4 packages: express (depth 0), body-parser (depth 1),
+  // @types/express (depth 1), bytes (depth 2)
+  EXPECT_EQ(results.size(), 4);
+
+  bool found_express = false;
+  bool found_body_parser = false;
+  bool found_types_express = false;
+  bool found_bytes = false;
+
+  for (const auto& row : results) {
+    auto name = row.at("name");
+    auto depth = row.at("depth");
+
+    if (name == "express") {
+      found_express = true;
+      EXPECT_EQ(depth, "0");
+      EXPECT_EQ(row.at("version"), "4.18.0");
+    } else if (name == "body-parser") {
+      found_body_parser = true;
+      EXPECT_EQ(depth, "1");
+      EXPECT_EQ(row.at("version"), "1.20.0");
+    } else if (name == "@types/express") {
+      found_types_express = true;
+      EXPECT_EQ(depth, "1");
+      EXPECT_EQ(row.at("version"), "4.17.0");
+    } else if (name == "bytes") {
+      found_bytes = true;
+      EXPECT_EQ(depth, "2");
+      EXPECT_EQ(row.at("version"), "3.1.0");
+    }
+
+    // All packages should have the root directory as their directory
+    EXPECT_EQ(row.at("directory"), temp_dir_.string());
+  }
+
+  EXPECT_TRUE(found_express) << "Did not find express at depth 0";
+  EXPECT_TRUE(found_body_parser) << "Did not find body-parser at depth 1";
+  EXPECT_TRUE(found_types_express) << "Did not find @types/express at depth 1";
+  EXPECT_TRUE(found_bytes) << "Did not find bytes at depth 2";
+}
+
+TEST_F(NpmPackagesUnitTest, test_max_depth_zero_no_recursion) {
+  GLOGLogger logger;
+
+  // Create a top-level package with nested dependencies
+  createRegularPackage("express", "4.18.0");
+  auto express_path = temp_dir_ / "node_modules" / "express";
+  createNestedRegularPackage(express_path, "body-parser", "1.20.0");
+
+  QueryData results;
+  // max_depth = 0 should only return top-level packages
+  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger, 0);
+
+  // Should find only 1 package (express at depth 0)
+  EXPECT_EQ(results.size(), 1);
+  EXPECT_EQ(results[0].at("name"), "express");
+  EXPECT_EQ(results[0].at("depth"), "0");
+}
+
+TEST_F(NpmPackagesUnitTest, test_max_depth_limits_recursion) {
+  GLOGLogger logger;
+
+  // Create packages at depths 0, 1, and 2
+  createRegularPackage("pkg-depth-0", "1.0.0");
+
+  auto depth0_path = temp_dir_ / "node_modules" / "pkg-depth-0";
+  createNestedRegularPackage(depth0_path, "pkg-depth-1", "1.0.0");
+
+  auto depth1_path = depth0_path / "node_modules" / "pkg-depth-1";
+  createNestedRegularPackage(depth1_path, "pkg-depth-2", "1.0.0");
+
+  // max_depth = 1 should return packages at depth 0 and 1, but not 2
+  QueryData results;
+  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger, 1);
+
+  EXPECT_EQ(results.size(), 2);
+
+  bool found_depth_0 = false;
+  bool found_depth_1 = false;
+
+  for (const auto& row : results) {
+    auto name = row.at("name");
+    if (name == "pkg-depth-0") {
+      found_depth_0 = true;
+      EXPECT_EQ(row.at("depth"), "0");
+    } else if (name == "pkg-depth-1") {
+      found_depth_1 = true;
+      EXPECT_EQ(row.at("depth"), "1");
+    } else {
+      FAIL() << "Unexpected package found: " << name
+             << " (should not find depth 2 with max_depth=1)";
+    }
+  }
+
+  EXPECT_TRUE(found_depth_0);
+  EXPECT_TRUE(found_depth_1);
+}
+
+TEST_F(NpmPackagesUnitTest, test_nested_scoped_packages) {
+  GLOGLogger logger;
+
+  // Create a scoped top-level package
+  createScopedPackage("@angular", "core", "15.0.0");
+
+  // Create nested packages inside the scoped package
+  auto angular_core_path = temp_dir_ / "node_modules" / "@angular" / "core";
+  createNestedRegularPackage(angular_core_path, "rxjs", "7.8.0");
+  createNestedScopedPackage(angular_core_path, "@angular", "common", "15.0.0");
+
+  QueryData results;
+  tables::genNodeSiteDirectories(temp_dir_.string(), results, logger, 100);
+
+  EXPECT_EQ(results.size(), 3);
+
+  bool found_angular_core = false;
+  bool found_rxjs = false;
+  bool found_angular_common = false;
+
+  for (const auto& row : results) {
+    auto name = row.at("name");
+    if (name == "@angular/core") {
+      found_angular_core = true;
+      EXPECT_EQ(row.at("depth"), "0");
+    } else if (name == "rxjs") {
+      found_rxjs = true;
+      EXPECT_EQ(row.at("depth"), "1");
+    } else if (name == "@angular/common") {
+      found_angular_common = true;
+      EXPECT_EQ(row.at("depth"), "1");
+    }
+  }
+
+  EXPECT_TRUE(found_angular_core) << "Did not find @angular/core at depth 0";
+  EXPECT_TRUE(found_rxjs) << "Did not find rxjs at depth 1";
+  EXPECT_TRUE(found_angular_common)
+      << "Did not find @angular/common at depth 1";
 }
 
 } // namespace table_tests

--- a/specs/npm_packages.table
+++ b/specs/npm_packages.table
@@ -8,7 +8,9 @@ schema([
     Column("license", TEXT, "License under which package is launched"),
     Column("homepage", TEXT, "Package supplied homepage"),
     Column("path", TEXT, "Path at which this module resides"),
-    Column("directory", TEXT, "Directory where node_modules are located", index=True, optimized=True)
+    Column("directory", TEXT, "Directory where node_modules are located", index=True, optimized=True),
+    Column("depth", INTEGER, "Nesting depth of the package (0 = direct dependency)"),
+    Column("max_depth", INTEGER, "Maximum depth to search for nested packages (default 100, -1 = unlimited)", additional=True, hidden=True),
 ])
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
@@ -18,6 +20,8 @@ implementation("npm_packages@genNodePackages")
 examples([
   "select * from npm_packages",
   "select * from npm_packages where directory = '/home/user/my_project'",
+  "select * from npm_packages where directory = '/home/user/my_project' and max_depth = 0",
+  "select name, version, depth from npm_packages where depth > 0",
 ])
 fuzz_paths([
     "/usr/lib/node_modules/",

--- a/tests/integration/tables/npm_packages.cpp
+++ b/tests/integration/tables/npm_packages.cpp
@@ -35,6 +35,7 @@ TEST_F(NpmPackagesTest, test_sanity) {
       {"license", NormalType},
       {"path", NonEmptyString},
       {"directory", NonEmptyString},
+      {"depth", IntType},
   };
 
   validate_rows(data, row_map);


### PR DESCRIPTION
Fixes: #8807

Over in #8807 we discussed how more and more of the NPM modules ship vendored packages. And that osquery doesn't support finding them. This adds a iterative depth search, with support for `max_depth`. The robots helped.

Stock osquery:
```
osquery> select count(*) from npm_packages where directory = "/opt/homebrew/lib";
+----------+
| count(*) |
+----------+
| 1        |
+----------+
```

PR:
```
osquery> select count(*) from npm_packages where directory = "/opt/homebrew/lib";
+----------+
| count(*) |
+----------+
| 201      |
+----------+

osquery> select depth, count(*) from npm_packages where directory = "/opt/homebrew/lib" GROUP BY depth;
+-------+----------+
| depth | count(*) |
+-------+----------+
| 0     | 1        |
| 1     | 172      |
| 2     | 28       |
+-------+----------+

osquery> select name, count(*) as c  from npm_packages where directory = "/opt/homebrew/lib" GROUP BY name ORDER BY c DESC LIMIT 10;
+-----------------------+---+
| name                  | c |
+-----------------------+---+
| strip-ansi            | 4 |
| string-width          | 4 |
| minipass              | 4 |
| spdx-expression-parse | 3 |
| minimatch             | 3 |
| emoji-regex           | 3 |
| ansi-regex            | 3 |
| yallist               | 2 |
| wrap-ansi             | 2 |
| which                 | 2 |
+-----------------------+---+
```

