### PR TITLE
Refactor to remove manual memory management

### DIFF
--- a/osquery/sql/sqlite_filesystem.cpp
+++ b/osquery/sql/sqlite_filesystem.cpp
@@ -178,9 +178,7 @@ static void getParentDirectory(sqlite3_context* context,
     sqlite3_result_null(context);
     return;
   }
-  char* result = reinterpret_cast<char*>(malloc(last_slash_pos));
-  memcpy(result, path, last_slash_pos);
-  sqlite3_result_text(context, result, last_slash_pos, free);
+  sqlite3_result_text(context, path, last_slash_pos, SQLITE_TRANSIENT);
 }
 
 void registerFilesystemExtensions(sqlite3* db) {

--- a/osquery/tables/networking/darwin/routes.cpp
+++ b/osquery/tables/networking/darwin/routes.cpp
@@ -7,12 +7,12 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
-#include <string>
 #include <iomanip>
+#include <string>
+#include <vector>
 
 #include <ifaddrs.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include <arpa/inet.h>
 #include <net/if_dl.h>
@@ -31,7 +31,7 @@ namespace tables {
 
 typedef std::pair<int, std::string> RouteType;
 typedef std::map<int, std::string> InterfaceMap;
-typedef std::vector<struct sockaddr *> AddressMap;
+typedef std::vector<struct sockaddr*> AddressMap;
 
 constexpr auto kDefaultIPv4Route = "0.0.0.0";
 constexpr auto kDefaultIPv6Route = "::";
@@ -65,7 +65,7 @@ InterfaceMap genInterfaceMap() {
     if (if_addr->ifa_addr != nullptr &&
         if_addr->ifa_addr->sa_family == AF_LINK) {
       auto route_type = std::string(if_addr->ifa_name);
-      auto sdl = (struct sockaddr_dl *)if_addr->ifa_addr;
+      auto sdl = (struct sockaddr_dl*)if_addr->ifa_addr;
       ifmap.insert(it, std::make_pair(sdl->sdl_index, route_type));
     }
   }
@@ -74,9 +74,9 @@ InterfaceMap genInterfaceMap() {
   return ifmap;
 }
 
-Status genRoute(const struct rt_msghdr *route,
-                const AddressMap &addr_map,
-                Row &r) {
+Status genRoute(const struct rt_msghdr* route,
+                const AddressMap& addr_map,
+                Row& r) {
   r["flags"] = INTEGER(route->rtm_flags);
   r["mtu"] = INTEGER(route->rtm_rmx.rmx_mtu);
   r["hopcount"] = INTEGER(route->rtm_rmx.rmx_hopcount);
@@ -109,9 +109,9 @@ Status genRoute(const struct rt_msghdr *route,
   return Status::success();
 }
 
-Status genArp(const struct rt_msghdr *route,
-              const AddressMap &addr_map,
-              Row &r) {
+Status genArp(const struct rt_msghdr* route,
+              const AddressMap& addr_map,
+              Row& r) {
   if (addr_map[RTAX_DST]->sa_family != AF_INET) {
     return Status(1, "Not in ARP cache");
   }
@@ -119,7 +119,7 @@ Status genArp(const struct rt_msghdr *route,
   // The cache will always know the address.
   r["address"] = ipAsString(addr_map[RTAX_DST]);
 
-  auto sdl = (struct sockaddr_dl *)addr_map[RTA_DST];
+  auto sdl = (struct sockaddr_dl*)addr_map[RTA_DST];
   if (sdl->sdl_alen > 0) {
     r["mac"] = macAsString(LLADDR(sdl));
   } else {
@@ -136,7 +136,7 @@ Status genArp(const struct rt_msghdr *route,
   return Status::success();
 }
 
-void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
+void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData& results) {
   size_t table_size;
   int mib[] = {CTL_NET, PF_ROUTE, 0, AF_UNSPEC, NET_RT_FLAGS, type.first};
   if (sysctl(mib, sizeof(mib) / sizeof(int), nullptr, &table_size, nullptr, 0) <
@@ -145,17 +145,21 @@ void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
     return;
   }
 
-  auto table = (char *)malloc(table_size);
-  if (sysctl(mib, sizeof(mib) / sizeof(int), table, &table_size, nullptr, 0) <
-      0) {
-    free(table);
+  std::vector<char> table(table_size);
+  if (sysctl(mib,
+             sizeof(mib) / sizeof(int),
+             table.data(),
+             &table_size,
+             nullptr,
+             0) < 0) {
     return;
   }
 
   size_t message_length = 0;
-  for (char *p = table; p < table + table_size; p += message_length) {
-    auto route = (struct rt_msghdr *)p;
-    auto sa = (struct sockaddr *)(route + 1);
+  for (char* p = table.data(); p < table.data() + table_size;
+       p += message_length) {
+    auto route = (struct rt_msghdr*)p;
+    auto sa = (struct sockaddr*)(route + 1);
     message_length = route->rtm_msglen;
 
     // Populate route's sockaddr table (dest, gw, mask).
@@ -163,7 +167,7 @@ void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
     for (int i = 0; i < RTAX_MAX; i++) {
       if (route->rtm_addrs & (1 << i)) {
         addr_map.push_back(sa);
-        sa = (struct sockaddr *)((char *)sa + (sa->sa_len));
+        sa = (struct sockaddr*)((char*)sa + (sa->sa_len));
       } else {
         addr_map.push_back(nullptr);
       }
@@ -188,29 +192,27 @@ void genRouteTableType(RouteType type, InterfaceMap ifmap, QueryData &results) {
       results.push_back(r);
     }
   }
-
-  free(table);
 }
 
-QueryData genArpCache(QueryContext &context) {
+QueryData genArpCache(QueryContext& context) {
   QueryData results;
   InterfaceMap ifmap;
 
   ifmap = genInterfaceMap();
-  for (const auto &arp_type : kArpTypes) {
+  for (const auto& arp_type : kArpTypes) {
     genRouteTableType(arp_type, ifmap, results);
   }
 
   return results;
 }
 
-QueryData genRoutes(QueryContext &context) {
+QueryData genRoutes(QueryContext& context) {
   QueryData results;
   InterfaceMap ifmap;
 
   // Need a map from index->name for each route entry.
   ifmap = genInterfaceMap();
-  for (const auto &route_type : kRouteTypes) {
+  for (const auto& route_type : kRouteTypes) {
     if (context.constraints["type"].notExistsOrMatches(route_type.second)) {
       genRouteTableType(route_type, ifmap, results);
     }
@@ -218,5 +220,5 @@ QueryData genRoutes(QueryContext &context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/sleuthkit/sleuthkit.cpp
+++ b/osquery/tables/sleuthkit/sleuthkit.cpp
@@ -7,8 +7,11 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <algorithm>
 #include <map>
+#include <memory>
 #include <set>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 #include <boost/noncopyable.hpp>
@@ -268,7 +271,7 @@ MultiHashes hashInode(TskFsFile* file) {
   Hash sha256(HASH_TYPE_SHA256);
 
   // We are guaranteed by the expected callsite to have a valid meta.
-  auto* meta = file->getMeta();
+  std::unique_ptr<TskFsMeta> meta(file->getMeta());
   if (meta == nullptr) {
     return MultiHashes();
   }
@@ -276,34 +279,27 @@ MultiHashes hashInode(TskFsFile* file) {
   // Set a maximum 'chunk' or block size to 1 page or the file size.
   TSK_OFF_T size = meta->getSize();
   if (size == 0) {
-    delete meta;
     return MultiHashes();
   }
 
   // Allocate some heap memory and iterate over reading a chunk and updating.
-  auto buffer_size = (size < 4096) ? size : 4096;
-  auto* buffer = (char*)malloc(buffer_size * sizeof(char));
-  if (buffer != nullptr) {
-    ssize_t chunk_size = 0;
-    for (ssize_t offset = 0; offset < size; offset += chunk_size) {
-      // Here max represents the local max requested bytes.
-      auto max = (size - offset < buffer_size) ? (size - offset) : buffer_size;
-      chunk_size =
-          file->read(offset, buffer, max, (TSK_FS_FILE_READ_FLAG_ENUM)0U);
-      if (chunk_size == -1 || chunk_size != max) {
-        // Huge problem, either a read failed or didn't read the max size.
-        free(buffer);
-        delete meta;
-        return MultiHashes();
-      }
-
-      md5.update(buffer, chunk_size);
-      sha1.update(buffer, chunk_size);
-      sha256.update(buffer, chunk_size);
+  auto buffer_size = std::min(size, TSK_OFF_T{4096});
+  std::vector<char> buffer(buffer_size);
+  ssize_t chunk_size = 0;
+  for (ssize_t offset = 0; offset < size; offset += chunk_size) {
+    // Here max represents the local max requested bytes.
+    auto max = std::min(size - offset, buffer_size);
+    chunk_size =
+        file->read(offset, buffer.data(), max, (TSK_FS_FILE_READ_FLAG_ENUM)0U);
+    if (chunk_size == -1 || chunk_size != max) {
+      // Huge problem, either a read failed or didn't read the max size.
+      return MultiHashes();
     }
-    free(buffer);
+
+    md5.update(buffer.data(), chunk_size);
+    sha1.update(buffer.data(), chunk_size);
+    sha256.update(buffer.data(), chunk_size);
   }
-  delete meta;
 
   // Convert the set of hashes into a device hashes transport.
   MultiHashes dhs = {};
@@ -325,41 +321,41 @@ QueryData genDeviceHash(QueryContext& context) {
     // For each require device path, open a device helper that checks the
     // image, checks the volume, and allows partition iteration.
     DeviceHelper dh(dev);
-    dh.partitions(([&results, &dev, &dh, &parts, &inodes](
-        const TskVsPartInfo* part) {
-      // The table also requires a partition for searching.
-      auto address = std::to_string(part->getAddr());
-      if (address != *parts.begin()) {
-        // If this partition does not match the requested, continue.
-        return;
-      }
+    dh.partitions(
+        ([&results, &dev, &dh, &parts, &inodes](const TskVsPartInfo* part) {
+          // The table also requires a partition for searching.
+          auto address = std::to_string(part->getAddr());
+          if (address != *parts.begin()) {
+            // If this partition does not match the requested, continue.
+            return;
+          }
 
-      auto* fs = new TskFsInfo();
-      auto status = fs->open(part, TSK_FS_TYPE_DETECT);
-      // Cannot retrieve file information without accessing the filesystem.
-      if (status) {
-        delete fs;
-        return;
-      }
+          auto* fs = new TskFsInfo();
+          auto status = fs->open(part, TSK_FS_TYPE_DETECT);
+          // Cannot retrieve file information without accessing the filesystem.
+          if (status) {
+            delete fs;
+            return;
+          }
 
-      dh.inodes(inodes,
-                fs,
-                ([&results, &address, &dev](const std::string& inode,
-                                            TskFsFile* file,
-                                            const std::string& path) {
-                  Row r;
-                  r["device"] = dev;
-                  r["partition"] = address;
-                  r["inode"] = inode;
+          dh.inodes(inodes,
+                    fs,
+                    ([&results, &address, &dev](const std::string& inode,
+                                                TskFsFile* file,
+                                                const std::string& path) {
+                      Row r;
+                      r["device"] = dev;
+                      r["partition"] = address;
+                      r["inode"] = inode;
 
-                  auto hashes = hashInode(file);
-                  r["md5"] = std::move(hashes.md5);
-                  r["sha1"] = std::move(hashes.sha1);
-                  r["sha256"] = std::move(hashes.sha256);
-                  results.push_back(r);
-                }));
-      delete fs;
-    }));
+                      auto hashes = hashInode(file);
+                      r["md5"] = std::move(hashes.md5);
+                      r["sha1"] = std::move(hashes.sha1);
+                      r["sha256"] = std::move(hashes.sha256);
+                      results.push_back(r);
+                    }));
+          delete fs;
+        }));
   }
 
   return results;
@@ -384,48 +380,49 @@ QueryData genDeviceFile(QueryContext& context) {
     // For each require device path, open a device helper that checks the
     // image, checks the volume, and allows partition iteration.
     DeviceHelper dh(dev);
-    dh.partitions(([&results, &dh, &parts, &inodes, &paths](
-                       const TskVsPartInfo* part) {
-      // The table also requires a partition for searching.
-      auto address = std::to_string(part->getAddr());
-      if (address != *parts.begin()) {
-        // If this partition does not match the requested, continue.
-        return;
-      }
+    dh.partitions(
+        ([&results, &dh, &parts, &inodes, &paths](const TskVsPartInfo* part) {
+          // The table also requires a partition for searching.
+          auto address = std::to_string(part->getAddr());
+          if (address != *parts.begin()) {
+            // If this partition does not match the requested, continue.
+            return;
+          }
 
-      auto* fs = new TskFsInfo();
-      auto status = fs->open(part, TSK_FS_TYPE_DETECT);
-      // Cannot retrieve file information without accessing the filesystem.
-      if (status) {
-        delete fs;
-        return;
-      }
+          auto* fs = new TskFsInfo();
+          auto status = fs->open(part, TSK_FS_TYPE_DETECT);
+          // Cannot retrieve file information without accessing the filesystem.
+          if (status) {
+            delete fs;
+            return;
+          }
 
-      // If no inodes or paths were provided as constraints assume a walk of
-      // the partition was requested.
-      if (inodes.empty() && paths.empty()) {
-        dh.generateFiles(address, fs, "/", results);
-        dh.resetStack();
-      }
+          // If no inodes or paths were provided as constraints assume a walk of
+          // the partition was requested.
+          if (inodes.empty() && paths.empty()) {
+            dh.generateFiles(address, fs, "/", results);
+            dh.resetStack();
+          }
 
-      // For each path the canonical name must be mapped to an inode address.
-      for (const auto& path : paths) {
-        auto* file = new TskFsFile();
-        if (file->open(fs, file, path.c_str()) == 0) {
-          dh.generateFile(address, file, fs, path, results);
-        }
-        delete file;
-      }
+          // For each path the canonical name must be mapped to an inode
+          // address.
+          for (const auto& path : paths) {
+            auto* file = new TskFsFile();
+            if (file->open(fs, file, path.c_str()) == 0) {
+              dh.generateFile(address, file, fs, path, results);
+            }
+            delete file;
+          }
 
-      dh.inodes(inodes,
-                fs,
-                ([&results, &address, &dh, &fs](const std::string& inode,
-                                                TskFsFile* file,
-                                                const std::string& path) {
-                  dh.generateFile(address, file, fs, path, results);
-                }));
-      delete fs;
-    }));
+          dh.inodes(inodes,
+                    fs,
+                    ([&results, &address, &dh, &fs](const std::string& inode,
+                                                    TskFsFile* file,
+                                                    const std::string& path) {
+                      dh.generateFile(address, file, fs, path, results);
+                    }));
+          delete fs;
+        }));
   }
 
   return results;
@@ -481,5 +478,5 @@ QueryData genDevicePartitions(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/darwin/system_info.cpp
+++ b/osquery/tables/system/darwin/system_info.cpp
@@ -9,6 +9,7 @@
 
 #include <mach/mach.h>
 #include <sys/sysctl.h>
+#include <vector>
 
 #include <IOKit/IOKitLib.h>
 #include <SystemConfiguration/SystemConfiguration.h>
@@ -32,20 +33,18 @@ namespace tables {
  */
 std::string getSysctlString(const std::string& name) {
   size_t len = 0;
-  std::string ret;
+  sysctlbyname(name.c_str(), nullptr, &len, nullptr, 0);
 
-  sysctlbyname(name.c_str(), NULL, &len, NULL, 0);
-
-  if (len > 0) {
-    char* value = (char*)malloc(len);
-    if (!sysctlbyname(name.c_str(), value, &len, NULL, 0)) {
-      ret = value;
-    }
-
-    free(value);
+  if (len == 0) {
+    return {};
   }
 
-  return ret;
+  std::vector<char> value(len);
+  if (sysctlbyname(name.c_str(), value.data(), &len, nullptr, 0) != 0) {
+    return {};
+  }
+
+  return std::string(value.data(), len - 1);
 }
 
 static inline void genHostInfo(Row& r) {

--- a/osquery/tables/system/linux/processes.cpp
+++ b/osquery/tables/system/linux/processes.cpp
@@ -95,31 +95,29 @@ inline std::string readProcLink(const std::string& attr,
   // The exe is a symlink to the binary on-disk.
   auto attr_path = getProcAttr(attr, pid);
 
-  std::string result = "";
   struct stat sb;
-  if (lstat(attr_path.c_str(), &sb) != -1) {
-    // Some symlinks may report 'st_size' as zero
-    // Use PATH_MAX as best guess
-    // For cases when 'st_size' is not zero but smaller than
-    // PATH_MAX we will still use PATH_MAX to minimize chance
-    // of output trucation during race condition
-    ssize_t buf_size = sb.st_size < PATH_MAX ? PATH_MAX : sb.st_size;
-    // +1 for \0, since readlink does not append a null
-    char* linkname = static_cast<char*>(malloc(buf_size + 1));
-    ssize_t r = readlink(attr_path.c_str(), linkname, buf_size);
-
-    if (r > 0) { // Success check
-      // r may not be equal to buf_size
-      // if r == buf_size there was race condition
-      // and link is longer than buf_size and because of this
-      // truncated
-      linkname[r] = '\0';
-      result = std::string(linkname);
-    }
-    free(linkname);
+  if (lstat(attr_path.c_str(), &sb) == -1) {
+    return {};
   }
 
-  return result;
+  // Some symlinks may report 'st_size' as zero
+  // Use PATH_MAX as best guess
+  // For cases when 'st_size' is not zero but smaller than
+  // PATH_MAX we will still use PATH_MAX to minimize chance
+  // of output truncation during race condition
+  ssize_t buf_size = std::max(ssize_t{PATH_MAX}, sb.st_size);
+  std::vector<char> linkname(buf_size);
+  ssize_t r = readlink(attr_path.c_str(), linkname.data(), buf_size);
+
+  if (r <= 0) {
+    return {};
+  }
+
+  // r may not be equal to buf_size
+  // if r == buf_size there was a race condition
+  // and link is longer than buf_size and because of this
+  // truncated
+  return std::string(linkname.data(), r);
 }
 
 // In the case where the linked binary path ends in " (deleted)", and a file


### PR DESCRIPTION
https://github.com/osquery/osquery/pull/8826 adds null checks after manual allocations.

This PR observes that manual memory management is not necessary and refactors it out.