### PR TITLE
Remove older cipher suites from kTLSCiphers

### DIFF
--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -27,7 +27,7 @@ const std::string kNodeKeyAuthScheme = "NodeKey";
 
 const std::string kTLSCiphers =
     "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:"
-    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS";
+    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS:!kDHE:!kRSA";
 
 /// Path to optional TLS client secret key, used for enrollment/requests.
 DECLARE_string(tls_client_key);

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -27,7 +27,7 @@ const std::string kNodeKeyAuthScheme = "NodeKey";
 
 const std::string kTLSCiphers =
     "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:"
-    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA";
+    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS";
 
 /// Path to optional TLS client secret key, used for enrollment/requests.
 DECLARE_string(tls_client_key);

--- a/osquery/remote/transports/tls.h
+++ b/osquery/remote/transports/tls.h
@@ -27,7 +27,8 @@ const std::string kNodeKeyAuthScheme = "NodeKey";
 
 const std::string kTLSCiphers =
     "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:"
-    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS:!kDHE:!kRSA";
+    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS:!kDHE:!"
+    "kRSA";
 
 /// Path to optional TLS client secret key, used for enrollment/requests.
 DECLARE_string(tls_client_key);


### PR DESCRIPTION
## Summary

Appends `!DSS:!kDHE:!kRSA` to the `kTLSCiphers` cipher string to remove
non-recommended and legacy cipher suites from osquery's TLS ClientHello.

## Problem

The `DH+AESGCM` / `DH+AES256` / `DH+AES` / `RSA+AESGCM` / `RSA+AES` patterns
in `kTLSCiphers` expand to include DHE_DSS, DHE_RSA, and static RSA key exchange
variants. This causes osquery to offer 10 cipher suites that are either
"Not Recommended" or "Legacy" under CCN-STIC-807 and other security frameworks.

## Removed cipher suites

| Cipher Suite | Hex | CCN-STIC-807 |
|---|---|---|
| TLS_DHE_DSS_WITH_AES_128_GCM_SHA256 | 0x00A2 | Not Recommended (NR) |
| TLS_DHE_DSS_WITH_AES_256_GCM_SHA384 | 0x00A3 | Not Recommended (NR) |
| TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 | 0x009E | Legacy (L) |
| TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 | 0x009F | Legacy (L) |
| TLS_DHE_RSA_WITH_AES_128_CCM | 0xC09E | Legacy (L) |
| TLS_DHE_RSA_WITH_AES_256_CCM | 0xC09F | Legacy (L) |
| TLS_RSA_WITH_AES_128_GCM_SHA256 | 0x009C | Legacy (L) |
| TLS_RSA_WITH_AES_256_GCM_SHA384 | 0x009D | Legacy (L) |
| TLS_RSA_WITH_AES_128_CCM | 0xC09C | Legacy (L) |
| TLS_RSA_WITH_AES_256_CCM | 0xC09D | Legacy (L) |

## Remaining cipher suites (all Recommended)

**TLS 1.3** (unaffected by cipher string, always available):
- TLS_AES_256_GCM_SHA384
- TLS_CHACHA20_POLY1305_SHA256
- TLS_AES_128_GCM_SHA256

**TLS 1.2:**
- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_ECDSA_WITH_AES_256_CCM
- TLS_ECDHE_ECDSA_WITH_AES_128_CCM

## Change

```diff
 const std::string kTLSCiphers =
     "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:"
-    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA";
+    "DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!CBC:!SHA:!DSS:!kDHE:!kRSA";
```

## Risk

None. DSS key exchange requires DSA certificates (not used in any modern deployment).
DHE_RSA and static RSA key exchange are classified as Legacy by CCN-STIC-807 and
are superseded by ECDHE. All modern Fleet/TLS servers support ECDHE — removing
these suites has zero impact on osquery's connectivity.

## Note

The `supported_groups` extension also includes FFDHE groups (ffdhe2048 etc.) via
OpenSSL 3.6.1 defaults. Restricting these requires a separate
`SSL_CTX_set1_groups_list()` call in `http_client.cpp` and could be addressed
in a follow-up PR.