### PR TITLE
Fix: certificates keychain corruption macOS 26

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -189,7 +189,7 @@ QueryData genCerts(QueryContext& context) {
     // with a search list built from SecKeychainCopyDomainSearchList. This
     // avoids SecKeychainOpen which corrupts the login keychain on macOS 26+.
     CFArrayRef certs = CreateAllKeychainCertificates();
-    if (certs != nullptr && CFGetTypeID(certs) == CFArrayGetTypeID()) {
+    if (certs != nullptr) {
       auto count = CFArrayGetCount(certs);
       for (CFIndex i = 0; i < count; i++) {
         auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -142,11 +142,7 @@ QueryData genCerts(QueryContext& context) {
   // Lock keychain access to 1 table/thread at a time.
   std::unique_lock<decltype(keychainMutex)> lock(keychainMutex);
 
-  // Allow the caller to set both an explicit keychain search path
-  // and certificate files on disk.
-  std::set<std::string> keychain_paths;
-
-  // Expand paths
+  // Expand paths from query constraints.
   auto paths = context.constraints["path"].getAll(EQUALS);
   context.expandConstraints(
       "path",
@@ -165,15 +161,15 @@ QueryData genCerts(QueryContext& context) {
       }));
 
   @autoreleasepool {
-    // Map of path to hash and keychain reference. This ensures we don't open
-    // the same keychain multiple times when the table's path constraint is
-    // used.
-    std::map<std::string,
-             std::tuple<boost::filesystem::path, std::string, SecKeychainRef>>
-        opened_keychains;
+    // Determine which paths are in the default keychain search list (Tier 1,
+    // safe) vs non-standard paths that need SecKeychainOpen (Tier 2, legacy).
+    auto default_kc_paths = getDefaultKeychainPaths();
+
+    std::set<std::string> standard_paths;
+    std::set<std::string> nonstandard_paths;
+
     if (!paths.empty()) {
       for (const auto& path : paths) {
-        // Check whether path is valid
         boost::system::error_code ec;
         auto source =
             boost::filesystem::canonical(boost::filesystem::path(path), ec);
@@ -182,125 +178,155 @@ QueryData genCerts(QueryContext& context) {
           continue;
         }
 
-        // Check cache
-        bool err = false;
-        std::string hash;
-        bool hit =
-            keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-        if (err) {
-          TLOG << "Could not read the file at " << path << "" << ec.message();
-          continue;
-        }
-        if (hit) {
-          continue;
-        }
-
-        SecKeychainRef keychain = nullptr;
-        SecKeychainStatus keychain_status;
-        OSStatus status;
-        OSQUERY_USE_DEPRECATED(status =
-                                   SecKeychainOpen(path.c_str(), &keychain));
-        bool genFileCert = false;
-        if (status != errSecSuccess || keychain == nullptr) {
-          genFileCert = true;
+        if (default_kc_paths.count(source.string()) > 0) {
+          standard_paths.insert(source.string());
         } else {
-          OSQUERY_USE_DEPRECATED(
-              status = SecKeychainGetStatus(keychain, &keychain_status));
-          if (status != errSecSuccess) {
-            genFileCert = true;
-          }
-        }
-        if (genFileCert) {
-          if (keychain != nullptr) {
-            CFRelease(keychain);
-          }
-          QueryData new_results;
-          genFileCertificate(path, new_results);
-          // Write new results to the cache.
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
-          results.insert(results.end(), new_results.begin(), new_results.end());
-        } else {
-          // This path will be re-accessed later.
-          keychain_paths.insert(path);
-          opened_keychains.insert(
-              {path, std::make_tuple(source, hash, keychain)});
+          nonstandard_paths.insert(path);
         }
       }
     } else {
-      keychain_paths = getKeychainPaths();
+      // No path constraints: enumerate all default keychain directories.
+      auto kc_dirs = getKeychainPaths();
+      auto expanded = expandPaths(kc_dirs);
+      for (const auto& p : expanded) {
+        boost::system::error_code ec;
+        auto source =
+            boost::filesystem::canonical(boost::filesystem::path(p), ec);
+        if (!ec.failed() && is_regular_file(source, ec) && !ec.failed()) {
+          if (default_kc_paths.count(source.string()) > 0) {
+            standard_paths.insert(source.string());
+          } else {
+            nonstandard_paths.insert(p);
+          }
+        }
+      }
     }
 
-    // Since we are used a cache for each keychain file, we must process
-    // certificates one keychain file at a time.
-    std::set<std::string> expanded_paths = expandPaths(keychain_paths);
-    for (const auto& path : expanded_paths) {
-      SecKeychainRef keychain = nullptr;
+    // --- Tier 1: Safe path using SecItemCopyMatching without SecKeychainOpen.
+    // Check per-path cache for standard paths first.
+    // Map of cache-miss paths to their file hashes.
+    std::map<std::string, std::string> cache_miss_hashes;
+
+    for (const auto& spath : standard_paths) {
+      boost::filesystem::path source(spath);
+      bool err = false;
       std::string hash;
-      boost::filesystem::path source;
-      auto it = opened_keychains.find(path);
-      if (it != opened_keychains.end()) {
-        source = std::get<0>(it->second);
-        hash = std::get<1>(it->second);
-        keychain = std::get<2>(it->second);
-      } else {
-        // Check whether path is valid
-        boost::system::error_code ec;
-        source =
-            boost::filesystem::canonical(boost::filesystem::path(path), ec);
-        if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
-          // File does not exist or user does not have access. Don't log here to
-          // reduce noise.
-          continue;
-        }
+      bool hit =
+          keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
+      if (err) {
+        TLOG << "Could not read the file at " << spath;
+        continue;
+      }
+      if (!hit) {
+        cache_miss_hashes[spath] = hash;
+      }
+    }
 
-        // Check cache
-        bool err = false;
-        bool hit =
-            keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-        if (err) {
-          TLOG << "Could not read the file at " << source.string() << ""
-               << ec.message();
-          continue;
-        }
-        if (hit) {
-          continue;
-        }
+    if (!cache_miss_hashes.empty()) {
+      CFArrayRef certs = CreateAllKeychainCertificates();
+      if (certs != nullptr && CFGetTypeID(certs) == CFArrayGetTypeID()) {
+        // Partition results by keychain path.
+        std::map<std::string, QueryData> partitioned;
+        auto count = CFArrayGetCount(certs);
+        for (CFIndex i = 0; i < count; i++) {
+          auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+          auto cert_path = getKeychainPath((SecKeychainItemRef)cert);
 
-        // Cache miss. We need to generate new results.
-        OSStatus status;
-        OSQUERY_USE_DEPRECATED(status =
-                                   SecKeychainOpen(source.c_str(), &keychain));
-        if (status != errSecSuccess || keychain == nullptr) {
-          if (keychain != nullptr) {
-            CFRelease(keychain);
+          if (cache_miss_hashes.count(cert_path) > 0) {
+            genKeychainCertificate(cert, partitioned[cert_path]);
           }
-          // Cache an empty result to prevent the above API call in the future.
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
-          continue;
+        }
+
+        // Write each partition to cache and append to results.
+        for (auto& [path, new_results] : partitioned) {
+          keychainCache.Write(boost::filesystem::path(path),
+                              KEYCHAIN_TABLE,
+                              cache_miss_hashes[path],
+                              new_results);
+          results.insert(
+              results.end(), new_results.begin(), new_results.end());
+          cache_miss_hashes.erase(path);
+        }
+
+        CFRelease(certs);
+      }
+
+      // Any remaining cache-miss paths had no certificates; cache empty.
+      for (const auto& [path, hash] : cache_miss_hashes) {
+        keychainCache.Write(
+            boost::filesystem::path(path), KEYCHAIN_TABLE, hash, {});
+      }
+    }
+
+    // --- Tier 2: Legacy path for non-standard keychains and cert files.
+    // Uses SecKeychainOpen as a fallback (risk accepted for non-standard paths).
+    std::set<std::string> expanded_nonstandard = expandPaths(nonstandard_paths);
+    for (const auto& path : expanded_nonstandard) {
+      boost::system::error_code ec;
+      auto source =
+          boost::filesystem::canonical(boost::filesystem::path(path), ec);
+      if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
+        continue;
+      }
+
+      bool err = false;
+      std::string hash;
+      bool hit =
+          keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
+      if (err || hit) {
+        continue;
+      }
+
+      // Try opening as a keychain database first.
+      SecKeychainRef keychain = nullptr;
+      SecKeychainStatus keychain_status;
+      OSStatus status;
+      OSQUERY_USE_DEPRECATED(status =
+                                 SecKeychainOpen(path.c_str(), &keychain));
+
+      bool use_file_cert = false;
+      if (status != errSecSuccess || keychain == nullptr) {
+        use_file_cert = true;
+      } else {
+        OSQUERY_USE_DEPRECATED(
+            status = SecKeychainGetStatus(keychain, &keychain_status));
+        if (status != errSecSuccess) {
+          use_file_cert = true;
         }
       }
 
-      auto keychains = CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
-      CFArrayAppendValue(keychains, keychain);
-      QueryData new_results;
-      // Keychains/certificate stores belonging to the OS.
-      CFArrayRef certs = CreateKeychainItems(keychains, kSecClassCertificate);
-      CFRelease(keychains);
-      // Must have returned an array of matching certificates.
-      if (certs != nullptr) {
-        if (CFGetTypeID(certs) == CFArrayGetTypeID()) {
-          auto certificate_count = CFArrayGetCount(certs);
-          for (CFIndex i = 0; i < certificate_count; i++) {
-            auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
-            genKeychainCertificate(cert, new_results);
-          }
+      if (use_file_cert) {
+        if (keychain != nullptr) {
+          CFRelease(keychain);
         }
-        CFRelease(certs);
+        QueryData new_results;
+        genFileCertificate(path, new_results);
         keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
         results.insert(results.end(), new_results.begin(), new_results.end());
       } else {
-        // Cache an empty result to prevent the above API call in the future.
-        keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+        auto keychains =
+            CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
+        CFArrayAppendValue(keychains, keychain);
+        QueryData new_results;
+        CFArrayRef items =
+            CreateKeychainItems(keychains, kSecClassCertificate);
+        CFRelease(keychains);
+        if (items != nullptr) {
+          if (CFGetTypeID(items) == CFArrayGetTypeID()) {
+            auto cert_count = CFArrayGetCount(items);
+            for (CFIndex i = 0; i < cert_count; i++) {
+              auto cert =
+                  (SecCertificateRef)CFArrayGetValueAtIndex(items, i);
+              genKeychainCertificate(cert, new_results);
+            }
+          }
+          CFRelease(items);
+          keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
+          results.insert(
+              results.end(), new_results.begin(), new_results.end());
+        } else {
+          keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+        }
       }
     }
   }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -208,9 +208,10 @@ QueryData genCerts(QueryContext& context) {
       CFRelease(certs);
     }
 
-    // Query system trusted anchor certificates via SecTrustCopyAnchorCertificates.
-    // This covers certs from SystemRootCertificates.keychain and X509Anchors
-    // that are not in the domain search lists above.
+    // Query system trusted anchor certificates via
+    // SecTrustCopyAnchorCertificates. This covers certs from
+    // SystemRootCertificates.keychain and X509Anchors that are not in the
+    // domain search lists above.
     CFArrayRef anchors = nullptr;
     if (SecTrustCopyAnchorCertificates(&anchors) == errSecSuccess &&
         anchors != nullptr) {

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -168,7 +168,6 @@ QueryData genCerts(QueryContext& context) {
 
     // Collect the set of valid path constraints for filtering.
     std::set<std::string> filter_paths;
-    std::set<std::string> cert_file_paths;
     if (!paths.empty()) {
       for (const auto& path : paths) {
         boost::system::error_code ec;
@@ -225,6 +224,9 @@ QueryData genCerts(QueryContext& context) {
         }
 
         genKeychainCertificate(cert, results);
+        if (!cert_path.empty()) {
+          satisfied_paths.insert(cert_path);
+        }
       }
       CFRelease(anchors);
     }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -161,13 +161,14 @@ QueryData genCerts(QueryContext& context) {
       }));
 
   @autoreleasepool {
-    // Determine which paths are in the default keychain search list (Tier 1,
-    // safe) vs non-standard paths that need SecKeychainOpen (Tier 2, legacy).
-    auto default_kc_paths = getDefaultKeychainPaths();
+    // Use SecItemCopyMatching to query all certificates from the system
+    // without calling SecKeychainOpen, which can trigger securityd write
+    // operations that corrupt the keychain database on unclean shutdown
+    // (macOS 26+). Results are filtered by path constraints afterward.
 
-    std::set<std::string> standard_paths;
-    std::set<std::string> nonstandard_paths;
-
+    // Collect the set of valid path constraints for filtering.
+    std::set<std::string> filter_paths;
+    std::set<std::string> cert_file_paths;
     if (!paths.empty()) {
       for (const auto& path : paths) {
         boost::system::error_code ec;
@@ -177,155 +178,78 @@ QueryData genCerts(QueryContext& context) {
           TLOG << "Could not access file " << path << " " << ec.message();
           continue;
         }
-
-        if (default_kc_paths.count(source.string()) > 0) {
-          standard_paths.insert(source.string());
-        } else {
-          nonstandard_paths.insert(path);
-        }
-      }
-    } else {
-      // No path constraints: enumerate all default keychain directories.
-      auto kc_dirs = getKeychainPaths();
-      auto expanded = expandPaths(kc_dirs);
-      for (const auto& p : expanded) {
-        boost::system::error_code ec;
-        auto source =
-            boost::filesystem::canonical(boost::filesystem::path(p), ec);
-        if (!ec.failed() && is_regular_file(source, ec) && !ec.failed()) {
-          if (default_kc_paths.count(source.string()) > 0) {
-            standard_paths.insert(source.string());
-          } else {
-            nonstandard_paths.insert(p);
-          }
-        }
+        filter_paths.insert(source.string());
       }
     }
 
-    // --- Tier 1: Safe path using SecItemCopyMatching without SecKeychainOpen.
-    // Check per-path cache for standard paths first.
-    // Map of cache-miss paths to their file hashes.
-    std::map<std::string, std::string> cache_miss_hashes;
+    // Track which paths have been satisfied so we can fall back to
+    // genFileCertificate for DER/PEM files.
+    std::set<std::string> satisfied_paths;
 
-    for (const auto& spath : standard_paths) {
-      boost::filesystem::path source(spath);
-      bool err = false;
-      std::string hash;
-      bool hit =
-          keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-      if (err) {
-        TLOG << "Could not read the file at " << spath;
-        continue;
+    // Query all certificates from all keychain domains via SecItemCopyMatching
+    // with a search list built from SecKeychainCopyDomainSearchList. This
+    // avoids SecKeychainOpen which corrupts the login keychain on macOS 26+.
+    CFArrayRef certs = CreateAllKeychainCertificates();
+    if (certs != nullptr && CFGetTypeID(certs) == CFArrayGetTypeID()) {
+      auto count = CFArrayGetCount(certs);
+      for (CFIndex i = 0; i < count; i++) {
+        auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+        auto cert_path = getKeychainPath((SecKeychainItemRef)cert);
+
+        if (!filter_paths.empty() && filter_paths.count(cert_path) == 0) {
+          continue;
+        }
+
+        genKeychainCertificate(cert, results);
+        if (!cert_path.empty()) {
+          satisfied_paths.insert(cert_path);
+        }
       }
-      if (!hit) {
-        cache_miss_hashes[spath] = hash;
+      CFRelease(certs);
+    }
+
+    // Query system trusted anchor certificates via SecTrustCopyAnchorCertificates.
+    // This covers certs from SystemRootCertificates.keychain and X509Anchors
+    // that are not in the domain search lists above.
+    // Deduplicate against certs already found by tracking SHA1 hashes.
+    std::set<std::string> seen_hashes;
+    for (const auto& r : results) {
+      if (r.count("sha1")) {
+        seen_hashes.insert(r.at("sha1"));
       }
     }
 
-    if (!cache_miss_hashes.empty()) {
-      CFArrayRef certs = CreateAllKeychainCertificates();
-      if (certs != nullptr && CFGetTypeID(certs) == CFArrayGetTypeID()) {
-        // Partition results by keychain path.
-        std::map<std::string, QueryData> partitioned;
-        auto count = CFArrayGetCount(certs);
-        for (CFIndex i = 0; i < count; i++) {
-          auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
-          auto cert_path = getKeychainPath((SecKeychainItemRef)cert);
+    CFArrayRef anchors = nullptr;
+    if (SecTrustCopyAnchorCertificates(&anchors) == errSecSuccess &&
+        anchors != nullptr) {
+      auto anchor_count = CFArrayGetCount(anchors);
+      for (CFIndex i = 0; i < anchor_count; i++) {
+        auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(anchors, i);
+        auto cert_path = getKeychainPath((SecKeychainItemRef)cert);
 
-          if (cache_miss_hashes.count(cert_path) > 0) {
-            genKeychainCertificate(cert, partitioned[cert_path]);
+        if (!filter_paths.empty() && filter_paths.count(cert_path) == 0) {
+          continue;
+        }
+
+        // Generate cert data to check for duplicates.
+        QueryData anchor_results;
+        genKeychainCertificate(cert, anchor_results);
+        for (auto& r : anchor_results) {
+          if (r.count("sha1") && seen_hashes.count(r.at("sha1")) == 0) {
+            seen_hashes.insert(r.at("sha1"));
+            results.push_back(std::move(r));
           }
         }
-
-        // Write each partition to cache and append to results.
-        for (auto& [path, new_results] : partitioned) {
-          keychainCache.Write(boost::filesystem::path(path),
-                              KEYCHAIN_TABLE,
-                              cache_miss_hashes[path],
-                              new_results);
-          results.insert(
-              results.end(), new_results.begin(), new_results.end());
-          cache_miss_hashes.erase(path);
-        }
-
-        CFRelease(certs);
       }
-
-      // Any remaining cache-miss paths had no certificates; cache empty.
-      for (const auto& [path, hash] : cache_miss_hashes) {
-        keychainCache.Write(
-            boost::filesystem::path(path), KEYCHAIN_TABLE, hash, {});
-      }
+      CFRelease(anchors);
     }
 
-    // --- Tier 2: Legacy path for non-standard keychains and cert files.
-    // Uses SecKeychainOpen as a fallback (risk accepted for non-standard paths).
-    std::set<std::string> expanded_nonstandard = expandPaths(nonstandard_paths);
-    for (const auto& path : expanded_nonstandard) {
-      boost::system::error_code ec;
-      auto source =
-          boost::filesystem::canonical(boost::filesystem::path(path), ec);
-      if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
-        continue;
-      }
-
-      bool err = false;
-      std::string hash;
-      bool hit =
-          keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-      if (err || hit) {
-        continue;
-      }
-
-      // Try opening as a keychain database first.
-      SecKeychainRef keychain = nullptr;
-      SecKeychainStatus keychain_status;
-      OSStatus status;
-      OSQUERY_USE_DEPRECATED(status =
-                                 SecKeychainOpen(path.c_str(), &keychain));
-
-      bool use_file_cert = false;
-      if (status != errSecSuccess || keychain == nullptr) {
-        use_file_cert = true;
-      } else {
-        OSQUERY_USE_DEPRECATED(
-            status = SecKeychainGetStatus(keychain, &keychain_status));
-        if (status != errSecSuccess) {
-          use_file_cert = true;
-        }
-      }
-
-      if (use_file_cert) {
-        if (keychain != nullptr) {
-          CFRelease(keychain);
-        }
-        QueryData new_results;
-        genFileCertificate(path, new_results);
-        keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
-        results.insert(results.end(), new_results.begin(), new_results.end());
-      } else {
-        auto keychains =
-            CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
-        CFArrayAppendValue(keychains, keychain);
-        QueryData new_results;
-        CFArrayRef items =
-            CreateKeychainItems(keychains, kSecClassCertificate);
-        CFRelease(keychains);
-        if (items != nullptr) {
-          if (CFGetTypeID(items) == CFArrayGetTypeID()) {
-            auto cert_count = CFArrayGetCount(items);
-            for (CFIndex i = 0; i < cert_count; i++) {
-              auto cert =
-                  (SecCertificateRef)CFArrayGetValueAtIndex(items, i);
-              genKeychainCertificate(cert, new_results);
-            }
-          }
-          CFRelease(items);
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
-          results.insert(
-              results.end(), new_results.begin(), new_results.end());
-        } else {
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+    // Any constrained paths not satisfied by keychain certs may be DER/PEM
+    // certificate files on disk.
+    if (!filter_paths.empty()) {
+      for (const auto& path : filter_paths) {
+        if (satisfied_paths.count(path) == 0) {
+          genFileCertificate(path, results);
         }
       }
     }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -211,14 +211,6 @@ QueryData genCerts(QueryContext& context) {
     // Query system trusted anchor certificates via SecTrustCopyAnchorCertificates.
     // This covers certs from SystemRootCertificates.keychain and X509Anchors
     // that are not in the domain search lists above.
-    // Deduplicate against certs already found by tracking SHA1 hashes.
-    std::set<std::string> seen_hashes;
-    for (const auto& r : results) {
-      if (r.count("sha1")) {
-        seen_hashes.insert(r.at("sha1"));
-      }
-    }
-
     CFArrayRef anchors = nullptr;
     if (SecTrustCopyAnchorCertificates(&anchors) == errSecSuccess &&
         anchors != nullptr) {
@@ -231,15 +223,7 @@ QueryData genCerts(QueryContext& context) {
           continue;
         }
 
-        // Generate cert data to check for duplicates.
-        QueryData anchor_results;
-        genKeychainCertificate(cert, anchor_results);
-        for (auto& r : anchor_results) {
-          if (r.count("sha1") && seen_hashes.count(r.at("sha1")) == 0) {
-            seen_hashes.insert(r.at("sha1"));
-            results.push_back(std::move(r));
-          }
-        }
+        genKeychainCertificate(cert, results);
       }
       CFRelease(anchors);
     }

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -78,14 +78,14 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
                                const CFTypeRef& item_type);
 
-// Query all certificates from the default keychain search list without
-// explicitly opening any keychain file. This avoids SecKeychainOpen which
-// can trigger securityd write operations that corrupt the keychain database
-// on unclean shutdown (macOS 26+).
+/// Query all certificates from the default keychain search list without
+/// explicitly opening any keychain file. This avoids SecKeychainOpen which
+/// can trigger securityd write operations that corrupt the keychain database
+/// on unclean shutdown (macOS 26+).
 CFArrayRef CreateAllKeychainCertificates();
 
-// Return the canonical file paths of keychains in the user's default search
-// list. Uses SecKeychainCopySearchList (read-only, does not open keychains).
+/// Return the canonical file paths of keychains in the user's default search
+/// list. Uses SecKeychainCopySearchList (read-only, does not open keychains).
 std::set<std::string> getDefaultKeychainPaths();
 
 std::set<std::string> getKeychainPaths();

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -84,10 +84,6 @@ CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
 /// on unclean shutdown (macOS 26+).
 CFArrayRef CreateAllKeychainCertificates();
 
-/// Return the canonical file paths of keychains in the user's default search
-/// list. Uses SecKeychainCopySearchList (read-only, does not open keychains).
-std::set<std::string> getDefaultKeychainPaths();
-
 std::set<std::string> getKeychainPaths();
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -78,6 +78,16 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
                                const CFTypeRef& item_type);
 
+// Query all certificates from the default keychain search list without
+// explicitly opening any keychain file. This avoids SecKeychainOpen which
+// can trigger securityd write operations that corrupt the keychain database
+// on unclean shutdown (macOS 26+).
+CFArrayRef CreateAllKeychainCertificates();
+
+// Return the canonical file paths of keychains in the user's default search
+// list. Uses SecKeychainCopySearchList (read-only, does not open keychains).
+std::set<std::string> getDefaultKeychainPaths();
+
 std::set<std::string> getKeychainPaths();
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -115,6 +115,34 @@ CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
 }
 
 CFArrayRef CreateAllKeychainCertificates() {
+  // Build a comprehensive search list from all keychain domains without
+  // calling SecKeychainOpen. SecKeychainCopyDomainSearchList returns refs
+  // to keychains already known to the system for each domain.
+  CFMutableArrayRef all_keychains =
+      CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
+
+  SecPreferencesDomain domains[] = {
+      kSecPreferencesDomainUser,
+      kSecPreferencesDomainSystem,
+      kSecPreferencesDomainCommon,
+      kSecPreferencesDomainDynamic,
+  };
+
+  for (auto domain : domains) {
+    CFArrayRef domain_list = nullptr;
+    OSStatus status;
+    OSQUERY_USE_DEPRECATED(
+        status = SecKeychainCopyDomainSearchList(domain, &domain_list));
+    if (status == errSecSuccess && domain_list != nullptr) {
+      auto count = CFArrayGetCount(domain_list);
+      for (CFIndex i = 0; i < count; i++) {
+        CFArrayAppendValue(
+            all_keychains, CFArrayGetValueAtIndex(domain_list, i));
+      }
+      CFRelease(domain_list);
+    }
+  }
+
   CFMutableDictionaryRef query;
   query = CFDictionaryCreateMutable(nullptr,
                                     0,
@@ -122,15 +150,18 @@ CFArrayRef CreateAllKeychainCertificates() {
                                     &kCFTypeDictionaryValueCallBacks);
   CFDictionaryAddValue(query, kSecClass, kSecClassCertificate);
   CFDictionaryAddValue(query, kSecReturnRef, kCFBooleanTrue);
-  CFDictionaryAddValue(query, kSecAttrCanVerify, kCFBooleanTrue);
   CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitAll);
-  // Intentionally omit kSecMatchSearchList so that SecItemCopyMatching
-  // searches the default keychain search list without calling SecKeychainOpen
-  // on any keychain file.
+  // Note: kSecAttrCanVerify is intentionally omitted. It is a legacy
+  // attribute not supported by the Data Protection keychain on macOS 26+.
+
+  if (CFArrayGetCount(all_keychains) > 0) {
+    CFDictionaryAddValue(query, kSecMatchSearchList, all_keychains);
+  }
 
   CFArrayRef items = nullptr;
   auto status = SecItemCopyMatching(query, (CFTypeRef*)&items);
   CFRelease(query);
+  CFRelease(all_keychains);
 
   if (status != errSecSuccess) {
     return nullptr;

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -140,6 +140,9 @@ CFArrayRef CreateAllKeychainCertificates() {
                            CFArrayGetValueAtIndex(domain_list, i));
       }
       CFRelease(domain_list);
+    } else {
+      VLOG(1) << "SecKeychainCopyDomainSearchList failed for domain "
+              << domain << " with status " << status;
     }
   }
 
@@ -153,10 +156,7 @@ CFArrayRef CreateAllKeychainCertificates() {
   CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitAll);
   // Note: kSecAttrCanVerify is intentionally omitted. It is a legacy
   // attribute not supported by the Data Protection keychain on macOS 26+.
-
-  if (CFArrayGetCount(all_keychains) > 0) {
-    CFDictionaryAddValue(query, kSecMatchSearchList, all_keychains);
-  }
+  CFDictionaryAddValue(query, kSecMatchSearchList, all_keychains);
 
   CFArrayRef items = nullptr;
   auto status = SecItemCopyMatching(query, (CFTypeRef*)&items);
@@ -164,44 +164,11 @@ CFArrayRef CreateAllKeychainCertificates() {
   CFRelease(all_keychains);
 
   if (status != errSecSuccess) {
+    VLOG(1) << "SecItemCopyMatching failed with status " << status;
     return nullptr;
   }
 
   return items;
-}
-
-std::set<std::string> getDefaultKeychainPaths() {
-  std::set<std::string> paths;
-
-  CFArrayRef search_list = nullptr;
-  OSStatus status;
-  OSQUERY_USE_DEPRECATED(status = SecKeychainCopySearchList(&search_list));
-  if (status != errSecSuccess || search_list == nullptr) {
-    return paths;
-  }
-
-  auto count = CFArrayGetCount(search_list);
-  for (CFIndex i = 0; i < count; i++) {
-    auto keychain = (SecKeychainRef)CFArrayGetValueAtIndex(search_list, i);
-    UInt32 path_size = 1024;
-    char keychain_path[1024] = {0};
-    OSQUERY_USE_DEPRECATED(
-        status = SecKeychainGetPath(keychain, &path_size, keychain_path));
-    if (status == errSecSuccess && path_size > 0 && keychain_path[0] != 0) {
-      boost::system::error_code ec;
-      auto canonical = boost::filesystem::canonical(
-          boost::filesystem::path(keychain_path), ec);
-      if (!ec.failed()) {
-        paths.insert(canonical.string());
-      } else {
-        // If canonical resolution fails, use the raw path.
-        paths.insert(std::string(keychain_path));
-      }
-    }
-  }
-
-  CFRelease(search_list);
-  return paths;
 }
 
 std::set<std::string> getKeychainPaths() {

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -141,8 +141,8 @@ CFArrayRef CreateAllKeychainCertificates() {
       }
       CFRelease(domain_list);
     } else {
-      VLOG(1) << "SecKeychainCopyDomainSearchList failed for domain "
-              << domain << " with status " << status;
+      VLOG(1) << "SecKeychainCopyDomainSearchList failed for domain " << domain
+              << " with status " << status;
     }
   }
 

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -114,6 +114,66 @@ CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
   return keychain_items;
 }
 
+CFArrayRef CreateAllKeychainCertificates() {
+  CFMutableDictionaryRef query;
+  query = CFDictionaryCreateMutable(nullptr,
+                                    0,
+                                    &kCFTypeDictionaryKeyCallBacks,
+                                    &kCFTypeDictionaryValueCallBacks);
+  CFDictionaryAddValue(query, kSecClass, kSecClassCertificate);
+  CFDictionaryAddValue(query, kSecReturnRef, kCFBooleanTrue);
+  CFDictionaryAddValue(query, kSecAttrCanVerify, kCFBooleanTrue);
+  CFDictionaryAddValue(query, kSecMatchLimit, kSecMatchLimitAll);
+  // Intentionally omit kSecMatchSearchList so that SecItemCopyMatching
+  // searches the default keychain search list without calling SecKeychainOpen
+  // on any keychain file.
+
+  CFArrayRef items = nullptr;
+  auto status = SecItemCopyMatching(query, (CFTypeRef*)&items);
+  CFRelease(query);
+
+  if (status != errSecSuccess) {
+    return nullptr;
+  }
+
+  return items;
+}
+
+std::set<std::string> getDefaultKeychainPaths() {
+  std::set<std::string> paths;
+
+  CFArrayRef search_list = nullptr;
+  OSStatus status;
+  OSQUERY_USE_DEPRECATED(status = SecKeychainCopySearchList(&search_list));
+  if (status != errSecSuccess || search_list == nullptr) {
+    return paths;
+  }
+
+  auto count = CFArrayGetCount(search_list);
+  for (CFIndex i = 0; i < count; i++) {
+    auto keychain =
+        (SecKeychainRef)CFArrayGetValueAtIndex(search_list, i);
+    UInt32 path_size = 1024;
+    char keychain_path[1024] = {0};
+    OSQUERY_USE_DEPRECATED(
+        status = SecKeychainGetPath(keychain, &path_size, keychain_path));
+    if (status == errSecSuccess && path_size > 0 && keychain_path[0] != 0) {
+      boost::system::error_code ec;
+      auto canonical = boost::filesystem::canonical(
+          boost::filesystem::path(keychain_path), ec);
+      if (!ec.failed()) {
+        paths.insert(canonical.string());
+      } else {
+        // If canonical resolution fails, use the raw path.
+        paths.insert(std::string(keychain_path));
+      }
+    }
+  }
+
+  CFRelease(search_list);
+  return paths;
+}
+
 std::set<std::string> getKeychainPaths() {
   std::set<std::string> keychain_paths;
 

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -146,6 +146,54 @@ CFArrayRef CreateAllKeychainCertificates() {
     }
   }
 
+  // When running as root, the User domain only returns root's keychains.
+  // Enumerate user home directories to find login keychains for all users,
+  // matching the old getKeychainPaths() behavior.
+  // We track paths already in the search list to avoid duplicates.
+  std::set<std::string> existing_paths;
+  for (CFIndex i = 0; i < CFArrayGetCount(all_keychains); i++) {
+    auto kc = (SecKeychainRef)CFArrayGetValueAtIndex(all_keychains, i);
+    UInt32 path_size = 1024;
+    char kc_path[1024] = {0};
+    OSStatus ps;
+    OSQUERY_USE_DEPRECATED(ps = SecKeychainGetPath(kc, &path_size, kc_path));
+    if (ps == errSecSuccess && path_size > 0 && kc_path[0] != 0) {
+      existing_paths.insert(std::string(kc_path));
+    }
+  }
+
+  try {
+    auto homes = getHomeDirectories();
+    for (const auto& dir : homes) {
+      for (const auto& keychains_dir : kUserKeychainPaths) {
+        auto kc_dir = (dir / keychains_dir).string();
+        if (!isDirectory(kc_dir).ok()) {
+          continue;
+        }
+        std::vector<std::string> files;
+        if (!listFilesInDirectory(kc_dir, files).ok()) {
+          continue;
+        }
+        for (const auto& file : files) {
+          if (existing_paths.count(file) > 0) {
+            continue;
+          }
+          SecKeychainRef keychain = nullptr;
+          OSStatus ks;
+          OSQUERY_USE_DEPRECATED(
+              ks = SecKeychainOpen(file.c_str(), &keychain));
+          if (ks == errSecSuccess && keychain != nullptr) {
+            CFArrayAppendValue(all_keychains, keychain);
+            existing_paths.insert(file);
+            CFRelease(keychain);
+          }
+        }
+      }
+    }
+  } catch (const std::exception& e) {
+    VLOG(1) << "Failed to enumerate user home directories: " << e.what();
+  }
+
   CFMutableDictionaryRef query;
   query = CFDictionaryCreateMutable(nullptr,
                                     0,

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -180,8 +180,7 @@ CFArrayRef CreateAllKeychainCertificates() {
           }
           SecKeychainRef keychain = nullptr;
           OSStatus ks;
-          OSQUERY_USE_DEPRECATED(
-              ks = SecKeychainOpen(file.c_str(), &keychain));
+          OSQUERY_USE_DEPRECATED(ks = SecKeychainOpen(file.c_str(), &keychain));
           if (ks == errSecSuccess && keychain != nullptr) {
             CFArrayAppendValue(all_keychains, keychain);
             existing_paths.insert(file);

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -136,8 +136,8 @@ CFArrayRef CreateAllKeychainCertificates() {
     if (status == errSecSuccess && domain_list != nullptr) {
       auto count = CFArrayGetCount(domain_list);
       for (CFIndex i = 0; i < count; i++) {
-        CFArrayAppendValue(
-            all_keychains, CFArrayGetValueAtIndex(domain_list, i));
+        CFArrayAppendValue(all_keychains,
+                           CFArrayGetValueAtIndex(domain_list, i));
       }
       CFRelease(domain_list);
     }
@@ -182,8 +182,7 @@ std::set<std::string> getDefaultKeychainPaths() {
 
   auto count = CFArrayGetCount(search_list);
   for (CFIndex i = 0; i < count; i++) {
-    auto keychain =
-        (SecKeychainRef)CFArrayGetValueAtIndex(search_list, i);
+    auto keychain = (SecKeychainRef)CFArrayGetValueAtIndex(search_list, i);
     UInt32 path_size = 1024;
     char keychain_path[1024] = {0};
     OSQUERY_USE_DEPRECATED(

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -118,9 +118,8 @@ TEST(KeychainUtilsTests, test_CreateAllKeychainCertificates_includes_system) {
       found_system = true;
     }
   }
-  EXPECT_TRUE(found_system)
-      << "System.keychain certs should be returned by "
-         "CreateAllKeychainCertificates";
+  EXPECT_TRUE(found_system) << "System.keychain certs should be returned by "
+                               "CreateAllKeychainCertificates";
 
   CFRelease(certs);
 }

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -103,5 +103,43 @@ TEST_F(CACertsTests, test_certificate_properties) {
   getCertificateAttributes(x_cert, is_ca, is_self_signed);
   EXPECT_TRUE(is_ca);
 }
+
+TEST(KeychainUtilsTests, test_getDefaultKeychainPaths_returns_nonempty) {
+  auto paths = getDefaultKeychainPaths();
+  // A standard macOS installation always has at least one keychain in the
+  // default search list (e.g. System.keychain or login.keychain-db).
+  EXPECT_FALSE(paths.empty());
+
+  bool found_system = false;
+  for (const auto& p : paths) {
+    if (p.find("System.keychain") != std::string::npos) {
+      found_system = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_system)
+      << "System.keychain should be in the default search list";
+}
+
+TEST(KeychainUtilsTests, test_CreateAllKeychainCertificates_returns_results) {
+  CFArrayRef certs = CreateAllKeychainCertificates();
+  ASSERT_NE(certs, nullptr);
+  EXPECT_GT(CFArrayGetCount(certs), 0);
+
+  bool found_path = false;
+  auto count = CFArrayGetCount(certs);
+  for (CFIndex i = 0; i < count && !found_path; i++) {
+    auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+    auto path = getKeychainPath((SecKeychainItemRef)cert);
+    if (!path.empty()) {
+      found_path = true;
+    }
+  }
+  EXPECT_TRUE(found_path)
+      << "At least one certificate should have a keychain path";
+
+  CFRelease(certs);
+}
+
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -104,22 +104,25 @@ TEST_F(CACertsTests, test_certificate_properties) {
   EXPECT_TRUE(is_ca);
 }
 
-TEST(KeychainUtilsTests, test_getDefaultKeychainPaths_returns_nonempty) {
-  auto paths = getDefaultKeychainPaths();
-  // A standard macOS installation always has at least one keychain in the
-  // default search list (e.g. System.keychain or login.keychain-db).
-  EXPECT_FALSE(paths.empty());
+TEST(KeychainUtilsTests, test_CreateAllKeychainCertificates_includes_system) {
+  CFArrayRef certs = CreateAllKeychainCertificates();
+  ASSERT_NE(certs, nullptr);
 
-  // Verify that the System keychain is present.
+  // Verify that at least one certificate comes from System.keychain.
   bool found_system = false;
-  for (const auto& p : paths) {
-    if (p.find("System.keychain") != std::string::npos) {
+  auto count = CFArrayGetCount(certs);
+  for (CFIndex i = 0; i < count && !found_system; i++) {
+    auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+    auto path = getKeychainPath((SecKeychainItemRef)cert);
+    if (path.find("System.keychain") != std::string::npos) {
       found_system = true;
-      break;
     }
   }
   EXPECT_TRUE(found_system)
-      << "System.keychain should be in the default search list";
+      << "System.keychain certs should be returned by "
+         "CreateAllKeychainCertificates";
+
+  CFRelease(certs);
 }
 
 TEST(KeychainUtilsTests, test_CreateAllKeychainCertificates_returns_results) {

--- a/osquery/tables/system/tests/darwin/certificates_tests.cpp
+++ b/osquery/tables/system/tests/darwin/certificates_tests.cpp
@@ -110,6 +110,7 @@ TEST(KeychainUtilsTests, test_getDefaultKeychainPaths_returns_nonempty) {
   // default search list (e.g. System.keychain or login.keychain-db).
   EXPECT_FALSE(paths.empty());
 
+  // Verify that the System keychain is present.
   bool found_system = false;
   for (const auto& p : paths) {
     if (p.find("System.keychain") != std::string::npos) {
@@ -123,9 +124,12 @@ TEST(KeychainUtilsTests, test_getDefaultKeychainPaths_returns_nonempty) {
 
 TEST(KeychainUtilsTests, test_CreateAllKeychainCertificates_returns_results) {
   CFArrayRef certs = CreateAllKeychainCertificates();
+  // A standard macOS installation has certificates in the System keychain
+  // (root CAs, etc.).
   ASSERT_NE(certs, nullptr);
   EXPECT_GT(CFArrayGetCount(certs), 0);
 
+  // Verify that at least one certificate has a resolvable keychain path.
   bool found_path = false;
   auto count = CFArrayGetCount(certs);
   for (CFIndex i = 0; i < count && !found_path; i++) {


### PR DESCRIPTION
## Problem

`SecKeychainOpen` causes `CSSMERR_DL_DATABASE_CORRUPT` on macOS 26+ when the login keychain has stored credentials. No force shutdown is required, just querying the certificates table corrupts it. (Verified by running this live query on Fleet's UI: `SELECT common_name, issuer, not_valid_after, path FROM certificates;`).

Issue: https://github.com/fleetdm/fleet/issues/43313           

<img width="1504" height="457" alt="Screenshot 2026-04-09 at 10 39 20 AM" src="https://github.com/user-attachments/assets/e02434c9-fb53-47ad-9c6b-bf4cb8aac3d9" />
                                                                                            

## Fix

Replace `SecKeychainOpen` with `SecItemCopyMatching` (using `SecKeychainCopyDomainSearchList` to build the search list) + `SecTrustCopyAnchorCertificates` to get the system root certs.

## Testing

Ran `SELECT common_name, issuer, not_valid_after, path FROM certificates;` live query on Fleet's UI.

#### Before

Exported results from Fleet: 
[osquery certs - Report (04-09-26 03-42-24).csv](https://github.com/user-attachments/files/26614837/osquery.certs.-.Report.04-09-26.03-42-24.csv)

Had 288 results, and noticed that some of these were duplicated, such as:

- `GlobalSign Root CA` - in `SystemRootCertificates.keychain` AND `X509Anchors`.                                                                              
- `QuoVadis Root CA 3` - in `SystemRootCertificates.keychain` AND `X509Anchors`.
- `XRamp Global Certification Authority` - in `SystemRootCertificates.keychain` AND `X509Anchors`.                                                                 

Seems like the old code found them separately because it opened each keychain file individually with `SecKeychainOpen`.
The new code returns each unique cert once via `SecTrustCopyAnchorCertificates`. 

#### After

167 results:
[newreport-afterfix.csv](https://github.com/user-attachments/files/26614875/newreport-afterfix.csv)

Note: Anchor certs have empty paths (Apple's modern API doesn't expose file associations).

<img width="1750" height="1313" alt="Screenshot 2026-04-09 at 6 11 38 PM" src="https://github.com/user-attachments/assets/728c313e-c8b9-4017-905c-c13723c3c22a" />

<img width="855" height="179" alt="Screenshot 2026-04-09 at 6 13 00 PM" src="https://github.com/user-attachments/assets/4fdbdf42-7f50-48f1-bac7-4884a74a4db5" />



<!-- Thank you for contributing to osquery! -->

- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [x] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [x] Ensure your PR contains a single logical change.
- [x] Ensure your PR contains tests for the changes you're submitting.
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.
- [x] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
