### PR TITLE
Split yara tables into `yara_process` and `yara_file`

### DIFF
--- a/docs/wiki/deployment/yara.md
+++ b/docs/wiki/deployment/yara.md
@@ -2,10 +2,10 @@
 
 YARA is a tool that allows you to find textual or binary patterns inside of files.
 
-There are two YARA-related tables in osquery, which serve very different purposes. The first table, called
+There are three YARA-related tables in osquery, which serve very different purposes. The first table, called
 `yara_events`, uses osquery's [Events framework](../development/pubsub-framework.md) to monitor for filesystem changes
-and will execute YARA when a file change event fires. The second table, just called `yara`, is a table for performing an
-on-demand YARA scan.
+and will execute YARA when a file change event fires. The remaining tables `yara_file` and `yara_process`, are tables for performing
+on-demand YARA scans.
 
 In this document, "signature file" is intended to be synonymous with "YARA rule file" (plain-text files commonly
 distributed with a `.yar` or `.yara` filename extension, although any extension is allowed).
@@ -94,13 +94,16 @@ and a couple of queries examples:
 
 ```sh
 # This is valid
-SELECT * FROM yara WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar';
+SELECT * FROM yara_file WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar';
 
 # This too
-SELECT * FROM yara WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/devel/CVE_Rules/CVE-2010-0805.yar';
+SELECT * FROM yara_file WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/devel/CVE_Rules/CVE-2010-0805.yar';
 
-# This is not allowed
-SELECT * FROM yara WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/devel/malware/APT_APT3102.yar';
+# Process scan example
+SELECT * FROM yara_process WHERE pid=1234 AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/devel/CVE_Rules/CVE-2010-0805.yar'
+
+# This is not allowed (not defined in yara config)
+SELECT * FROM yara_file WHERE path="/usr/bin/ls" AND sigurl='https://raw.githubusercontent.com/Yara-Rules/rules/devel/malware/APT_APT3102.yar';
 
 YARA signature url https://raw.githubusercontent.com/Yara-Rules/rules/devel/malware/APT_APT3102.yar not allowed
 Failed to get YARA rule url: https://raw.githubusercontent.com/Yara-Rules/rules/devel/malware/APT_APT3102.yar
@@ -164,7 +167,7 @@ As you can see, even though no matches were found, a row is still created and st
 
 ## On-demand YARA scanning
 
-The [`yara`](https://osquery.io/schema/current/#yara) table is used for on-demand scanning. With this table
+The [`yara_file`](https://osquery.io/schema/current/#yara_file) table is used for on-demand scanning. With this table
 you can arbitrarily YARA scan any available file on the filesystem with any available signature files or
 signature group from the configuration. In order to scan, the table must be given a constraint which says
 where to scan and what to scan with.
@@ -179,17 +182,17 @@ file on the filesystem, not a relative path. The signature file will be compiled
 of this one query and removed afterwards. The `sig_group` constraint must consist of a named signature
 grouping from your configuration file.
 
-Here are some examples of the `yara` table in action:
+Here are some examples of the `yara_file` table in action:
 
 ```sql
-osquery> SELECT * FROM yara WHERE path="/bin/ls" AND sig_group="sig_group_1";
+osquery> SELECT * FROM yara_file WHERE path="/bin/ls" AND sig_group="sig_group_1";
 +---------+-------------+-------+-------------+---------+---------+---------+
 | path    | matches     | count | sig_group   | sigfile | strings | tags    |
 +---------+-------------+-------+-------------+---------+---------+---------+
 | /bin/ls | always_true | 1     | sig_group_1 |         |         |         |
 +---------+-------------+-------+-------------+---------+---------+---------+
 
-osquery> SELECT * FROM yara WHERE path="/bin/ls" AND sig_group="sig_group_2";
+osquery> SELECT * FROM yara_file WHERE path="/bin/ls" AND sig_group="sig_group_2";
 +---------+---------+-------+-------------+---------+---------+---------+
 | path    | matches | count | sig_group   | sigfile | strings | tags    |
 +---------+---------+-------+-------------+---------+---------+---------+
@@ -200,7 +203,7 @@ osquery> SELECT * FROM yara WHERE path="/bin/ls" AND sig_group="sig_group_2";
 As you can see in these examples, we scan the same file with two different signature groups and get different results.
 
 ```sql
-osquery> SELECT * FROM yara WHERE path LIKE "/bin/%sh" AND sig_group="sig_group_1";
+osquery> SELECT * FROM yara_file WHERE path LIKE "/bin/%sh" AND sig_group="sig_group_1";
 +-----------+-------------+-------+-------------+---------+----------+----------+
 | path      | matches     | count | sig_group   | sigfile | strings  | tags     |
 +-----------+-------------+-------+-------------+---------+----------+----------+
@@ -216,7 +219,7 @@ osquery> SELECT * FROM yara WHERE path LIKE "/bin/%sh" AND sig_group="sig_group_
 The above illustrates using the `path LIKE` constraint to scan `/bin/%sh` with a signature group.
 
 ```sql
-osquery> select * from yara where path LIKE 'C:\tmp\%' and sigfile = "C:\tmp\test.yar.txt";
+osquery> select * from yara_file where path LIKE 'C:\tmp\%' and sigfile = "C:\tmp\test.yar.txt";
 +------------------------------+-------------+-------+-----------+---------------------+-----------------+------+
 | path                         | matches     | count | sig_group | sigfile             | strings         | tags |
 +------------------------------+-------------+-------+-----------+---------------------+-----------------+------+
@@ -230,6 +233,60 @@ contains the string its rule is searching for, it has also returned itself as a 
 
 **Tip:** you can specify `AND count > 0` in your query to return only positive YARA results.
 
+### Scanning process memory with yara_process
+
+The `yara_process` table scans the memory of a running process rather than a file on disk. It is useful for detecting in-memory artifacts — packed, injected, or fileless payloads — that would not appear in a file-based scan.
+
+The `pid` constraint is required and must be a single process id. Unlike `yara_file`'s `path`, `pid` does not support `LIKE` or wildcard matching; to scan multiple processes, use a subquery against the `processes` table and let osquery evaluate the `pid IN (...)` set.
+
+Scan a single process with a named signature group:
+
+```sql
+osquery> SELECT * FROM yara_process WHERE pid = 1234 AND sig_group = "sig_group_1";
++------+-------------+-------+-------------+---------+---------+------+
+| pid  | matches     | count | sig_group   | sigfile | strings | tags |
++------+-------------+-------+-------------+---------+---------+------+
+| 1234 | always_true | 1     | sig_group_1 |         |         |      |
++------+-------------+-------+-------------+---------+---------+------+
+```
+
+Scan every running process with a signature file on disk, returning only positive matches:
+
+```sql
+osquery> SELECT yp.pid, p.name, yp.matches, yp.count
+    ...> FROM yara_process yp
+    ...> JOIN processes p USING (pid)
+    ...> WHERE yp.pid IN (SELECT pid FROM processes)
+    ...>   AND yp.sigfile = '/etc/osquery/yara/suspicious.yar'
+    ...>   AND yp.count > 0;
+```
+
+Scan a single process with an inline rule:
+
+```sql
+osquery> SELECT * FROM yara_process WHERE pid = 1234
+    ...>   AND sigrule = 'rule has_mz { strings: $mz = "MZ" condition: $mz }';
+```
+
+Scan a process using a signature fetched from a configured `signature_urls` entry:
+
+```sql
+osquery> SELECT * FROM yara_process WHERE pid = 1234
+    ...>   AND sigurl = 'https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar';
+```
+
+On Linux, the hidden `pid_with_namespace` column (set to `1`) can be used to scan processes inside PID namespaces (e.g. containers) from a host-level osqueryd:
+
+```sql
+osquery> SELECT * FROM yara_process WHERE pid = 4321 AND pid_with_namespace = 1 AND sig_group = "sig_group_1";
+```
+
+**Notes on process scanning:**
+
+- Reading another process's memory requires sufficient privileges (typically root on Linux/macOS, or an elevated session with `SeDebugPrivilege` on Windows). Scans of protected or kernel-adjacent processes may fail or return no data.
+- Process memory scans are more expensive than file scans — avoid scheduling them against `SELECT pid FROM processes` at a high cadence on production hosts.
+- A process's memory is a moving target; a match reflects the state observed at scan time and may not be reproducible a moment later.
+
 ### Inline YARA rules with sigrule
 
 Above, we documented how to query the `yara` table using YARA signatures specified in a local file or retrieved from a
@@ -241,14 +298,14 @@ YARA rules take the form of `'rule rulename { condition: [whatever] }'` and foll
 For example:
 
 ```sql
-osquery> select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }';
+osquery> select * from yara_file where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }';
 ```
 
 YARA rules don't have a line-terminating character. To enter a multi-line YARA rule, use newlines. This
 even works in `osqueryi`:
 
 ```sql
-osquery> select * from yara where path LIKE 'C:\tmp\%' and sigrule = 'rule hello_world {
+osquery> select * from yara_file where path LIKE 'C:\tmp\%' and sigrule = 'rule hello_world {
     ...> strings:
     ...> $a = "Hello world"
     ...> condition: $a

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -470,13 +470,9 @@ QueryData genYaraFileScanImpl(QueryContext& context, Logger& logger) {
 
   // Scan every path pair with the yara rules
   auto& rules = state.yaraParser->rules();
-  logger.log(google::GLOG_WARNING,
-             "YARA file scan initialized with " + std::to_string(rules.size()) +
-                 " rules");
 
   // Scan files
   for (const auto& path : paths) {
-    logger.log(google::GLOG_WARNING, "Scanning file: " + path);
     for (const auto& sign : state.scanContext) {
       auto hash = hashStr(sign.second, sign.first);
       auto rules_it = rules.find(hash);

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -225,6 +225,8 @@ void doYARAScanPath(YR_RULES* rules,
   // Perform the scan, using the static YARA subscriber callback.
   int result = yr_rules_scan_file(
       rules, path.c_str(), SCAN_FLAGS_FAST_MODE, YARACallback, (void*)&row, 0);
+  VLOG(1) << "YARA scan of file " << path
+          << " completed with result code: " << result;
   if (result == ERROR_SUCCESS) {
     results.push_back(std::move(row));
   }
@@ -332,67 +334,110 @@ Status getYaraRules(YARAConfigParser parser,
   return Status::success();
 }
 
-QueryData genYaraImpl(QueryContext& context, Logger& logger) {
-  QueryData results;
+class YaraState {
+ public:
   YaraScanContext scanContext;
+  YARAConfigParser yaraParser;
+  Status initStatus;
+  Logger& logger;
 
-  // Initialize yara library
-  auto init_status = yaraInitialize();
-  if (!init_status.ok()) {
-    logger.log(google::GLOG_WARNING, init_status.toString());
-    return results;
-  }
+  YaraState(QueryContext& context, Logger& logger) : logger(logger) {
+    initStatus = yaraInitialize();
+    if (!initStatus.ok()) {
+      return;
+    }
 
-  auto yaraParser = getYaraParser();
-  if (isNull(yaraParser)) {
-    return results;
-  }
+    yaraParser = getYaraParser();
+    if (isNull(yaraParser)) {
+      initStatus = Status::failure("YARA config parser plugin not found");
+      return;
+    }
+    // The query must specify one of sig_groups, sigfile, or sigrule
+    // for scan. The signature rules are compiled and added to the
+    // scan context.
+    if (context.hasConstraint("sig_group", EQUALS)) {
+      auto groups = context.constraints["sig_group"].getAll(EQUALS);
+      for (const auto& group : groups) {
+        scanContext.insert(std::make_pair(YC_GROUP, group));
+      }
+    }
 
-  // The query must specify one of sig_groups, sigfile, or sigrule
-  // for scan. The signature rules are compiled and added to the
-  // scan context.
-  if (context.hasConstraint("sig_group", EQUALS)) {
-    auto groups = context.constraints["sig_group"].getAll(EQUALS);
-    for (const auto& group : groups) {
-      scanContext.insert(std::make_pair(YC_GROUP, group));
+    // Compile signature file if query has sigfile constraint and
+    // add them to the scan context
+    if (context.hasConstraint("sigfile", EQUALS)) {
+      auto sigfiles = context.constraints["sigfile"].getAll(EQUALS);
+      auto status = getYaraRules(yaraParser, sigfiles, YC_FILE, scanContext);
+      if (!status.ok()) {
+        initStatus = Status::failure("YARA config parser plugin not found");
+        return;
+      }
+    }
+
+    // Compile signature string if query has sigrule constraint and
+    // add them to the scan context
+    if (context.hasConstraint("sigrule", EQUALS)) {
+      auto sigrules = context.constraints["sigrule"].getAll(EQUALS);
+      auto status = getYaraRules(yaraParser, sigrules, YC_RULE, scanContext);
+      if (!status.ok()) {
+        initStatus = Status::failure("YARA config parser plugin not found");
+        return;
+      }
+    }
+
+    if (context.hasConstraint("sigurl", EQUALS)) {
+      auto sigurls = context.constraints["sigurl"].getAll(EQUALS);
+      auto status = getYaraRules(yaraParser, sigurls, YC_URL, scanContext);
+      if (!status.ok()) {
+        initStatus = Status::failure("YARA config parser plugin not found");
+        return;
+      }
+    }
+
+    // scan context is empty. One of sig_group, sigfile, or sigrule
+    // must be specified with the query
+    if (scanContext.empty()) {
+      initStatus = Status::failure(
+          "Query must specify sig_group, sigfile, or sigrule for scan");
+      return;
     }
   }
 
-  // Compile signature file if query has sigfile constraint and
-  // add them to the scan context
-  if (context.hasConstraint("sigfile", EQUALS)) {
-    auto sigfiles = context.constraints["sigfile"].getAll(EQUALS);
-    auto status = getYaraRules(yaraParser, sigfiles, YC_FILE, scanContext);
-    if (!status.ok()) {
-      logger.log(google::GLOG_WARNING, status.toString());
-      return results;
+  ~YaraState() {
+    // Rule string is hashed before adding to the cache. There are
+    // possibilities of collision when arbitrary queries are executed
+    // with distributed API. Clear the hash string from the cache
+    // Also cleanup the cache block if rules are downloaded from url
+    auto& rules = yaraParser->rules();
+    for (const auto& sign : scanContext) {
+      if (sign.first == YC_RULE || sign.first == YC_URL) {
+        auto hash = hashStr(sign.second, sign.first);
+        auto it = rules.find(hash);
+        if (it != rules.end()) {
+          rules.erase(hash);
+        }
+      }
     }
-  }
 
-  // Compile signature string if query has sigrule constraint and
-  // add them to the scan context
-  if (context.hasConstraint("sigrule", EQUALS)) {
-    auto sigrules = context.constraints["sigrule"].getAll(EQUALS);
-    auto status = getYaraRules(yaraParser, sigrules, YC_RULE, scanContext);
-    if (!status.ok()) {
-      logger.log(google::GLOG_WARNING, status.toString());
-      return results;
+    // Clean-up after finish scanning; If yr_initialize is called
+    // more than once it will decrease the reference counter and return
+    auto fini_status = yaraFinalize();
+    if (!fini_status.ok()) {
+      logger.log(google::GLOG_WARNING, fini_status.toString());
     }
-  }
 
-  if (context.hasConstraint("sigurl", EQUALS)) {
-    auto sigurls = context.constraints["sigurl"].getAll(EQUALS);
-    auto status = getYaraRules(yaraParser, sigurls, YC_URL, scanContext);
-    if (!status.ok()) {
-      logger.log(google::GLOG_WARNING, status.toString());
-      return results;
-    }
+#ifdef OSQUERY_LINUX
+    // Attempt to release some unused memory kept by malloc internal caching
+    releaseRetainedMemory();
+#endif
   }
+};
 
-  // scan context is empty. One of sig_group, sigfile, or sigrule
-  // must be specified with the query
-  if (scanContext.empty()) {
-    VLOG(1) << "Query must specify sig_group, sigfile, or sigrule for scan";
+QueryData genYaraFileScanImpl(QueryContext& context, Logger& logger) {
+  QueryData results;
+  YaraState state(context, logger);
+
+  if (!state.initStatus.ok()) {
+    state.logger.log(google::GLOG_WARNING, state.initStatus.toString());
     return results;
   }
 
@@ -423,20 +468,16 @@ QueryData genYaraImpl(QueryContext& context, Logger& logger) {
         return status;
       }));
 
-  // Get all pids specified
-  auto pids = context.constraints["pid"].getAll<int>(EQUALS);
-
-  if (paths.empty() && pids.empty()) {
-    LOG(WARNING) << "Query must specify at least one path or pid for YARA scan";
-    return results;
-  }
-
   // Scan every path pair with the yara rules
-  auto& rules = yaraParser->rules();
+  auto& rules = state.yaraParser->rules();
+  logger.log(google::GLOG_WARNING,
+             "YARA file scan initialized with " + std::to_string(rules.size()) +
+                 " rules");
 
   // Scan files
   for (const auto& path : paths) {
-    for (const auto& sign : scanContext) {
+    logger.log(google::GLOG_WARNING, "Scanning file: " + path);
+    for (const auto& sign : state.scanContext) {
       auto hash = hashStr(sign.second, sign.first);
       auto rules_it = rules.find(hash);
       if (rules_it != rules.end()) {
@@ -453,6 +494,21 @@ QueryData genYaraImpl(QueryContext& context, Logger& logger) {
     }
   }
 
+  return results;
+}
+
+QueryData genYaraProcessScanImpl(QueryContext& context, Logger& logger) {
+  QueryData results;
+  YaraState state(context, logger);
+
+  if (!state.initStatus.ok()) {
+    logger.log(google::GLOG_WARNING, state.initStatus.toString());
+    return results;
+  }
+
+  // Get all pids specified
+  auto pids = context.constraints["pid"].getAll<int>(EQUALS);
+
   // Scan process memory if pid or pids are specified
   if (!pids.empty()) {
 #ifdef WINDOWS
@@ -463,9 +519,12 @@ QueryData genYaraImpl(QueryContext& context, Logger& logger) {
     // privilege is reset to its original state after the scan is done.
     SeDebugPrivilegeGuard debug_priv_guard;
 #endif
+    // Scan every path pair with the yara rules
+    auto& rules = state.yaraParser->rules();
+
     // Scan processes
     for (const auto& pid : pids) {
-      for (const auto& sign : scanContext) {
+      for (const auto& sign : state.scanContext) {
         auto hash = hashStr(sign.second, sign.first);
         auto rules_it = rules.find(hash);
         if (rules_it != rules.end()) {
@@ -479,42 +538,24 @@ QueryData genYaraImpl(QueryContext& context, Logger& logger) {
       }
     }
   }
-
-  // Rule string is hashed before adding to the cache. There are
-  // possibilities of collision when arbitrary queries are executed
-  // with distributed API. Clear the hash string from the cache
-  // Also cleanup the cache block if rules are downloaded from url
-  for (const auto& sign : scanContext) {
-    if (sign.first == YC_RULE || sign.first == YC_URL) {
-      auto hash = hashStr(sign.second, sign.first);
-      auto it = rules.find(hash);
-      if (it != rules.end()) {
-        rules.erase(hash);
-      }
-    }
-  }
-
-  // Clean-up after finish scanning; If yr_initialize is called
-  // more than once it will decrease the reference counter and return
-  auto fini_status = yaraFinalize();
-  if (!fini_status.ok()) {
-    logger.log(google::GLOG_WARNING, fini_status.toString());
-  }
-
-#ifdef OSQUERY_LINUX
-  // Attempt to release some unused memory kept by malloc internal caching
-  releaseRetainedMemory();
-#endif
-
   return results;
 }
 
-QueryData genYara(QueryContext& context) {
+QueryData genYaraFileScan(QueryContext& context) {
   if (hasNamespaceConstraint(context)) {
-    return generateInNamespace(context, "yara", genYaraImpl);
+    return generateInNamespace(context, "yara", genYaraFileScanImpl);
   } else {
     GLOGLogger logger;
-    return genYaraImpl(context, logger);
+    return genYaraFileScanImpl(context, logger);
+  }
+}
+
+QueryData genYaraProcessScan(QueryContext& context) {
+  if (hasNamespaceConstraint(context)) {
+    return generateInNamespace(context, "yara", genYaraProcessScanImpl);
+  } else {
+    GLOGLogger logger;
+    return genYaraProcessScanImpl(context, logger);
   }
 }
 

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -225,8 +225,6 @@ void doYARAScanPath(YR_RULES* rules,
   // Perform the scan, using the static YARA subscriber callback.
   int result = yr_rules_scan_file(
       rules, path.c_str(), SCAN_FLAGS_FAST_MODE, YARACallback, (void*)&row, 0);
-  VLOG(1) << "YARA scan of file " << path
-          << " completed with result code: " << result;
   if (result == ERROR_SUCCESS) {
     results.push_back(std::move(row));
   }

--- a/osquery/tables/yara/yara.cpp
+++ b/osquery/tables/yara/yara.cpp
@@ -395,7 +395,7 @@ class YaraState {
     // must be specified with the query
     if (scanContext.empty()) {
       initStatus = Status::failure(
-          "Query must specify sig_group, sigfile, or sigrule for scan");
+          "Query must specify sig_group, sigfile, sigrule, or sigurl for scan");
       return;
     }
   }
@@ -435,7 +435,7 @@ QueryData genYaraFileScanImpl(QueryContext& context, Logger& logger) {
   YaraState state(context, logger);
 
   if (!state.initStatus.ok()) {
-    state.logger.log(google::GLOG_WARNING, state.initStatus.toString());
+    state.logger.log(google::GLOG_ERROR, state.initStatus.toString());
     return results;
   }
 
@@ -496,7 +496,7 @@ QueryData genYaraProcessScanImpl(QueryContext& context, Logger& logger) {
   YaraState state(context, logger);
 
   if (!state.initStatus.ok()) {
-    logger.log(google::GLOG_WARNING, state.initStatus.toString());
+    logger.log(google::GLOG_ERROR, state.initStatus.toString());
     return results;
   }
 

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -74,8 +74,8 @@ function(generateNativeTables)
     utility/osquery_registry.table
     utility/osquery_schedule.table
     utility/time.table
-    yara.table
-    yara_process_scan.table
+    yara_file.table
+    yara_process.table
     yara_events.table
     ycloud_instance_metadata.table
   )

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -75,6 +75,7 @@ function(generateNativeTables)
     utility/osquery_schedule.table
     utility/time.table
     yara.table
+    yara_process_scan.table
     yara_events.table
     ycloud_instance_metadata.table
   )

--- a/specs/yara_file.table
+++ b/specs/yara_file.table
@@ -1,5 +1,5 @@
 table_name("yara_file", aliases=["yara"])
-description("Triggers one-off YARA query for files or processes at the specified path. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
+description("Triggers one-off YARA query for files at the specified path. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
 schema([
     Column("path", TEXT, "The path scanned",
         index=True, required=True),

--- a/specs/yara_file.table
+++ b/specs/yara_file.table
@@ -1,4 +1,4 @@
-table_name("yara")
+table_name("yara_file", aliases=["yara"])
 description("Triggers one-off YARA query for files or processes at the specified path. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
 schema([
     Column("path", TEXT, "The path scanned",
@@ -21,8 +21,7 @@ extended_schema(LINUX, [
 ])
 implementation("yara@genYaraFileScan")
 examples([
-  "select * from yara where path = '/etc/passwd'",
-  "select * from yara where path LIKE '/etc/%'",
+  "select * from yara where path LIKE '/etc/%' and sigurl = 'https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar'",
   "select * from yara where path = '/etc/passwd' and sigfile = '/etc/osquery/yara/test.yara'",
   "select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }'",
 ])

--- a/specs/yara_process.table
+++ b/specs/yara_process.table
@@ -1,4 +1,4 @@
-table_name("yara_process_scan")
+table_name("yara_process")
 description("Triggers one-off YARA query for process memory of the specified pid. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
 schema([
     Column("pid", INTEGER, "The pid scanned (process memory)",
@@ -21,8 +21,7 @@ extended_schema(LINUX, [
 ])
 implementation("yara@genYaraProcessScan")
 examples([
-  "select * from yara where pid = 1234",
-  "select * from yara where pid in (select pid from processes)",
+  "select * from yara where pid in (select pid from processes) and sigurl = 'https://raw.githubusercontent.com/Yara-Rules/rules/master/cve_rules/CVE-2010-0805.yar'",
   "select * from yara where pid = 1234 and sigfile = '/etc/osquery/yara/test.yara'",
   "select * from yara where pid = 1234 and sigrule = 'rule always_true { condition: true }'",
 ])

--- a/specs/yara_process_scan.table
+++ b/specs/yara_process_scan.table
@@ -1,7 +1,7 @@
-table_name("yara")
-description("Triggers one-off YARA query for files or processes at the specified path. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
+table_name("yara_process_scan")
+description("Triggers one-off YARA query for process memory of the specified pid. Additionally requires one of `sig_group`, `sigfile`, or `sigrule`.")
 schema([
-    Column("path", TEXT, "The path scanned",
+    Column("pid", INTEGER, "The pid scanned (process memory)",
         index=True, required=True),
     Column("matches", TEXT, "List of YARA matches"),
     Column("count", INTEGER, "Number of YARA matches"),
@@ -19,10 +19,10 @@ schema([
 extended_schema(LINUX, [
     Column("pid_with_namespace", INTEGER, "Pids that contain a namespace", additional=True, hidden=True),
 ])
-implementation("yara@genYaraFileScan")
+implementation("yara@genYaraProcessScan")
 examples([
-  "select * from yara where path = '/etc/passwd'",
-  "select * from yara where path LIKE '/etc/%'",
-  "select * from yara where path = '/etc/passwd' and sigfile = '/etc/osquery/yara/test.yara'",
-  "select * from yara where path = '/etc/passwd' and sigrule = 'rule always_true { condition: true }'",
+  "select * from yara where pid = 1234",
+  "select * from yara where pid in (select pid from processes)",
+  "select * from yara where pid = 1234 and sigfile = '/etc/osquery/yara/test.yara'",
+  "select * from yara where pid = 1234 and sigrule = 'rule always_true { condition: true }'",
 ])


### PR DESCRIPTION
This PR splits the yara process scanning into its own table, while still sharing core code between the two tables.  This allows us to define both `path` and `pid` as required fields in their respective tables;

Resolves: https://github.com/osquery/osquery/issues/8816

```sql
osquery> select * from yara_file where (path = 'C:\bin\test.txt' or path LIKE 'C:\bin\%.ps1') and sigrule = 'rule always_true { condition: true }';   
+----------------------------------+-------------+-------+-----------+---------+---------+------+
| path                             | matches     | count | sig_group | sigfile | strings | tags |
+----------------------------------+-------------+-------+-----------+---------+---------+------+
| C:\bin\test.txt                  | always_true | 1     |           |         |         |      |
| C:\bin\osquery_build_prereqs.ps1 | always_true | 1     |           |         |         |      |
| C:\bin\set_up_ssh_keys.ps1       | always_true | 1     |           |         |         |      |
+----------------------------------+-------------+-------+-----------+---------+---------+------+
```

```sql
osquery> select y.*, p.name, p.cmdline from yara_process as y JOIN processes as p using(pid) where pid in (select pid from processes where pid > 1000 limit 10) and sigrule = 'rule always_true { condition: true }';    
+------+-------------+-------+-----------+---------+---------+------+-----------------+--------------------------------------------------------------------------------------+
| pid  | matches     | count | sig_group | sigfile | strings | tags | name            | cmdline                                                                              |
+------+-------------+-------+-----------+---------+---------+------+-----------------+--------------------------------------------------------------------------------------+
| 1068 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\system32\svchost.exe -k DcomLaunch -p                                     |
| 1100 | always_true | 1     |           |         |         |      | fontdrvhost.exe | "fontdrvhost.exe"                                                                    |
| 1108 | always_true | 1     |           |         |         |      | fontdrvhost.exe | "fontdrvhost.exe"                                                                    |
| 1204 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\system32\svchost.exe -k RPCSS -p                                          |
| 1248 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\system32\svchost.exe -k DcomLaunch -p -s LSM                              |
| 1312 | always_true | 1     |           |         |         |      | dwm.exe         | "dwm.exe"                                                                            |
| 1496 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\System32\svchost.exe -k LocalServiceNetworkRestricted -p -s lmhosts       |
| 1504 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\system32\svchost.exe -k LocalServiceNoNetwork -p                          |
| 1544 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\system32\svchost.exe -k LocalServiceNetworkRestricted -p -s TimeBrokerSvc |
| 1672 | always_true | 1     |           |         |         |      | svchost.exe     | C:\WINDOWS\System32\svchost.exe -k LocalSystemNetworkRestricted -p -s NcbService     |
+------+-------------+-------+-----------+---------+---------+------+-----------------+--------------------------------------------------------------------------------------+
```
