### PR TITLE
bitlocker_info: read ProtectionStatus via GetProtectionStatus() method to avoid stale cached value

### DIFF
--- a/osquery/tables/system/windows/bitlocker_info.cpp
+++ b/osquery/tables/system/windows/bitlocker_info.cpp
@@ -113,15 +113,26 @@ QueryData genBitlockerInfo(QueryContext& context) {
   }
   const std::vector<WmiResultItem>& wmiResults = wmiSystemReq->results();
   for (const auto& data : wmiResults) {
-    long status = 0;
-    long emethod;
+    long conversionStatus = 0;
+    long emethod = 0;
     data.GetString("DeviceID", r["device_id"]);
     data.GetString("DriveLetter", r["drive_letter"]);
     data.GetString("PersistentVolumeID", r["persistent_volume_id"]);
-    data.GetLong("ConversionStatus", status);
-    r["conversion_status"] = INTEGER(status);
-    data.GetLong("ProtectionStatus", status);
-    r["protection_status"] = INTEGER(status);
+    data.GetLong("ConversionStatus", conversionStatus);
+    r["conversion_status"] = INTEGER(conversionStatus);
+
+    // ProtectionStatus is exposed both as a cached property on
+    // Win32_EncryptableVolume and as the WMI method GetProtectionStatus().
+    // The cached property can be stale — observed on Win11 26100 where drives
+    // that manage-bde reports as "Protection Off, Method=None, Fully Decrypted"
+    // still surface ProtectionStatus=1. Calling the method forces a fresh
+    // evaluation and matches manage-bde / Get-BitLockerVolume output.
+    fetchMethodResultLong(r["protection_status"],
+                          *wmiSystemReq,
+                          data,
+                          "GetProtectionStatus",
+                          "ProtectionStatus");
+
     data.GetLong("EncryptionMethod", emethod);
     std::string emethod_str;
     std::map<long, std::string> methods;


### PR DESCRIPTION
## Summary

`Win32_EncryptableVolume.ProtectionStatus` is a cached property and can return stale values. Drives whose BitLocker has been disabled may still report `ProtectionStatus=1` ("Protection On") even though Microsoft tooling (`manage-bde`, `Get-BitLockerVolume`) correctly reports the drive as unprotected.

Switching to the WMI method `GetProtectionStatus()` forces a fresh evaluation and matches what `manage-bde -status` shows.

## Reproducer

Observed on **Windows 11 24H2, OS Build 26100** across a fleet of Wacom Cintiq shared workstations. The same machine returns contradictory data:

```text
PS> manage-bde -status C:
Volume C: []
[OS Volume]
    BitLocker Version:    None
    Conversion Status:    Fully Decrypted
    Percentage Encrypted: 0.0%
    Encryption Method:    None
    Protection Status:    Protection Off          <-- correct

osquery> SELECT drive_letter, conversion_status, protection_status, encryption_method
         FROM bitlocker_info;
+--------------+-------------------+-------------------+-------------------+
| drive_letter | conversion_status | protection_status | encryption_method |
+--------------+-------------------+-------------------+-------------------+
| C:           | 0                 | 1                 | None              |  <-- wrong
+--------------+-------------------+-------------------+-------------------+
```

`conversion_status=0` (FullyDecrypted) plus `encryption_method=None` plus `protection_status=1` is internally inconsistent. The first two are correct; the third comes from the stale cached property.

Microsoft documents `GetProtectionStatus()` as the canonical accessor — the `ProtectionStatus` property is only refreshed as a side-effect of method calls.

## Real-world impact

In our deployment (ReportMate fleet security monitoring, ~250 Windows endpoints) this false-positive flagged ~30% of unencrypted shared workstations as "BitLocker On", masking the actual encryption gap from IT.

## Changes

1. Use the existing `fetchMethodResultLong` helper to call `GetProtectionStatus()` — same pattern already used for `percentage_encrypted`, `version`, and `lock_status`.
2. Rename the reused local `status` to `conversionStatus` to remove a latent variable-aliasing risk between the two `GetLong` calls (if one had failed the other would silently inherit its value).

## Compatibility

- Output column unchanged (still integer 0/1/2)
- Returns `-1` on method-call failure (matching the behavior of other method-derived columns)
- No new dependencies