### PR TITLE
Update macOS CI configurations

### DIFF
--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -805,7 +805,7 @@ jobs:
         echo "REL_UNSIGNED_RELEASE_PACKAGE_DATA_PATH=$(ls ${{ steps.build_paths.outputs.REL_PACKAGE_BUILD }}/package_data.tar.gz)" >> $GITHUB_OUTPUT
 
     - name: Store the ${{ matrix.architecture }} unsigned release package data artifact
-      if: matrix.build_type == 'Release' && matrix.os == 'macos-14'
+      if: matrix.build_type == 'Release' && matrix.os == 'macos-26'
       uses: actions/upload-artifact@v4.4.0
       with:
         name: macos_unsigned_release_package_data_${{ matrix.architecture }}
@@ -822,7 +822,7 @@ jobs:
   build_universal_macos_artifacts:
     needs: build_macos
 
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - name: Clone the osquery repository

--- a/.github/workflows/hosted_runners.yml
+++ b/.github/workflows/hosted_runners.yml
@@ -591,7 +591,10 @@ jobs:
       matrix:
         build_type: [Release, Debug]
         architecture: [x86_64, arm64]
-        os: [macos-14, macos-15]
+        os: [macos-26, macos-15]
+
+    env:
+      MACOS_DEPLOYMENT_TARGET: 10.15
 
     steps:
     - name: Select the build job count
@@ -718,25 +721,6 @@ jobs:
           "${{ steps.build_paths.outputs.INSTALL }}" \
           "3.21.4"
 
-    - name: Select the Xcode version
-      shell: bash
-      id: xcode_selector
-      run: |
-        if [[ "${{ matrix.os }}" == "macos-14" ]]; then
-          xcode_path="/Applications/Xcode_15.4.app/Contents/Developer"
-        elif [[ "${{ matrix.os }}" == "macos-15" ]]; then
-          xcode_path="/Applications/Xcode_16.app/Contents/Developer"
-        else
-          echo "Invalid matrix.os: ${{ matrix.os }}"
-          exit 1
-        fi
-
-        echo "PATH=${path}" >> $GITHUB_OUTPUT
-
-        sudo xcode-select -s "${xcode_path}"
-
-        echo "DEPLOYMENT_TARGET=10.15" >> $GITHUB_OUTPUT
-
     # We don't have enough space on the worker to actually generate all
     # the debug symbols (osquery + dependencies), so we have a flag to
     # disable them when running a Debug build
@@ -764,7 +748,7 @@ jobs:
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.architecture }}" \
-          -DCMAKE_OSX_DEPLOYMENT_TARGET="${{ steps.xcode_selector.outputs.DEPLOYMENT_TARGET }}" \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET="${{ env.MACOS_DEPLOYMENT_TARGET }}" \
           -DCMAKE_BUILD_TYPE:STRING="${{ matrix.build_type }}" \
           -DOSQUERY_BUILD_TESTS=ON \
           -DOSQUERY_NO_DEBUG_SYMBOLS=${{ steps.debug_symbols_settings.outputs.VALUE }} \


### PR DESCRIPTION
- Use macOS 26 & 15, remove macOS 14
- Use default XCode versions on each OS
- Move SDK target to env variable