### PR TITLE
Preserve object identifiers in Windows certificates table via subject2/issuer2

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -425,65 +425,34 @@ void addCertRow(PCCERT_CONTEXT certContext,
                     static_cast<unsigned long>(certBuff.size()));
   r["common_name"] = wstringToString(certBuff.data());
 
-  auto subjSize = CertNameToStr(certContext->dwCertEncodingType,
-                                &(certContext->pCertInfo->Subject),
-                                CERT_SIMPLE_NAME_STR,
-                                nullptr,
-                                0);
-  certBuff.resize(subjSize, 0);
-  std::fill(certBuff.begin(), certBuff.end(), 0);
-  subjSize = CertNameToStr(certContext->dwCertEncodingType,
-                           &(certContext->pCertInfo->Subject),
-                           CERT_SIMPLE_NAME_STR,
-                           certBuff.data(),
-                           subjSize);
-  r["subject"] = subjSize == 0 ? "" : wstringToString(certBuff.data());
+  // Convert a distinguished name blob to a string using the given format flag.
+  // CERT_SIMPLE_NAME_STR yields only the attribute values (legacy
+  // subject/issuer behavior), while CERT_X500_NAME_STR preserves the attribute
+  // keys (OIDs), e.g. "CN=Example, O=Example Inc, C=US"
+  auto nameBlobToString = [&](PCERT_NAME_BLOB nameBlob,
+                              DWORD strType) -> std::string {
+    auto size = CertNameToStr(
+        certContext->dwCertEncodingType, nameBlob, strType, nullptr, 0);
+    if (size == 0) {
+      return ""; // defensive: CertNameToStr is documented to return >= 1
+    }
+    std::vector<WCHAR> nameBuff(size, 0);
+    size = CertNameToStr(certContext->dwCertEncodingType,
+                         nameBlob,
+                         strType,
+                         nameBuff.data(),
+                         size);
+    return size == 0 ? "" : wstringToString(nameBuff.data());
+  };
 
-  // CERT_X500_NAME_STR preserves the attribute keys (OIDs) in the distinguished
-  // name, e.g. "CN=Example, O=Example Inc, C=US", to align the subject2 column
-  // with the key/value formatting used by the Darwin and Linux implementations.
-  auto subjectX500Size = CertNameToStr(certContext->dwCertEncodingType,
-                                       &(certContext->pCertInfo->Subject),
-                                       CERT_X500_NAME_STR,
-                                       nullptr,
-                                       0);
-  certBuff.resize(subjectX500Size, 0);
-  std::fill(certBuff.begin(), certBuff.end(), 0);
-  subjectX500Size = CertNameToStr(certContext->dwCertEncodingType,
-                                  &(certContext->pCertInfo->Subject),
-                                  CERT_X500_NAME_STR,
-                                  certBuff.data(),
-                                  subjectX500Size);
-  r["subject2"] = subjectX500Size == 0 ? "" : wstringToString(certBuff.data());
-
-  auto issuerSize = CertNameToStr(certContext->dwCertEncodingType,
-                                  &(certContext->pCertInfo->Issuer),
-                                  CERT_SIMPLE_NAME_STR,
-                                  nullptr,
-                                  0);
-  certBuff.resize(issuerSize, 0);
-  std::fill(certBuff.begin(), certBuff.end(), 0);
-  issuerSize = CertNameToStr(certContext->dwCertEncodingType,
-                             &(certContext->pCertInfo->Issuer),
-                             CERT_SIMPLE_NAME_STR,
-                             certBuff.data(),
-                             issuerSize);
-  r["issuer"] = issuerSize == 0 ? "" : wstringToString(certBuff.data());
-
-  // See the subject2 comment above for why CERT_X500_NAME_STR is used here.
-  auto issuerX500Size = CertNameToStr(certContext->dwCertEncodingType,
-                                      &(certContext->pCertInfo->Issuer),
-                                      CERT_X500_NAME_STR,
-                                      nullptr,
-                                      0);
-  certBuff.resize(issuerX500Size, 0);
-  std::fill(certBuff.begin(), certBuff.end(), 0);
-  issuerX500Size = CertNameToStr(certContext->dwCertEncodingType,
-                                 &(certContext->pCertInfo->Issuer),
-                                 CERT_X500_NAME_STR,
-                                 certBuff.data(),
-                                 issuerX500Size);
-  r["issuer2"] = issuerX500Size == 0 ? "" : wstringToString(certBuff.data());
+  r["subject"] = nameBlobToString(&(certContext->pCertInfo->Subject),
+                                  CERT_SIMPLE_NAME_STR);
+  r["subject2"] =
+      nameBlobToString(&(certContext->pCertInfo->Subject), CERT_X500_NAME_STR);
+  r["issuer"] =
+      nameBlobToString(&(certContext->pCertInfo->Issuer), CERT_SIMPLE_NAME_STR);
+  r["issuer2"] =
+      nameBlobToString(&(certContext->pCertInfo->Issuer), CERT_X500_NAME_STR);
 
   // TODO(#5654) 1: Find the right API calls to get whether a cert is for a CA
   r["ca"] = INTEGER(-1);

--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -439,6 +439,23 @@ void addCertRow(PCCERT_CONTEXT certContext,
                            subjSize);
   r["subject"] = subjSize == 0 ? "" : wstringToString(certBuff.data());
 
+  // CERT_X500_NAME_STR preserves the attribute keys (OIDs) in the distinguished
+  // name, e.g. "CN=Example, O=Example Inc, C=US", to align the subject2 column
+  // with the key/value formatting used by the Darwin and Linux implementations.
+  auto subjectX500Size = CertNameToStr(certContext->dwCertEncodingType,
+                                       &(certContext->pCertInfo->Subject),
+                                       CERT_X500_NAME_STR,
+                                       nullptr,
+                                       0);
+  certBuff.resize(subjectX500Size, 0);
+  std::fill(certBuff.begin(), certBuff.end(), 0);
+  subjectX500Size = CertNameToStr(certContext->dwCertEncodingType,
+                                  &(certContext->pCertInfo->Subject),
+                                  CERT_X500_NAME_STR,
+                                  certBuff.data(),
+                                  subjectX500Size);
+  r["subject2"] = subjectX500Size == 0 ? "" : wstringToString(certBuff.data());
+
   auto issuerSize = CertNameToStr(certContext->dwCertEncodingType,
                                   &(certContext->pCertInfo->Issuer),
                                   CERT_SIMPLE_NAME_STR,
@@ -452,6 +469,21 @@ void addCertRow(PCCERT_CONTEXT certContext,
                              certBuff.data(),
                              issuerSize);
   r["issuer"] = issuerSize == 0 ? "" : wstringToString(certBuff.data());
+
+  // See the subject2 comment above for why CERT_X500_NAME_STR is used here.
+  auto issuerX500Size = CertNameToStr(certContext->dwCertEncodingType,
+                                      &(certContext->pCertInfo->Issuer),
+                                      CERT_X500_NAME_STR,
+                                      nullptr,
+                                      0);
+  certBuff.resize(issuerX500Size, 0);
+  std::fill(certBuff.begin(), certBuff.end(), 0);
+  issuerX500Size = CertNameToStr(certContext->dwCertEncodingType,
+                                 &(certContext->pCertInfo->Issuer),
+                                 CERT_X500_NAME_STR,
+                                 certBuff.data(),
+                                 issuerX500Size);
+  r["issuer2"] = issuerX500Size == 0 ? "" : wstringToString(certBuff.data());
 
   // TODO(#5654) 1: Find the right API calls to get whether a cert is for a CA
   r["ca"] = INTEGER(-1);

--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -3,7 +3,9 @@ description("Certificate Authorities installed in Keychains/ca-bundles. NOTE: os
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate distinguished name (deprecated, use subject2)"),
+    Column("subject2", TEXT, "Certificate distinguished name", hidden=True),
     Column("issuer", TEXT, "Certificate issuer distinguished name (deprecated, use issuer2)"),
+    Column("issuer2", TEXT, "Certificate issuer distinguished name", hidden=True),
     Column("ca", INTEGER, "1 if CA: true (certificate is an authority) else 0"),
     Column("self_signed", INTEGER, "1 if self-signed, else 0"),
     Column("not_valid_before", DATETIME, "Lower bound of valid date"),
@@ -26,11 +28,6 @@ extended_schema(WINDOWS, [
     Column("store", TEXT, "Certificate system store"),
     Column("username", TEXT, "Username"),
     Column("store_id", TEXT, "Exists for service/user stores. Contains raw store id provided by WinAPI."),
-])
-
-extended_schema(POSIX, [
-    Column("issuer2", TEXT, "Certificate issuer distinguished name", hidden=True),
-    Column("subject2", TEXT, "Certificate distinguished name", hidden=True),
 ])
 
 attributes(cacheable=True)

--- a/specs/certificates.table
+++ b/specs/certificates.table
@@ -3,9 +3,9 @@ description("Certificate Authorities installed in Keychains/ca-bundles. NOTE: os
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate distinguished name (deprecated, use subject2)"),
-    Column("subject2", TEXT, "Certificate distinguished name", hidden=True),
+    Column("subject2", TEXT, "Certificate distinguished name"),
     Column("issuer", TEXT, "Certificate issuer distinguished name (deprecated, use issuer2)"),
-    Column("issuer2", TEXT, "Certificate issuer distinguished name", hidden=True),
+    Column("issuer2", TEXT, "Certificate issuer distinguished name"),
     Column("ca", INTEGER, "1 if CA: true (certificate is an authority) else 0"),
     Column("self_signed", INTEGER, "1 if self-signed, else 0"),
     Column("not_valid_before", DATETIME, "Lower bound of valid date"),

--- a/tests/integration/tables/certificates.cpp
+++ b/tests/integration/tables/certificates.cpp
@@ -46,7 +46,9 @@ TEST_F(certificates, test_sanity) {
   ValidationMap row_map = {
       {"common_name", NormalType},
       {"subject", NormalType},
+      {"subject2", NormalType},
       {"issuer", NormalType},
+      {"issuer2", NormalType},
       {"ca", IntType},
       {"self_signed", IntType},
       {"not_valid_before", NormalType},


### PR DESCRIPTION
Resolves #8730

The Windows certificates table generated the `subject` and `issuer` columns with CertNameToStr using CERT_SIMPLE_NAME_STR, which discards the attribute keys (OIDs), unlike the Darwin and Linux implementations.

This change populates the `subject2` and `issuer2` columns on Windows using CERT_X500_NAME_STR so the distinguished name keys (CN, O, OU, C, ...) are preserved, matching the key/value format used on the other platforms. Move these two columns into the base schema so they are available on all platforms. The existing `subject` and `issuer` columns are left unchanged for backward compatibility.

Verified on Windows.

<!--

The PR will be reviewed by an osquery committer.
Here are some common things we look for:

- Common utilities within `./osquery/utils` are used where appropriate (avoid reinventions).
- Modern C++ structures and patterns are used whenever possible.
- No memory or file descriptor leaks, please check all early-return and destructors.
- No explicit casting, such as `return (int)my_var`, instead use `static_cast`.
- The minimal amount of includes are used, only include what you use.
- Comments for methods, structures, and classes follow our common patterns.
- `Status` and `LOG(N)` messages do not use punctuation or contractions.
- The code mostly looks and feels similar to the existing codebase.

-->
