### PR TITLE
fix: clear errno before getmntent_r to avoid false error logs at EOF

### DIFF
--- a/osquery/filesystem/linux/mounts.cpp
+++ b/osquery/filesystem/linux/mounts.cpp
@@ -57,14 +57,14 @@ Status getMountedFilesystems(MountedFilesystems& mounted_fs_info) {
 
   for (;;) {
     mntent ent = {};
+    errno = 0;
     if (getmntent_r(mount_data.get(),
                     &ent,
                     string_buffer.data(),
                     string_buffer.size()) == nullptr) {
-      if (errno != ENOENT) {
+      if (errno != 0) {
         LOG(ERROR) << "getmntent_r failed with errno " << std::to_string(errno);
       }
-
       break;
     }
 


### PR DESCRIPTION
Resolves #8648.

Currently, querying the mounts table can result in false-positive error logs like getmntent_r failed with errno 22.

This happens because getmntent_r returns nullptr when it reaches EOF, but it does not clear errno. If a completely unrelated system call failed earlier in the daemon's lifecycle, errno retains that stale error code. When getmntent_r hits EOF, the current logic checks the dangling errno, sees it isn't ENOENT, and incorrectly assumes getmntent_r actually failed.

The Fix:
Explicitly set errno = 0 right before calling getmntent_r. This is a standard pattern for handling functions that return NULL for both EOF and actual errors, ensuring we don't leak prior error states into this check.

Testing:

Built on an Ubuntu VM using the osquery toolchain.

Ran `./osqueryi --verbose` and executed `SELECT * FROM mounts;` and did not observe any additional errors.