### PR TITLE
office_mru table was always empty due to a change in registry globbing

### DIFF
--- a/osquery/tables/applications/windows/office_mru.cpp
+++ b/osquery/tables/applications/windows/office_mru.cpp
@@ -22,8 +22,7 @@ namespace tables {
 
 // Get all Office applications and get all installed versions
 constexpr auto kOfficePath = "\\Software\\Microsoft\\Office\\%\\%\\File MRU";
-constexpr auto kOffice365Path =
-    "\\Software\\Microsoft\\Office\\%\\%\\User MRU";
+constexpr auto kOffice365Path = "\\Software\\Microsoft\\Office\\%\\%\\User MRU";
 
 // Parse all the office MRU entries.
 void parseOfficeData(QueryData& results,

--- a/osquery/tables/applications/windows/office_mru.cpp
+++ b/osquery/tables/applications/windows/office_mru.cpp
@@ -21,9 +21,9 @@ namespace osquery {
 namespace tables {
 
 // Get all Office applications and get all installed versions
-constexpr auto kOfficePath = "\\Software\\Microsoft\\Office\\%\\%\\File MRU\\%";
+constexpr auto kOfficePath = "\\Software\\Microsoft\\Office\\%\\%\\File MRU";
 constexpr auto kOffice365Path =
-    "\\Software\\Microsoft\\Office\\%\\%\\User MRU\\%";
+    "\\Software\\Microsoft\\Office\\%\\%\\User MRU";
 
 // Parse all the office MRU entries.
 void parseOfficeData(QueryData& results,


### PR DESCRIPTION
Commit 4ea9f2c changed registry globbing (with '%') and broke the logic of retrieving Office MRU.

Tested with Office keys and Office 365 keys.

Fixed #7698
