### PR TITLE
Fix container bounds checking vulnerabilities

### DIFF
--- a/osquery/tables/system/darwin/homebrew_packages.cpp
+++ b/osquery/tables/system/darwin/homebrew_packages.cpp
@@ -50,7 +50,10 @@ std::vector<std::string> getHomebrewAppInfoPlistPaths(const std::string& root) {
 
 std::string getHomebrewNameFromInfoPlistPath(const std::string& path) {
   auto bits = osquery::split(path, "/");
-  return bits[bits.size() - 1];
+  if (bits.empty()) {
+    return "";
+  }
+  return bits.back();
 }
 
 // Homebrew formulas are under a path like

--- a/osquery/tables/system/linux/apt_sources.cpp
+++ b/osquery/tables/system/linux/apt_sources.cpp
@@ -84,7 +84,7 @@ Status parseAptSourceLine(const std::string& input_line,
 
   apt_source.base_uri = tokens[offset];
   // Cannot have trailing slashes
-  while (apt_source.base_uri.back() == '/') {
+  while (!apt_source.base_uri.empty() && apt_source.base_uri.back() == '/') {
     apt_source.base_uri.pop_back();
   }
 
@@ -264,7 +264,7 @@ Status parseDeb822Block(const std::string& input_block,
           continue;
         }
         // Cannot have trailing slashes
-        while (uri.back() == '/') {
+        while (!uri.empty() && uri.back() == '/') {
           uri.pop_back();
         }
         uris.push_back(uri);

--- a/osquery/tables/system/linux/portage.cpp
+++ b/osquery/tables/system/linux/portage.cpp
@@ -66,7 +66,7 @@ class PortagePackage : boost::noncopyable {
 std::pair<std::string, std::string> portageSplitPackageVersion(
     const std::string& pkg_str) {
   std::string package_str = pkg_str;
-  if (package_str.back() == '/') {
+  if (!package_str.empty() && package_str.back() == '/') {
     package_str.pop_back();
   }
 

--- a/osquery/tables/system/linux/process_open_pipes.cpp
+++ b/osquery/tables/system/linux/process_open_pipes.cpp
@@ -47,7 +47,11 @@ bool isReaderWriterPair(const pipe_info& p1, const pipe_info& p2) {
 }
 
 bool isUnconnectedPipe(ino_t inode, const InodeToPipesMap& pipe_partners) {
-  return (pipe_partners.at(inode).size() == 1);
+  auto it = pipe_partners.find(inode);
+  if (it == pipe_partners.end()) {
+    return false;
+  }
+  return (it->second.size() == 1);
 }
 
 int parseInode(const std::string& pipe_str) {
@@ -180,7 +184,11 @@ void genResults(const std::string& process,
 
   for (const auto& ps :
        pipe_desc_iter->second) { // iterate over vector of pipe_info
-    for (const auto& partner_ps : pipe_partners.at(ps.get().inode)) {
+    auto partner_it = pipe_partners.find(ps.get().inode);
+    if (partner_it == pipe_partners.end()) {
+      continue;
+    }
+    for (const auto& partner_ps : partner_it->second) {
       if (isUnconnectedPipe(ps.get().inode, pipe_partners)) {
         createRow(process, ps, results);
       } else if (isSamePipe(ps, partner_ps) ||

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -88,7 +88,10 @@ QueryData genShims(QueryContext& context) {
     QueryData regResults;
     std::string subkey = rKey.at("path");
     auto toks = split(rKey.at("path"), "\\");
-    auto executable = toks[toks.size() - 1];
+    if (toks.empty()) {
+      continue;
+    }
+    auto executable = toks.back();
     queryKey(subkey, regResults);
     for (const auto& aKey : regResults) {
       Row r;

--- a/osquery/tables/system/windows/appcompat_shims.cpp
+++ b/osquery/tables/system/windows/appcompat_shims.cpp
@@ -11,7 +11,7 @@
 
 #include <osquery/core/core.h>
 #include <osquery/core/tables.h>
-
+#include <osquery/logger/logger.h>
 #include <osquery/utils/conversions/split.h>
 
 #include <osquery/tables/system/windows/registry.h>
@@ -89,6 +89,8 @@ QueryData genShims(QueryContext& context) {
     std::string subkey = rKey.at("path");
     auto toks = split(rKey.at("path"), "\\");
     if (toks.empty()) {
+      VLOG(1) << "Unable to determine executable from registry path '"
+              << rKey.at("path") << "'";
       continue;
     }
     auto executable = toks.back();


### PR DESCRIPTION
Add proper empty/size checks before accessing container elements to prevent undefined behavior from potential underflows and invalid memory access.

Changes:
- appcompat_shims.cpp: Add empty check before accessing split() result with .back() instead of unsafe [size()-1] indexing
- homebrew_packages.cpp: Add empty check before accessing split() result with .back() instead of unsafe [size()-1] indexing
- process_open_pipes.cpp: Replace unsafe .at() with .find() for map access to check key existence before dereferencing (2 locations)
- portage.cpp: Add empty check before .back() and .pop_back() access on string
- apt_sources.cpp: Add empty check before .back() and .pop_back() access on strings (2 locations)

These fixes prevent potential crashes from:
- Integer underflow when calling size()-1 on empty containers
- Out-of-bounds access via .at() on non-existent map keys
- Undefined behavior from .back()/.pop_back() on empty containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
