### PR TITLE
file table : lnk-related columns were not always computed on Windows

### DIFF
--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -357,7 +357,8 @@ QueryData genFileWindows(QueryContext& context, Logger& logger) {
       // Iterate over the directory and generate info for each regular file.
       fs::directory_iterator begin(directory_string), end;
       for (; begin != end; ++begin) {
-        genFileInfoWindows(begin->path(), directory_string, "", false, results);
+        genFileInfoWindows(
+            begin->path(), directory_string, "", get_shortcut_data, results);
       }
     } catch (const fs::filesystem_error& /* e */) {
       continue;

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -140,15 +140,9 @@ boost::optional<std::size_t> getRowIndexForFileName(
 }
 } // namespace
 
-TEST_F(FileTests, test_sanity) {
-  std::string path_constraint =
-      (directory / boost::filesystem::path("%.txt")).string();
-  std::string link_constraint =
-      (directory / boost::filesystem::path("%.lnk")).string();
-  QueryData data =
-      execute_query("select * from file where path like \"" + path_constraint +
-                    "\" OR path like \"" + link_constraint + "\"");
-
+static void test_sanity_common(const QueryData& data,
+                               const boost::filesystem::path& directory,
+                               const std::string& path_constraint) {
   if (isPlatform(PlatformType::TYPE_WINDOWS)) {
     EXPECT_EQ(data.size(), kFileNameList.size() * 2);
   } else {
@@ -243,6 +237,29 @@ TEST_F(FileTests, test_sanity) {
     validate_container_rows(
         "file", row_map, "path like \"" + path_constraint + "\"");
   }
+}
+
+TEST_F(FileTests, test_sanity_path) {
+  std::string path_constraint =
+      (directory / boost::filesystem::path("%.txt")).string();
+  std::string link_constraint =
+      (directory / boost::filesystem::path("%.lnk")).string();
+  QueryData data =
+      execute_query("select * from file where path like \"" + path_constraint +
+                    "\" OR path like \"" + link_constraint + "\"");
+
+  test_sanity_common(data, directory, path_constraint);
+}
+
+TEST_F(FileTests, test_sanity_directory) {
+  std::string path_constraint =
+      (directory / boost::filesystem::path("%.txt")).string();
+
+  QueryData data = execute_query(
+      "select * from file where directory = \"" + directory.string() +
+      "\" AND (filename like \"%.txt\" or filename like \"%.lnk\")");
+
+  test_sanity_common(data, directory, path_constraint);
 }
 
 TEST_F(FileTests, test_nested_directory_traversal) {


### PR DESCRIPTION
file table : lnk-related columns were not computed when query filters on `directory` instead of `path`.

lnk-related columns computation is done only if one of the lnk-related columns is requested. However, when filter is based on `directory`, lnk-related columns computation was explicitly disabled (with no obvious reason). This commit restores computation when filters is based on `directory`.

Also added a unit test for that.

Fixes #8727
