### PR TITLE
Fix format string vulnerability in shell.cpp disconnect_socket()

### DIFF
--- a/osquery/devtools/shell.cpp
+++ b/osquery/devtools/shell.cpp
@@ -308,10 +308,10 @@ static void disconnect_socket() {
   print_bold("\n");
 
   std::string backup_prompt(mainPrompt + strlen("[*]"));
-  sqlite3_snprintf(sizeof(mainPrompt), mainPrompt, backup_prompt.c_str());
+  sqlite3_snprintf(sizeof(mainPrompt), mainPrompt, "%s", backup_prompt.c_str());
   backup_prompt = continuePrompt + strlen("[*]");
   sqlite3_snprintf(
-      sizeof(continuePrompt), continuePrompt, backup_prompt.c_str());
+      sizeof(continuePrompt), continuePrompt, "%s", backup_prompt.c_str());
 }
 
 /*


### PR DESCRIPTION
This fixes a format string vulnerability in the disconnect_socket() function where user-controlled data (backup_prompt.c_str()) was being passed directly as the format string argument to sqlite3_snprintf().

The vulnerability allowed an attacker who could control the prompt strings (mainPrompt or continuePrompt) to exploit format string specifiers, potentially leading to information disclosure or code execution.

The fix adds "%s" as an explicit format string argument before backup_prompt.c_str() in both sqlite3_snprintf() calls (lines 311 and 314), matching the safe pattern already used in the connect_socket() function above.

Generated with [Claude Code](https://claude.com/claude-code)
