### PR TITLE
docs: updating build instructions with semver override

### DIFF
--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -42,7 +42,7 @@ cd osquery
 
 # Build osquery with a semver
 mkdir build; cd build
-=cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain -DOSQUERY_VERSION=5.22.1 ..
+cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain -DOSQUERY_VERSION=5.22.1 ..
 cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 

--- a/docs/wiki/development/building.md
+++ b/docs/wiki/development/building.md
@@ -40,9 +40,9 @@ sudo tar xvf osquery-toolchain-1.3.0-${ARCH}.tar.xz -C /usr/local
 git clone https://github.com/osquery/osquery
 cd osquery
 
-# Build osquery
+# Build osquery with a semver
 mkdir build; cd build
-cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..
+=cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain -DOSQUERY_VERSION=5.22.1 ..
 cmake --build . -j10 # where 10 is the number of parallel build jobs
 ```
 


### PR DESCRIPTION
Currently the build instructions on linux error out: https://osquery.readthedocs.io/en/latest/development/building/

specifically:
```
cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..
```
errors out:

```
smaerz@instance-20260501-200200:~/osquery/build$ cd ~/osquery
smaerz@instance-20260501-200200:~/osquery$ git fetch --tags
smaerz@instance-20260501-200200:~/osquery$ cd build
smaerz@instance-20260501-200200:~/osquery/build$ cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain ..CMake Error at cmake/options.cmake:50 (message): Version should have at least 3 components (semver).Call Stack (most recent call first): cmake/options.cmake:152 (detectOsqueryVersion) CMakeLists.txt:23 (include)




-- Configuring incomplete, errors occurred!

See also "/home/smaerz/osquery/build/CMakeFiles/CMakeOutput.log".

See also "/home/smaerz/osquery/build/CMakeFiles/CMakeError.log".
```







If we pass `DOSQUERY_VERSION` into the cmake command it completes as expected:
```
cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain -DOSQUERY_VERSION=5.12.0 ..
```

I assume at some point the build tooling was updated to reference git tags looking for semver structure, so this PR just updates the docs to align with that.