### PR TITLE
Truncate response body on stderr if HTML response received

### DIFF
--- a/osquery/remote/transports/tests/tls_transports_tests.cpp
+++ b/osquery/remote/transports/tests/tls_transports_tests.cpp
@@ -310,4 +310,74 @@ TEST_F(TLSTransportsTests, test_node_key_header_not_set) {
   EXPECT_TRUE(std::string(r[kAuthorizationHeader]).empty());
 }
 
+TEST(TruncateAndDetectHTMLTests, detects_doctype_html_prefix) {
+  std::string body =
+      "<!DOCTYPE html><html><head><title>403 Forbidden</title></head>"
+      "<body><h1>403 Forbidden</h1></body></html>";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_TRUE(isHTML);
+  EXPECT_EQ(snippet, body);
+}
+
+TEST(TruncateAndDetectHTMLTests, detects_uppercase_html_tag) {
+  std::string body = "<HTML><HEAD><TITLE>Error</TITLE></HEAD></HTML>";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_TRUE(isHTML);
+  EXPECT_EQ(snippet, body);
+}
+
+TEST(TruncateAndDetectHTMLTests, truncates_long_html) {
+  std::string body =
+      "<!DOCTYPE html><html><body>" + std::string(500, 'A') + "</body></html>";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_TRUE(isHTML);
+  EXPECT_EQ(snippet.size(), 203u); // 200 + "..."
+  EXPECT_EQ(snippet.substr(snippet.size() - 3), "...");
+}
+
+TEST(TruncateAndDetectHTMLTests, truncates_long_plain_text) {
+  std::string body(250, 'a');
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_FALSE(isHTML);
+  EXPECT_EQ(snippet, std::string(200, 'a') + "...");
+}
+
+TEST(TruncateAndDetectHTMLTests, passes_through_short_plain_text) {
+  std::string body = "Connection refused";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_FALSE(isHTML);
+  EXPECT_EQ(snippet, body);
+}
+
+TEST(TruncateAndDetectHTMLTests, passes_through_short_json) {
+  std::string body = R"({"ok":true})";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_FALSE(isHTML);
+  EXPECT_EQ(snippet, body);
+}
+
+TEST(TruncateAndDetectHTMLTests, handles_empty_body) {
+  auto [snippet, isHTML] = truncateAndDetectHTML("", 200);
+  EXPECT_FALSE(isHTML);
+  EXPECT_TRUE(snippet.empty());
+}
+
+TEST(TruncateAndDetectHTMLTests, exact_max_len_not_truncated) {
+  std::string body(200, 'x');
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_FALSE(isHTML);
+  EXPECT_EQ(snippet, body);
+  EXPECT_EQ(snippet.size(), 200u);
+}
+
+TEST(TruncateAndDetectHTMLTests, html_marker_past_cap_not_detected) {
+  // If the HTML marker only appears past max_len, the truncated snippet
+  // won't contain it, so we won't flag. This is acceptable: the first 200
+  // bytes don't look like HTML to an operator either.
+  std::string body(300, ' ');
+  body += "<html>";
+  auto [snippet, isHTML] = truncateAndDetectHTML(body, 200);
+  EXPECT_FALSE(isHTML);
+}
+
 } // namespace osquery

--- a/osquery/remote/transports/tls.cpp
+++ b/osquery/remote/transports/tls.cpp
@@ -9,6 +9,8 @@
 
 #include "tls.h"
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <osquery/core/core.h>
 #include <osquery/filesystem/filesystem.h>
@@ -223,6 +225,22 @@ void printRawStderr(const std::string& s) {
   fprintf(stderr, "%s\n", s.c_str());
 }
 
+/// Cap on dumped response-body length when --tls_dump is enabled.
+constexpr std::size_t kMaxDumpLen = 200;
+
+std::pair<std::string, bool> truncateAndDetectHTML(const std::string& body,
+                                                   std::size_t max_len) {
+  std::string truncated =
+      body.size() > max_len ? body.substr(0, max_len) + "..." : body;
+  std::string lowered = truncated;
+  std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](char c) {
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  });
+  bool isHTML = lowered.find("<html") != std::string::npos ||
+                lowered.find("<!doctype") != std::string::npos;
+  return {std::move(truncated), isHTML};
+}
+
 Status TLSTransport::sendRequest() {
   if (destination_.find("https://") == std::string::npos) {
     return Status::failure(
@@ -242,7 +260,14 @@ Status TLSTransport::sendRequest() {
     const auto& response_body = response_.body();
     if (FLAGS_verbose && FLAGS_tls_dump) {
       // Not using VLOG to avoid logging whole body to logging destination.
-      printRawStderr(response_body);
+      auto [snippet, isHTML] =
+          truncateAndDetectHTML(response_body, kMaxDumpLen);
+      if (isHTML) {
+        printRawStderr("server returned HTML instead of JSON, body: " +
+                       snippet);
+      } else {
+        printRawStderr(snippet);
+      }
     }
     response_status_ =
         serializer_->deserialize(response_body, response_params_);
@@ -293,7 +318,14 @@ Status TLSTransport::sendRequest(const std::string& params, bool compress) {
     const auto& response_body = response_.body();
     if (FLAGS_verbose && FLAGS_tls_dump) {
       // Not using VLOG to avoid logging whole body to logging destination.
-      printRawStderr(response_body);
+      auto [snippet, isHTML] =
+          truncateAndDetectHTML(response_body, kMaxDumpLen);
+      if (isHTML) {
+        printRawStderr("server returned HTML instead of JSON, body: " +
+                       snippet);
+      } else {
+        printRawStderr(snippet);
+      }
     }
     response_status_ =
         serializer_->deserialize(response_body, response_params_);

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -48,6 +48,23 @@ enum HTTPVerb {
 };
 
 /**
+ * @brief Truncate a response body for debug logging and detect whether it
+ * looks like HTML.
+ *
+ * When an HTML payload is returned instead of the expected JSON payload,
+ * dumping the full body to stderr floods logs with unreadable markup. 
+ * This helper caps the snippet length and flags HTML bodies so the caller 
+ * can prefix a hint.
+ *
+ * @param body the raw response body
+ * @param max_len maximum number of bytes to retain; longer bodies are
+ *     truncated and suffixed with "..."
+ * @return pair of (truncated snippet, isHTML)
+ */
+std::pair<std::string, bool> truncateAndDetectHTML(const std::string& body,
+                                                   std::size_t max_len);
+
+/**
  * @brief HTTPS (TLS) transport.
  */
 class TLSTransport : public Transport {


### PR DESCRIPTION
Fixes https://github.com/fleetdm/fleet/issues/33019

If `--verbose --tls_dump` is enabled and an HTML payload is received from the server instead of the expected JSON payload, truncate the response instead of emitting the whole body to stderr.