### PR TITLE
Switch authenticode getOriginalProgramName to CryptDecodeObjectEx

### DIFF
--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -291,7 +291,7 @@ Status getOriginalProgramName(SignatureInformation& signature_info,
                          publisher_info_ptr->rgValue[0].pbData,
                          publisher_info_ptr->rgValue[0].cbData,
                          0,
-                         publisher_info_ptr,
+                         publisher_info_blob_ptr,
                          &publisher_info_size)) {
     return Status(1, "Failed to decode the publisher information");
   }

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -22,10 +22,10 @@
 #include <iomanip>
 // clang-format on
 
+#include <osquery/core/tables.h>
 #include <osquery/filesystem/filesystem.h>
 #include <osquery/logger/logger.h>
 #include <osquery/sql/sql.h>
-#include <osquery/core/tables.h>
 #include <osquery/utils/conversions/tryto.h>
 #include <osquery/utils/conversions/windows/strings.h>
 
@@ -275,6 +275,11 @@ Status getOriginalProgramName(SignatureInformation& signature_info,
 
   if (publisher_info_ptr == nullptr) {
     return Status(1, "The publisher information could not be found");
+  }
+
+  if (publisher_info_ptr->cValue == 0 ||
+      publisher_info_ptr->rgValue == nullptr) {
+    return Status(1, "The publisher information is empty");
   }
 
   PSPC_SP_OPUS_INFO publisher_info_blob_ptr = nullptr;
@@ -531,5 +536,5 @@ QueryData genAuthenticode(QueryContext& context) {
 
   return results;
 }
-}
-}
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/authenticode.cpp
+++ b/osquery/tables/system/windows/authenticode.cpp
@@ -56,6 +56,14 @@ using unique_certcontext =
 using unique_hcryptmsg =
     CustomUniquePtr<HCRYPTMSG, decltype(&CryptMsgClose), CryptMsgClose>;
 
+void OpusInfoDeleter(PSPC_SP_OPUS_INFO p) {
+  LocalFree(p);
+}
+
+using unique_opus_info = CustomUniquePtr<PSPC_SP_OPUS_INFO,
+                                         decltype(&OpusInfoDeleter),
+                                         OpusInfoDeleter>;
+
 struct SignatureInformation final {
   enum class Result { Valid, Trusted, Invalid, Missing, Distrusted, Untrusted };
 
@@ -269,32 +277,19 @@ Status getOriginalProgramName(SignatureInformation& signature_info,
     return Status(1, "The publisher information could not be found");
   }
 
-  DWORD publisher_info_size;
-  if (!CryptDecodeObject(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
-                         SPC_SP_OPUS_INFO_OBJID,
-                         publisher_info_ptr->rgValue[0].pbData,
-                         publisher_info_ptr->rgValue[0].cbData,
-                         0,
-                         nullptr,
-                         &publisher_info_size)) {
-    return Status(1, "Failed to access the publisher information");
-  }
-
-  std::vector<std::uint8_t> publisher_info_blob_buffer(
-      static_cast<std::size_t>(publisher_info_size));
-
-  PSPC_SP_OPUS_INFO publisher_info_blob_ptr =
-      reinterpret_cast<PSPC_SP_OPUS_INFO>(publisher_info_blob_buffer.data());
-
-  if (!CryptDecodeObject(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
-                         SPC_SP_OPUS_INFO_OBJID,
-                         publisher_info_ptr->rgValue[0].pbData,
-                         publisher_info_ptr->rgValue[0].cbData,
-                         0,
-                         publisher_info_blob_ptr,
-                         &publisher_info_size)) {
+  PSPC_SP_OPUS_INFO publisher_info_blob_ptr = nullptr;
+  DWORD publisher_info_size = 0;
+  if (!CryptDecodeObjectEx(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                           SPC_SP_OPUS_INFO_OBJID,
+                           publisher_info_ptr->rgValue[0].pbData,
+                           publisher_info_ptr->rgValue[0].cbData,
+                           CRYPT_DECODE_ALLOC_FLAG,
+                           nullptr,
+                           &publisher_info_blob_ptr,
+                           &publisher_info_size)) {
     return Status(1, "Failed to decode the publisher information");
   }
+  unique_opus_info::type publisher_info_blob_owner(publisher_info_blob_ptr);
 
   if (publisher_info_blob_ptr->pwszProgramName != nullptr) {
     signature_info.original_program_name =

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -11,6 +11,7 @@
 // Spec file: specs/windows/authenticode.table
 
 #include <osquery/tests/integration/tables/helper.h>
+#include <osquery/utils/system/env.h>
 
 namespace osquery {
 namespace table_tests {

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -23,25 +23,27 @@ class authenticode : public testing::Test {
 };
 
 TEST_F(authenticode, test_sanity) {
-  // 1. Query data
-  auto const data = execute_query("select * from authenticode where path = ''");
-  // 2. Check size before validation
-  // ASSERT_GE(data.size(), 0ul);
-  // ASSERT_EQ(data.size(), 1ul);
-  // ASSERT_EQ(data.size(), 0ul);
-  // 3. Build validation map
-  // See helper.h for available flags
-  // Or use custom DataCheck object
-  // ValidationMap row_map = {
-  //      {"path", NormalType}
-  //      {"original_program_name", NormalType}
-  //      {"serial_number", NormalType}
-  //      {"issuer_name", NormalType}
-  //      {"subject_name", NormalType}
-  //      {"result", NormalType}
-  //}
-  // 4. Perform validation
-  // validate_rows(data, row_map);
+  // notepad.exe is universally present on Windows and is Authenticode-signed
+  // by Microsoft with an SPC_SP_OPUS_INFO publisher info blob that carries a
+  // non-empty pwszProgramName. Asserting original_program_name is non-empty
+  // also guards against regression of GHSA-hr28-jvpx-68cx, where the wrong
+  // output buffer was passed to CryptDecodeObject and the program name was
+  // silently always empty.
+  auto const data = execute_query(
+      "select * from authenticode "
+      "where path = 'C:\\Windows\\System32\\notepad.exe'");
+
+  ASSERT_EQ(data.size(), 1ul);
+
+  ValidationMap row_map = {
+      {"path", NonEmptyString},
+      {"original_program_name", NonEmptyString},
+      {"serial_number", NonEmptyString},
+      {"issuer_name", NonEmptyString},
+      {"subject_name", NonEmptyString},
+      {"result", NonEmptyString},
+  };
+  validate_rows(data, row_map);
 }
 
 } // namespace table_tests

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -10,6 +10,8 @@
 // Sanity check integration test for authenticode
 // Spec file: specs/windows/authenticode.table
 
+#include <sstream>
+
 #include <osquery/tests/integration/tables/helper.h>
 #include <osquery/utils/system/env.h>
 
@@ -31,11 +33,11 @@ TEST_F(authenticode, test_sanity) {
   // output buffer was passed to CryptDecodeObject and the program name was
   // silently always empty.
   auto windir = getEnvVar("WINDIR");
-  EXPECT_TRUE(windir);
+  ASSERT_TRUE(windir);
   std::stringstream ss;
   ss << "select * from authenticode "
         "where path = '"
-     << windir << "\\System32\\notepad.exe'";
+     << *windir << "\\System32\\notepad.exe'";
 
   auto const data = execute_query(ss.str());
 

--- a/tests/integration/tables/authenticode.cpp
+++ b/tests/integration/tables/authenticode.cpp
@@ -29,9 +29,14 @@ TEST_F(authenticode, test_sanity) {
   // also guards against regression of GHSA-hr28-jvpx-68cx, where the wrong
   // output buffer was passed to CryptDecodeObject and the program name was
   // silently always empty.
-  auto const data = execute_query(
-      "select * from authenticode "
-      "where path = 'C:\\Windows\\System32\\notepad.exe'");
+  auto windir = getEnvVar("WINDIR");
+  EXPECT_TRUE(windir);
+  std::stringstream ss;
+  ss << "select * from authenticode "
+        "where path = '"
+     << windir << "\\System32\\notepad.exe'";
+
+  auto const data = execute_query(ss.str());
 
   ASSERT_EQ(data.size(), 1ul);
 


### PR DESCRIPTION
Microsoft documents CryptDecodeObjectEx as the recommended replacement
for CryptDecodeObject, with significant performance improvements and
support for CRYPT_DECODE_ALLOC_FLAG, which has the crypto API allocate
the output buffer itself. Using it here collapses the previous
size-query + manual-allocation + decode pattern into a single call and
removes the separate caller-allocated buffer entirely. The LocalAlloc'd
output is owned by a unique_opus_info RAII wrapper that mirrors the
file's existing CustomUniquePtr idiom for other Crypto API handle types.

As a side effect, this resolves GHSA-hr28-jvpx-68cx. In the previous
two-call form, the second CryptDecodeObject was passed publisher_info_ptr
(a pointer into the caller's signer_information buffer) instead of
publisher_info_blob_ptr (the correctly-sized buffer allocated for the
decode output). A crafted PE file with a large SPC_SP_OPUS_INFO attribute
could cause that call to write past the end of the signer info buffer,
and the decoded program name was always read from the untouched, zero-
initialized scratch buffer, so original_program_name was silently empty
for every signed binary. Letting the crypto API own the output buffer
makes the "wrong output buffer" class of bug structurally impossible.

Also fill in the existing integration test scaffold for the authenticode
table: query the always-present, Microsoft-signed notepad.exe and assert
original_program_name is non-empty. The previous scaffold queried
`path = ''` (no rows returned) with the validation map commented out,
so it could not have caught the empty-name regression; the updated test
would have failed before this change and passes after.