### PR TITLE
feat: Add the column protector_types to the table bitlocker_info

### DIFF
--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -40,6 +40,32 @@ static void fetchMethodResultLong(std::string& result,
   }
 }
 
+static std::string fetchProtectorTypes(const WmiRequest& req,
+                                       const WmiResultItem& object) {
+  std::string protectorTypes = "";
+
+  for (int i = 1; i <= 10; i++) {
+    WmiMethodArgs args;
+    WmiResultItem out;
+    std::vector<std::string> protectorIds;
+
+    args.Put("KeyProtectorType", std::to_string(i));
+    auto status = req.ExecMethod(object, "GetKeyProtectors", args, out);
+    if (status.ok()) {
+      status = out.GetVectorOfStrings("VolumeKeyProtectorID", protectorIds);
+      if (status.ok()) {
+        if (protectorIds.size() > 0) {
+          protectorTypes = protectorTypes + std::to_string(i) + ", ";
+        }
+      }
+    }
+  }
+  if (protectorTypes.length() > 0) {
+    protectorTypes = protectorTypes.substr(0, protectorTypes.length() - 2);
+  }
+  return protectorTypes;
+}
+
 QueryData genBitlockerInfo(QueryContext& context) {
   Row r;
   QueryData results;
@@ -82,6 +108,8 @@ QueryData genBitlockerInfo(QueryContext& context) {
       emethod_str = "UNKNOWN";
     }
     r["encryption_method"] = emethod_str;
+
+    r["protector_types"] = fetchProtectorTypes(*wmiSystemReq, data);
 
     fetchMethodResultLong(
         r["version"], *wmiSystemReq, data, "GetVersion", "Version");

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -48,25 +48,33 @@ static std::string getProtectorType(const WmiRequest& req,
   WmiResultItem out;
   long protectorType;
 
-  std::map<long, std::string> types;
-
-  types[1] = "TPM";
-  types[2] = "EXTERNAL_KEY";
-  types[3] = "NUMERIC_PASSWORD";
-  types[4] = "TPM_AND_PIN";
-  types[5] = "TPM_AND_STARTUP_KEY";
-  types[6] = "TPM_AND_PIN_AND_STARTUP_KEY";
-  types[7] = "PUBLIC_KEY";
-  types[8] = "PASSPHRASE";
-  types[9] = "TPM_CERTIFICATE";
-  types[10] = "SID";
-
   args.Put("VolumeKeyProtectorID", protectorId);
   auto status = req.ExecMethod(object, "GetKeyProtectorType", args, out);
   if (status.ok()) {
     status = out.GetLong("KeyProtectorType", protectorType);
     if (status.ok()) {
-      return types[protectorType];
+      switch (protectorType) {
+      case 1:
+        return "TPM";
+      case 2:
+        return "EXTERNAL_KEY";
+      case 3:
+        return "NUMERIC_PASSWORD";
+      case 4:
+        return "TPM_AND_PIN";
+      case 5:
+        return "TPM_AND_STARTUP_KEY";
+      case 6:
+        return "TPM_AND_PIN_AND_STARTUP_KEY";
+      case 7:
+        return "PUBLIC_KEY";
+      case 8:
+        return "PASSPHRASE";
+      case 9:
+        return "TPM_CERTIFICATE";
+      case 10:
+        return "SID";
+      }
     }
   }
   return "UNKNOWN";

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -41,23 +41,50 @@ static void fetchMethodResultLong(std::string& result,
   }
 }
 
-static std::string fetchProtectorTypes(const WmiRequest& req,
-                                       const WmiResultItem& object) {
-  std::vector<std::string> protectorTypes;
+static std::string getProtectorType(const WmiRequest& req,
+                                    const WmiResultItem& object,
+                                    std::string protectorId) {
+  WmiMethodArgs args;
+  WmiResultItem out;
+  long protectorType;
 
-  for (int i = 1; i <= 10; i++) {
-    WmiMethodArgs args;
-    WmiResultItem out;
-    std::vector<std::string> protectorIds;
+  std::map<long, std::string> types;
 
-    args.Put("KeyProtectorType", std::to_string(i));
-    auto status = req.ExecMethod(object, "GetKeyProtectors", args, out);
+  types[1] = "TPM";
+  types[2] = "EXTERNAL_KEY";
+  types[3] = "NUMERIC_PASSWORD";
+  types[4] = "TPM_AND_PIN";
+  types[5] = "TPM_AND_STARTUP_KEY";
+  types[6] = "TPM_AND_PIN_AND_STARTUP_KEY";
+  types[7] = "PUBLIC_KEY";
+  types[8] = "PASSPHRASE";
+  types[9] = "TPM_CERTIFICATE";
+  types[10] = "SID";
+
+  args.Put("VolumeKeyProtectorID", protectorId);
+  auto status = req.ExecMethod(object, "GetKeyProtectorType", args, out);
+  if (status.ok()) {
+    status = out.GetLong("KeyProtectorType", protectorType);
     if (status.ok()) {
-      status = out.GetVectorOfStrings("VolumeKeyProtectorID", protectorIds);
-      if (status.ok()) {
-        if (protectorIds.size() > 0) {
-          protectorTypes.push_back(std::to_string(i));
-        }
+      return types[protectorType];
+    }
+  }
+  return "UNKNOWN";
+}
+
+static std::string getProtectorTypes(const WmiRequest& req,
+                                     const WmiResultItem& object) {
+  std::vector<std::string> protectorTypes;
+  WmiMethodArgs args;
+  WmiResultItem out;
+  std::vector<std::string> protectorIds;
+
+  auto status = req.ExecMethod(object, "GetKeyProtectors", args, out);
+  if (status.ok()) {
+    status = out.GetVectorOfStrings("VolumeKeyProtectorID", protectorIds);
+    if (status.ok()) {
+      for (auto& protectorId : protectorIds) {
+        protectorTypes.push_back(getProtectorType(req, object, protectorId));
       }
     }
   }
@@ -107,7 +134,7 @@ QueryData genBitlockerInfo(QueryContext& context) {
     }
     r["encryption_method"] = emethod_str;
 
-    r["protector_types"] = fetchProtectorTypes(*wmiSystemReq, data);
+    r["protector_types"] = getProtectorTypes(*wmiSystemReq, data);
 
     fetchMethodResultLong(
         r["version"], *wmiSystemReq, data, "GetVersion", "Version");

--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -13,6 +13,7 @@
 #include <osquery/sql/sql.h>
 
 #include "osquery/core/windows/wmi.h"
+#include <osquery/utils/conversions/join.h>
 #include <osquery/utils/conversions/tryto.h>
 
 namespace osquery {
@@ -42,7 +43,7 @@ static void fetchMethodResultLong(std::string& result,
 
 static std::string fetchProtectorTypes(const WmiRequest& req,
                                        const WmiResultItem& object) {
-  std::string protectorTypes = "";
+  std::vector<std::string> protectorTypes;
 
   for (int i = 1; i <= 10; i++) {
     WmiMethodArgs args;
@@ -55,15 +56,12 @@ static std::string fetchProtectorTypes(const WmiRequest& req,
       status = out.GetVectorOfStrings("VolumeKeyProtectorID", protectorIds);
       if (status.ok()) {
         if (protectorIds.size() > 0) {
-          protectorTypes = protectorTypes + std::to_string(i) + ", ";
+          protectorTypes.push_back(std::to_string(i));
         }
       }
     }
   }
-  if (protectorTypes.length() > 0) {
-    protectorTypes = protectorTypes.substr(0, protectorTypes.length() - 2);
-  }
-  return protectorTypes;
+  return osquery::join(protectorTypes, ",");
 }
 
 QueryData genBitlockerInfo(QueryContext& context) {

--- a/specs/windows/bitlocker_info.table
+++ b/specs/windows/bitlocker_info.table
@@ -8,6 +8,7 @@ schema([
   Column("conversion_status", INTEGER, "The bitlocker conversion status of the drive."),
   Column("protection_status", INTEGER, "The bitlocker protection status of the drive."),
   Column("encryption_method", TEXT, "The encryption type of the device."),
+  Column("protector_types", TEXT, "Protector types used to secure the volume's encryption key."),
   Column("version", INTEGER, "The FVE metadata version of the drive."),
   Column("percentage_encrypted", INTEGER, "The percentage of the drive that is encrypted."),
   Column("lock_status", INTEGER, "The accessibility status of the drive from Windows."),


### PR DESCRIPTION
Retrieve the type of protectors used to secure a BitLocker-encrypted drive, as a string composed of comma-separated integers.

This is useful for monitoring Bitlocker configuration, to ensure devices are not protected with TPM only, which can be bypassed with bus-sniffing.

Merging key protector types in a single string seems more convenient than making a jointure with a hypothetical bitlocker_protectors table. Protector types can be checked with a simple "SELECT drive_letter, protector_types FROM bitlocker_info;"