### PR TITLE
Fix GCC 15 compatibility

### DIFF
--- a/osquery/events/types.h
+++ b/osquery/events/types.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
GCC 15 no longer transitively includes `<cstdint>` through other standard headers, which causes compilation to fail with:

```
error: 'uint64_t' does not name a type
```

Add the explicit include so that `uint64_t` and `std::uint64_t` are available regardless of transitive include behavior.

This patch has been included in the Arch Linux package for osquery for almost a year now, see:
https://gitlab.archlinux.org/archlinux/packaging/packages/osquery/-/commit/2ef9d392735c876090b032a469baa4bd72b8d3f9