### PR TITLE
docs: fix install_date column descriptions for patches and shared_resources tables

### DIFF
--- a/specs/windows/patches.table
+++ b/specs/windows/patches.table
@@ -7,7 +7,7 @@ schema([
   Column("description", TEXT, "Fuller description of the patch."),
   Column("fix_comments", TEXT, "Additional comments about the patch."),
   Column("installed_by", TEXT, "The system context in which the patch as installed."),
-  Column("install_date", TEXT, "Indicates when the patch was installed. Lack of a value does not indicate that the patch was not installed."),
+  Column("install_date", TEXT, "Indicates when the patch was installed. Lack of a value indicates that the patch was not installed."),
   Column("installed_on", TEXT, "The date when the patch was installed."),
 ])
 implementation("system/windows/patches@genInstalledPatches")

--- a/specs/windows/shared_resources.table
+++ b/specs/windows/shared_resources.table
@@ -2,7 +2,7 @@ table_name("shared_resources")
 description("Displays shared resources on a computer system running Windows. This may be a disk drive, printer, interprocess communication, or other sharable device.")
 schema([
     Column("description", TEXT, "A textual description of the object"),
-    Column("install_date", TEXT, "Indicates when the object was installed. Lack of a value does not indicate that the object is not installed."),
+    Column("install_date", TEXT, "Indicates when the object was installed. Lack of a value indicates that the object is not installed."),
     Column("status", TEXT, "String that indicates the current status of the object."),
     Column("allow_maximum", INTEGER, "Number of concurrent users for this resource has been limited. If True, the value in the MaximumAllowed property is ignored."),
     Column("maximum_allowed", BIGINT, "Limit on the maximum number of users allowed to use this resource concurrently. The value is only valid if the AllowMaximum property is set to FALSE."),


### PR DESCRIPTION
## Summary

Fixes #6350

The `install_date` column descriptions for the `patches` and `shared_resources` tables contain a double-negative that contradicts the actual behavior: "Lack of a value does not indicate that the patch/object is not installed." The descriptions should clearly state that a missing `install_date` means the item was not installed.

## Root Cause

The column descriptions in `specs/windows/patches.table` (line 10) and `specs/windows/shared_resources.table` (line 5) used "does not indicate that the ... was not installed" — a double negative that obscures the intended meaning.

## Fix

Removed the double negative from both column descriptions:

- `patches.table`: Changed "Lack of a value does not indicate that the patch was not installed." to "Lack of a value indicates that the patch was not installed."
- `shared_resources.table`: Changed "Lack of a value does not indicate that the object is not installed." to "Lack of a value indicates that the object is not installed."

## Changes

- `specs/windows/patches.table`: updated `install_date` column description (+1 -1 words)
- `specs/windows/shared_resources.table`: updated `install_date` column description (+1 -1 words)

## Testing

- Verified the old strings no longer appear in either file ✅
- Verified the new descriptions are grammatically correct and unambiguous ✅
- No functional code changes — only column description strings in spec files ✅