### PR TITLE
Fix Linux audit-based process_file_events cache cleanup

### DIFF
--- a/osquery/tables/events/linux/process_file_events.cpp
+++ b/osquery/tables/events/linux/process_file_events.cpp
@@ -1538,10 +1538,17 @@ void AuditdFimProcessMap::save(
   if (process_it == data_.end()) {
     process_it = data_.insert({process_id, AuditdFimFdMap(process_id)}).first;
 
-    // Try to limit the amount of processes we are tracking. When
-    // removing, start from the oldest ones
+    // Try to limit the amount of processes we are tracking. When the map
+    // grows too large, evict the entry with the smallest PID (note:
+    // std::map is ordered by key, not insertion order). If the
+    // just-inserted entry happens to be the minimum, skip eviction this
+    // round rather than discarding tracking state for another live process;
+    // the map will be trimmed on the next insertion.
     if (data_.size() > 4096) {
-      data_.erase(data_.begin());
+      auto victim = data_.begin();
+      if (victim != process_it) {
+        data_.erase(victim);
+      }
     }
   }
 


### PR DESCRIPTION
Previously the cleanup could, in rare cases, erase a cache entry before that same entry was used. There were a couple of different possible ways to fix this but just skipping the deletion in that rare case seemed simplest to me.
