### PR TITLE
Add `ROOT\default` to WMI tables

### DIFF
--- a/osquery/core/windows/wmi.h
+++ b/osquery/core/windows/wmi.h
@@ -24,6 +24,12 @@
 
 namespace osquery {
 
+/// WMI namespaces commonly used for event subscription persistence detection
+const std::vector<std::wstring> kWmiEventNamespaces = {
+    L"ROOT\\Subscription",
+    L"ROOT\\default",
+};
+
 using WmiMethodArgsMap = std::unordered_map<std::string, VARIANT>;
 
 namespace impl {

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <sstream>
-#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -18,22 +17,13 @@
 namespace osquery {
 namespace tables {
 
-namespace {
-const std::vector<std::wstring> kWmiNamespaces = {
-    L"ROOT\\Subscription",
-    L"ROOT\\default",
-};
-} // namespace
-
 QueryData genWmiCliConsumers(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM CommandLineEventConsumer";
 
-  for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.c_str());
-    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-    ::SysFreeString(bstr);
+  for (const auto& ns : kWmiEventNamespaces) {
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), ns);
 
     if (request && request->getStatus().ok()) {
       const auto& results = request->results();

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <sstream>
+#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -17,26 +18,36 @@
 namespace osquery {
 namespace tables {
 
+namespace {
+const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
+    {L"ROOT\\Subscription", "ROOT\\Subscription"},
+    {L"ROOT\\default", "ROOT\\default"},
+};
+} // namespace
+
 QueryData genWmiCliConsumers(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM CommandLineEventConsumer";
 
-  BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-  ::SysFreeString(bstr);
+  for (const auto& ns : kWmiNamespaces) {
+    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
+    ::SysFreeString(bstr);
 
-  if (request && request->getStatus().ok()) {
-    const auto& results = request->results();
-    for (const auto& result : results) {
-      Row r;
+    if (request && request->getStatus().ok()) {
+      const auto& results = request->results();
+      for (const auto& result : results) {
+        Row r;
 
-      result.GetString("CommandLineTemplate", r["command_line_template"]);
-      result.GetString("ExecutablePath", r["executable_path"]);
-      result.GetString("Name", r["name"]);
-      result.GetString("__CLASS", r["class"]);
-      result.GetString("__RELPATH", r["relative_path"]);
-      results_data.push_back(r);
+        r["namespace"] = ns.second;
+        result.GetString("CommandLineTemplate", r["command_line_template"]);
+        result.GetString("ExecutablePath", r["executable_path"]);
+        result.GetString("Name", r["name"]);
+        result.GetString("__CLASS", r["class"]);
+        result.GetString("__RELPATH", r["relative_path"]);
+        results_data.push_back(r);
+      }
     }
   }
 

--- a/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_cli_event_consumers.cpp
@@ -19,9 +19,9 @@ namespace osquery {
 namespace tables {
 
 namespace {
-const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
-    {L"ROOT\\Subscription", "ROOT\\Subscription"},
-    {L"ROOT\\default", "ROOT\\default"},
+const std::vector<std::wstring> kWmiNamespaces = {
+    L"ROOT\\Subscription",
+    L"ROOT\\default",
 };
 } // namespace
 
@@ -31,7 +31,7 @@ QueryData genWmiCliConsumers(QueryContext& context) {
   ss << "SELECT * FROM CommandLineEventConsumer";
 
   for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    BSTR bstr = ::SysAllocString(ns.c_str());
     const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
     ::SysFreeString(bstr);
 
@@ -40,7 +40,7 @@ QueryData genWmiCliConsumers(QueryContext& context) {
       for (const auto& result : results) {
         Row r;
 
-        r["namespace"] = ns.second;
+        r["namespace"] = std::string(ns.begin(), ns.end());
         result.GetString("CommandLineTemplate", r["command_line_template"]);
         result.GetString("ExecutablePath", r["executable_path"]);
         result.GetString("Name", r["name"]);

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -19,9 +19,9 @@ namespace osquery {
 namespace tables {
 
 namespace {
-const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
-    {L"ROOT\\Subscription", "ROOT\\Subscription"},
-    {L"ROOT\\default", "ROOT\\default"},
+const std::vector<std::wstring> kWmiNamespaces = {
+    L"ROOT\\Subscription",
+    L"ROOT\\default",
 };
 } // namespace
 
@@ -31,7 +31,7 @@ QueryData genWmiFilters(QueryContext& context) {
   ss << "SELECT * FROM __EventFilter";
 
   for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    BSTR bstr = ::SysAllocString(ns.c_str());
     const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
     ::SysFreeString(bstr);
 
@@ -40,7 +40,7 @@ QueryData genWmiFilters(QueryContext& context) {
       for (const auto& result : results) {
         Row r;
 
-        r["namespace"] = ns.second;
+        r["namespace"] = std::string(ns.begin(), ns.end());
         result.GetString("Name", r["name"]);
         result.GetString("Query", r["query"]);
         result.GetString("QueryLanguage", r["query_language"]);

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <sstream>
-#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -18,22 +17,13 @@
 namespace osquery {
 namespace tables {
 
-namespace {
-const std::vector<std::wstring> kWmiNamespaces = {
-    L"ROOT\\Subscription",
-    L"ROOT\\default",
-};
-} // namespace
-
 QueryData genWmiFilters(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM __EventFilter";
 
-  for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.c_str());
-    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-    ::SysFreeString(bstr);
+  for (const auto& ns : kWmiEventNamespaces) {
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), ns);
 
     if (request && request->getStatus().ok()) {
       const auto& results = request->results();

--- a/osquery/tables/system/windows/wmi_event_filters.cpp
+++ b/osquery/tables/system/windows/wmi_event_filters.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <sstream>
+#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -17,26 +18,36 @@
 namespace osquery {
 namespace tables {
 
+namespace {
+const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
+    {L"ROOT\\Subscription", "ROOT\\Subscription"},
+    {L"ROOT\\default", "ROOT\\default"},
+};
+} // namespace
+
 QueryData genWmiFilters(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM __EventFilter";
 
-  BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-  ::SysFreeString(bstr);
+  for (const auto& ns : kWmiNamespaces) {
+    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
+    ::SysFreeString(bstr);
 
-  if (request && request->getStatus().ok()) {
-    const auto& results = request->results();
-    for (const auto& result : results) {
-      Row r;
+    if (request && request->getStatus().ok()) {
+      const auto& results = request->results();
+      for (const auto& result : results) {
+        Row r;
 
-      result.GetString("Name", r["name"]);
-      result.GetString("Query", r["query"]);
-      result.GetString("QueryLanguage", r["query_language"]);
-      result.GetString("__CLASS", r["class"]);
-      result.GetString("__RELPATH", r["relative_path"]);
-      results_data.push_back(r);
+        r["namespace"] = ns.second;
+        result.GetString("Name", r["name"]);
+        result.GetString("Query", r["query"]);
+        result.GetString("QueryLanguage", r["query_language"]);
+        result.GetString("__CLASS", r["class"]);
+        result.GetString("__RELPATH", r["relative_path"]);
+        results_data.push_back(r);
+      }
     }
   }
 

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <sstream>
+#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -17,25 +18,35 @@
 namespace osquery {
 namespace tables {
 
+namespace {
+const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
+    {L"ROOT\\Subscription", "ROOT\\Subscription"},
+    {L"ROOT\\default", "ROOT\\default"},
+};
+} // namespace
+
 QueryData genFilterConsumer(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
-  BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-  ::SysFreeString(bstr);
+  for (const auto& ns : kWmiNamespaces) {
+    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
+    ::SysFreeString(bstr);
 
-  if (request && request->getStatus().ok()) {
-    const auto& results = request->results();
-    for (const auto& result : results) {
-      Row r;
+    if (request && request->getStatus().ok()) {
+      const auto& results = request->results();
+      for (const auto& result : results) {
+        Row r;
 
-      result.GetString("Consumer", r["consumer"]);
-      result.GetString("Filter", r["filter"]);
-      result.GetString("__CLASS", r["class"]);
-      result.GetString("__RELPATH", r["relative_path"]);
-      results_data.push_back(r);
+        r["namespace"] = ns.second;
+        result.GetString("Consumer", r["consumer"]);
+        result.GetString("Filter", r["filter"]);
+        result.GetString("__CLASS", r["class"]);
+        result.GetString("__RELPATH", r["relative_path"]);
+        results_data.push_back(r);
+      }
     }
   }
 

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -19,9 +19,9 @@ namespace osquery {
 namespace tables {
 
 namespace {
-const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
-    {L"ROOT\\Subscription", "ROOT\\Subscription"},
-    {L"ROOT\\default", "ROOT\\default"},
+const std::vector<std::wstring> kWmiNamespaces = {
+    L"ROOT\\Subscription",
+    L"ROOT\\default",
 };
 } // namespace
 
@@ -31,7 +31,7 @@ QueryData genFilterConsumer(QueryContext& context) {
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
   for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    BSTR bstr = ::SysAllocString(ns.c_str());
     const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
     ::SysFreeString(bstr);
 
@@ -40,7 +40,7 @@ QueryData genFilterConsumer(QueryContext& context) {
       for (const auto& result : results) {
         Row r;
 
-        r["namespace"] = ns.second;
+        r["namespace"] = std::string(ns.begin(), ns.end());
         result.GetString("Consumer", r["consumer"]);
         result.GetString("Filter", r["filter"]);
         result.GetString("__CLASS", r["class"]);

--- a/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
+++ b/osquery/tables/system/windows/wmi_filter_consumer_binding.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <sstream>
-#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -18,22 +17,13 @@
 namespace osquery {
 namespace tables {
 
-namespace {
-const std::vector<std::wstring> kWmiNamespaces = {
-    L"ROOT\\Subscription",
-    L"ROOT\\default",
-};
-} // namespace
-
 QueryData genFilterConsumer(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM __FilterToConsumerBinding";
 
-  for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.c_str());
-    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-    ::SysFreeString(bstr);
+  for (const auto& ns : kWmiEventNamespaces) {
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), ns);
 
     if (request && request->getStatus().ok()) {
       const auto& results = request->results();

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <sstream>
+#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -17,27 +18,37 @@
 namespace osquery {
 namespace tables {
 
+namespace {
+const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
+    {L"ROOT\\Subscription", "ROOT\\Subscription"},
+    {L"ROOT\\default", "ROOT\\default"},
+};
+} // namespace
+
 QueryData genScriptConsumers(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
-  BSTR bstr = ::SysAllocString(L"ROOT\\Subscription");
-  const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-  ::SysFreeString(bstr);
+  for (const auto& ns : kWmiNamespaces) {
+    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
+    ::SysFreeString(bstr);
 
-  if (request && request->getStatus().ok()) {
-    const auto& results = request->results();
-    for (const auto& result : results) {
-      Row r;
+    if (request && request->getStatus().ok()) {
+      const auto& results = request->results();
+      for (const auto& result : results) {
+        Row r;
 
-      result.GetString("ScriptText", r["script_text"]);
-      result.GetString("ScriptFileName", r["script_file_name"]);
-      result.GetString("ScriptingEngine", r["scripting_engine"]);
-      result.GetString("Name", r["name"]);
-      result.GetString("__CLASS", r["class"]);
-      result.GetString("__RELPATH", r["relative_path"]);
-      results_data.push_back(r);
+        r["namespace"] = ns.second;
+        result.GetString("ScriptText", r["script_text"]);
+        result.GetString("ScriptFileName", r["script_file_name"]);
+        result.GetString("ScriptingEngine", r["scripting_engine"]);
+        result.GetString("Name", r["name"]);
+        result.GetString("__CLASS", r["class"]);
+        result.GetString("__RELPATH", r["relative_path"]);
+        results_data.push_back(r);
+      }
     }
   }
 

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -19,9 +19,9 @@ namespace osquery {
 namespace tables {
 
 namespace {
-const std::vector<std::pair<std::wstring, std::string>> kWmiNamespaces = {
-    {L"ROOT\\Subscription", "ROOT\\Subscription"},
-    {L"ROOT\\default", "ROOT\\default"},
+const std::vector<std::wstring> kWmiNamespaces = {
+    L"ROOT\\Subscription",
+    L"ROOT\\default",
 };
 } // namespace
 
@@ -31,7 +31,7 @@ QueryData genScriptConsumers(QueryContext& context) {
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
   for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.first.c_str());
+    BSTR bstr = ::SysAllocString(ns.c_str());
     const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
     ::SysFreeString(bstr);
 
@@ -40,7 +40,7 @@ QueryData genScriptConsumers(QueryContext& context) {
       for (const auto& result : results) {
         Row r;
 
-        r["namespace"] = ns.second;
+        r["namespace"] = std::string(ns.begin(), ns.end());
         result.GetString("ScriptText", r["script_text"]);
         result.GetString("ScriptFileName", r["script_file_name"]);
         result.GetString("ScriptingEngine", r["scripting_engine"]);

--- a/osquery/tables/system/windows/wmi_script_event_consumers.cpp
+++ b/osquery/tables/system/windows/wmi_script_event_consumers.cpp
@@ -8,7 +8,6 @@
  */
 
 #include <sstream>
-#include <vector>
 
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
@@ -18,22 +17,13 @@
 namespace osquery {
 namespace tables {
 
-namespace {
-const std::vector<std::wstring> kWmiNamespaces = {
-    L"ROOT\\Subscription",
-    L"ROOT\\default",
-};
-} // namespace
-
 QueryData genScriptConsumers(QueryContext& context) {
   QueryData results_data;
   std::stringstream ss;
   ss << "SELECT * FROM ActiveScriptEventConsumer";
 
-  for (const auto& ns : kWmiNamespaces) {
-    BSTR bstr = ::SysAllocString(ns.c_str());
-    const auto request = WmiRequest::CreateWmiRequest(ss.str(), bstr);
-    ::SysFreeString(bstr);
+  for (const auto& ns : kWmiEventNamespaces) {
+    const auto request = WmiRequest::CreateWmiRequest(ss.str(), ns);
 
     if (request && request->getStatus().ok()) {
       const auto& results = request->results();

--- a/specs/windows/wmi_cli_event_consumers.table
+++ b/specs/windows/wmi_cli_event_consumers.table
@@ -1,6 +1,7 @@
 table_name("wmi_cli_event_consumers")
 description("WMI CommandLineEventConsumer, which can be used for persistence on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details.")
 schema([
+    Column("namespace", TEXT, "The WMI namespace where the consumer was found."),
     Column("name", TEXT, "Unique name of a consumer."),
     Column("command_line_template", TEXT, "Standard string template that specifies the process to be started. This property can be NULL, and the ExecutablePath property is used as the command line."),
     Column("executable_path", TEXT, "Module to execute. The string can specify the full path and file name of the module to execute, or it can specify a partial name. If a partial name is specified, the current drive and current directory are assumed."),

--- a/specs/windows/wmi_event_filters.table
+++ b/specs/windows/wmi_event_filters.table
@@ -1,6 +1,7 @@
 table_name("wmi_event_filters")
 description("Lists WMI event filters.")
 schema([
+    Column("namespace", TEXT, "The WMI namespace where the filter was found."),
     Column("name", TEXT, "Unique identifier of an event filter."),
     Column("query", TEXT, "Windows Management Instrumentation Query Language (WQL) event query that specifies the set of events for consumer notification, and the specific conditions for notification."),
     Column("query_language", TEXT, "Query language that the query is written in."),

--- a/specs/windows/wmi_filter_consumer_binding.table
+++ b/specs/windows/wmi_filter_consumer_binding.table
@@ -1,6 +1,7 @@
 table_name("wmi_filter_consumer_binding")
 description("Lists the relationship between event consumers and filters.")
 schema([
+    Column("namespace", TEXT, "The WMI namespace where the binding was found."),
     Column("consumer", TEXT, "Reference to an instance of __EventConsumer that represents the object path to a logical consumer, the recipient of an event."),
     Column("filter", TEXT, "Reference to an instance of __EventFilter that represents the object path to an event filter which is a query that specifies the type of event to be received."),
     Column("class", TEXT, "The name of the class."),

--- a/specs/windows/wmi_script_event_consumers.table
+++ b/specs/windows/wmi_script_event_consumers.table
@@ -1,6 +1,7 @@
 table_name("wmi_script_event_consumers")
 description("WMI ActiveScriptEventConsumer, which can be used for persistence on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details.")
 schema([
+    Column("namespace", TEXT, "The WMI namespace where the consumer was found."),
     Column("name", TEXT, "Unique identifier for the event consumer. "),
     Column("scripting_engine", TEXT, "Name of the scripting engine to use, for example, 'VBScript'. This property cannot be NULL."),
     Column("script_file_name", TEXT, "Name of the file from which the script text is read, intended as an alternative to specifying the text of the script in the ScriptText property."),


### PR DESCRIPTION
Expand the four WMI event subscription tables to query both `ROOT\Subscription` and `ROOT\default` namespaces, improving detection coverage for WMI persistence techniques. Attackers can use either namespace for persistence mechanisms.

Changes:
- Query both `ROOT\Subscription` and `ROOT\default` namespaces
- Add new `namespace` column to identify the source namespace

Affected tables:
- wmi_cli_event_consumers
- wmi_event_filters
- wmi_filter_consumer_binding
- wmi_script_event_consumers

Fixes #3924
