### PR TITLE
Fix gatekeeper table on macOS 15+

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -354,6 +354,7 @@ function(generateOsqueryTablesSystemSystemtable)
       darwin/keychain.h
       darwin/packages.h
       darwin/smbios_utils.h
+      darwin/os_version.h
     )
 
   elseif(DEFINED PLATFORM_WINDOWS)

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -16,6 +16,7 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sqlite_util.h>
+#include <osquery/tables/system/darwin/os_version.h>
 #include <osquery/utils/conversions/tryto.h>
 
 namespace fs = boost::filesystem;
@@ -23,11 +24,12 @@ namespace fs = boost::filesystem;
 namespace osquery {
 namespace tables {
 
-const std::string kLegacyGkeStatusPath = "/var/db/SystemPolicy-prefs.plist";
+const std::string kGkeStatusPathBeforeSequoia =
+    "/var/db/SystemPolicy-prefs.plist";
 const std::string kGkeStatusPath =
     "/var/db/SystemPolicyConfiguration/SystemPolicy-prefs.plist";
 
-const std::string kLegacyGkeBundlePath =
+const std::string kGkeBundlePathBeforeSequoia =
     "/var/db/gke.bundle/Contents/version.plist";
 const std::string kGkeBundlePath =
     "/var/db/SystemPolicyConfiguration/gke.bundle/Contents/version.plist";
@@ -35,28 +37,13 @@ const std::string kGkeBundlePath =
 const std::string kGkeOpaquePath =
     "/var/db/gkopaque.bundle/Contents/version.plist";
 
-const std::string kLegacyPolicyDb = "/var/db/SystemPolicy";
+const std::string kPolicyDbBeforeSequoia = "/var/db/SystemPolicy";
 const std::string kPolicyDb = "/var/db/SystemPolicyConfiguration/SystemPolicy";
 
-static bool getMajorOSVersion(int& version) {
-  auto os_version = SQL::selectAllFrom("os_version");
-  if (os_version.size() != 1) {
-    return false;
-  }
-
-  auto major_version = tryTo<int>(os_version.front().at("major"));
-  if (major_version) {
-    version = major_version.take();
-    return true;
-  }
-
-  return false;
-}
-
-bool isGateKeeperDevIdEnabled(int os_version) {
+bool isGateKeeperDevIdEnabled(bool is_sequoia_or_newer) {
   sqlite3* db = nullptr;
   auto rc = sqlite3_open_v2(
-      (os_version < 15) ? kLegacyPolicyDb.c_str() : kPolicyDb.c_str(),
+      is_sequoia_or_newer ? kPolicyDb.c_str() : kPolicyDbBeforeSequoia.c_str(),
       &db,
       (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
       nullptr);
@@ -99,17 +86,13 @@ bool isGateKeeperDevIdEnabled(int os_version) {
 QueryData genGateKeeper(QueryContext& context) {
   Row r;
 
-  int os_version;
-  if (getMajorOSVersion(os_version) == false) {
-    LOG(WARNING) << "Could not determine OS version";
-    return {};
-  }
+  bool is_sequoia_or_newer = isOperatingSystemAtLeastVersion(15, 0, 0);
 
   auto gke_status = SQL::selectAllFrom(
       "plist",
       "path",
       EQUALS,
-      (os_version < 15) ? kLegacyGkeStatusPath : kGkeStatusPath);
+      is_sequoia_or_newer ? kGkeStatusPath : kGkeStatusPathBeforeSequoia);
 
   if (gke_status.empty()) {
     // The absence of the file indicates that Gatekeeper is fully enabled
@@ -123,8 +106,9 @@ QueryData genGateKeeper(QueryContext& context) {
     }
     if (row.at("key") == "enabled" && row.at("value") == "yes") {
       r["assessments_enabled"] = INTEGER(1);
-      r["dev_id_enabled"] =
-          isGateKeeperDevIdEnabled(os_version) ? INTEGER(1) : INTEGER(0);
+      r["dev_id_enabled"] = isGateKeeperDevIdEnabled(is_sequoia_or_newer)
+                                ? INTEGER(1)
+                                : INTEGER(0);
     } else {
       r["assessments_enabled"] = INTEGER(0);
       r["dev_id_enabled"] = INTEGER(0);
@@ -135,7 +119,7 @@ QueryData genGateKeeper(QueryContext& context) {
       "plist",
       "path",
       EQUALS,
-      os_version < 15 ? kLegacyGkeBundlePath : kGkeBundlePath);
+      is_sequoia_or_newer ? kGkeBundlePath : kGkeBundlePathBeforeSequoia);
 
   if (gke_bundle.empty()) {
     r["version"] = std::string();
@@ -186,16 +170,12 @@ void genGateKeeperApprovedAppRow(sqlite3_stmt* const stmt, Row& r) {
 QueryData genGateKeeperApprovedApps(QueryContext& context) {
   QueryData results;
 
-  int os_version;
-  if (getMajorOSVersion(os_version) == false) {
-    LOG(WARNING) << "Could not determine OS version";
-    return {};
-  }
+  bool is_sequoia_or_newer = isOperatingSystemAtLeastVersion(15, 0, 0);
 
   sqlite3* db = nullptr;
 
   auto rc = sqlite3_open_v2(
-      (os_version < 15) ? kLegacyPolicyDb.c_str() : kPolicyDb.c_str(),
+      is_sequoia_or_newer ? kPolicyDb.c_str() : kPolicyDbBeforeSequoia.c_str(),
       &db,
       (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
       nullptr);

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -22,19 +22,40 @@ namespace fs = boost::filesystem;
 namespace osquery {
 namespace tables {
 
-const std::string kGkeStatusPath = "/var/db/SystemPolicy-prefs.plist";
+const std::string kLegacyGkeStatusPath = "/var/db/SystemPolicy-prefs.plist";
+const std::string kGkeStatusPath =
+    "/var/db/SystemPolicyConfiguration/SystemPolicy-prefs.plist";
 
-const std::string kGkeBundlePath = "/var/db/gke.bundle/Contents/version.plist";
+const std::string kLegacyGkeBundlePath =
+    "/var/db/gke.bundle/Contents/version.plist";
+const std::string kGkeBundlePath =
+    "/var/db/SystemPolicyConfiguration/gke.bundle/Contents/version.plist";
 
 const std::string kGkeOpaquePath =
     "/var/db/gkopaque.bundle/Contents/version.plist";
 
-const std::string kPolicyDb = "/var/db/SystemPolicy";
+const std::string kLegacyPolicyDb = "/var/db/SystemPolicy";
+const std::string kPolicyDb = "/var/db/SystemPolicyConfiguration/SystemPolicy";
 
-bool isGateKeeperDevIdEnabled() {
+static bool getMajorOSVersion(int& version) {
+  auto os_version = SQL::selectAllFrom("os_version");
+  if (os_version.size() != 1) {
+    return false;
+  }
+
+  try {
+    version = std::stoi(os_version.front().at("major"));
+    return true;
+  } catch (const std::exception&) {
+  }
+
+  return false;
+}
+
+bool isGateKeeperDevIdEnabled(int os_version) {
   sqlite3* db = nullptr;
   auto rc = sqlite3_open_v2(
-      kPolicyDb.c_str(),
+      (os_version < 15) ? kLegacyPolicyDb.c_str() : kPolicyDb.c_str(),
       &db,
       (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
       nullptr);
@@ -77,7 +98,17 @@ bool isGateKeeperDevIdEnabled() {
 QueryData genGateKeeper(QueryContext& context) {
   Row r;
 
-  auto gke_status = SQL::selectAllFrom("plist", "path", EQUALS, kGkeStatusPath);
+  int os_version;
+  if (getMajorOSVersion(os_version) == false) {
+    LOG(WARNING) << "Could not determine OS version";
+    return {};
+  }
+
+  auto gke_status = SQL::selectAllFrom(
+      "plist",
+      "path",
+      EQUALS,
+      (os_version < 15) ? kLegacyGkeStatusPath : kGkeStatusPath);
 
   if (gke_status.empty()) {
     // The absence of the file indicates that Gatekeeper is fully enabled
@@ -92,14 +123,18 @@ QueryData genGateKeeper(QueryContext& context) {
     if (row.at("key") == "enabled" && row.at("value") == "yes") {
       r["assessments_enabled"] = INTEGER(1);
       r["dev_id_enabled"] =
-          isGateKeeperDevIdEnabled() ? INTEGER(1) : INTEGER(0);
+          isGateKeeperDevIdEnabled(os_version) ? INTEGER(1) : INTEGER(0);
     } else {
       r["assessments_enabled"] = INTEGER(0);
       r["dev_id_enabled"] = INTEGER(0);
     }
   }
 
-  auto gke_bundle = SQL::selectAllFrom("plist", "path", EQUALS, kGkeBundlePath);
+  auto gke_bundle = SQL::selectAllFrom(
+      "plist",
+      "path",
+      EQUALS,
+      os_version < 15 ? kLegacyGkeBundlePath : kGkeBundlePath);
 
   if (gke_bundle.empty()) {
     r["version"] = std::string();
@@ -150,10 +185,16 @@ void genGateKeeperApprovedAppRow(sqlite3_stmt* const stmt, Row& r) {
 QueryData genGateKeeperApprovedApps(QueryContext& context) {
   QueryData results;
 
+  int os_version;
+  if (getMajorOSVersion(os_version) == false) {
+    LOG(WARNING) << "Could not determine OS version";
+    return {};
+  }
+
   sqlite3* db = nullptr;
 
   auto rc = sqlite3_open_v2(
-      kPolicyDb.c_str(),
+      (os_version < 15) ? kLegacyPolicyDb.c_str() : kPolicyDb.c_str(),
       &db,
       (SQLITE_OPEN_READONLY | SQLITE_OPEN_PRIVATECACHE | SQLITE_OPEN_NOMUTEX),
       nullptr);

--- a/osquery/tables/system/darwin/gatekeeper.cpp
+++ b/osquery/tables/system/darwin/gatekeeper.cpp
@@ -16,6 +16,7 @@
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sqlite_util.h>
+#include <osquery/utils/conversions/tryto.h>
 
 namespace fs = boost::filesystem;
 
@@ -43,10 +44,10 @@ static bool getMajorOSVersion(int& version) {
     return false;
   }
 
-  try {
-    version = std::stoi(os_version.front().at("major"));
+  auto major_version = tryTo<int>(os_version.front().at("major"));
+  if (major_version) {
+    version = major_version.take();
     return true;
-  } catch (const std::exception&) {
   }
 
   return false;

--- a/osquery/tables/system/darwin/os_version.h
+++ b/osquery/tables/system/darwin/os_version.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+namespace osquery {
+namespace tables {
+
+bool isOperatingSystemAtLeastVersion(int majorVersion,
+                                     int minorVersion,
+                                     int patchVersion);
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/os_version.mm
+++ b/osquery/tables/system/darwin/os_version.mm
@@ -110,7 +110,7 @@ QueryData genOSVersion(QueryContext& context) {
   r["platform_like"] = "darwin";
 
   // Determine architecture
-  struct utsname uname_buf{};
+  struct utsname uname_buf {};
 
   if (uname(&uname_buf) == 0) {
     r["arch"] = SQL_TEXT(uname_buf.machine);

--- a/osquery/tables/system/darwin/os_version.mm
+++ b/osquery/tables/system/darwin/os_version.mm
@@ -15,10 +15,12 @@
 #include <osquery/core/tables.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
+#include <osquery/tables/system/darwin/os_version.h>
 #include <osquery/utils/conversions/darwin/cfstring.h>
 #include <osquery/utils/conversions/split.h>
 
 #import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
 
 namespace osquery {
 namespace tables {
@@ -108,7 +110,7 @@ QueryData genOSVersion(QueryContext& context) {
   r["platform_like"] = "darwin";
 
   // Determine architecture
-  struct utsname uname_buf {};
+  struct utsname uname_buf{};
 
   if (uname(&uname_buf) == 0) {
     r["arch"] = SQL_TEXT(uname_buf.machine);
@@ -186,5 +188,16 @@ QueryData genOSVersion(QueryContext& context) {
   results.push_back(r);
   return results;
 }
+
+bool isOperatingSystemAtLeastVersion(int majorVersion,
+                                     int minorVersion,
+                                     int patchVersion) {
+  NSProcessInfo* processInfo = [NSProcessInfo processInfo];
+  NSOperatingSystemVersion min_version = {
+      majorVersion, minorVersion, patchVersion};
+
+  return [processInfo isOperatingSystemAtLeastVersion:(min_version)];
+}
+
 } // namespace tables
 } // namespace osquery


### PR DESCRIPTION
Since macOS 15, location of files containing gatekeeper configuration changed (although their content seems to be the same). This commit accounts for the various locations, depending on the OS version.

With this commit, on macOS 15+:

- `assessments_enabled` and `dev_id_enabled` columns now contain correct values. They were previously always set to '1' (error case) even if gatekeeper was disabled ;
- `version` column is now filled in. It was previously left empty.

Tests were performed on macOS 14, macOS15 and macOS 26.

This commit should also make table `gatekeeper_approved_apps` be populated correctly on macOS 15+. I was not able to test because gatekeeper approved apps can no more be easily added.

Fixes #8528
