### PR TITLE
Fix keychain corruption when accessing non-SSV keychain files by copying to temporary files first

### DIFF
--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -131,8 +131,7 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
 //   2. SQLite-backed legacy keychain — "SQLite format 3\0" at offset 0.
 //      SQLite magic alone is ambiguous: Data Protection Keychain databases
 //      (keychain-2.db) share it. We additionally require the basename to
-//      end with ".keychain-db" and not with "keychain-2.db" to
-//      disambiguate. Covers login.keychain-db, metadata.keychain-db.
+//      end with ".keychain-db". Covers login.keychain-db, metadata.keychain-db.
 //
 // We use this to prevent securityd logging the following messages when
 // SecKeychainOpen attempts to parse files that are not supported keychain
@@ -158,6 +157,9 @@ static bool isLegacyKeychainFile(const std::string& path) {
   static const std::string kSqliteMagic("SQLite format 3\0", 16);
   if (read == 16 && header == kSqliteMagic) {
     std::string name = boost::filesystem::path(path).filename().string();
+    // NOTE: We don't want to process files that end with "keychain-2.db"
+    // because they are "Data Protection Keychain" databases that fail to parse
+    // with SecKeychainOpen.
     return boost::algorithm::ends_with(name, ".keychain-db");
   }
 
@@ -177,22 +179,9 @@ class OpenedKeychain {
       : ref_(other.ref_), temp_dir_(std::move(other.temp_dir_)) {
     other.ref_ = nullptr;
   }
-  OpenedKeychain& operator=(OpenedKeychain&& other) noexcept {
-    if (this != &other) {
-      reset();
-      ref_ = other.ref_;
-      temp_dir_ = std::move(other.temp_dir_);
-      other.ref_ = nullptr;
-    }
-    return *this;
-  }
-  OpenedKeychain(const OpenedKeychain&) = delete;
-  OpenedKeychain& operator=(const OpenedKeychain&) = delete;
-
   ~OpenedKeychain() {
     reset();
   }
-
   SecKeychainRef get() const {
     return ref_;
   }

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -211,20 +211,17 @@ static bool copyAndOpenKeychain(const std::string& original_path,
     return false;
   }
 
-  const char* env_tmpdir = std::getenv("TMPDIR");
-  std::string dir_tmpl =
-      (env_tmpdir != nullptr && env_tmpdir[0] != '\0') ? env_tmpdir : "/tmp";
-  if (dir_tmpl.back() != '/') {
-    dir_tmpl.push_back('/');
-  }
-  dir_tmpl += "osquery-kc-XXXXXX";
-
-  std::vector<char> dir_buf(dir_tmpl.begin(), dir_tmpl.end());
-  dir_buf.push_back('\0');
-  if (mkdtemp(dir_buf.data()) == nullptr) {
+  boost::system::error_code ec;
+  boost::filesystem::path tmp_root = boost::filesystem::temp_directory_path(ec);
+  if (ec) {
     return false;
   }
-  std::string temp_dir(dir_buf.data());
+  std::string dir_tmpl = (tmp_root / "osquery-kc-XXXXXX").string();
+
+  if (mkdtemp(dir_tmpl.data()) == nullptr) {
+    return false;
+  }
+  std::string temp_dir(dir_tmpl);
   std::string temp_path = temp_dir + "/" + filename;
 
   // COPYFILE_CLONE: atomic APFS clonefile snapshot when possible, copying

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -118,7 +118,7 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
   CFRelease(der_encoded_data);
 }
 
-// True iff the file at `path` looks like a container SecKeychainOpen can
+// True if the file at `path` looks like a container SecKeychainOpen can
 // parse. Positive identification by leading bytes, so unknown files under
 // the keychain directories are skipped by default and any new file type
 // with a legacy-keychain magic is auto-accepted.

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -7,10 +7,15 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <cstdlib>
+#include <unistd.h>
+
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+
+#include <boost/filesystem.hpp>
 
 #include <osquery/core/core.h>
 #include <osquery/filesystem/filesystem.h>
@@ -89,6 +94,7 @@ void genCertificate(X509* cert, const std::string& path, QueryData& results) {
 }
 
 void genKeychainCertificate(const SecCertificateRef& SecCert,
+                            const std::string& path,
                             QueryData& results) {
   auto der_encoded_data = SecCertificateCopyData(SecCert);
   if (der_encoded_data == nullptr) {
@@ -100,12 +106,73 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
   auto cert = d2i_X509(nullptr, &der_bytes, length);
 
   if (cert != nullptr) {
-    auto path = getKeychainPath((SecKeychainItemRef)SecCert);
     genCertificate(cert, path, results);
     X509_free(cert);
   }
 
   CFRelease(der_encoded_data);
+}
+
+// Copy the given keychain file to a private temp file and open the copy via
+// SecKeychainOpen. Used for non-SSV-protected keychains (under
+// /Library/Keychains and ~/Library/Keychains). On macOS 26+, passing the live
+// user keychain file to SecKeychainOpen can corrupt it; the copy is
+// disposable and is cleaned up by the caller.
+//
+// On success, populates *keychain_out with the opened SecKeychainRef (caller
+// releases) and temp_path_out with the temp file path (caller deletes), and
+// returns true. Returns false on any failure, with *keychain_out == nullptr.
+static bool copyAndOpenKeychain(const std::string& original_path,
+                                std::string& temp_path_out,
+                                SecKeychainRef* keychain_out) {
+  *keychain_out = nullptr;
+  temp_path_out.clear();
+
+  boost::filesystem::path orig(original_path);
+  std::string suffix = orig.extension().string();
+
+  const char* env_tmpdir = std::getenv("TMPDIR");
+  std::string tmpl =
+      (env_tmpdir != nullptr && env_tmpdir[0] != '\0') ? env_tmpdir : "/tmp";
+  if (tmpl.back() != '/') {
+    tmpl.push_back('/');
+  }
+  tmpl += "osquery-kc-XXXXXX";
+  tmpl += suffix;
+
+  std::vector<char> buf(tmpl.begin(), tmpl.end());
+  buf.push_back('\0');
+
+  int fd = mkstemps(buf.data(), static_cast<int>(suffix.size()));
+  if (fd < 0) {
+    return false;
+  }
+  ::close(fd);
+  std::string temp_path(buf.data());
+
+  boost::system::error_code ec;
+  boost::filesystem::copy_file(
+      orig, temp_path, boost::filesystem::copy_options::overwrite_existing, ec);
+  if (ec.failed()) {
+    boost::filesystem::remove(temp_path, ec);
+    return false;
+  }
+
+  SecKeychainRef keychain = nullptr;
+  OSStatus status;
+  OSQUERY_USE_DEPRECATED(status =
+                             SecKeychainOpen(temp_path.c_str(), &keychain));
+  if (status != errSecSuccess || keychain == nullptr) {
+    if (keychain != nullptr) {
+      CFRelease(keychain);
+    }
+    boost::filesystem::remove(temp_path, ec);
+    return false;
+  }
+
+  *keychain_out = keychain;
+  temp_path_out = std::move(temp_path);
+  return true;
 }
 
 void genFileCertificate(const std::string& path, QueryData& results) {
@@ -164,13 +231,35 @@ QueryData genCerts(QueryContext& context) {
         return status;
       }));
 
+  // RAII cleanup for keychain refs and temp-file copies: runs on normal exit,
+  // early return, or exception. Refs are released before temp files are
+  // unlinked so Security.framework holds no handle on a copy when it's
+  // removed.
+  struct KeychainCleanup {
+    std::vector<SecKeychainRef> refs;
+    std::vector<std::string> temp_files;
+    ~KeychainCleanup() {
+      for (SecKeychainRef ref : refs) {
+        CFRelease(ref);
+      }
+      boost::system::error_code ec;
+      for (const auto& tf : temp_files) {
+        boost::filesystem::remove(tf, ec);
+      }
+    }
+  } cleanup;
+
   @autoreleasepool {
-    // Map of path to hash and keychain reference. This ensures we don't open
-    // the same keychain multiple times when the table's path constraint is
-    // used.
+    auto& temp_files = cleanup.temp_files;
+    auto& opened_refs = cleanup.refs;
+
+    // Map of user-provided path to (canonical source, hash, opened keychain).
+    // Ensures we don't open the same keychain twice when a path constraint
+    // is specified.
     std::map<std::string,
              std::tuple<boost::filesystem::path, std::string, SecKeychainRef>>
         opened_keychains;
+
     if (!paths.empty()) {
       for (const auto& path : paths) {
         // Check whether path is valid
@@ -196,42 +285,61 @@ QueryData genCerts(QueryContext& context) {
         }
 
         SecKeychainRef keychain = nullptr;
-        SecKeychainStatus keychain_status;
-        OSStatus status;
-        OSQUERY_USE_DEPRECATED(status =
-                                   SecKeychainOpen(path.c_str(), &keychain));
-        bool genFileCert = false;
-        if (status != errSecSuccess || keychain == nullptr) {
-          genFileCert = true;
+        bool opened = false;
+        if (isSSVProtectedPath(source.string())) {
+          // /System/Library/Keychains/*
+          //
+          // SSV-protected keychains are on a read-only volume; opening them
+          // directly via the legacy API cannot corrupt them.
+          SecKeychainStatus keychain_status;
+          OSStatus status;
+          OSQUERY_USE_DEPRECATED(status =
+                                     SecKeychainOpen(path.c_str(), &keychain));
+          if (status == errSecSuccess && keychain != nullptr) {
+            OSQUERY_USE_DEPRECATED(
+                status = SecKeychainGetStatus(keychain, &keychain_status));
+            if (status == errSecSuccess) {
+              opened = true;
+            }
+          }
+          if (!opened && keychain != nullptr) {
+            CFRelease(keychain);
+            keychain = nullptr;
+          }
         } else {
-          OSQUERY_USE_DEPRECATED(
-              status = SecKeychainGetStatus(keychain, &keychain_status));
-          if (status != errSecSuccess) {
-            genFileCert = true;
+          // ~/Library/Keychains/* and /Library/Keychains/*
+          //
+          // Non-SSV: copy the file to a private temp path and open the copy.
+          // Calling SecKeychainOpen on the live user file can corrupt it on
+          // macOS 26+.
+          std::string temp_path;
+          if (copyAndOpenKeychain(source.string(), temp_path, &keychain)) {
+            temp_files.push_back(temp_path);
+            opened = true;
           }
         }
-        if (genFileCert) {
-          if (keychain != nullptr) {
-            CFRelease(keychain);
-          }
+
+        if (!opened) {
+          // Either the open failed outright or the file isn't a keychain.
+          // Fall back to treating it as a DER/PEM cert file on disk.
           QueryData new_results;
           genFileCertificate(path, new_results);
-          // Write new results to the cache.
           keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
           results.insert(results.end(), new_results.begin(), new_results.end());
-        } else {
-          // This path will be re-accessed later.
-          keychain_paths.insert(path);
-          opened_keychains.insert(
-              {path, std::make_tuple(source, hash, keychain)});
+          continue;
         }
+
+        opened_refs.push_back(keychain);
+        keychain_paths.insert(path);
+        opened_keychains.insert(
+            {path, std::make_tuple(source, hash, keychain)});
       }
     } else {
       keychain_paths = getKeychainPaths();
     }
 
-    // Since we are used a cache for each keychain file, we must process
-    // certificates one keychain file at a time.
+    // Since we use a cache per keychain file, we must process certificates
+    // one keychain file at a time.
     std::set<std::string> expanded_paths = expandPaths(keychain_paths);
     for (const auto& path : expanded_paths) {
       SecKeychainRef keychain = nullptr;
@@ -248,8 +356,8 @@ QueryData genCerts(QueryContext& context) {
         source =
             boost::filesystem::canonical(boost::filesystem::path(path), ec);
         if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
-          // File does not exist or user does not have access. Don't log here to
-          // reduce noise.
+          // File does not exist or user does not have access. Don't log here
+          // to reduce noise.
           continue;
         }
 
@@ -266,33 +374,52 @@ QueryData genCerts(QueryContext& context) {
           continue;
         }
 
-        // Cache miss. We need to generate new results.
-        OSStatus status;
-        OSQUERY_USE_DEPRECATED(status =
-                                   SecKeychainOpen(source.c_str(), &keychain));
-        if (status != errSecSuccess || keychain == nullptr) {
-          if (keychain != nullptr) {
-            CFRelease(keychain);
+        // Cache miss: open the keychain using the path-appropriate strategy.
+        if (isSSVProtectedPath(source.string())) {
+          // /System/Library/Keychains/*
+          OSStatus status;
+          OSQUERY_USE_DEPRECATED(
+              status = SecKeychainOpen(source.c_str(), &keychain));
+          if (status != errSecSuccess || keychain == nullptr) {
+            if (keychain != nullptr) {
+              CFRelease(keychain);
+              keychain = nullptr;
+            }
           }
-          // Cache an empty result to prevent the above API call in the future.
+        } else {
+          // ~/Library/Keychains/* and /Library/Keychains/*
+          //
+          // Non-SSV: copy the file to a private temp path and open the copy.
+          // Calling SecKeychainOpen on the live user file can corrupt it on
+          // macOS 26+.
+          std::string temp_path;
+          if (copyAndOpenKeychain(source.string(), temp_path, &keychain)) {
+            temp_files.push_back(temp_path);
+          }
+        }
+
+        if (keychain == nullptr) {
+          // Cache an empty result to prevent the above API call in the
+          // future.
           keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
           continue;
         }
+        opened_refs.push_back(keychain);
       }
 
       auto keychains = CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
       CFArrayAppendValue(keychains, keychain);
       QueryData new_results;
-      // Keychains/certificate stores belonging to the OS.
+      // Query certificates in this one keychain via SecItemCopyMatching.
       CFArrayRef certs = CreateKeychainItems(keychains, kSecClassCertificate);
       CFRelease(keychains);
-      // Must have returned an array of matching certificates.
       if (certs != nullptr) {
         if (CFGetTypeID(certs) == CFArrayGetTypeID()) {
           auto certificate_count = CFArrayGetCount(certs);
           for (CFIndex i = 0; i < certificate_count; i++) {
             auto cert = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
-            genKeychainCertificate(cert, new_results);
+            // Attribute the row to the original path, not the temp copy.
+            genKeychainCertificate(cert, source.string(), new_results);
           }
         }
         CFRelease(certs);

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -374,7 +374,7 @@ QueryData genCerts(QueryContext& context) {
           // /System/Library/Keychains/*
           //
           // SSV-protected keychains are on a read-only volume; opening them
-          // directly via the legacy API cannot corrupt them.
+          // directly via the legacy API does not seem to corrupt them.
           SecKeychainStatus keychain_status;
           OSStatus status;
           OSQUERY_USE_DEPRECATED(status =

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -141,46 +141,23 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
 //  osqueryd: (Security) [com.apple.securityd:security_exception]
 // CSSM Exception: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
 static bool isLegacyKeychainFile(const std::string& path) {
-  std::array<char, 16> header{};
   std::ifstream in(path, std::ios::binary);
   if (!in.is_open()) {
     return false;
   }
-  in.read(header.data(), header.size());
+  std::string header(16, '\0');
+  in.read(header.data(), 16);
   std::streamsize read = in.gcount();
 
-  static constexpr char kCssmMagic[4] = {'k', 'y', 'c', 'h'};
-  if (read >= 4 &&
-      std::memcmp(header.data(), kCssmMagic, sizeof(kCssmMagic)) == 0) {
+  if (read >= 4 && header.compare(0, 4, "kych", 4) == 0) {
     return true;
   }
 
   // "SQLite format 3" + trailing null byte, 16 bytes total.
-  static constexpr char kSqliteMagic[16] = {'S',
-                                            'Q',
-                                            'L',
-                                            'i',
-                                            't',
-                                            'e',
-                                            ' ',
-                                            'f',
-                                            'o',
-                                            'r',
-                                            'm',
-                                            'a',
-                                            't',
-                                            ' ',
-                                            '3',
-                                            '\0'};
-  if (read == static_cast<std::streamsize>(header.size()) &&
-      std::memcmp(header.data(), kSqliteMagic, sizeof(kSqliteMagic)) == 0) {
+  static const std::string kSqliteMagic("SQLite format 3\0", 16);
+  if (read == 16 && header == kSqliteMagic) {
     std::string name = boost::filesystem::path(path).filename().string();
-    auto ends_with = [&](const char* suffix) {
-      size_t len = std::strlen(suffix);
-      return name.size() >= len &&
-             name.compare(name.size() - len, len, suffix) == 0;
-    };
-    return ends_with(".keychain-db") && !ends_with("keychain-2.db");
+    return boost::algorithm::ends_with(name, ".keychain-db");
   }
 
   return false;

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -133,10 +133,13 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
 //      end with ".keychain-db" and not with "keychain-2.db" to
 //      disambiguate. Covers login.keychain-db, metadata.keychain-db.
 //
-// We use this to prevent securityd logging the following messages when SecKeychainOpen
-// attempts to parse files that are not supported keychain formats:
-//  osqueryd: (Security) [com.apple.securityd:integrity] dbBlobVersion() failed for a CssmError: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
-//  osqueryd: (Security) [com.apple.securityd:security_exception] CSSM Exception: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
+// We use this to prevent securityd logging the following messages when
+// SecKeychainOpen attempts to parse files that are not supported keychain
+// formats:
+//  osqueryd: (Security) [com.apple.securityd:integrity] dbBlobVersion() failed
+//  for a CssmError: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
+//  osqueryd: (Security) [com.apple.securityd:security_exception]
+// CSSM Exception: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
 static bool isLegacyKeychainFile(const std::string& path) {
   std::array<char, 16> header{};
   std::ifstream in(path, std::ios::binary);

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -20,6 +20,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 
 #include <osquery/core/core.h>
@@ -163,74 +164,120 @@ static bool isLegacyKeychainFile(const std::string& path) {
   return false;
 }
 
-// Copy the given keychain file into a private temp directory and open the
-// copy via SecKeychainOpen. Used for non-SSV-protected keychains (under
-// /Library/Keychains and ~/Library/Keychains). On macOS 26+, passing the live
-// user keychain file to SecKeychainOpen can corrupt it; the copy is
-// disposable and the caller removes the whole temp directory.
-//
-// The copy goes through copyfile(3) with COPYFILE_CLONE: on APFS this is an
-// atomic clonefile(2) snapshot (immune to concurrent writes by securityd) and
-// preserves ACLs + extended attributes that Security.framework's integrity
-// checks may consult. On non-APFS volumes copyfile silently falls back to a
-// regular copy that still copies xattrs and ACLs.
-//
-// On success, populates *keychain_out with the opened SecKeychainRef (caller
-// releases) and temp_dir_out with the temp directory (caller removes with
-// remove_all). Returns false on any failure with *keychain_out == nullptr
-// and the temp directory already removed.
-static bool copyAndOpenKeychain(const std::string& original_path,
-                                std::string& temp_dir_out,
-                                SecKeychainRef* keychain_out) {
-  *keychain_out = nullptr;
-  temp_dir_out.clear();
+// RAII over an opened SecKeychainRef plus, optionally, the temp directory
+// holding the disposable copy it was opened from. Empty temp_dir => opened
+// in place (SSV). Move-only; cleanup runs on scope exit or exception.
+class OpenedKeychain {
+ public:
+  OpenedKeychain() = default;
+  OpenedKeychain(SecKeychainRef ref, std::string temp_dir)
+      : ref_(ref), temp_dir_(std::move(temp_dir)) {}
 
-  boost::filesystem::path orig(original_path);
-  std::string filename = orig.filename().string();
-  if (filename.empty()) {
-    return false;
+  OpenedKeychain(OpenedKeychain&& other) noexcept
+      : ref_(other.ref_), temp_dir_(std::move(other.temp_dir_)) {
+    other.ref_ = nullptr;
   }
-
-  boost::system::error_code ec;
-  boost::filesystem::path tmp_root = boost::filesystem::temp_directory_path(ec);
-  if (ec) {
-    return false;
-  }
-  std::string dir_tmpl = (tmp_root / "osquery-kc-XXXXXX").string();
-
-  if (mkdtemp(dir_tmpl.data()) == nullptr) {
-    return false;
-  }
-  std::string temp_dir(dir_tmpl);
-  std::string temp_path = temp_dir + "/" + filename;
-
-  // COPYFILE_CLONE: atomic APFS clonefile snapshot when possible, copying
-  // data + ACLs + xattrs. Falls back to a regular copy (still with ACL/xattr)
-  // on filesystems that don't support cloning.
-  if (copyfile(
-          original_path.c_str(), temp_path.c_str(), nullptr, COPYFILE_CLONE) !=
-      0) {
-    boost::system::error_code rm_ec;
-    boost::filesystem::remove_all(temp_dir, rm_ec);
-    return false;
-  }
-
-  SecKeychainRef keychain = nullptr;
-  OSStatus status;
-  OSQUERY_USE_DEPRECATED(status =
-                             SecKeychainOpen(temp_path.c_str(), &keychain));
-  if (status != errSecSuccess || keychain == nullptr) {
-    if (keychain != nullptr) {
-      CFRelease(keychain);
+  OpenedKeychain& operator=(OpenedKeychain&& other) noexcept {
+    if (this != &other) {
+      reset();
+      ref_ = other.ref_;
+      temp_dir_ = std::move(other.temp_dir_);
+      other.ref_ = nullptr;
     }
-    boost::system::error_code rm_ec;
-    boost::filesystem::remove_all(temp_dir, rm_ec);
-    return false;
+    return *this;
+  }
+  OpenedKeychain(const OpenedKeychain&) = delete;
+  OpenedKeychain& operator=(const OpenedKeychain&) = delete;
+
+  ~OpenedKeychain() {
+    reset();
   }
 
-  *keychain_out = keychain;
-  temp_dir_out = std::move(temp_dir);
-  return true;
+  SecKeychainRef get() const {
+    return ref_;
+  }
+  explicit operator bool() const {
+    return ref_ != nullptr;
+  }
+
+ private:
+  void reset() {
+    // Release the ref before unlinking so Security.framework holds no handle
+    // on a file that's about to disappear.
+    if (ref_ != nullptr) {
+      CFRelease(ref_);
+      ref_ = nullptr;
+    }
+    if (!temp_dir_.empty()) {
+      boost::system::error_code ec;
+      boost::filesystem::remove_all(temp_dir_, ec);
+      temp_dir_.clear();
+    }
+  }
+
+  SecKeychainRef ref_{nullptr};
+  std::string temp_dir_;
+};
+
+// Open a keychain for reading. SSV-protected paths are opened in place (the
+// read-only volume makes direct opens safe). Non-SSV paths (/Library/Keychains
+// and ~/Library/Keychains) are cloned into a private temp directory first,
+// because on macOS 26+ SecKeychainOpen on the live user file can corrupt it.
+//
+// The clone uses copyfile(3) with COPYFILE_CLONE: an atomic APFS clonefile(2)
+// snapshot when supported (immune to concurrent writes by securityd) that
+// also carries ACLs and extended attributes Security.framework's integrity
+// checks may consult. On non-APFS volumes copyfile falls back to a regular
+// copy that still preserves ACLs/xattrs.
+static OpenedKeychain openKeychainForPath(const std::string& original_path) {
+  std::string path_to_open = original_path;
+  std::string temp_dir;
+
+  if (!isSSVProtectedPath(original_path)) {
+    boost::filesystem::path orig(original_path);
+    std::string filename = orig.filename().string();
+    if (filename.empty()) {
+      return {};
+    }
+
+    boost::system::error_code ec;
+    boost::filesystem::path tmp_root =
+        boost::filesystem::temp_directory_path(ec);
+    if (ec) {
+      return {};
+    }
+
+    std::string dir_tmpl = (tmp_root / "osquery-kc-XXXXXX").string();
+    if (mkdtemp(dir_tmpl.data()) == nullptr) {
+      return {};
+    }
+    temp_dir = dir_tmpl;
+    path_to_open = temp_dir + "/" + filename;
+
+    if (copyfile(original_path.c_str(),
+                 path_to_open.c_str(),
+                 nullptr,
+                 COPYFILE_CLONE) != 0) {
+      boost::system::error_code rm_ec;
+      boost::filesystem::remove_all(temp_dir, rm_ec);
+      return {};
+    }
+  }
+
+  SecKeychainRef ref = nullptr;
+  OSStatus status;
+  OSQUERY_USE_DEPRECATED(status = SecKeychainOpen(path_to_open.c_str(), &ref));
+  if (status != errSecSuccess || ref == nullptr) {
+    if (ref != nullptr) {
+      CFRelease(ref);
+    }
+    if (!temp_dir.empty()) {
+      boost::system::error_code ec;
+      boost::filesystem::remove_all(temp_dir, ec);
+    }
+    return {};
+  }
+  return OpenedKeychain{ref, std::move(temp_dir)};
 }
 
 void genFileCertificate(const std::string& path, QueryData& results) {
@@ -289,111 +336,24 @@ QueryData genCerts(QueryContext& context) {
         return status;
       }));
 
-  // RAII cleanup for keychain refs and temp-directory copies: runs on normal
-  // exit, early return, or exception. Refs are released before temp dirs are
-  // removed so Security.framework holds no handle on a copy when it's
-  // unlinked.
-  struct KeychainCleanup {
-    std::vector<SecKeychainRef> refs;
-    std::vector<std::string> temp_dirs;
-    ~KeychainCleanup() {
-      for (SecKeychainRef ref : refs) {
-        CFRelease(ref);
-      }
-      boost::system::error_code ec;
-      for (const auto& td : temp_dirs) {
-        boost::filesystem::remove_all(td, ec);
-      }
-    }
-  } cleanup;
+  // Owns every keychain opened during this invocation (ref + any temp copy).
+  // Destructors run on scope exit or exception; refs are released before
+  // temp dirs are unlinked.
+  std::vector<OpenedKeychain> owned;
 
   @autoreleasepool {
-    auto& temp_dirs = cleanup.temp_dirs;
-    auto& opened_refs = cleanup.refs;
-
-    // Map of user-provided path to (canonical source, hash, opened keychain).
-    // Ensures we don't open the same keychain twice when a path constraint
-    // is specified.
-    std::map<std::string,
-             std::tuple<boost::filesystem::path, std::string, SecKeychainRef>>
-        opened_keychains;
-
     if (!paths.empty()) {
       for (const auto& path : paths) {
-        // Check whether path is valid
-        boost::system::error_code ec;
-        auto source =
-            boost::filesystem::canonical(boost::filesystem::path(path), ec);
-        if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
-          TLOG << "Could not access file " << path << " " << ec.message();
+        if (isLegacyKeychainFile(path)) {
+          keychain_paths.insert(path);
           continue;
         }
-
-        // Check cache
-        bool err = false;
-        std::string hash;
-        bool hit =
-            keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-        if (err) {
-          TLOG << "Could not read the file at " << path << "" << ec.message();
-          continue;
-        }
-        if (hit) {
-          continue;
-        }
-
-        SecKeychainRef keychain = nullptr;
-        bool opened = false;
-        if (!isLegacyKeychainFile(source.string())) {
-          // Not a legacy keychain container the SecKeychain API can parse.
-          // Leave `opened` false so we fall through to the DER/PEM path.
-        } else if (isSSVProtectedPath(source.string())) {
-          // /System/Library/Keychains/*
-          //
-          // SSV-protected keychains are on a read-only volume; opening them
-          // directly via the legacy API does not seem to corrupt them.
-          SecKeychainStatus keychain_status;
-          OSStatus status;
-          OSQUERY_USE_DEPRECATED(status =
-                                     SecKeychainOpen(path.c_str(), &keychain));
-          if (status == errSecSuccess && keychain != nullptr) {
-            OSQUERY_USE_DEPRECATED(
-                status = SecKeychainGetStatus(keychain, &keychain_status));
-            if (status == errSecSuccess) {
-              opened = true;
-            }
-          }
-          if (!opened && keychain != nullptr) {
-            CFRelease(keychain);
-            keychain = nullptr;
-          }
-        } else {
-          // ~/Library/Keychains/* and /Library/Keychains/*
-          //
-          // Non-SSV: copy the file to a private temp dir and open the copy.
-          // Calling SecKeychainOpen on the live user file can corrupt it on
-          // macOS 26+.
-          std::string temp_dir;
-          if (copyAndOpenKeychain(source.string(), temp_dir, &keychain)) {
-            temp_dirs.push_back(temp_dir);
-            opened = true;
-          }
-        }
-
-        if (!opened) {
-          // Either the open failed outright or the file isn't a keychain.
-          // Fall back to treating it as a DER/PEM cert file on disk.
-          QueryData new_results;
-          genFileCertificate(path, new_results);
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, new_results);
-          results.insert(results.end(), new_results.begin(), new_results.end());
-          continue;
-        }
-
-        opened_refs.push_back(keychain);
-        keychain_paths.insert(path);
-        opened_keychains.insert(
-            {path, std::make_tuple(source, hash, keychain)});
+        // Not a legacy keychain container; try parsing as a DER/PEM cert.
+        QueryData new_results;
+        genFileCertificate(path, new_results);
+        // DER/PEM certificates won't be cached so they will be parsed every
+        // time the user queries.
+        results.insert(results.end(), new_results.begin(), new_results.end());
       }
     } else {
       keychain_paths = getKeychainPaths();
@@ -403,76 +363,45 @@ QueryData genCerts(QueryContext& context) {
     // one keychain file at a time.
     std::set<std::string> expanded_paths = expandPaths(keychain_paths);
     for (const auto& path : expanded_paths) {
-      SecKeychainRef keychain = nullptr;
-      std::string hash;
-      boost::filesystem::path source;
-      auto it = opened_keychains.find(path);
-      if (it != opened_keychains.end()) {
-        source = std::get<0>(it->second);
-        hash = std::get<1>(it->second);
-        keychain = std::get<2>(it->second);
-      } else {
-        // Check whether path is valid
-        boost::system::error_code ec;
-        source =
-            boost::filesystem::canonical(boost::filesystem::path(path), ec);
-        if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
-          // File does not exist or user does not have access. Don't log here
-          // to reduce noise.
-          continue;
-        }
-
-        // Skip anything that isn't a legacy keychain container. Feeding
-        // non-keychains to SecKeychainOpen/SecItemCopyMatching produces
-        // CSSMERR_DL_DATABASE_CORRUPT / dbBlobVersion() errors in the
-        // unified log when Security.framework tries to parse the blob.
-        if (!isLegacyKeychainFile(source.string())) {
-          continue;
-        }
-
-        // Check cache
-        bool err = false;
-        bool hit =
-            keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
-        if (err) {
-          TLOG << "Could not read the file at " << source.string() << ""
-               << ec.message();
-          continue;
-        }
-        if (hit) {
-          continue;
-        }
-
-        // Cache miss: open the keychain using the path-appropriate strategy.
-        if (isSSVProtectedPath(source.string())) {
-          // /System/Library/Keychains/*
-          OSStatus status;
-          OSQUERY_USE_DEPRECATED(
-              status = SecKeychainOpen(source.c_str(), &keychain));
-          if (status != errSecSuccess || keychain == nullptr) {
-            if (keychain != nullptr) {
-              CFRelease(keychain);
-              keychain = nullptr;
-            }
-          }
-        } else {
-          // ~/Library/Keychains/* and /Library/Keychains/*
-          //
-          // Non-SSV: copy the file to a private temp dir and open the copy.
-          std::string temp_dir;
-          if (copyAndOpenKeychain(source.string(), temp_dir, &keychain)) {
-            temp_dirs.push_back(temp_dir);
-          }
-        }
-
-        if (keychain == nullptr) {
-          // Cache an empty result to prevent the above API call in the
-          // future.
-          keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
-          continue;
-        }
-        opened_refs.push_back(keychain);
+      boost::system::error_code ec;
+      auto source =
+          boost::filesystem::canonical(boost::filesystem::path(path), ec);
+      if (ec.failed() || !is_regular_file(source, ec) || ec.failed()) {
+        // File does not exist or user does not have access. Don't log here
+        // to reduce noise.
+        continue;
       }
+
+      // Skip anything that isn't a legacy keychain container. Feeding
+      // non-keychains to SecKeychainOpen/SecItemCopyMatching produces
+      // CSSMERR_DL_DATABASE_CORRUPT / dbBlobVersion() errors in the
+      // unified log when Security.framework tries to parse the blob.
+      if (!isLegacyKeychainFile(source.string())) {
+        continue;
+      }
+
+      // Check cache
+      bool err = false;
+      std::string hash;
+      bool hit = keychainCache.Read(source, KEYCHAIN_TABLE, hash, results, err);
+      if (err) {
+        TLOG << "Could not read the file at " << source.string() << ""
+             << ec.message();
+        continue;
+      }
+      if (hit) {
+        continue;
+      }
+
+      // Cache miss: open the keychain (SSV in place, non-SSV via temp copy).
+      auto opened = openKeychainForPath(source.string());
+      if (!opened) {
+        // Cache an empty result to prevent the above API call in the future.
+        keychainCache.Write(source, KEYCHAIN_TABLE, hash, {});
+        continue;
+      }
+      SecKeychainRef keychain = opened.get();
+      owned.push_back(std::move(opened));
 
       auto keychains = CFArrayCreateMutable(nullptr, 1, &kCFTypeArrayCallBacks);
       CFArrayAppendValue(keychains, keychain);

--- a/osquery/tables/system/darwin/certificates.mm
+++ b/osquery/tables/system/darwin/certificates.mm
@@ -7,8 +7,13 @@
  * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
  */
 
+#include <array>
 #include <cstdlib>
+#include <cstring>
+#include <fstream>
 #include <unistd.h>
+
+#include <copyfile.h>
 
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
@@ -113,48 +118,123 @@ void genKeychainCertificate(const SecCertificateRef& SecCert,
   CFRelease(der_encoded_data);
 }
 
-// Copy the given keychain file to a private temp file and open the copy via
-// SecKeychainOpen. Used for non-SSV-protected keychains (under
-// /Library/Keychains and ~/Library/Keychains). On macOS 26+, passing the live
-// user keychain file to SecKeychainOpen can corrupt it; the copy is
-// disposable and is cleaned up by the caller.
+// True iff the file at `path` looks like a container SecKeychainOpen can
+// parse. Positive identification by leading bytes, so unknown files under
+// the keychain directories are skipped by default and any new file type
+// with a legacy-keychain magic is auto-accepted.
 //
-// On success, populates *keychain_out with the opened SecKeychainRef (caller
-// releases) and temp_path_out with the temp file path (caller deletes), and
-// returns true. Returns false on any failure, with *keychain_out == nullptr.
-static bool copyAndOpenKeychain(const std::string& original_path,
-                                std::string& temp_path_out,
-                                SecKeychainRef* keychain_out) {
-  *keychain_out = nullptr;
-  temp_path_out.clear();
-
-  boost::filesystem::path orig(original_path);
-  std::string suffix = orig.extension().string();
-
-  const char* env_tmpdir = std::getenv("TMPDIR");
-  std::string tmpl =
-      (env_tmpdir != nullptr && env_tmpdir[0] != '\0') ? env_tmpdir : "/tmp";
-  if (tmpl.back() != '/') {
-    tmpl.push_back('/');
-  }
-  tmpl += "osquery-kc-XXXXXX";
-  tmpl += suffix;
-
-  std::vector<char> buf(tmpl.begin(), tmpl.end());
-  buf.push_back('\0');
-
-  int fd = mkstemps(buf.data(), static_cast<int>(suffix.size()));
-  if (fd < 0) {
+// Two legacy keychain formats are accepted by SecKeychainOpen:
+//   1. CSSM "Mac OS X Keychain File" — 4-byte "kych" magic at offset 0.
+//      Covers System.keychain, apsd.keychain, SystemRootCertificates.keychain,
+//      X509Anchors, etc. Magic bytes are a bulletproof positive signal.
+//   2. SQLite-backed legacy keychain — "SQLite format 3\0" at offset 0.
+//      SQLite magic alone is ambiguous: Data Protection Keychain databases
+//      (keychain-2.db) share it. We additionally require the basename to
+//      end with ".keychain-db" and not with "keychain-2.db" to
+//      disambiguate. Covers login.keychain-db, metadata.keychain-db.
+//
+// We use this to prevent securityd logging the following messages when SecKeychainOpen
+// attempts to parse files that are not supported keychain formats:
+//  osqueryd: (Security) [com.apple.securityd:integrity] dbBlobVersion() failed for a CssmError: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
+//  osqueryd: (Security) [com.apple.securityd:security_exception] CSSM Exception: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
+static bool isLegacyKeychainFile(const std::string& path) {
+  std::array<char, 16> header{};
+  std::ifstream in(path, std::ios::binary);
+  if (!in.is_open()) {
     return false;
   }
-  ::close(fd);
-  std::string temp_path(buf.data());
+  in.read(header.data(), header.size());
+  std::streamsize read = in.gcount();
 
-  boost::system::error_code ec;
-  boost::filesystem::copy_file(
-      orig, temp_path, boost::filesystem::copy_options::overwrite_existing, ec);
-  if (ec.failed()) {
-    boost::filesystem::remove(temp_path, ec);
+  static constexpr char kCssmMagic[4] = {'k', 'y', 'c', 'h'};
+  if (read >= 4 &&
+      std::memcmp(header.data(), kCssmMagic, sizeof(kCssmMagic)) == 0) {
+    return true;
+  }
+
+  // "SQLite format 3" + trailing null byte, 16 bytes total.
+  static constexpr char kSqliteMagic[16] = {'S',
+                                            'Q',
+                                            'L',
+                                            'i',
+                                            't',
+                                            'e',
+                                            ' ',
+                                            'f',
+                                            'o',
+                                            'r',
+                                            'm',
+                                            'a',
+                                            't',
+                                            ' ',
+                                            '3',
+                                            '\0'};
+  if (read == static_cast<std::streamsize>(header.size()) &&
+      std::memcmp(header.data(), kSqliteMagic, sizeof(kSqliteMagic)) == 0) {
+    std::string name = boost::filesystem::path(path).filename().string();
+    auto ends_with = [&](const char* suffix) {
+      size_t len = std::strlen(suffix);
+      return name.size() >= len &&
+             name.compare(name.size() - len, len, suffix) == 0;
+    };
+    return ends_with(".keychain-db") && !ends_with("keychain-2.db");
+  }
+
+  return false;
+}
+
+// Copy the given keychain file into a private temp directory and open the
+// copy via SecKeychainOpen. Used for non-SSV-protected keychains (under
+// /Library/Keychains and ~/Library/Keychains). On macOS 26+, passing the live
+// user keychain file to SecKeychainOpen can corrupt it; the copy is
+// disposable and the caller removes the whole temp directory.
+//
+// The copy goes through copyfile(3) with COPYFILE_CLONE: on APFS this is an
+// atomic clonefile(2) snapshot (immune to concurrent writes by securityd) and
+// preserves ACLs + extended attributes that Security.framework's integrity
+// checks may consult. On non-APFS volumes copyfile silently falls back to a
+// regular copy that still copies xattrs and ACLs.
+//
+// On success, populates *keychain_out with the opened SecKeychainRef (caller
+// releases) and temp_dir_out with the temp directory (caller removes with
+// remove_all). Returns false on any failure with *keychain_out == nullptr
+// and the temp directory already removed.
+static bool copyAndOpenKeychain(const std::string& original_path,
+                                std::string& temp_dir_out,
+                                SecKeychainRef* keychain_out) {
+  *keychain_out = nullptr;
+  temp_dir_out.clear();
+
+  boost::filesystem::path orig(original_path);
+  std::string filename = orig.filename().string();
+  if (filename.empty()) {
+    return false;
+  }
+
+  const char* env_tmpdir = std::getenv("TMPDIR");
+  std::string dir_tmpl =
+      (env_tmpdir != nullptr && env_tmpdir[0] != '\0') ? env_tmpdir : "/tmp";
+  if (dir_tmpl.back() != '/') {
+    dir_tmpl.push_back('/');
+  }
+  dir_tmpl += "osquery-kc-XXXXXX";
+
+  std::vector<char> dir_buf(dir_tmpl.begin(), dir_tmpl.end());
+  dir_buf.push_back('\0');
+  if (mkdtemp(dir_buf.data()) == nullptr) {
+    return false;
+  }
+  std::string temp_dir(dir_buf.data());
+  std::string temp_path = temp_dir + "/" + filename;
+
+  // COPYFILE_CLONE: atomic APFS clonefile snapshot when possible, copying
+  // data + ACLs + xattrs. Falls back to a regular copy (still with ACL/xattr)
+  // on filesystems that don't support cloning.
+  if (copyfile(
+          original_path.c_str(), temp_path.c_str(), nullptr, COPYFILE_CLONE) !=
+      0) {
+    boost::system::error_code rm_ec;
+    boost::filesystem::remove_all(temp_dir, rm_ec);
     return false;
   }
 
@@ -166,12 +246,13 @@ static bool copyAndOpenKeychain(const std::string& original_path,
     if (keychain != nullptr) {
       CFRelease(keychain);
     }
-    boost::filesystem::remove(temp_path, ec);
+    boost::system::error_code rm_ec;
+    boost::filesystem::remove_all(temp_dir, rm_ec);
     return false;
   }
 
   *keychain_out = keychain;
-  temp_path_out = std::move(temp_path);
+  temp_dir_out = std::move(temp_dir);
   return true;
 }
 
@@ -231,26 +312,26 @@ QueryData genCerts(QueryContext& context) {
         return status;
       }));
 
-  // RAII cleanup for keychain refs and temp-file copies: runs on normal exit,
-  // early return, or exception. Refs are released before temp files are
-  // unlinked so Security.framework holds no handle on a copy when it's
-  // removed.
+  // RAII cleanup for keychain refs and temp-directory copies: runs on normal
+  // exit, early return, or exception. Refs are released before temp dirs are
+  // removed so Security.framework holds no handle on a copy when it's
+  // unlinked.
   struct KeychainCleanup {
     std::vector<SecKeychainRef> refs;
-    std::vector<std::string> temp_files;
+    std::vector<std::string> temp_dirs;
     ~KeychainCleanup() {
       for (SecKeychainRef ref : refs) {
         CFRelease(ref);
       }
       boost::system::error_code ec;
-      for (const auto& tf : temp_files) {
-        boost::filesystem::remove(tf, ec);
+      for (const auto& td : temp_dirs) {
+        boost::filesystem::remove_all(td, ec);
       }
     }
   } cleanup;
 
   @autoreleasepool {
-    auto& temp_files = cleanup.temp_files;
+    auto& temp_dirs = cleanup.temp_dirs;
     auto& opened_refs = cleanup.refs;
 
     // Map of user-provided path to (canonical source, hash, opened keychain).
@@ -286,7 +367,10 @@ QueryData genCerts(QueryContext& context) {
 
         SecKeychainRef keychain = nullptr;
         bool opened = false;
-        if (isSSVProtectedPath(source.string())) {
+        if (!isLegacyKeychainFile(source.string())) {
+          // Not a legacy keychain container the SecKeychain API can parse.
+          // Leave `opened` false so we fall through to the DER/PEM path.
+        } else if (isSSVProtectedPath(source.string())) {
           // /System/Library/Keychains/*
           //
           // SSV-protected keychains are on a read-only volume; opening them
@@ -309,12 +393,12 @@ QueryData genCerts(QueryContext& context) {
         } else {
           // ~/Library/Keychains/* and /Library/Keychains/*
           //
-          // Non-SSV: copy the file to a private temp path and open the copy.
+          // Non-SSV: copy the file to a private temp dir and open the copy.
           // Calling SecKeychainOpen on the live user file can corrupt it on
           // macOS 26+.
-          std::string temp_path;
-          if (copyAndOpenKeychain(source.string(), temp_path, &keychain)) {
-            temp_files.push_back(temp_path);
+          std::string temp_dir;
+          if (copyAndOpenKeychain(source.string(), temp_dir, &keychain)) {
+            temp_dirs.push_back(temp_dir);
             opened = true;
           }
         }
@@ -361,6 +445,14 @@ QueryData genCerts(QueryContext& context) {
           continue;
         }
 
+        // Skip anything that isn't a legacy keychain container. Feeding
+        // non-keychains to SecKeychainOpen/SecItemCopyMatching produces
+        // CSSMERR_DL_DATABASE_CORRUPT / dbBlobVersion() errors in the
+        // unified log when Security.framework tries to parse the blob.
+        if (!isLegacyKeychainFile(source.string())) {
+          continue;
+        }
+
         // Check cache
         bool err = false;
         bool hit =
@@ -389,12 +481,10 @@ QueryData genCerts(QueryContext& context) {
         } else {
           // ~/Library/Keychains/* and /Library/Keychains/*
           //
-          // Non-SSV: copy the file to a private temp path and open the copy.
-          // Calling SecKeychainOpen on the live user file can corrupt it on
-          // macOS 26+.
-          std::string temp_path;
-          if (copyAndOpenKeychain(source.string(), temp_path, &keychain)) {
-            temp_files.push_back(temp_path);
+          // Non-SSV: copy the file to a private temp dir and open the copy.
+          std::string temp_dir;
+          if (copyAndOpenKeychain(source.string(), temp_dir, &keychain)) {
+            temp_dirs.push_back(temp_dir);
           }
         }
 

--- a/osquery/tables/system/darwin/keychain.h
+++ b/osquery/tables/system/darwin/keychain.h
@@ -78,6 +78,13 @@ std::string getKeychainPath(const SecKeychainItemRef& item);
 CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
                                const CFTypeRef& item_type);
 
+/// Returns true if the given keychain file path resides on the Signed System
+/// Volume (under /System/Library/Keychains) and is therefore read-only and
+/// safe to open via SecKeychainOpen. On macOS 26+, opening a live non-SSV
+/// keychain file can corrupt it, so callers should copy the file to a private
+/// temp location and open the copy instead.
+bool isSSVProtectedPath(const std::string& path);
+
 std::set<std::string> getKeychainPaths();
 } // namespace tables
 } // namespace osquery

--- a/osquery/tables/system/darwin/keychain_utils.cpp
+++ b/osquery/tables/system/darwin/keychain_utils.cpp
@@ -114,6 +114,21 @@ CFArrayRef CreateKeychainItems(CFMutableArrayRef keychains,
   return keychain_items;
 }
 
+bool isSSVProtectedPath(const std::string& path) {
+  // The Signed System Volume mounts /System/Library read-only, so keychain
+  // files under /System/Library/Keychains cannot be modified and are safe to
+  // open via the legacy SecKeychainOpen API.
+  static const std::string kSSVPrefix = "/System/Library/Keychains";
+  if (path.size() < kSSVPrefix.size()) {
+    return false;
+  }
+  if (path.compare(0, kSSVPrefix.size(), kSSVPrefix) != 0) {
+    return false;
+  }
+  // Ensure it's either exactly the prefix or a path component boundary.
+  return path.size() == kSSVPrefix.size() || path[kSSVPrefix.size()] == '/';
+}
+
 std::set<std::string> getKeychainPaths() {
   std::set<std::string> keychain_paths;
 

--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -1,5 +1,5 @@
 table_name("certificates")
-description("Certificate Authorities installed in Keychains/ca-bundles. NOTE: osquery limits frequent access to keychain files on macOS. This limit is controlled by keychain_access_interval flag.")
+description("Certificate Authorities installed in Keychains/ca-bundles. NOTE: osquery limits frequent access to keychain files on macOS. This limit is controlled by keychain_access_interval flag. On macOS, 'path' may point to either a keychain file or a DER/PEM-encoded certificate file; non-keychain files are parsed as DER/PEM.")
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate distinguished name (deprecated, use subject2)"),


### PR DESCRIPTION
Attempt to fix https://github.com/fleetdm/fleet/issues/43313 with the learnings from https://github.com/osquery/osquery/pull/8815.

Gist of the change: 
- Make a temporary copy of the keychain files that are not protected by Signed System Volume (SSV) before using `SecKeychainOpen` (which is what seems to cause corruption).
- Skip files that are not keychain files [*] to prevent `securityd` from logging `CORRUPT` [**] errors in `log stream` when running `SecKeychainOpen` on them (red herring).

[*] I ran the following query on ~40 macOS devices on our Fleet:
```sql
SELECT distinct filename FROM file
WHERE path like '/System/Library/Keychains/%' OR
path like '/Library/Keychains/%' OR
path like '/Users/%/Library/Keychains/%' AND
filename <> '.';
```
Result:
```
metadata.keychain-db
login.keychain-db
apsd.keychain
System.keychain
X509Anchors
SystemRootCertificates.keychain
apsd.keychain.sb-[redacted]
login_renamed_2.keychain-db << these seem to happen after corruption 
login_renamed_1.keychain-db << these seem to happen after corruption
[redacted]_shared.keychain-db
apsd.backup.keychain
metadata.keychain-db.[redacted-UUID]
com.[redacted].keychain-db
[redacted]_shared.keychain.prl_lock << now skipped by because it's not an sqlite or legacy keychain file
system-keychain-2.db-wal << now skipped by because it's not an sqlite or lehacy keychain file
system-keychain-2.db-shm << now skipped by because it's not an sqlite or legacy keychain file
system-keychain-2.db << now skipped by because it's a "Data Protection" keychain (explicit skip on "keychain-2.db" suffix)
SystemTrustSettings.plist << now skipped by because it's not an sqlite or legacy keychain file
EVRoots.plist << now skipped by because it's not an sqlite or legacy keychain file
```

[**] Red herring errors in `log show`:
```
2026-04-22 14:54:50.908992-0300 0x75723    Default     0x23f894             50024  0    osqueryd: (Security) [com.apple.securityd:integrity] dbBlobVersion() failed for a CssmError: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
2026-04-22 14:54:50.909061-0300 0x75723    Default     0x23f894             50024  0    osqueryd: (Security) [com.apple.securityd:security_exception] CSSM Exception: -2147413759 CSSMERR_DL_DATABASE_CORRUPT
```