### PR TITLE
Vagrant configuration for testing across linux distributions/architectures

### DIFF
--- a/tools/testing/vagrant-linux-on-macos/README.md
+++ b/tools/testing/vagrant-linux-on-macos/README.md
@@ -2,6 +2,8 @@
 
 This directory contains Vagrant configuration for running various Linux distributions to test osquery binaries. Currently it is designed to use macOS on Apple Silicon as the Host OS.
 
+Guest OSes range from Ubuntu 16-24 and CentOS 6-10 on both x86 and aarch64.
+
 ## Prerequisites
 
 - [Vagrant](https://www.vagrantup.com/downloads)
@@ -17,18 +19,18 @@ vagrant plugin install virtualbox
 
 ## Usage
 
-Start up all defined VMs (there are a lot!):
+On a well-specced Macbook Pro, I am able to spin up many VMs at once (for example, all x86):
 
 ```bash
-vagrant up
+vagrant status | grep x86 | awk '{print $1}' | xargs -P0 -I {} vagrant up {}
 ```
 
-Start up only ubuntu:
+Change `grep x86` to `grep arm` or any other target you'd like. Note that standard `vagrant up` does not run in parallel with the qemu or Virtualbox providers so is much slower than this approach with `xargs -P0`.
 
-```bash
-vagrant up '/ubuntu.*/'
-```
+The contents of this directory are synced into the `/vagrant` directory of the VM when it is started. If you put an osqueryd binary in this directory, you can then try executing it on each of the running VMs:
 
 ```bash
-vagrant status | grep running | cut -d ' ' -f1 | xargs -I {} vagrant ssh {} -c "/vagrant/osqueryd -S 'select * from os_version'"
+vagrant status | grep running | cut -d ' ' -f1 | xargs -P0 -I {} vagrant ssh {} -c "/vagrant/osqueryd -S 'select * from os_version'"
 ```
+
+Remember that each architecture needs a different osqueryd binary.

--- a/tools/testing/vagrant-linux-on-macos/README.md
+++ b/tools/testing/vagrant-linux-on-macos/README.md
@@ -1,0 +1,34 @@
+# Vagrant Linux on macOS
+
+This directory contains Vagrant configuration for running various Linux distributions to test osquery binaries. Currently it is designed to use macOS on Apple Silicon as the Host OS.
+
+## Prerequisites
+
+- [Vagrant](https://www.vagrantup.com/downloads)
+- [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+- [QEMU](https://www.qemu.org/download)
+
+Install required Vagrant plugins:
+
+```bash
+vagrant plugin install vagrant-qemu
+vagrant plugin install virtualbox
+```
+
+## Usage
+
+Start up all defined VMs (there are a lot!):
+
+```bash
+vagrant up
+```
+
+Start up only ubuntu:
+
+```bash
+vagrant up '/ubuntu.*/'
+```
+
+```bash
+vagrant status | grep running | cut -d ' ' -f1 | xargs -I {} vagrant ssh {} -c "/vagrant/osqueryd -S 'select * from os_version'"
+```

--- a/tools/testing/vagrant-linux-on-macos/Vagrantfile
+++ b/tools/testing/vagrant-linux-on-macos/Vagrantfile
@@ -32,17 +32,16 @@ Vagrant.configure("2") do |config|
         vb.cpus = 2
         vb.gui = false
         vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
-        vb.customize ["modifyvm", :id, "--longmode", "on"]
       end
     end
   end
 
   centos_versions = [
-    { name: "centos6", version: "6", box: "generic/centos6", arm64_box: nil },
-    { name: "centos7", version: "7", box: "generic/centos7", arm64_box: nil },
-    { name: "centos8", version: "8", box: "generic/centos8", arm64_box: nil },
-    { name: "centos-stream-9", version: "stream-9", box: "bento/centos-stream-9", arm64_box: "bento/centos-stream-9" },
-    { name: "centos-stream-10", version: "stream-10", box: "bento/centos-stream-10", arm64_box: "bento/centos-stream-10" }
+    { name: "centos6", box: "generic/centos6"},
+    { name: "centos7", box: "generic/centos7"},
+    { name: "centos8", box: "generic/centos8"},
+    { name: "centos-stream-9", box: "bento/centos-stream-9", arm64_box: "bento/centos-stream-9" },
+    { name: "centos-stream-10", box: "bento/centos-stream-10", arm64_box: "bento/centos-stream-10" }
   ]
 
   centos_versions.each do |vm_config|
@@ -73,7 +72,7 @@ Vagrant.configure("2") do |config|
         vb.gui = false
         vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
         vb.customize ["modifyvm", :id, "--ioapic", "on"]
-        vb.customize ["modifyvm", :id, "--paravirtprovider", "minimal"]
+        vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
       end
     end
   end

--- a/tools/testing/vagrant-linux-on-macos/Vagrantfile
+++ b/tools/testing/vagrant-linux-on-macos/Vagrantfile
@@ -1,0 +1,80 @@
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = "vagrant-qemu"
+
+  ubuntu_versions = [
+    { name: "ubuntu16", version: "16.04", amd_arch: "unknown" },
+    { name: "ubuntu18", version: "18.04", amd_arch: "unknown" },
+    { name: "ubuntu20", version: "20.04", amd_arch: "amd64" },
+    { name: "ubuntu22", version: "22.04", amd_arch: "amd64" },
+    { name: "ubuntu24", version: "24.04", amd_arch: "amd64" }
+  ]
+
+  ubuntu_versions.each do |vm_config|
+    # ARM64 version
+    config.vm.define vm_config[:name] do |ubuntu|
+      ubuntu.vm.box = "cloud-image/ubuntu-#{vm_config[:version]}"
+      ubuntu.vm.box_architecture = "arm64"
+      ubuntu.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
+      ubuntu.vm.provider "qemu" do |qe|
+        qe.memory = "1G"
+        qe.ssh_auto_correct = true
+        qe.qemu_dir = "/opt/homebrew/share/qemu"
+      end
+    end
+
+    # x86_64 version
+    config.vm.define "#{vm_config[:name]}-x86" do |ubuntu|
+      ubuntu.vm.box = "bento/ubuntu-#{vm_config[:version]}"
+      ubuntu.vm.box_architecture = vm_config[:amd_arch]
+      ubuntu.vm.synced_folder ".", "/vagrant"
+      ubuntu.vm.provider "virtualbox" do |vb|
+        vb.memory = "1024"
+        vb.cpus = 2
+        vb.gui = false
+        vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
+        vb.customize ["modifyvm", :id, "--longmode", "on"]
+      end
+    end
+  end
+
+  centos_versions = [
+    { name: "centos6", version: "6", box: "generic/centos6", arm64_box: nil },
+    { name: "centos7", version: "7", box: "generic/centos7", arm64_box: nil },
+    { name: "centos8", version: "8", box: "generic/centos8", arm64_box: nil },
+    { name: "centos-stream-9", version: "stream-9", box: "bento/centos-stream-9", arm64_box: "bento/centos-stream-9" },
+    { name: "centos-stream-10", version: "stream-10", box: "bento/centos-stream-10", arm64_box: "bento/centos-stream-10" }
+  ]
+
+  centos_versions.each do |vm_config|
+    # ARM64 version (only for CentOS Stream 9+)
+    if vm_config[:arm64_box]
+      config.vm.define vm_config[:name] do |centos|
+        centos.vm.box = vm_config[:arm64_box]
+        centos.vm.box_architecture = "arm64"
+        centos.vm.synced_folder ".", "/vagrant"
+        centos.vm.provider "virtualbox" do |vb|
+          vb.memory = "1024"
+          vb.cpus = 2
+          vb.gui = false
+          vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
+          vb.customize ["modifyvm", :id, "--ioapic", "on"]
+        end
+      end
+    end
+
+    # x86_64 version
+    config.vm.define "#{vm_config[:name]}-x86" do |centos|
+      centos.vm.box = vm_config[:box]
+      centos.vm.box_architecture = "amd64"
+      centos.vm.synced_folder ".", "/vagrant"
+      centos.vm.provider "virtualbox" do |vb|
+        vb.memory = "1024"
+        vb.cpus = 2
+        vb.gui = false
+        vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
+        vb.customize ["modifyvm", :id, "--ioapic", "on"]
+        vb.customize ["modifyvm", :id, "--paravirtprovider", "minimal"]
+      end
+    end
+  end
+end

--- a/tools/testing/vagrant-linux-on-macos/Vagrantfile
+++ b/tools/testing/vagrant-linux-on-macos/Vagrantfile
@@ -1,22 +1,25 @@
 Vagrant.configure("2") do |config|
-  config.vagrant.plugins = "vagrant-qemu"
+  config.vagrant.plugins = ["vagrant-qemu", "virtualbox"]
+
+  config.ssh.connect_timeout = 5
 
   ubuntu_versions = [
-    { name: "ubuntu16", version: "16.04", amd_arch: "unknown" },
-    { name: "ubuntu18", version: "18.04", amd_arch: "unknown" },
-    { name: "ubuntu20", version: "20.04", amd_arch: "amd64" },
-    { name: "ubuntu22", version: "22.04", amd_arch: "amd64" },
-    { name: "ubuntu24", version: "24.04", amd_arch: "amd64" }
+    { name: "ubuntu16", box: "bento/ubuntu-16.04", arm_box: "cloud-image/ubuntu-16.04", amd_arch: "unknown" },
+    { name: "ubuntu18", box: "bento/ubuntu-18.04", arm_box: "cloud-image/ubuntu-18.04", amd_arch: "unknown" },
+    { name: "ubuntu20", box: "bento/ubuntu-20.04", arm_box: "cloud-image/ubuntu-20.04", amd_arch: "amd64" },
+    { name: "ubuntu22", box: "bento/ubuntu-22.04", arm_box: "cloud-image/ubuntu-22.04", amd_arch: "amd64" },
+    { name: "ubuntu24", box: "bento/ubuntu-24.04", arm_box: "cloud-image/ubuntu-24.04", amd_arch: "amd64" }
   ]
 
   ubuntu_versions.each do |vm_config|
     # ARM64 version
-    config.vm.define vm_config[:name] do |ubuntu|
-      ubuntu.vm.box = "cloud-image/ubuntu-#{vm_config[:version]}"
+    config.vm.define "#{vm_config[:name]}-arm" do |ubuntu|
+      ubuntu.vm.box = vm_config[:arm_box]
       ubuntu.vm.box_architecture = "arm64"
       ubuntu.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
       ubuntu.vm.provider "qemu" do |qe|
-        qe.memory = "1G"
+        qe.memory = "2G"
+        qe.smp = 2
         qe.ssh_auto_correct = true
         qe.qemu_dir = "/opt/homebrew/share/qemu"
       end
@@ -24,8 +27,11 @@ Vagrant.configure("2") do |config|
 
     # x86_64 version
     config.vm.define "#{vm_config[:name]}-x86" do |ubuntu|
-      ubuntu.vm.box = "bento/ubuntu-#{vm_config[:version]}"
-      ubuntu.vm.box_architecture = vm_config[:amd_arch]
+      ubuntu.vm.box = vm_config[:box]
+      # Only set box_architecture if it's a valid value (not "unknown")
+      if vm_config[:amd_arch] != "unknown"
+        ubuntu.vm.box_architecture = vm_config[:amd_arch]
+      end
       ubuntu.vm.synced_folder ".", "/vagrant"
       ubuntu.vm.provider "virtualbox" do |vb|
         vb.memory = "1024"
@@ -40,15 +46,15 @@ Vagrant.configure("2") do |config|
     { name: "centos6", box: "generic/centos6"},
     { name: "centos7", box: "generic/centos7"},
     { name: "centos8", box: "generic/centos8"},
-    { name: "centos-stream-9", box: "bento/centos-stream-9", arm64_box: "bento/centos-stream-9" },
-    { name: "centos-stream-10", box: "bento/centos-stream-10", arm64_box: "bento/centos-stream-10" }
+    { name: "centos-stream-9", box: "bento/centos-stream-9", arm_box: "bento/centos-stream-9" },
+    { name: "centos-stream-10", box: nil, arm_box: "bento/centos-stream-10" } # could not find a working centos stream 10 for amd64
   ]
 
   centos_versions.each do |vm_config|
     # ARM64 version (only for CentOS Stream 9+)
-    if vm_config[:arm64_box]
-      config.vm.define vm_config[:name] do |centos|
-        centos.vm.box = vm_config[:arm64_box]
+    if vm_config[:arm_box]
+      config.vm.define "#{vm_config[:name]}-arm" do |centos|
+        centos.vm.box = vm_config[:arm_box]
         centos.vm.box_architecture = "arm64"
         centos.vm.synced_folder ".", "/vagrant"
         centos.vm.provider "virtualbox" do |vb|
@@ -62,17 +68,19 @@ Vagrant.configure("2") do |config|
     end
 
     # x86_64 version
-    config.vm.define "#{vm_config[:name]}-x86" do |centos|
-      centos.vm.box = vm_config[:box]
-      centos.vm.box_architecture = "amd64"
-      centos.vm.synced_folder ".", "/vagrant"
-      centos.vm.provider "virtualbox" do |vb|
-        vb.memory = "1024"
-        vb.cpus = 2
-        vb.gui = false
-        vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
-        vb.customize ["modifyvm", :id, "--ioapic", "on"]
-        vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+    if vm_config[:box]
+      config.vm.define "#{vm_config[:name]}-x86" do |centos|
+        centos.vm.box = vm_config[:box]
+        centos.vm.box_architecture = "amd64"
+        centos.vm.synced_folder ".", "/vagrant"
+        centos.vm.provider "virtualbox" do |vb|
+          vb.memory = "1024"
+          vb.cpus = 2
+          vb.gui = false
+          vb.customize ["modifyvm", :id, "--ostype", "RedHat_64"]
+          vb.customize ["modifyvm", :id, "--ioapic", "on"]
+          vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
+        end
       end
     end
   end

--- a/tools/testing/vagrant-linux-on-macos/Vagrantfile
+++ b/tools/testing/vagrant-linux-on-macos/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure("2") do |config|
   config.ssh.connect_timeout = 5
 
   ubuntu_versions = [
-    { name: "ubuntu16", box: "bento/ubuntu-16.04", arm_box: "cloud-image/ubuntu-16.04", amd_arch: "unknown" },
+    { name: "ubuntu16", box: "bento/ubuntu-16.04", arm_box: nil , amd_arch: "unknown" }, # could not find working ubuntu 16.04 for arm64
     { name: "ubuntu18", box: "bento/ubuntu-18.04", arm_box: "cloud-image/ubuntu-18.04", amd_arch: "unknown" },
     { name: "ubuntu20", box: "bento/ubuntu-20.04", arm_box: "cloud-image/ubuntu-20.04", amd_arch: "amd64" },
     { name: "ubuntu22", box: "bento/ubuntu-22.04", arm_box: "cloud-image/ubuntu-22.04", amd_arch: "amd64" },
@@ -13,15 +13,17 @@ Vagrant.configure("2") do |config|
 
   ubuntu_versions.each do |vm_config|
     # ARM64 version
-    config.vm.define "#{vm_config[:name]}-arm" do |ubuntu|
-      ubuntu.vm.box = vm_config[:arm_box]
-      ubuntu.vm.box_architecture = "arm64"
-      ubuntu.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
-      ubuntu.vm.provider "qemu" do |qe|
-        qe.memory = "2G"
-        qe.smp = 2
-        qe.ssh_auto_correct = true
-        qe.qemu_dir = "/opt/homebrew/share/qemu"
+    if vm_config[:arm_box]
+      config.vm.define "#{vm_config[:name]}-arm" do |ubuntu|
+        ubuntu.vm.box = vm_config[:arm_box]
+        ubuntu.vm.box_architecture = "arm64"
+        ubuntu.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__auto: true
+        ubuntu.vm.provider "qemu" do |qe|
+          qe.memory = "2G"
+          qe.smp = 2
+          qe.ssh_auto_correct = true
+          qe.qemu_dir = "/opt/homebrew/share/qemu"
+        end
       end
     end
 


### PR DESCRIPTION
This makes testing osquery builds much easier on an Apple Silicon device.

Guest OSes range from Ubuntu 16-24 and CentOS 6-10 on both x86 and aarch64.