### PR TITLE
Add NULL checks after malloc calls to prevent dereferencing null pointers

### DIFF
--- a/osquery/sql/sqlite_filesystem.cpp
+++ b/osquery/sql/sqlite_filesystem.cpp
@@ -178,7 +178,23 @@ static void getParentDirectory(sqlite3_context* context,
     sqlite3_result_null(context);
     return;
   }
+  if (last_slash_pos == 0) {
+    // Special case: root path (e.g., "/file")
+    // Parent directory is "/" which needs 1 byte
+    char* result = reinterpret_cast<char*>(malloc(1));
+    if (result == nullptr) {
+      sqlite3_result_error_nomem(context);
+      return;
+    }
+    memcpy(result, path, 1);
+    sqlite3_result_text(context, result, 1, free);
+    return;
+  }
   char* result = reinterpret_cast<char*>(malloc(last_slash_pos));
+  if (result == nullptr) {
+    sqlite3_result_error_nomem(context);
+    return;
+  }
   memcpy(result, path, last_slash_pos);
   sqlite3_result_text(context, result, last_slash_pos, free);
 }

--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -146,6 +146,9 @@ void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
   }
 
   auto table = (char *)malloc(table_size);
+  if (table == nullptr) {
+    return;
+  }
   if (sysctl(mib, sizeof(mib) / sizeof(int), table, &table_size, nullptr, 0) <
       0) {
     free(table);

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -283,26 +283,29 @@ MultiHashes hashInode(TskFsFile* file) {
   // Allocate some heap memory and iterate over reading a chunk and updating.
   auto buffer_size = (size < 4096) ? size : 4096;
   auto* buffer = (char*)malloc(buffer_size * sizeof(char));
-  if (buffer != nullptr) {
-    ssize_t chunk_size = 0;
-    for (ssize_t offset = 0; offset < size; offset += chunk_size) {
-      // Here max represents the local max requested bytes.
-      auto max = (size - offset < buffer_size) ? (size - offset) : buffer_size;
-      chunk_size =
-          file->read(offset, buffer, max, (TSK_FS_FILE_READ_FLAG_ENUM)0U);
-      if (chunk_size == -1 || chunk_size != max) {
-        // Huge problem, either a read failed or didn't read the max size.
-        free(buffer);
-        delete meta;
-        return MultiHashes();
-      }
-
-      md5.update(buffer, chunk_size);
-      sha1.update(buffer, chunk_size);
-      sha256.update(buffer, chunk_size);
-    }
-    free(buffer);
+  if (buffer == nullptr) {
+    delete meta;
+    return MultiHashes();
   }
+
+  ssize_t chunk_size = 0;
+  for (ssize_t offset = 0; offset < size; offset += chunk_size) {
+    // Here max represents the local max requested bytes.
+    auto max = (size - offset < buffer_size) ? (size - offset) : buffer_size;
+    chunk_size =
+        file->read(offset, buffer, max, (TSK_FS_FILE_READ_FLAG_ENUM)0U);
+    if (chunk_size == -1 || chunk_size != max) {
+      // Huge problem, either a read failed or didn't read the max size.
+      free(buffer);
+      delete meta;
+      return MultiHashes();
+    }
+
+    md5.update(buffer, chunk_size);
+    sha1.update(buffer, chunk_size);
+    sha256.update(buffer, chunk_size);
+  }
+  free(buffer);
   delete meta;
 
   // Convert the set of hashes into a device hashes transport.

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -38,6 +38,9 @@ std::string getSysctlString(const std::string& name) {
 
   if (len > 0) {
     char* value = (char*)malloc(len);
+    if (value == nullptr) {
+      return ret;
+    }
     if (!sysctlbyname(name.c_str(), value, &len, NULL, 0)) {
       ret = value;
     }

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -106,6 +106,9 @@ inline std::string readProcLink(const std::string& attr,
     ssize_t buf_size = sb.st_size < PATH_MAX ? PATH_MAX : sb.st_size;
     // +1 for \0, since readlink does not append a null
     char* linkname = static_cast<char*>(malloc(buf_size + 1));
+    if (linkname == nullptr) {
+      return result;
+    }
     ssize_t r = readlink(attr_path.c_str(), linkname, buf_size);
 
     if (r > 0) { // Success check


### PR DESCRIPTION
This commit adds missing NULL checks after malloc() calls in several files to prevent potential null pointer dereferences and improve code safety:

- processes.cpp: Check malloc result before readlink buffer usage
- routes.cpp: Check malloc result before sysctl buffer usage
- system_info.cpp: Check malloc result before sysctlbyname buffer usage
- sqlite_filesystem.cpp: Check malloc result and handle malloc(0) edge case for root paths
- sleuthkit.cpp: Check malloc result before file hashing buffer usage

Each check returns an appropriate error value for its context (empty string, early return, or SQLite error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

