### PR TITLE
Fix `process_open_handles` comments and spec

### DIFF
--- a/osquery/tables/system/windows/process_open_handles.cpp
+++ b/osquery/tables/system/windows/process_open_handles.cpp
@@ -1253,14 +1253,12 @@ class HandleEnumeration {
 } // namespace handles
 
 // osquery table entry point for the "handles" table.
-// If no pid constraint is provided, defaults to the current (osquery)
-// process.  Requires SeDebugPrivilege for cross-process enumeration.
+// Requires SeDebugPrivilege for cross-process enumeration.
 QueryData genProcessOpenHandles(QueryContext& context) {
   // Determine pid constraints, pid is a required column
   std::set<int> pidlist = context.constraints.at("pid").getAll<int>(EQUALS);
 
   if (pidlist.empty()) {
-    // If no pid constraints are provided, default to the current process
     VLOG(1) << "No pid constraint provided for handles table";
     return QueryData();
   }

--- a/specs/windows/process_open_handles.table
+++ b/specs/windows/process_open_handles.table
@@ -1,5 +1,5 @@
 table_name("process_open_handles")
-description("Enumerate open handles for a specified process. Defaults to the osquery process if no pid constraint is provided.")
+description("Enumerate open handles for a specified process.")
 schema([
     Column("pid", BIGINT, "The process identifier that owns the handle.", required=True, index=True, optimized=True),
     Column("value", BIGINT, "The handle value"),


### PR DESCRIPTION
The spec and comments referred to removed functionality about defaulting to osquery's PID