### PR TITLE
Add substr bounds validation to prevent out-of-bounds exceptions

### DIFF
--- a/osquery/tables/system/darwin/kernel_info.cpp
+++ b/osquery/tables/system/darwin/kernel_info.cpp
@@ -140,7 +140,14 @@ QueryData genKernelInfo(QueryContext& context) {
       auto signature = stringFromCFString((CFStringRef)property);
       CFRelease(property);
 
-      r["version"] = signature.substr(22, signature.find(':') - 22);
+      auto colon_pos = signature.find(':');
+      if (colon_pos != std::string::npos && signature.size() >= 22 &&
+          colon_pos > 22) {
+        r["version"] = signature.substr(22, colon_pos - 22);
+      } else {
+        LOG(WARNING) << "Unexpected kernel version signature format: "
+                     << signature;
+      }
     }
   }
 

--- a/osquery/tables/system/linux/kernel_info.cpp
+++ b/osquery/tables/system/linux/kernel_info.cpp
@@ -32,9 +32,9 @@ QueryData genKernelInfo(QueryContext& context) {
 
       // Iterate over each space-tokenized argument.
       for (const auto& argument : arguments) {
-        if (argument.substr(0, 11) == "BOOT_IMAGE=") {
+        if (argument.size() >= 11 && argument.substr(0, 11) == "BOOT_IMAGE=") {
           r["path"] = argument.substr(11);
-        } else if (argument.substr(0, 5) == "root=") {
+        } else if (argument.size() >= 5 && argument.substr(0, 5) == "root=") {
           r["device"] = argument.substr(5);
         } else {
           if (additional_arguments.size() > 0) {

--- a/osquery/tables/system/windows/shimcache.cpp
+++ b/osquery/tables/system/windows/shimcache.cpp
@@ -50,6 +50,11 @@ namespace tables {
 auto parseShimcacheData(const std::string& token,
                         const boost::optional<bool>& execution_flag_exists) {
   ShimcacheData shimcache;
+  if (token.size() < 20) {
+    LOG(WARNING) << "Token too short for shimcache path length";
+    shimcache.last_modified = 0LL;
+    return shimcache;
+  }
   std::string path_length = token.substr(16, 4);
 
   // swap endianess
@@ -70,6 +75,11 @@ auto parseShimcacheData(const std::string& token,
   }
 
   // Registry data is in Unicode (extra 0x00)
+  if (token.size() < 20 + (size_t)shimcache_file_path * 2) {
+    LOG(WARNING) << "Token too short for shimcache path";
+    shimcache.last_modified = 0LL;
+    return shimcache;
+  }
   std::string path = token.substr(20, (size_t)shimcache_file_path * 2);
   boost::erase_all(path, "00");
 
@@ -99,6 +109,12 @@ auto parseShimcacheData(const std::string& token,
   } else {
     shimcache_modified_start = 20;
   }
+  if (token.size() <
+      shimcache_modified_start + (size_t)shimcache_file_path * 2 + 16) {
+    LOG(WARNING) << "Token too short for shimcache modified time";
+    shimcache.last_modified = 0LL;
+    return shimcache;
+  }
   std::string shimcache_time = token.substr(
       shimcache_modified_start + (size_t)shimcache_file_path * 2, 16);
 
@@ -109,6 +125,11 @@ auto parseShimcacheData(const std::string& token,
                                 : littleEndianToUnixTime(shimcache_time);
 
   if (execution_flag_exists == true) {
+    if (token.size() <
+        execution_flag_start + (size_t)shimcache_file_path * 2 + 2) {
+      LOG(WARNING) << "Token too short for shimcache execution flag";
+      return shimcache;
+    }
     int shimcache_flag =
         tryTo<int>(
             token.substr(execution_flag_start + (size_t)shimcache_file_path * 2,
@@ -133,19 +154,25 @@ void parseEntry(const Row& aKey, size_t& index, QueryData& results) {
   // Check if Registry data starts with any of supported WIN_START
   // values and if the Shimcache delimiter exists at the specific
   // substring
-  if ((boost::starts_with(data, kWin8Start)) &&
+  if ((boost::starts_with(data, kWin8Start)) && (data.size() >= kWin8 + 8) &&
       (data.substr(kWin8, 8) == kWin8110ShimcacheDelimiter)) {
     execution_flag_exists = true;
     delimter = kWin8110ShimcacheDelimiter;
   } else if (boost::starts_with(data, kWin10Start) &&
+             (data.size() >= kWin10PreCreator + 8) &&
              (data.substr(kWin10PreCreator, 8) == kWin8110ShimcacheDelimiter)) {
     delimter = kWin8110ShimcacheDelimiter;
   } else if (boost::starts_with(data, kWin10CreatorStart) &&
+             (data.size() >= kWin10Creator + 8) &&
              (data.substr(kWin10Creator, 8) == kWin8110ShimcacheDelimiter)) {
     delimter = kWin8110ShimcacheDelimiter;
   } else {
-    LOG(WARNING) << "Unknown or unsupported shimcache data: "
-                 << data.substr(256, 8);
+    if (data.size() >= 264) {
+      LOG(WARNING) << "Unknown or unsupported shimcache data: "
+                   << data.substr(256, 8);
+    } else {
+      LOG(WARNING) << "Unknown or unsupported shimcache data (too short)";
+    }
     return;
   }
 

--- a/osquery/tables/system/windows/userassist.cpp
+++ b/osquery/tables/system/windows/userassist.cpp
@@ -25,7 +25,7 @@ constexpr auto kFullRegPath =
 
 // Get execution count
 std::size_t executionNum(const std::string& assist_data) {
-  if (assist_data.length() <= 16) {
+  if (assist_data.length() < 16) {
     LOG(WARNING) << "Userassist execution count format is incorrect";
     return -1;
   }
@@ -80,7 +80,19 @@ QueryData genUserAssist(QueryContext& context) {
 
         // split reg path by \Count\ to get Key values
         auto count_key = subkey.find("Count\\");
+        if (count_key == std::string::npos) {
+          LOG(WARNING) << "Could not find Count\\ in subkey path";
+          continue;
+        }
+        if (subkey.size() < count_key) {
+          LOG(WARNING) << "Subkey too short for value key extraction";
+          continue;
+        }
         auto value_key = subkey.substr(count_key);
+        if (value_key.size() < 6) {
+          LOG(WARNING) << "Value key too short";
+          continue;
+        }
         std::string value_key_reg = value_key.substr(6, std::string::npos);
 
         std::string decoded_value_key = rotDecode(value_key_reg);
@@ -98,7 +110,7 @@ QueryData genUserAssist(QueryContext& context) {
         } else {
           std::string assist_data = aKey.at("data");
           auto time_str = 0LL;
-          if (assist_data.length() <= 136) {
+          if (assist_data.length() < 136) {
             LOG(WARNING)
                 << "Userassist last execute Timestamp format is incorrect";
           } else {

--- a/osquery/utils/windows/shellitem.cpp
+++ b/osquery/utils/windows/shellitem.cpp
@@ -39,6 +39,12 @@ const std::string kPropertySets[15] = {"000214A1-0000-0000-C000-000000000046",
                                        "F29F85E0-4FF9-1068-AB91-08002B27B3D9"};
 namespace osquery {
 std::string guidParse(const std::string& guid_little) {
+  // Validate string length before substr operations
+  if (guid_little.size() < 32) {
+    LOG(WARNING) << "GUID string too short: " << guid_little.size() << " bytes";
+    return "";
+  }
+
   std::vector<std::string> guids;
   guids.push_back(guid_little.substr(0, 8));
   guids.push_back(guid_little.substr(8, 4));
@@ -66,6 +72,11 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
   // Find "0400EFBE" offset
   if (shell_data.find("0400EFBE") != std::string::npos) {
     offset = shell_data.find("0400EFBE");
+    if (shell_data.size() < offset + 8) {
+      LOG(WARNING) << "Shell data too short for extension signature";
+      file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+      return file_entry;
+    }
     extension_sig = shell_data.substr(offset, 8);
     entry_offset = offset - 8;
   }
@@ -79,6 +90,11 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
     return file_entry;
   }
 
+  if (shell_data.size() < entry_offset + 8) {
+    LOG(WARNING) << "Shell data too short for version info";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
+  }
   std::string version = shell_data.substr(entry_offset + 4, 4);
   version = swapEndianess(version);
   file_entry.version = tryTo<int>(version, 16).takeOr(0);
@@ -95,13 +111,28 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
   // offset 0x18
   std::string timestamp = "";
   if (shell_data.find("43465346") != std::string::npos) {
+    if (shell_data.size() < 44) {
+      LOG(WARNING) << "Shell data too short for timestamp";
+      file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+      return file_entry;
+    }
     timestamp = shell_data.substr(36, 8);
     file_entry.dos_modified =
         (timestamp == "00000000") ? 0LL : parseFatTime(timestamp);
   } else {
+    if (shell_data.size() < 24) {
+      LOG(WARNING) << "Shell data too short for timestamp";
+      file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+      return file_entry;
+    }
     timestamp = shell_data.substr(16, 8);
     file_entry.dos_modified =
         (timestamp == "00000000") ? 0LL : parseFatTime(timestamp);
+  }
+  if (shell_data.size() < entry_offset + 56) {
+    LOG(WARNING) << "Shell data too short for NTFS data";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
   }
   timestamp = shell_data.substr(entry_offset + 16, 8);
   file_entry.dos_created =
@@ -111,6 +142,11 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
       (timestamp == "00000000") ? 0LL : parseFatTime(timestamp);
   file_entry.identifier = shell_data.substr(entry_offset + 32, 4);
   std::string ntfs_data = shell_data.substr(entry_offset + 40, 16);
+  if (ntfs_data.size() < 16) {
+    LOG(WARNING) << "NTFS data too short";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
+  }
   std::string mft_entry = ntfs_data.substr(0, 12);
   mft_entry = swapEndianess(mft_entry);
 
@@ -128,6 +164,11 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
     file_entry.mft_sequence = tryTo<int>(mft_sequence, 16).takeOr(0);
   }
 
+  if (shell_data.size() < entry_offset + 76) {
+    LOG(WARNING) << "Shell data too short for string size";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
+  }
   std::string string_size = shell_data.substr(entry_offset + 72, 4);
   string_size = swapEndianess(string_size);
   file_entry.string_size = tryTo<int>(string_size, 16).takeOr(0);
@@ -139,10 +180,20 @@ ShellFileEntryData fileEntry(const std::string& shell_data) {
   } else if (file_entry.version == 7) {
     name_offset = 72;
   }
+  if (shell_data.size() < entry_offset + name_offset) {
+    LOG(WARNING) << "Shell data too short for entry name";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
+  }
   std::string entry_name = shell_data.substr(entry_offset + name_offset);
 
   // path name ends with 0000 (end of string)
   size_t name_end = entry_name.find("0000");
+  if (name_end == std::string::npos) {
+    LOG(WARNING) << "Could not find name end marker";
+    file_entry.path = "[UNSUPPORTED SHELL EXTENSION]";
+    return file_entry;
+  }
   std::string shell_name = entry_name.substr(0, name_end);
   // Path is in unicode, extra 00
   boost::erase_all(shell_name, "00");
@@ -171,6 +222,10 @@ std::string propertyStore(const std::string& shell_data,
                           const std::vector<size_t>& wps_list) {
   std::string guid_string;
   for (const auto& offsets : wps_list) {
+    if (shell_data.size() < offsets + 40) {
+      LOG(WARNING) << "Shell data too short for GUID at offset " << offsets;
+      continue;
+    }
     std::string guid_little = shell_data.substr(offsets + 8, 32);
     guid_string = guidParse(guid_little);
     // If GUID property set is found get the property set name
@@ -178,9 +233,17 @@ std::string propertyStore(const std::string& shell_data,
       if (guid_string != property_list) {
         continue;
       }
+      if (shell_data.size() < offsets + 56) {
+        LOG(WARNING) << "Shell data too short for name size";
+        return guid_string;
+      }
       std::string name_size = shell_data.substr(offsets + 48, 8);
       name_size = swapEndianess(name_size);
       int size = tryTo<int>(name_size, 16).takeOr(0);
+      if (shell_data.size() < offsets + 74 + (size + 1) * 4) {
+        LOG(WARNING) << "Shell data too short for property name";
+        return guid_string;
+      }
       std::string string_hex = shell_data.substr(offsets + 74, (size + 1) * 4);
       boost::erase_all(string_hex, "00");
       std::string name;
@@ -200,11 +263,23 @@ std::string propertyStore(const std::string& shell_data,
 }
 
 std::string networkShareItem(const std::string& shell_data) {
+  if (shell_data.size() < 6) {
+    LOG(WARNING) << "Shell data too short for network share ID";
+    return "[UNKNOWN NETWORK SHELL ITEM]";
+  }
   for (const auto& net_id : kNetworkShareIds) {
     if (net_id == shell_data.substr(4, 2)) {
       // Network path ends with "00"
-      std::string network_path =
-          shell_data.substr(10, shell_data.find("00", 10) - 10);
+      auto path_end = shell_data.find("00", 10);
+      if (path_end == std::string::npos || path_end < 10) {
+        LOG(WARNING) << "Could not find network path end marker";
+        return "[UNKNOWN NETWORK SHELL ITEM]";
+      }
+      if (shell_data.size() < path_end) {
+        LOG(WARNING) << "Shell data too short for network path";
+        return "[UNKNOWN NETWORK SHELL ITEM]";
+      }
+      std::string network_path = shell_data.substr(10, path_end - 10);
       std::string name;
       try {
         name = boost::algorithm::unhex(network_path);
@@ -220,10 +295,18 @@ std::string networkShareItem(const std::string& shell_data) {
 }
 
 std::string zipContentItem(const std::string& shell_data) {
+  if (shell_data.size() < 172) {
+    LOG(WARNING) << "Shell data too short for zip path size";
+    return "[ZIP PATH DECODE ERROR]";
+  }
   std::string path_size_string = shell_data.substr(168, 4);
   path_size_string = swapEndianess(path_size_string);
   int path_size = tryTo<int>(path_size_string, 16).takeOr(0);
 
+  if (shell_data.size() < 184 + path_size * 4) {
+    LOG(WARNING) << "Shell data too short for zip path";
+    return "[ZIP PATH DECODE ERROR]";
+  }
   std::string path = shell_data.substr(184, path_size * 4);
   // Path is in unicode, extra 00
   boost::erase_all(path, "00");
@@ -236,11 +319,21 @@ std::string zipContentItem(const std::string& shell_data) {
     return "[ZIP PATH DECODE ERROR]";
   }
   // Zip folders can go down a max of two directories
+  if (shell_data.size() < 180) {
+    LOG(WARNING) << "Shell data too short for second path size";
+    return path;
+  }
   std::string second_path_size_string = shell_data.substr(176, 4);
   second_path_size_string = swapEndianess(second_path_size_string);
   int second_path_size = tryTo<int>(second_path_size_string, 16).takeOr(0);
 
   if (second_path_size != 0) {
+    if (shell_data.size() <
+        184 + (path_size * 4) + 4 + (second_path_size * 4)) {
+      LOG(WARNING) << "Shell data too short for second zip path";
+      path += "/[ZIP PATH DECODE ERROR]";
+      return path;
+    }
     path += "/";
     std::string second_path =
         shell_data.substr((184 + (path_size * 4) + 4), second_path_size * 4);
@@ -260,12 +353,20 @@ std::string zipContentItem(const std::string& shell_data) {
 }
 
 std::string rootFolderItem(const std::string& shell_data) {
+  if (shell_data.size() < 40) {
+    LOG(WARNING) << "Shell data too short for root folder GUID";
+    return "";
+  }
   std::string guid_little = shell_data.substr(8, 32);
   std::string guid_string = guidParse(guid_little);
   return guid_string;
 }
 
 std::string driveLetterItem(const std::string& shell_data) {
+  if (shell_data.size() < 12) {
+    LOG(WARNING) << "Shell data too short for drive letter";
+    return "[UNKNOWN DRIVE VOLUME]";
+  }
   std::string volume;
   try {
     volume = boost::algorithm::unhex(shell_data.substr(6, 6));
@@ -278,6 +379,10 @@ std::string driveLetterItem(const std::string& shell_data) {
 }
 
 std::string controlPanelCategoryItem(const std::string& shell_data) {
+  if (shell_data.size() < 18) {
+    LOG(WARNING) << "Shell data too short for panel category";
+    return "[UNKNOWN PANEL CATEGORY]";
+  }
   std::string panel_id = shell_data.substr(16, 2);
   if (panel_id == "00") {
     return "All Control Panel Items";
@@ -310,6 +415,10 @@ std::string controlPanelCategoryItem(const std::string& shell_data) {
 }
 
 std::string controlPanelItem(const std::string& shell_data) {
+  if (shell_data.size() < 60) {
+    LOG(WARNING) << "Shell data too short for control panel GUID";
+    return "";
+  }
   std::string guid_little = shell_data.substr(28, 32);
   std::string guid_string = guidParse(guid_little);
   return guid_string;
@@ -317,6 +426,12 @@ std::string controlPanelItem(const std::string& shell_data) {
 
 std::vector<std::string> ftpItem(const std::string& shell_data) {
   std::vector<std::string> ftp_data;
+  if (shell_data.size() < 12) {
+    LOG(WARNING) << "Shell data too short for FTP item";
+    ftp_data.push_back("0000000000000000");
+    ftp_data.push_back("[UNKNOWN NAME]");
+    return ftp_data;
+  }
   std::string unicode = shell_data.substr(6, 2);
   std::string uri_size = shell_data.substr(8, 4);
   if (uri_size == "0000") {
@@ -336,7 +451,17 @@ std::vector<std::string> ftpItem(const std::string& shell_data) {
   if (uri_size == "0000" && unicode == "80") {
     // find end of string
     size_t offset = shell_data.find("0000", 16);
+    if (offset == std::string::npos || offset < 12) {
+      LOG(WARNING) << "Could not find FTP hostname end marker";
+      ftp_data.push_back("[UNKNOWN NAME]");
+      return ftp_data;
+    }
     size_t hostname_size = offset - 12;
+    if (shell_data.size() < 12 + hostname_size) {
+      LOG(WARNING) << "Shell data too short for FTP hostname";
+      ftp_data.push_back("[UNKNOWN NAME]");
+      return ftp_data;
+    }
     std::string ftp_hostname = shell_data.substr(12, hostname_size);
     std::string name;
     boost::erase_all(ftp_hostname, "00");
@@ -372,6 +497,11 @@ std::vector<std::string> ftpItem(const std::string& shell_data) {
     ftp_data.push_back("[UNKNOWN NAME]");
     return ftp_data;
   }
+  if (shell_data.size() < 92 + hostname_size) {
+    LOG(WARNING) << "Shell data too short for FTP hostname";
+    ftp_data.push_back("[UNKNOWN NAME]");
+    return ftp_data;
+  }
   std::string ftp_hostname = shell_data.substr(92, hostname_size);
   std::string name;
   boost::erase_all(ftp_hostname, "00");
@@ -389,6 +519,10 @@ std::vector<std::string> ftpItem(const std::string& shell_data) {
 }
 
 std::string propertyViewDrive(const std::string& shell_data) {
+  if (shell_data.size() < 32) {
+    LOG(WARNING) << "Shell data too short for property view drive";
+    return "[UNKNOWN USER PROPERTY DRIVE NAME]";
+  }
   std::string drive_hex = shell_data.substr(26, 6);
   std::string name;
   try {
@@ -415,6 +549,10 @@ std::string variableFtp(const std::string& shell_data) {
     LOG(WARNING) << "Could not identify Variable FTP name: " << shell_data;
     return "[UNKNOWN VARIABLE FTP NAME]";
   }
+  if (name_start.size() < offset) {
+    LOG(WARNING) << "Name start too short for long name";
+    return "[UNKNOWN VARIABLE FTP NAME]";
+  }
   std::string long_name = name_start.substr(offset);
   boost::erase_all(long_name, "00");
   // Check to make sure name is even, fixes issues with 10 base characters
@@ -434,15 +572,27 @@ std::string variableFtp(const std::string& shell_data) {
 }
 
 std::string variableGuid(const std::string& shell_data) {
+  if (shell_data.size() < 60) {
+    LOG(WARNING) << "Shell data too short for variable GUID";
+    return "";
+  }
   std::string guid_little = shell_data.substr(28, 32);
   std::string guid_string = guidParse(guid_little);
   return guid_string;
 }
 
 std::string mtpFolder(const std::string& shell_data) {
+  if (shell_data.size() < 132) {
+    LOG(WARNING) << "Shell data too short for MTP folder name size";
+    return "[UNKNOWN MTP FOLDER NAME]";
+  }
   std::string name_size = shell_data.substr(124, 8);
   name_size = swapEndianess(name_size);
   int size = tryTo<int>(name_size, 16).takeOr(0);
+  if (shell_data.size() < 148 + size * 4) {
+    LOG(WARNING) << "Shell data too short for MTP folder name";
+    return "[UNKNOWN MTP FOLDER NAME]";
+  }
   std::string path_name = shell_data.substr(148, size * 4);
   boost::erase_all(path_name, "00");
   std::string name;
@@ -457,9 +607,17 @@ std::string mtpFolder(const std::string& shell_data) {
 }
 
 std::string mtpDevice(const std::string& shell_data) {
+  if (shell_data.size() < 84) {
+    LOG(WARNING) << "Shell data too short for MTP device name size";
+    return "[UNKNOWN MTP DEVICE NAME]";
+  }
   std::string name_size = shell_data.substr(76, 8);
   name_size = swapEndianess(name_size);
   int size = tryTo<int>(name_size, 16).takeOr(0);
+  if (shell_data.size() < 108 + size * 4) {
+    LOG(WARNING) << "Shell data too short for MTP device name";
+    return "[UNKNOWN MTP DEVICE NAME]";
+  }
   std::string path_name = shell_data.substr(108, size * 4);
   boost::erase_all(path_name, "00");
   std::string name;
@@ -474,7 +632,19 @@ std::string mtpDevice(const std::string& shell_data) {
 }
 
 std::string mtpRoot(const std::string& shell_data) {
+  if (shell_data.size() < 80) {
+    LOG(WARNING) << "Shell data too short for MTP root name";
+    return "[UNKNOWN MTP ROOT NAME]";
+  }
   size_t name_end = shell_data.find("000000", 80);
+  if (name_end == std::string::npos || name_end < 80) {
+    LOG(WARNING) << "Could not find MTP root name end marker";
+    return "[UNKNOWN MTP ROOT NAME]";
+  }
+  if (shell_data.size() < name_end) {
+    LOG(WARNING) << "Shell data too short for MTP root path name";
+    return "[UNKNOWN MTP ROOT NAME]";
+  }
   std::string path_name = shell_data.substr(80, name_end - 80);
   boost::erase_all(path_name, "00");
   std::string name;


### PR DESCRIPTION
This commit adds comprehensive bounds checking before all substr() operations across multiple files to prevent std::out_of_range exceptions when processing malformed or incomplete data.

Changes:
- osquery/utils/windows/shellitem.cpp: Added validation for 20+ substr calls in guidParse, fileEntry, propertyStore, networkShareItem, zipContentItem, and other shell item parsing functions
- osquery/tables/system/windows/shimcache.cpp: Added bounds checks for shimcache data parsing including path length and execution flags
- osquery/tables/system/windows/userassist.cpp: Added validation for execution count and subkey extraction
- osquery/tables/system/linux/kernel_info.cpp: Added length checks before extracting BOOT_IMAGE and root parameters
- osquery/tables/system/darwin/kernel_info.cpp: Added validation for kernel version extraction with find() result checking

The pattern used is to check string size before substr operations and handle std::string::npos from find() operations before using the result in arithmetic or substr calls. When validation fails, appropriate error messages are logged and safe fallback values are returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Thank you for contributing to osquery! -->

To submit a PR please make sure to follow the next steps:

- [ ] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.  
      If it is not, then move the committed files to the git staging area,
      build the `format` target to format them, and then re-commit.
      [More information is available on the wiki](https://osquery.readthedocs.io/en/latest/development/building/#formatting-the-code).
- [ ] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
- [ ] Describe your changes with as much detail as you can.
- [ ] Link any issues this PR is related to.
- [ ] Remove the text above.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
