### PR TITLE
Fix multiple security vulnerabilities in smc_keys.cpp

### DIFF
--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -20,6 +20,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <osquery/core/tables.h>
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
@@ -375,6 +376,10 @@ kern_return_t SMCHelper::call(uint32_t selector,
 }
 
 inline uint32_t strtoul(const char *str, size_t size, size_t base) {
+  // Security fix: Prevent shift overflow for sizes > 4 bytes (32-bit limit)
+  if (size > 4) {
+    return 0;
+  }
   uint32_t total = 0;
   for (size_t i = 0; i < size; i++) {
     total += (unsigned char)(str[i]) << (size - 1 - i) * 8;
@@ -383,6 +388,10 @@ inline uint32_t strtoul(const char *str, size_t size, size_t base) {
 }
 
 inline uint64_t strtoull(const char* str, size_t size, size_t base) {
+  // Security fix: Prevent shift overflow for sizes > 8 bytes (64-bit limit)
+  if (size > 8) {
+    return 0;
+  }
   uint64_t total = 0;
   for (size_t i = 0; i < size; i++) {
     total += static_cast<uint64_t>(static_cast<unsigned char>(str[i]))
@@ -444,6 +453,12 @@ double getConvertedValue(const std::string& smcType,
                  << ", fractional: " << fractionalBits << ")";
       return -1.0;
     }
+    // Security fix: Prevent signed shift overflow
+    if (fractionalBits >= 31) {
+      LOG(ERROR) << "Invalid fractional bits for SMC type: " << type
+                 << " (fractional: " << fractionalBits << ")";
+      return -1.0;
+    }
     int divisor = 1 << fractionalBits;
     // Get the integer value represented by the decoded hex string, and divide
     // by the divisor to get the float value.
@@ -486,6 +501,11 @@ bool SMCHelper::read(const std::string &key, SMCValue_t *val) const {
   memset(&out, 0, sizeof(SMCKeyData_t));
   memset(val, 0, sizeof(SMCValue_t));
 
+  // Security fix: Validate key size to prevent heap overread
+  if (key.size() < 4) {
+    return false;
+  }
+
   in.key = strtoul(key.c_str(), 4, 16);
   memcpy(val->key.bytes, key.c_str(), 4);
   in.data8 = SMCCMDType::READ_KEYINFO;
@@ -515,7 +535,9 @@ bool SMCHelper::read(const std::string &key, SMCValue_t *val) const {
 size_t SMCHelper::getKeysCount() const {
   SMCValue_t val;
   read("#KEY", &val);
-  return ((int)val.bytes.bytes[2] << 8) + ((unsigned)val.bytes.bytes[3] & 0xff);
+  // Security fix: Cast to unsigned char before shift to prevent signed overflow
+  return ((unsigned char)val.bytes.bytes[2] << 8) +
+         ((unsigned char)val.bytes.bytes[3] & 0xff);
 }
 
 std::vector<std::string> SMCHelper::getKeys() const {
@@ -756,7 +778,12 @@ QueryData genFanSpeedSensors(QueryContext &context) {
   }
 
   // Get attributes for each fan.
-  int numFans = std::stoi(smcRow["value"]);
+  // Security fix: Use tryTo to safely convert string to int
+  auto numFansExp = tryTo<int>(smcRow["value"]);
+  if (numFansExp.isError()) {
+    return results;
+  }
+  int numFans = numFansExp.take();
   for (int fanIdx = 0; fanIdx < numFans; fanIdx++) {
     Row r;
     r["fan"] = std::to_string(fanIdx);


### PR DESCRIPTION
This commit addresses five critical security issues in the macOS SMC keys table:

1. Heap overread vulnerability (line 490): Added validation to ensure SMC key strings are at least 4 characters before memcpy to prevent reading beyond buffer bounds when keys from SQL queries are shorter than expected.

2. Shift overflow in strtoul (lines 377-383): Added size check to prevent shift operations from exceeding 32-bit boundaries when size > 4 bytes.

3. Shift overflow in strtoull (lines 385-392): Added size check to prevent shift operations from exceeding 64-bit boundaries when size > 8 bytes.

4. Signed shift overflow (line 447): Added validation to ensure fractionalBits is less than 31 to prevent undefined behavior from shifting into sign bit.

5. Uncaught std::stoi exception (line 759): Replaced std::stoi with tryTo<int>
   to safely handle string-to-integer conversion without throwing exceptions.

6. Signed char shift (line 538): Cast char to unsigned char before shift operation to prevent potential sign extension issues.

All fixes include appropriate error handling and logging where applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
