### PR TITLE
Fix: Windows prefetch table does not report full executable path

### DIFF
--- a/osquery/tables/system/windows/prefetch.cpp
+++ b/osquery/tables/system/windows/prefetch.cpp
@@ -51,6 +51,7 @@ struct PrefetchFileInfo {
   LONGLONG last_run_time;
   std::string run_times;
   size_t run_count;
+  std::string executable_path;
 };
 
 struct PrefetchVolumeInfo {
@@ -107,6 +108,9 @@ typedef struct _PREFETCH_FILE_INFORMATION {
       FILETIME OtherRunTimes[7];
       DWORD Reserved2[2];
       DWORD RunCount;
+      DWORD Reserved3[2];
+      DWORD HashStringOffset;
+      DWORD HashStringSize;
     } v30v2, v31; // v31 does not seem to have substantial differences.
   } ext;
 } PREFETCH_FILE_INFORMATION, *PPREFETCH_FILE_INFORMATION;
@@ -130,6 +134,22 @@ typedef struct _DIRECTORY_STRING {
 #pragma pack(pop)
 
 } // namespace
+
+std::string parseExecutablePath(const std::vector<UCHAR>& data,
+                                DWORD hash_string_offset,
+                                DWORD hash_string_size) {
+  if (hash_string_offset == 0 ||
+      hash_string_offset + hash_string_size > data.size()) {
+    return {};
+  }
+  auto path_wstr = (PWCHAR)(&data[0] + hash_string_offset);
+  auto max_wchars = hash_string_size / sizeof(WCHAR);
+  auto path_len = wcsnlen_s(path_wstr, max_wchars);
+  if (path_len == 0 || path_len >= max_wchars) {
+    return {};
+  }
+  return wstringToString(path_wstr);
+}
 
 PrefetchHeader parseHeader(const PREFETCH_FILE_HEADER* header) {
   PrefetchHeader result;
@@ -165,7 +185,10 @@ PrefetchFileInfo parseFileInfo(
       }
     }
     result.run_times = osquery::join(run_times, ",");
-
+    result.executable_path =
+        parseExecutablePath(data,
+                            prefetch_file_info->ext.v30v2.HashStringOffset,
+                            prefetch_file_info->ext.v30v2.HashStringSize);
     break;
   case kPrefetchVersionWindows8:
     last_run_time = prefetch_file_info->ext.v26.LastRunTime;
@@ -321,6 +344,7 @@ void parsePrefetchData(RowYield& yield,
   auto r = make_table_row();
   r["path"] = file_path;
   r["filename"] = SQL_TEXT(header.filename);
+  r["executable_path"] = SQL_TEXT(file_info.executable_path);
   r["hash"] = header.prefetch_hash;
   r["size"] = INTEGER(header.file_size);
   r["accessed_files_count"] = INTEGER(file_info.files_count);

--- a/specs/windows/prefetch.table
+++ b/specs/windows/prefetch.table
@@ -13,7 +13,8 @@ schema([
     Column("accessed_files_count", INTEGER, "Number of files accessed."),
     Column("accessed_directories_count", INTEGER, "Number of directories accessed."),
     Column("accessed_files", TEXT, "Files accessed by application within ten seconds of launch."),
-    Column("accessed_directories", TEXT, "Directories accessed by application within ten seconds of launch.")
+    Column("accessed_directories", TEXT, "Directories accessed by application within ten seconds of launch."),
+    Column("executable_path", TEXT, "Full path of the executable.")
 ])
 implementation("prefetch@genPrefetch", generator=True)
 examples([

--- a/tests/integration/tables/prefetch.cpp
+++ b/tests/integration/tables/prefetch.cpp
@@ -32,6 +32,7 @@ TEST_F(PrefetchTest, test_sanity) {
   ValidationMap row_map = {
       {"path", NonEmptyString},
       {"filename", NormalType},
+      {"executable_path", NormalType},
       {"hash", NormalType},
       {"last_run_time", IntType},
       {"other_run_times", NormalType},


### PR DESCRIPTION
### Description
This PR fixes issue #8685, where the Windows prefetch table did not report the full executable path of parsed prefetch files.

### Changes
* **Schema:** Added the `executable_path` column to `specs/windows/prefetch.table`.
* **Implementation:** 
  * Updated the Windows 10/11 prefetch parsing struct in `osquery/tables/system/windows/prefetch.cpp` to read the `HashStringOffset` and `HashStringSize` fields.
  * Added a `parseExecutablePath` helper function to extract the wide-character executable path from the file data using these offsets.
* **Tests:** Added validation rules for `executable_path` in `tests/integration/tables/prefetch.cpp`.

### References
* [libscca FileInformation (Version 30 Variant 2) Specification](https://github.com/libyal/libscca/blob/main/documentation/Windows%20Prefetch%20File%20(PF)%20format.asciidoc#file-information---version-30---variant-2)
* Verification: The path offset and size could be successfully read at offsets `212` and `216` of the decompressed data (which corresponds to offset `128` within the `FileInformation` struct starting at offset `84`).

### Related Issues
Closes #8685
