### PR TITLE
Fix: save file times in file carves

### DIFF
--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -252,6 +252,15 @@ std::set<fs::path> Carver::carveAll() {
       }
     }
 
+    // Capture source timestamps before reading the file, since read() updates
+    // atime on Linux when the filesystem is mounted with strict atime
+    // semantics.
+    PlatformTime srcTimes;
+    bool hasSrcTimes = src.getFileTimes(srcTimes);
+    if (!hasSrcTimes) {
+      VLOG(1) << "Failed to read source file timestamps: " << srcPath;
+    }
+
     PlatformFile dst(dstPath, PF_CREATE_NEW | PF_WRITE);
     if (!dst.isValid()) {
       VLOG(1) << "Destination temporary file is invalid: " << dstPath;
@@ -259,14 +268,11 @@ std::set<fs::path> Carver::carveAll() {
     }
     Status s = blockwiseCopy(src, dst);
     if (s.ok()) {
-      PlatformTime srcTimes;
-      if (src.getFileTimes(srcTimes)) {
+      if (hasSrcTimes) {
         if (!dst.setFileTimes(srcTimes)) {
           VLOG(1) << "Failed to preserve timestamps for carved file: "
                   << dstPath;
         }
-      } else {
-        VLOG(1) << "Failed to read source file timestamps: " << srcPath;
       }
       carvedFiles.insert(dstPath);
     } else {

--- a/osquery/carver/carver.cpp
+++ b/osquery/carver/carver.cpp
@@ -259,6 +259,15 @@ std::set<fs::path> Carver::carveAll() {
     }
     Status s = blockwiseCopy(src, dst);
     if (s.ok()) {
+      PlatformTime srcTimes;
+      if (src.getFileTimes(srcTimes)) {
+        if (!dst.setFileTimes(srcTimes)) {
+          VLOG(1) << "Failed to preserve timestamps for carved file: "
+                  << dstPath;
+        }
+      } else {
+        VLOG(1) << "Failed to read source file timestamps: " << srcPath;
+      }
       carvedFiles.insert(dstPath);
     } else {
       VLOG(1) << "Failed to copy file from " << srcPath << " to " << dstPath

--- a/osquery/carver/tests/carver_tests.cpp
+++ b/osquery/carver/tests/carver_tests.cpp
@@ -11,6 +11,12 @@
 
 #include <gtest/gtest.h>
 
+#ifdef WIN32
+#include <sys/utime.h>
+#else
+#include <sys/time.h>
+#endif
+
 #include <osquery/carver/carver.h>
 #include <osquery/carver/carver_utils.h>
 #include <osquery/core/core.h>
@@ -49,6 +55,7 @@ class FakeCarver : public Carver {
   FRIEND_TEST(CarverTests, test_carve_files_locally);
   FRIEND_TEST(CarverTests, test_carve_start);
   FRIEND_TEST(CarverTests, test_carve_files_not_exists);
+  FRIEND_TEST(CarverTests, test_carve_preserves_timestamps);
 };
 
 class FakeCarverRunner : public CarverRunner<FakeCarver> {
@@ -131,6 +138,74 @@ TEST_F(CarverTests, test_carve_files_locally) {
   PlatformFile tar(tarPath, PF_OPEN_EXISTING | PF_READ);
   EXPECT_TRUE(tar.isValid());
   EXPECT_GT(tar.size(), 0U);
+}
+
+TEST_F(CarverTests, test_carve_preserves_timestamps) {
+  // Verify that carving preserves the original file's atime and mtime.
+  // This is a regression test: the copy to the staging directory must not
+  // replace the file's timestamps with the time of the carve operation.
+
+  const auto srcPath = getFilesToCarveDir() / "timestamped.txt";
+  ASSERT_TRUE(writeTextFile(srcPath, "timestamp preservation test").ok());
+
+  // Set a known, old timestamp so we can tell it apart from "now".
+  // atime = 2020-09-13, mtime = 2017-07-14 (both in the past).
+  const time_t expected_atime = 1600000000;
+  const time_t expected_mtime = 1500000000;
+
+#ifdef WIN32
+  struct __utimbuf64 times;
+  times.actime = expected_atime;
+  times.modtime = expected_mtime;
+  ASSERT_EQ(_wutime64(srcPath.wstring().c_str(), &times), 0)
+      << "Failed to set file timestamps";
+#else
+  struct timeval times[2];
+  times[0].tv_sec = expected_atime;
+  times[0].tv_usec = 0;
+  times[1].tv_sec = expected_mtime;
+  times[1].tv_usec = 0;
+  ASSERT_EQ(utimes(srcPath.string().c_str(), times), 0)
+      << "Failed to set file timestamps";
+#endif
+
+  const std::set<std::string> pathsToCarve = {srcPath.string()};
+  auto guid = createCarveGuid();
+  std::string requestId = createCarveGuid();
+  FakeCarver carve(pathsToCarve, guid, requestId);
+
+  ASSERT_TRUE(carve.createPaths().ok());
+  const auto carvedFiles = carve.carveAll();
+  ASSERT_EQ(carvedFiles.size(), 1U);
+
+  const auto& dstPath = *carvedFiles.begin();
+
+  PlatformFile dstFile(dstPath, PF_OPEN_EXISTING | PF_READ);
+  ASSERT_TRUE(dstFile.isValid());
+
+  PlatformTime dstTimes;
+  ASSERT_TRUE(dstFile.getFileTimes(dstTimes));
+
+  // PlatformTime.times[0] = atime, times[1] = mtime (struct timeval on POSIX,
+  // FILETIME on Windows). Compare the seconds component.
+#ifdef WIN32
+  // Convert FILETIME to Unix time for comparison.
+  auto filetimeToUnix = [](const FILETIME& ft) -> time_t {
+    ULARGE_INTEGER ull;
+    ull.LowPart = ft.dwLowDateTime;
+    ull.HighPart = ft.dwHighDateTime;
+    return static_cast<time_t>((ull.QuadPart / 10000000ULL) - 11644473600ULL);
+  };
+  EXPECT_EQ(filetimeToUnix(dstTimes.times[0]), expected_atime)
+      << "Carved file atime does not match original";
+  EXPECT_EQ(filetimeToUnix(dstTimes.times[1]), expected_mtime)
+      << "Carved file mtime does not match original";
+#else
+  EXPECT_EQ(dstTimes.times[0].tv_sec, expected_atime)
+      << "Carved file atime does not match original";
+  EXPECT_EQ(dstTimes.times[1].tv_sec, expected_mtime)
+      << "Carved file mtime does not match original";
+#endif
 }
 
 TEST_F(CarverTests, test_carve) {

--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -273,6 +273,9 @@ class PlatformFile : private boost::noncopyable {
   /// Return the modified, created, birth, updated, etc times.
   bool getFileTimes(PlatformTime& times);
 
+  /// Set the access and modification times (atime, mtime) of the file.
+  bool setFileTimes(const PlatformTime& times);
+
   /// Read a number of bytes into a buffer.
   ssize_t read(void* buf, size_t nbyte);
 

--- a/osquery/filesystem/posix/fileops.cpp
+++ b/osquery/filesystem/posix/fileops.cpp
@@ -184,6 +184,14 @@ bool PlatformFile::getFileTimes(PlatformTime& times) {
   return true;
 }
 
+bool PlatformFile::setFileTimes(const PlatformTime& times) {
+  if (!isValid()) {
+    return false;
+  }
+
+  return (::futimes(handle_, times.times) == 0);
+}
+
 ssize_t PlatformFile::read(void* buf, size_t nbyte) {
   if (!isValid()) {
     return -1;

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1076,6 +1076,15 @@ bool PlatformFile::getFileTimes(PlatformTime& times) {
           FALSE);
 }
 
+bool PlatformFile::setFileTimes(const PlatformTime& times) {
+  if (!isValid()) {
+    return false;
+  }
+
+  return (::SetFileTime(handle_, nullptr, &times.times[0], &times.times[1]) !=
+          FALSE);
+}
+
 ssize_t PlatformFile::getOverlappedResultForRead(void* buf,
                                                  size_t requested_size) {
   ssize_t nret = 0;

--- a/tools/deployment/macos_packaging/osquery.entitlements
+++ b/tools/deployment/macos_packaging/osquery.entitlements
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.developer.endpoint-security.client</key>
     <true/>
+    <key>com.apple.developer.networking.wifi-info</key>
+    <true/>
     <key>com.apple.application-identifier</key>
     <string>3522FA9PXF.io.osquery.agent</string>
 </dict>

--- a/tools/deployment/macos_packaging/osquery.entitlements
+++ b/tools/deployment/macos_packaging/osquery.entitlements
@@ -4,8 +4,6 @@
 <dict>
     <key>com.apple.developer.endpoint-security.client</key>
     <true/>
-    <key>com.apple.developer.networking.wifi-info</key>
-    <true/>
     <key>com.apple.application-identifier</key>
     <string>3522FA9PXF.io.osquery.agent</string>
 </dict>


### PR DESCRIPTION
Fix for #8752, which did not properly preserve the timestamps due to file copying.