### PR TITLE
Conditionally install init.d script and fix postrm cleanup

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -40,7 +40,7 @@ concurrency:
 # Please remember to update values for both x86 and aarch64 workflows.
 env:
   PACKAGING_REPO: https://github.com/osquery/osquery-packaging
-  PACKAGING_COMMIT: c089fb2d3d796d976e3b2fbea7ee69a1616b9576
+  PACKAGING_COMMIT: 528b57ae758f41f0aaafde25bf2d3844785dd848
   SUBMODULE_CACHE_VERSION: 3
   OSQUERY_TOOLCHAIN_VERSION: 1.2.0
 

--- a/cmake/install_directives.cmake
+++ b/cmake/install_directives.cmake
@@ -21,6 +21,16 @@ function(generateInstallDirectives)
     )
 
     install(
+      FILES "tools/deployment/linux_packaging/deb/postrm"
+      DESTINATION "/control/deb"
+
+      PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ             GROUP_EXECUTE
+        WORLD_READ             WORLD_EXECUTE
+    )
+
+    install(
       FILES "tools/deployment/linux_packaging/deb/osqueryd.service"
       DESTINATION "/control/deb/lib/systemd/system"
     )

--- a/tools/deployment/linux_packaging/deb/conffiles
+++ b/tools/deployment/linux_packaging/deb/conffiles
@@ -1,2 +1,1 @@
-/etc/init.d/osqueryd
 /etc/default/osqueryd

--- a/tools/deployment/linux_packaging/deb/postrm
+++ b/tools/deployment/linux_packaging/deb/postrm
@@ -1,0 +1,6 @@
+#!/bin/sh
+case "$1" in
+  remove|purge)
+    rm -f /etc/init.d/osqueryd
+    ;;
+esac

--- a/tools/deployment/linux_packaging/postinst
+++ b/tools/deployment/linux_packaging/postinst
@@ -10,12 +10,18 @@
 # Handle the cases we want to hook or silently claim success.
 case "$1" in
   configure|2)
-    : # Fall through to systemctl handle.
+    : # Fall through to install-time setup.
     ;;
   *)
     exit 0
     ;;
 esac
+
+# Install the SysV init script only when the system uses init.d
+if [ -d /etc/init.d ] && [ -f /usr/share/osquery/initd/osqueryd ]; then
+  cp /usr/share/osquery/initd/osqueryd /etc/init.d/osqueryd
+  chmod 0755 /etc/init.d/osqueryd
+fi
 
 # If we have a systemd, daemon-reload away now
 if [ -x /bin/systemctl ] && pidof systemd ; then


### PR DESCRIPTION
This PR is related to a deployment issue, filed in [osquery-packaging](https://github.com/osquery/osquery-packaging/issues/27). On some VMs, the directory /etc/init.d is not present, which prevents the package to be installed.

This PR goes with https://github.com/osquery/osquery-packaging/pull/28

Stage the init.d script only on systemd-only hosts and update postrm to only remove the init script on remove/purge.

Fixes https://github.com/osquery/osquery/issues/7949