### PR TITLE
Replace unsafe std::sto* functions with tryTo<>

### DIFF
--- a/osquery/core/query.cpp
+++ b/osquery/core/query.cpp
@@ -16,6 +16,7 @@
 #include <osquery/core/query.h>
 #include <osquery/database/database.h>
 #include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/tryto.h>
 
 #include <osquery/utils/json/json.h>
 
@@ -33,13 +34,12 @@ FLAG(bool,
 FLAG_ALIAS(bool, log_numerics_as_numbers, logger_numerics);
 
 uint64_t Query::getPreviousEpoch() const {
-  uint64_t epoch = 0;
   std::string raw;
   auto status = getDatabaseValue(kQueries, name_ + "epoch", raw);
   if (status.ok()) {
-    epoch = std::stoull(raw);
+    return tryTo<uint64_t>(raw).takeOr(0ull);
   }
-  return epoch;
+  return 0;
 }
 
 uint64_t Query::getQueryCounter(bool is_reset,
@@ -59,7 +59,10 @@ uint64_t Query::getQueryCounter(bool is_reset,
   std::string raw;
   auto status = getDatabaseValue(kQueries, name_ + "counter", raw);
   if (status.ok()) {
-    counter = std::stoull(raw) + 1;
+    auto counterExp = tryTo<uint64_t>(raw);
+    if (!counterExp.isError()) {
+      counter = counterExp.get() + 1;
+    }
   }
   return counter;
 }

--- a/osquery/database/database.cpp
+++ b/osquery/database/database.cpp
@@ -211,7 +211,7 @@ Status DatabasePlugin::call(const PluginRequest& request,
     // Optionally allow the caller to request a max number of keys.
     size_t max = 0;
     if (request.count("max") > 0) {
-      max = std::stoul(request.at("max"));
+      max = tryTo<size_t>(request.at("max")).takeOr(0ull);
     }
     auto status = this->scan(domain, keys, request.at("prefix"), max);
     for (const auto& k : keys) {
@@ -318,7 +318,11 @@ Status getDatabaseValue(const std::string& domain,
   std::string result;
   auto s = getDatabaseValue(domain, key, result);
   if (s.ok()) {
-    value = std::stoi(result);
+    auto valueExp = tryTo<int>(result);
+    if (valueExp.isError()) {
+      return Status(1, "Failed to convert database value to int");
+    }
+    value = valueExp.get();
   }
   return s;
 }

--- a/osquery/tables/applications/posix/docker.cpp
+++ b/osquery/tables/applications/posix/docker.cpp
@@ -27,6 +27,7 @@
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
 #include <osquery/utils/conversions/join.h>
+#include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/info/platform_type.h>
 #include <osquery/utils/json/json.h>
 
@@ -809,13 +810,13 @@ long diffNanos(const std::string& iso1, const std::string& iso2) {
     return 0L;
   }
 
-  try {
-    return std::stol(iso1.substr(pos1 + 1), nullptr, 10) -
-           std::stol(iso2.substr(pos2 + 1), nullptr, 10);
-  } catch (std::out_of_range& e) {
+  auto nano1Exp = tryTo<long>(iso1.substr(pos1 + 1), 10);
+  auto nano2Exp = tryTo<long>(iso2.substr(pos2 + 1), 10);
+  if (nano1Exp.isError() || nano2Exp.isError()) {
     VLOG(1) << "Failed to parse nano seconds in: " << iso1 << " and " << iso2;
     return 0L;
   }
+  return nano1Exp.get() - nano2Exp.get();
 }
 
 /**

--- a/osquery/tables/system/darwin/sip_config.cpp
+++ b/osquery/tables/system/darwin/sip_config.cpp
@@ -12,6 +12,7 @@
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
 #include <osquery/utils/conversions/darwin/iokit.h>
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
@@ -103,10 +104,12 @@ QueryData genSIPConfig(QueryContext& context) {
   }
 
   // bail out if running on OS X < 10.11
-  if (os_version.front().at("major") == "10" &&
-      std::stoi(os_version.front().at("minor")) < 11) {
-    VLOG(1) << "Not running on OS X 10.11 or higher";
-    return {};
+  if (os_version.front().at("major") == "10") {
+    auto minorExp = tryTo<int>(os_version.front().at("minor"));
+    if (minorExp.isError() || minorExp.get() < 11) {
+      VLOG(1) << "Not running on OS X 10.11 or higher";
+      return {};
+    }
   }
 
   QueryData results;

--- a/osquery/tables/system/darwin/smc_keys.cpp
+++ b/osquery/tables/system/darwin/smc_keys.cpp
@@ -20,6 +20,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <osquery/core/tables.h>
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
@@ -756,7 +757,11 @@ QueryData genFanSpeedSensors(QueryContext &context) {
   }
 
   // Get attributes for each fan.
-  int numFans = std::stoi(smcRow["value"]);
+  auto numFansExp = tryTo<int>(smcRow["value"]);
+  if (numFansExp.isError()) {
+    return results;
+  }
+  int numFans = numFansExp.get();
   for (int fanIdx = 0; fanIdx < numFans; fanIdx++) {
     Row r;
     r["fan"] = std::to_string(fanIdx);

--- a/osquery/tables/system/darwin/unified_log.mm
+++ b/osquery/tables/system/darwin/unified_log.mm
@@ -110,11 +110,13 @@ struct SequentialContext {
 void SequentialContext::load() {
   std::string str;
   auto s = getDatabaseValue(kPersistentSettings, kUALtimestampKey, str);
-  if (s.ok())
-    timestamp = std::stod(str);
+  if (s.ok()) {
+    timestamp = tryTo<double>(str).takeOr(0.0);
+  }
   s = getDatabaseValue(kPersistentSettings, kUALcountKey, str);
-  if (s.ok())
-    count = std::stoi(str);
+  if (s.ok()) {
+    count = tryTo<int>(str).takeOr(0);
+  }
 }
 
 void SequentialContext::save() {

--- a/osquery/tables/system/linux/md_tables.cpp
+++ b/osquery/tables/system/linux/md_tables.cpp
@@ -146,7 +146,17 @@ std::string MD::getDevName(int major, int minor) {
     const char* devMajor = udev_device_get_property_value(device, "MAJOR");
     const char* devMinor = udev_device_get_property_value(device, "MINOR");
 
-    if (std::stoi(devMajor) == major && std::stoi(devMinor) == minor) {
+    if (devMajor == nullptr || devMinor == nullptr) {
+      return false;
+    }
+
+    auto majorExp = tryTo<int>(devMajor);
+    auto minorExp = tryTo<int>(devMinor);
+    if (majorExp.isError() || minorExp.isError()) {
+      return false;
+    }
+
+    if (majorExp.get() == major && minorExp.get() == minor) {
       devName = udev_device_get_property_value(device, "DEVNAME");
       return true;
     }
@@ -426,7 +436,12 @@ MDDrive parseMDDrive(const std::string& name) {
   }
 
   // No need to check name length since we know it is at least 2 characters.
-  drive.pos = std::stoi(name.substr(start + 1, end - start - 1));
+  auto posExp = tryTo<int>(name.substr(start + 1, end - start - 1));
+  if (posExp.isError()) {
+    LOG(WARNING) << "Could not parse drive position from: " << name;
+    return drive;
+  }
+  drive.pos = posExp.get();
 
   return drive;
 }

--- a/osquery/tables/system/linux/process_open_pipes.cpp
+++ b/osquery/tables/system/linux/process_open_pipes.cpp
@@ -12,6 +12,7 @@
 #include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
+#include <osquery/utils/conversions/tryto.h>
 #include <regex>
 
 namespace osquery {
@@ -53,10 +54,9 @@ bool isUnconnectedPipe(ino_t inode, const InodeToPipesMap& pipe_partners) {
 int parseInode(const std::string& pipe_str) {
   std::smatch match;
   if (std::regex_search(pipe_str, match, std::regex("\\d+"))) {
-    return std::stoul(match[0]);
-  } else {
-    return 0;
+    return static_cast<int>(tryTo<unsigned long>(match[0].str()).takeOr(0ul));
   }
+  return 0;
 }
 
 std::string getMode(const std::string& pid, const std::string& fd) {
@@ -101,8 +101,13 @@ std::unique_ptr<pipe_info> getNamedPipeInfo(
       !S_ISFIFO(file_stat.st_mode)) { // not a pipe
     return nullptr;
   }
-  return createPipeInfoStruct(std::stoi(process),
-                              std::stoi(desc.first),
+  auto pidExp = tryTo<pid_t>(process);
+  auto fdExp = tryTo<int>(desc.first);
+  if (pidExp.isError() || fdExp.isError()) {
+    return nullptr;
+  }
+  return createPipeInfoStruct(pidExp.get(),
+                              fdExp.get(),
                               getMode(process, desc.first),
                               file_stat.st_ino,
                               "named");
@@ -112,8 +117,13 @@ std::unique_ptr<pipe_info> getPipeInfo(
     const std::string& process,
     const std::pair<std::string, std::string>& desc) {
   if (desc.second.find("pipe:") != std::string::npos) { // found unnamed pipe
-    return createPipeInfoStruct(std::stoi(process),
-                                std::stoi(desc.first),
+    auto pidExp = tryTo<pid_t>(process);
+    auto fdExp = tryTo<int>(desc.first);
+    if (pidExp.isError() || fdExp.isError()) {
+      return nullptr;
+    }
+    return createPipeInfoStruct(pidExp.get(),
+                                fdExp.get(),
                                 getMode(process, desc.first),
                                 parseInode(desc.second),
                                 "anonymous");
@@ -173,7 +183,11 @@ void genResults(const std::string& process,
                 const PidToPipesMap& pipe_desc,
                 const InodeToPipesMap& pipe_partners,
                 QueryData& results) {
-  auto pipe_desc_iter = pipe_desc.find((std::stoi(process)));
+  auto pidExp = tryTo<pid_t>(process);
+  if (pidExp.isError()) {
+    return;
+  }
+  auto pipe_desc_iter = pipe_desc.find(pidExp.get());
   if (pipe_desc_iter == pipe_desc.end()) {
     return;
   }

--- a/osquery/tables/system/linux/system_info.cpp
+++ b/osquery/tables/system/linux/system_info.cpp
@@ -21,6 +21,7 @@
 #include <osquery/sql/sql.h>
 #include <osquery/tables/system/linux/smbios_utils.h>
 #include <osquery/utils/conversions/split.h>
+#include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
 namespace tables {
@@ -86,11 +87,16 @@ QueryData genSystemInfo(QueryContext& context) {
       } else if (line.find("siblings") == 0) {
         auto details = osquery::split(line, ":");
         if (details.size() == 2) {
-          unsigned int logical_cores_per_socket = std::stoi(details[1]);
-          r["cpu_sockets"] =
-              (logical_cores > 0 && logical_cores_per_socket > 0)
-                  ? INTEGER(logical_cores / logical_cores_per_socket)
-                  : "-1";
+          auto coresExp = tryTo<unsigned int>(details[1]);
+          if (coresExp.isError()) {
+            r["cpu_sockets"] = "-1";
+          } else {
+            unsigned int logical_cores_per_socket = coresExp.get();
+            r["cpu_sockets"] =
+                (logical_cores > 0 && logical_cores_per_socket > 0)
+                    ? INTEGER(logical_cores / logical_cores_per_socket)
+                    : "-1";
+          }
         }
       }
 

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -13,6 +13,7 @@
 #include <osquery/core/tables.h>
 
 #include <osquery/utils/conversions/split.h>
+#include <osquery/utils/conversions/tryto.h>
 
 #include <osquery/tables/system/windows/registry.h>
 
@@ -62,8 +63,12 @@ QueryData genShims(QueryContext& context) {
       }
       if (aKey.at("name") == "DatabaseInstallTimeStamp") {
         // take this crazy windows timestamp to a unix timestamp
-        sdb.installTimestamp = std::stoull(aKey.at("data"));
-        sdb.installTimestamp = (sdb.installTimestamp / 10000000) - 11644473600;
+        auto timestampExp = tryTo<unsigned long long>(aKey.at("data"));
+        if (!timestampExp.isError()) {
+          sdb.installTimestamp = timestampExp.get();
+          sdb.installTimestamp =
+              (sdb.installTimestamp / 10000000) - 11644473600;
+        }
       }
       if (aKey.at("name") == "DatabasePath") {
         sdb.path = aKey.at("data");

--- a/osquery/tables/system/windows/windows_search.cpp
+++ b/osquery/tables/system/windows/windows_search.cpp
@@ -27,6 +27,7 @@
 #include <osquery/logger/logger.h>
 #include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/split.h>
+#include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
 #include <osquery/utils/conversions/windows/windows_time.h>
 #include <osquery/utils/json/json.h>
@@ -367,7 +368,7 @@ QueryData genWindowsSearch(QueryContext& context) {
     auto maxResultsConstraint =
         context.constraints["max_results"].getAll(EQUALS);
     auto maxResultsStr = SQL_TEXT(*maxResultsConstraint.begin());
-    maxResults = std::stol(maxResultsStr);
+    maxResults = tryTo<long>(maxResultsStr).takeOr(100L);
   }
 
   class windowsToOsqueryColumn {

--- a/osquery/utils/conversions/windows/windows_time.cpp
+++ b/osquery/utils/conversions/windows/windows_time.cpp
@@ -68,16 +68,26 @@ LONGLONG parseFatTime(const std::string& fat_data) {
   std::string fat_date_data = fat_data.substr(0, 4);
   std::string fat_time_data = fat_data.substr(4, 4);
 
-  auto fat_date = std::stoi(fat_date_data.substr(2, 2), nullptr, 16) << 8;
-  fat_date |= std::stoi(fat_date_data.substr(0, 2), nullptr, 16);
+  auto fat_date_high = tryTo<int>(fat_date_data.substr(2, 2), 16);
+  auto fat_date_low = tryTo<int>(fat_date_data.substr(0, 2), 16);
+  if (fat_date_high.isError() || fat_date_low.isError()) {
+    LOG(WARNING) << "Failed to parse FAT date: " << fat_date_data;
+    return 0ll;
+  }
+  auto fat_date = (fat_date_high.get() << 8) | fat_date_low.get();
 
   // Year is stored as number of years after 1980. Ex: 2020 is stored as 40
   int fat_year = ((fat_date & 0xfe00) >> 9) + 1980;
   int fat_month = (fat_date & 0x1e0) >> 5;
   int fat_day = fat_date & 0x1f;
 
-  auto fat_time = std::stoi(fat_time_data.substr(2, 2), nullptr, 16) << 8;
-  fat_time |= std::stoi(fat_time_data.substr(0, 2), nullptr, 16);
+  auto fat_time_high = tryTo<int>(fat_time_data.substr(2, 2), 16);
+  auto fat_time_low = tryTo<int>(fat_time_data.substr(0, 2), 16);
+  if (fat_time_high.isError() || fat_time_low.isError()) {
+    LOG(WARNING) << "Failed to parse FAT time: " << fat_time_data;
+    return 0ll;
+  }
+  auto fat_time = (fat_time_high.get() << 8) | fat_time_low.get();
   int fat_sec = (fat_time & 0x1f) * 2;
   int fat_min = (fat_time & 0x7e0) >> 5;
   int fat_hour = (fat_time & 0xf800) >> 11;


### PR DESCRIPTION
This commit replaces all instances of std::stoi, std::stol, std::stoul, std::stoull, and std::stod with the safer tryTo<> template function to prevent security vulnerabilities from uncaught exceptions and undefined behavior.

Changes include:
- Added NULL pointer checks before conversion in udev property handlers
- Added error handling for all string-to-integer conversions
- Replaced exception-based error handling with tryTo's Expected type
- Fixed incorrect exception handling in docker.cpp (was only catching std::out_of_range, not std::invalid_argument)

Files modified:
- osquery/tables/system/linux/md_tables.cpp
- osquery/tables/system/linux/system_info.cpp
- osquery/tables/system/linux/process_open_pipes.cpp
- osquery/tables/system/darwin/smc_keys.cpp
- osquery/tables/system/darwin/sip_config.cpp
- osquery/tables/system/darwin/unified_log.mm
- osquery/tables/system/windows/appcompat_shims.cpp
- osquery/tables/system/windows/windows_search.cpp
- osquery/tables/applications/posix/docker.cpp
- osquery/utils/conversions/windows/windows_time.cpp
- osquery/database/database.cpp
- osquery/core/query.cpp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
