### PR TITLE
Win secureboot certs

### DIFF
--- a/osquery/tables/system/CMakeLists.txt
+++ b/osquery/tables/system/CMakeLists.txt
@@ -210,6 +210,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/registry.cpp
       windows/scheduled_tasks.cpp
       windows/secureboot.cpp
+      windows/secureboot_certificates.cpp
       windows/security_profile_info_utils.cpp
       windows/security_profile_info.cpp
       windows/services.cpp
@@ -242,6 +243,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/prefetch.cpp
       windows/token_privileges.cpp
       windows/process_open_handles.cpp
+      windows/wincert_utils.cpp
     )
   endif()
 
@@ -370,6 +372,7 @@ function(generateOsqueryTablesSystemSystemtable)
       windows/windows_update_history.h
       windows/security_profile_info_utils.h
       windows/startup_items.h
+      windows/wincert_utils.h
     )
   endif()
 

--- a/osquery/tables/system/tests/CMakeLists.txt
+++ b/osquery/tables/system/tests/CMakeLists.txt
@@ -194,6 +194,7 @@ function(generateOsqueryTablesSystemWindowsTests)
     windows/certificates_tests.cpp
     windows/programs_tests.cpp
     windows/registry_tests.cpp
+    windows/secureboot_certificates_tests.cpp
     windows/token_privileges_tests.cpp
     windows/windows_eventlog_tests.cpp
     windows/windows_optional_features_tests.cpp

--- a/osquery/tables/system/tests/windows/secureboot_certificates_tests.cpp
+++ b/osquery/tables/system/tests/windows/secureboot_certificates_tests.cpp
@@ -1,0 +1,409 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <gtest/gtest.h>
+
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+
+#include <osquery/core/tables.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace osquery {
+namespace tables {
+
+// ---------------------------------------------------------------------------
+// Forward-declare the internal parseEslData function exposed for testing.
+// This function is defined at namespace scope in secureboot_certificates.cpp.
+// ---------------------------------------------------------------------------
+void parseEslData(const std::string& content,
+                  bool revoked,
+                  const std::string& path,
+                  QueryData& results);
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class SecurebootCertificatesTests : public testing::Test {};
+
+// ---------------------------------------------------------------------------
+// Helper: Build a minimal ESL blob.
+//
+// Layout (bytes):
+//   One EFI_SIGNATURE_LIST structure:
+//       [0..15]  GUID (first byte controls X.509 detection)
+//       [16..19] SignatureListSize  (LE uint32)
+//       [20..23] SignatureHeaderSize (LE uint32, usually 0)
+//       [24..27] SignatureSize      (LE uint32, includes 16-byte owner GUID)
+//       [28..]   sig_payload bytes
+// ---------------------------------------------------------------------------
+
+static std::string buildEslBlob(uint8_t guid_first_byte,
+                                uint32_t sig_size,
+                                uint32_t sig_header_size,
+                                const std::vector<uint8_t>& sig_payload) {
+  const uint32_t sigs_area_size =
+      sig_payload.empty() ? 0U : static_cast<uint32_t>(sig_payload.size());
+  const uint32_t sig_list_size = 28U + sig_header_size + sigs_area_size;
+
+  std::string blob(sig_list_size, '\x00');
+  uint8_t* esl = reinterpret_cast<uint8_t*>(&blob[0]);
+
+  esl[0] = guid_first_byte;
+
+  // SignatureListSize [16..19] LE.
+  esl[16] = static_cast<uint8_t>(sig_list_size & 0xFF);
+  esl[17] = static_cast<uint8_t>((sig_list_size >> 8) & 0xFF);
+  esl[18] = static_cast<uint8_t>((sig_list_size >> 16) & 0xFF);
+  esl[19] = static_cast<uint8_t>((sig_list_size >> 24) & 0xFF);
+
+  // SignatureHeaderSize [20..23] LE.
+  esl[20] = static_cast<uint8_t>(sig_header_size & 0xFF);
+  esl[21] = static_cast<uint8_t>((sig_header_size >> 8) & 0xFF);
+  esl[22] = static_cast<uint8_t>((sig_header_size >> 16) & 0xFF);
+  esl[23] = static_cast<uint8_t>((sig_header_size >> 24) & 0xFF);
+
+  // SignatureSize [24..27] LE.
+  esl[24] = static_cast<uint8_t>(sig_size & 0xFF);
+  esl[25] = static_cast<uint8_t>((sig_size >> 8) & 0xFF);
+  esl[26] = static_cast<uint8_t>((sig_size >> 16) & 0xFF);
+  esl[27] = static_cast<uint8_t>((sig_size >> 24) & 0xFF);
+
+  if (!sig_payload.empty()) {
+    std::memcpy(
+        esl + 28 + sig_header_size, sig_payload.data(), sig_payload.size());
+  }
+
+  return blob;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Build an ESL blob containing a single real X.509 DER certificate.
+// ---------------------------------------------------------------------------
+
+static std::string buildX509EslBlob(const std::vector<uint8_t>& der_cert) {
+  const uint32_t sig_size = static_cast<uint32_t>(16U + der_cert.size());
+  const uint32_t sig_list_size = 28U + sig_size;
+
+  std::string blob(sig_list_size, '\x00');
+  uint8_t* esl = reinterpret_cast<uint8_t*>(&blob[0]);
+
+  esl[0] = 0xa1U; // EFI_CERT_X509_GUID first byte
+
+  // SignatureListSize
+  esl[16] = static_cast<uint8_t>(sig_list_size & 0xFF);
+  esl[17] = static_cast<uint8_t>((sig_list_size >> 8) & 0xFF);
+  esl[18] = static_cast<uint8_t>((sig_list_size >> 16) & 0xFF);
+  esl[19] = static_cast<uint8_t>((sig_list_size >> 24) & 0xFF);
+
+  // SignatureSize
+  esl[24] = static_cast<uint8_t>(sig_size & 0xFF);
+  esl[25] = static_cast<uint8_t>((sig_size >> 8) & 0xFF);
+  esl[26] = static_cast<uint8_t>((sig_size >> 16) & 0xFF);
+  esl[27] = static_cast<uint8_t>((sig_size >> 24) & 0xFF);
+
+  // 16-byte owner GUID is left as zeros; certificate bytes follow.
+  std::memcpy(esl + 28 + 16, der_cert.data(), der_cert.size());
+
+  return blob;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: Generate a minimal self-signed DER certificate using OpenSSL.
+// ---------------------------------------------------------------------------
+
+static std::vector<uint8_t> makeSelfSignedDerCert(
+    const char* cn = "osquery-test-cert", int key_bits = 2048) {
+  EVP_PKEY* pkey = EVP_PKEY_new();
+  if (pkey == nullptr) {
+    return {};
+  }
+
+  RSA* rsa = RSA_new();
+  BIGNUM* exponent = BN_new();
+  BN_set_word(exponent, RSA_F4);
+  const int rc = RSA_generate_key_ex(rsa, key_bits, exponent, nullptr);
+  BN_free(exponent);
+  if (rc != 1) {
+    RSA_free(rsa);
+    EVP_PKEY_free(pkey);
+    return {};
+  }
+  EVP_PKEY_assign_RSA(pkey, rsa); // pkey takes ownership of rsa
+
+  X509* cert = X509_new();
+  if (cert == nullptr) {
+    EVP_PKEY_free(pkey);
+    return {};
+  }
+
+  X509_set_version(cert, 2);
+  ASN1_INTEGER_set(X509_get_serialNumber(cert), 1);
+  X509_gmtime_adj(X509_get_notBefore(cert), 0);
+  X509_gmtime_adj(X509_get_notAfter(cert), 365 * 24 * 3600L);
+  X509_set_pubkey(cert, pkey);
+
+  X509_NAME* name = X509_get_subject_name(cert);
+  X509_NAME_add_entry_by_txt(name,
+                             "CN",
+                             MBSTRING_ASC,
+                             reinterpret_cast<const unsigned char*>(cn),
+                             -1,
+                             -1,
+                             0);
+  X509_set_issuer_name(cert, name);
+
+  if (X509_sign(cert, pkey, EVP_sha256()) == 0) {
+    X509_free(cert);
+    EVP_PKEY_free(pkey);
+    return {};
+  }
+
+  int der_len = i2d_X509(cert, nullptr);
+  if (der_len <= 0) {
+    X509_free(cert);
+    EVP_PKEY_free(pkey);
+    return {};
+  }
+
+  std::vector<uint8_t> der(static_cast<std::size_t>(der_len));
+  uint8_t* ptr = der.data();
+  i2d_X509(cert, &ptr);
+
+  X509_free(cert);
+  EVP_PKEY_free(pkey);
+  return der;
+}
+
+// ===========================================================================
+// Edge-case tests (no real certificate required)
+// ===========================================================================
+
+// Content completely empty.
+TEST_F(SecurebootCertificatesTests, ParseEslData_TooShort_Empty) {
+  QueryData results;
+  parseEslData("", false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// Content shorter than minimum ESL header (28 bytes).
+TEST_F(SecurebootCertificatesTests, ParseEslData_TooShort_Partial) {
+  const std::string blob(27, '\x00');
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// ESL with a non-X.509 GUID should be skipped.
+TEST_F(SecurebootCertificatesTests, ParseEslData_NonX509GuidSkipped) {
+  // Use a first byte (0x26) that definitely doesn't match 0xA1.
+  const std::string blob =
+      buildEslBlob(0x26U, 20U, 0U, std::vector<uint8_t>(20, 0xAA));
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// ESL with X.509 GUID but sig_size too small to even contain owner GUID (16
+// bytes).
+TEST_F(SecurebootCertificatesTests, ParseEslData_SigSizeTooSmall) {
+  const std::string blob =
+      buildEslBlob(0xa1U, 16U, 0U, std::vector<uint8_t>(16, 0x00));
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// sig_list_size == 0 — parser must break immediately.
+TEST_F(SecurebootCertificatesTests, ParseEslData_ZeroSigListSize) {
+  std::string blob(28, '\x00');
+  uint8_t* data = reinterpret_cast<uint8_t*>(&blob[0]);
+  data[0] = 0xa1;
+  // sig_list_size bytes [16..19] are all zero → sig_list_size == 0.
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// sig_list_size extends past the buffer — must break.
+TEST_F(SecurebootCertificatesTests, ParseEslData_OversizedSigListSize) {
+  std::string blob(28, '\x00');
+  uint8_t* data = reinterpret_cast<uint8_t*>(&blob[0]);
+  data[0] = 0xa1;
+  // Set sig_list_size = 0xFFFFFFFF.
+  data[16] = 0xFF;
+  data[17] = 0xFF;
+  data[18] = 0xFF;
+  data[19] = 0xFF;
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  EXPECT_TRUE(results.empty());
+}
+
+// A non-zero sig_header_size means there is padding between the ESL header
+// and the first EFI_SIGNATURE_DATA entry.  The parser must skip it correctly.
+TEST_F(SecurebootCertificatesTests, ParseEslData_NonZeroSigHeaderSize) {
+  const auto der_cert = makeSelfSignedDerCert();
+  ASSERT_FALSE(der_cert.empty());
+
+  // sig_size = 16 (owner GUID) + cert bytes
+  const uint32_t sig_size = static_cast<uint32_t>(16U + der_cert.size());
+  // sig_header_size = 8 bytes of padding inserted between the ESL header and
+  // the first EFI_SIGNATURE_DATA entry.
+  constexpr uint32_t kSigHeaderSize = 8U;
+
+  // Build the signature payload: owner GUID (16 zeros) + cert.
+  // The sig_header_size padding is handled by buildEslBlob.
+  std::vector<uint8_t> payload(sig_size, 0x00);
+  // Copy DER cert after owner GUID in the payload.
+  std::memcpy(payload.data() + 16, der_cert.data(), der_cert.size());
+
+  const std::string blob =
+      buildEslBlob(0xa1U, sig_size, kSigHeaderSize, payload);
+
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+
+  // The cert should still be parsed correctly despite the header padding.
+  ASSERT_EQ(results.size(), 1U);
+  EXPECT_EQ(results[0].at("revoked"), "0");
+  EXPECT_EQ(results[0].at("common_name"), "osquery-test-cert");
+}
+
+// ===========================================================================
+// End-to-end tests with real self-signed DER certificates
+// ===========================================================================
+
+// A valid X.509 cert should produce exactly one row with expected field values.
+TEST_F(SecurebootCertificatesTests, ParseEslData_ValidX509Cert_OneRow) {
+  const auto der_cert = makeSelfSignedDerCert();
+  ASSERT_FALSE(der_cert.empty()) << "Failed to generate test certificate";
+
+  const std::string blob = buildX509EslBlob(der_cert);
+
+  QueryData results;
+  parseEslData(blob, /* revoked= */ false, "db", results);
+
+  ASSERT_EQ(results.size(), 1U);
+
+  const auto& row = results[0];
+  EXPECT_EQ(row.at("revoked"), "0");
+  EXPECT_EQ(row.at("path"), "db");
+  EXPECT_EQ(row.at("common_name"), "osquery-test-cert");
+  EXPECT_FALSE(row.at("sha1").empty());
+  EXPECT_FALSE(row.at("serial").empty());
+  EXPECT_EQ(row.at("self_signed"), "1");
+  EXPECT_EQ(row.at("key_algorithm"), "RSA");
+  EXPECT_EQ(row.at("key_strength"), "2048");
+}
+
+// Two concatenated ESL entries in the same blob should produce two rows.
+TEST_F(SecurebootCertificatesTests, ParseEslData_TwoEntries_TwoRows) {
+  const auto der_cert = makeSelfSignedDerCert();
+  ASSERT_FALSE(der_cert.empty()) << "Failed to generate test certificate";
+
+  const std::string single = buildX509EslBlob(der_cert);
+  // Concatenate two ESL entries.
+  const std::string blob = single + single;
+
+  QueryData results;
+  parseEslData(blob, /* revoked= */ true, "dbx", results);
+
+  ASSERT_EQ(results.size(), 2U);
+  EXPECT_EQ(results[0].at("revoked"), "1");
+  EXPECT_EQ(results[1].at("revoked"), "1");
+}
+
+// revoked=true and the path string must be propagated into every row.
+TEST_F(SecurebootCertificatesTests, ParseEslData_RevokedAndPathPropagated) {
+  const auto der_cert = makeSelfSignedDerCert();
+  ASSERT_FALSE(der_cert.empty());
+
+  const std::string blob = buildX509EslBlob(der_cert);
+
+  QueryData results;
+  parseEslData(blob, /* revoked= */ true, "dbx", results);
+
+  ASSERT_EQ(results.size(), 1U);
+  EXPECT_EQ(results[0].at("revoked"), "1");
+  EXPECT_EQ(results[0].at("path"), "dbx");
+}
+
+// revoked=false matches the "db" (allowlist) store.
+TEST_F(SecurebootCertificatesTests, ParseEslData_DbStoreNotRevoked) {
+  const auto der_cert = makeSelfSignedDerCert("osquery-db-cert");
+  ASSERT_FALSE(der_cert.empty());
+
+  const std::string blob = buildX509EslBlob(der_cert);
+
+  QueryData results;
+  parseEslData(blob, /* revoked= */ false, "db", results);
+
+  ASSERT_EQ(results.size(), 1U);
+  EXPECT_EQ(results[0].at("revoked"), "0");
+  EXPECT_EQ(results[0].at("common_name"), "osquery-db-cert");
+}
+
+// ESL blob with an X.509 GUID but garbled cert bytes must not crash.
+TEST_F(SecurebootCertificatesTests, ParseEslData_GarbageCertBytes_NoRow) {
+  // Build a sig payload of 16 (owner GUID) + 32 (junk cert bytes).
+  std::vector<uint8_t> payload(16 + 32, 0xDE);
+  const uint32_t sig_size = static_cast<uint32_t>(payload.size());
+  const std::string blob = buildEslBlob(0xa1U, sig_size, 0U, payload);
+
+  QueryData results;
+  ASSERT_NO_THROW(parseEslData(blob, false, "db", results));
+  // The DER parse will fail on junk bytes, so no rows should be added.
+  EXPECT_TRUE(results.empty());
+}
+
+// Verify that all expected column names are present in a result row.
+TEST_F(SecurebootCertificatesTests, ParseEslData_AllColumnsPresent) {
+  const auto der_cert = makeSelfSignedDerCert();
+  ASSERT_FALSE(der_cert.empty());
+
+  const std::string blob = buildX509EslBlob(der_cert);
+  QueryData results;
+  parseEslData(blob, false, "db", results);
+  ASSERT_EQ(results.size(), 1U);
+
+  const auto& row = results[0];
+  static const std::vector<std::string> expected_columns = {
+      "common_name",
+      "subject",
+      "issuer",
+      "not_valid_before",
+      "not_valid_after",
+      "sha1",
+      "serial",
+      "revoked",
+      "path",
+      "is_ca",
+      "self_signed",
+      "key_usage",
+      "authority_key_id",
+      "subject_key_id",
+      "signing_algorithm",
+      "key_algorithm",
+      "key_strength",
+  };
+  for (const auto& col : expected_columns) {
+    EXPECT_TRUE(row.count(col) > 0) << "Missing column: " << col;
+  }
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/prefetch.cpp
+++ b/osquery/tables/system/windows/prefetch.cpp
@@ -51,6 +51,7 @@ struct PrefetchFileInfo {
   LONGLONG last_run_time;
   std::string run_times;
   size_t run_count;
+  std::string executable_path;
 };
 
 struct PrefetchVolumeInfo {
@@ -107,6 +108,9 @@ typedef struct _PREFETCH_FILE_INFORMATION {
       FILETIME OtherRunTimes[7];
       DWORD Reserved2[2];
       DWORD RunCount;
+      DWORD Reserved3[2];
+      DWORD HashStringOffset;
+      DWORD HashStringSize;
     } v30v2, v31; // v31 does not seem to have substantial differences.
   } ext;
 } PREFETCH_FILE_INFORMATION, *PPREFETCH_FILE_INFORMATION;
@@ -130,6 +134,22 @@ typedef struct _DIRECTORY_STRING {
 #pragma pack(pop)
 
 } // namespace
+
+std::string parseExecutablePath(const std::vector<UCHAR>& data,
+                                DWORD hash_string_offset,
+                                DWORD hash_string_size) {
+  if (hash_string_offset == 0 ||
+      hash_string_offset + hash_string_size > data.size()) {
+    return {};
+  }
+  auto path_wstr = (PWCHAR)(&data[0] + hash_string_offset);
+  auto max_wchars = hash_string_size / sizeof(WCHAR);
+  auto path_len = wcsnlen_s(path_wstr, max_wchars);
+  if (path_len == 0 || path_len >= max_wchars) {
+    return {};
+  }
+  return wstringToString(path_wstr);
+}
 
 PrefetchHeader parseHeader(const PREFETCH_FILE_HEADER* header) {
   PrefetchHeader result;
@@ -165,7 +185,10 @@ PrefetchFileInfo parseFileInfo(
       }
     }
     result.run_times = osquery::join(run_times, ",");
-
+    result.executable_path =
+        parseExecutablePath(data,
+                            prefetch_file_info->ext.v30v2.HashStringOffset,
+                            prefetch_file_info->ext.v30v2.HashStringSize);
     break;
   case kPrefetchVersionWindows8:
     last_run_time = prefetch_file_info->ext.v26.LastRunTime;
@@ -321,6 +344,7 @@ void parsePrefetchData(RowYield& yield,
   auto r = make_table_row();
   r["path"] = file_path;
   r["filename"] = SQL_TEXT(header.filename);
+  r["executable_path"] = SQL_TEXT(file_info.executable_path);
   r["hash"] = header.prefetch_hash;
   r["size"] = INTEGER(header.file_size);
   r["accessed_files_count"] = INTEGER(file_info.files_count);

--- a/osquery/tables/system/windows/secureboot_certificates.cpp
+++ b/osquery/tables/system/windows/secureboot_certificates.cpp
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <Windows.h>
+#include <wincrypt.h>
+
+#include <osquery/core/tables.h>
+#include <osquery/logger/logger.h>
+#include <osquery/tables/system/secureboot.hpp>
+#include <osquery/tables/system/windows/wincert_utils.h>
+#include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/info/firmware.h>
+
+#include <boost/endian/conversion.hpp>
+#include <boost/optional.hpp>
+
+#include <cstdint>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+static const std::string kEfiImageSecurityDbGuid =
+    "{d719b2cb-3d3a-4596-a3bc-dad00e67656f}";
+
+static constexpr std::size_t kEslHeaderSize = 28U;
+
+static constexpr std::size_t kSignatureOwnerGuidSize = 16U;
+
+// First byte of EFI_CERT_X509_GUID as stored on disk in little-endian order.
+// EFI_CERT_X509_GUID = {0xa5c059a1, ...} -> disk byte 0 == 0xa1
+static constexpr uint8_t kX509GuidFirstByte = 0xa1U;
+
+// Minimum ESL payload size we consider meaningful.
+static constexpr std::size_t kMinEslSize = 28U;
+
+// Maximum EFI variable size we will allocate (4 MiB). Prevents unbounded
+// buffer growth when GetFirmwareEnvironmentVariableA keeps returning
+// ERROR_INSUFFICIENT_BUFFER with a bogus required size.
+static constexpr std::size_t kMaxEfiVarSize = 4U * 1024U * 1024U;
+
+using UniqueCertContext =
+    std::unique_ptr<const CERT_CONTEXT, decltype(&CertFreeCertificateContext)>;
+
+struct EfiCertInfo {
+  std::string common_name;
+  std::string subject;
+  std::string issuer;
+  std::time_t not_valid_before{0};
+  std::time_t not_valid_after{0};
+  std::string sha1;
+  std::string serial;
+  bool is_ca{false};
+  bool is_self_signed{false};
+  std::string key_usage;
+  std::string authority_key_id;
+  std::string subject_key_id;
+  std::string signing_algorithm;
+  std::string key_algorithm;
+  std::string key_strength;
+};
+
+// RAII wrapper for a Windows HANDLE that calls CloseHandle on destruction.
+struct ScopedHandle {
+  explicit ScopedHandle(HANDLE h) : handle(h) {}
+  ~ScopedHandle() {
+    if (handle != INVALID_HANDLE_VALUE && handle != nullptr) {
+      CloseHandle(handle);
+    }
+  }
+  ScopedHandle(const ScopedHandle&) = delete;
+  ScopedHandle& operator=(const ScopedHandle&) = delete;
+  HANDLE handle;
+};
+
+bool enableSystemEnvironmentNamePrivilege() {
+  TOKEN_PRIVILEGES token_privileges{};
+  token_privileges.PrivilegeCount = 1;
+
+  if (!LookupPrivilegeValueW(nullptr,
+                             L"SeSystemEnvironmentPrivilege",
+                             &token_privileges.Privileges[0].Luid)) {
+    auto error_code = GetLastError();
+    LOG(ERROR) << "secureboot: Failed to lookup the required privilege: "
+               << errorDwordToString(error_code);
+    return false;
+  }
+
+  token_privileges.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+  HANDLE raw_token{INVALID_HANDLE_VALUE};
+  if (OpenProcessToken(
+          GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &raw_token) == 0) {
+    auto error_code = GetLastError();
+    LOG(ERROR) << "secureboot: Failed to open the process token: "
+               << errorDwordToString(error_code);
+    return false;
+  }
+  ScopedHandle process_token(raw_token);
+
+  if (!AdjustTokenPrivileges(process_token.handle,
+                             FALSE,
+                             &token_privileges,
+                             sizeof(TOKEN_PRIVILEGES),
+                             nullptr,
+                             nullptr)) {
+    auto error_code = GetLastError();
+    LOG(ERROR) << "secureboot: Failed to adjust token privileges: "
+               << errorDwordToString(error_code);
+    return false;
+  }
+
+  auto error_code = GetLastError();
+  if (error_code == ERROR_NOT_ALL_ASSIGNED) {
+    LOG(ERROR) << "secureboot: SeSystemEnvironmentPrivilege could not be "
+                  "assigned (process may not be running as Administrator). "
+                  "EFI variable reads may fail."
+               << errorDwordToString(error_code);
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace
+
+boost::optional<EfiCertInfo> parseDerCertificate(const uint8_t* data,
+                                                 std::size_t len) {
+  UniqueCertContext cert(CertCreateCertificateContext(
+                             X509_ASN_ENCODING, data, static_cast<DWORD>(len)),
+                         CertFreeCertificateContext);
+  if (!cert) {
+    return boost::none;
+  }
+
+  EfiCertInfo info;
+  info.common_name = wstringToString(getCertificateCommonName(cert.get()));
+  info.subject = wstringToString(getCertificateSubjectName(cert.get()));
+  info.issuer = wstringToString(getCertificateIssuerName(cert.get()));
+
+  info.not_valid_before = getCertificateNotValidBefore(cert.get());
+  info.not_valid_after = getCertificateNotValidAfter(cert.get());
+
+  info.sha1 = wstringToString(getCertificateSHA1Digest(cert.get()));
+  info.serial = wstringToString(getCertificateSerialNumber(cert.get()));
+
+  info.is_self_signed = isCertificateSelfSigned(cert.get());
+  info.is_ca = isCertificateAuthority(cert.get());
+
+  info.key_usage = wstringToString(getCertificateKeyUsage(cert.get()));
+  info.authority_key_id =
+      wstringToString(getCertificateAuthorityKeyID(cert.get()));
+  info.subject_key_id = wstringToString(getCertificateSubjectKeyID(cert.get()));
+
+  info.signing_algorithm =
+      wstringToString(getCertificateSigningAlgorithm(cert.get()));
+  info.key_algorithm = wstringToString(getCertificateKeyAlgorithm(cert.get()));
+  info.key_strength = std::to_string(getCertificateKeyStrength(cert.get()));
+
+  return info;
+}
+
+std::string getEfiVariable(std::string namespace_guid,
+                           const std::string& db_name) {
+  std::vector<BYTE> buffer(65536);
+  while (true) {
+    DWORD buf_size = static_cast<DWORD>(buffer.size());
+    auto status = GetFirmwareEnvironmentVariableA(
+        db_name.c_str(), namespace_guid.c_str(), buffer.data(), buf_size);
+    if (status > 0) {
+      return std::string(buffer.begin(), buffer.begin() + status);
+    }
+    auto error = GetLastError();
+    if (error == ERROR_ENVVAR_NOT_FOUND) {
+      LOG(ERROR) << "secureboot_certificates: Unable to get EFI variable "
+                 << namespace_guid << "::" << db_name
+                 << ". Error: " << errorDwordToString(error);
+      return "";
+    }
+    if (error != ERROR_INSUFFICIENT_BUFFER) {
+      LOG(ERROR) << "secureboot_certificates: Unable to get EFI variable "
+                 << namespace_guid << "::" << db_name
+                 << ". Error: " << errorDwordToString(error);
+      return "";
+    }
+    // Guard against unbounded growth — EFI variables are never legitimately
+    // larger than a few megabytes.
+    std::size_t next_size = buffer.size() * 2;
+    if (next_size > kMaxEfiVarSize) {
+      LOG(ERROR) << "secureboot_certificates: EFI variable " << db_name
+                 << " exceeds maximum allowed size (" << kMaxEfiVarSize
+                 << " bytes). Aborting read.";
+      return "";
+    }
+    buffer.resize(next_size);
+  }
+}
+// Parse a sequence of concatenated EFI_SIGNATURE_LIST structures and add any
+// X.509 certificates found to results.
+void parseEslData(const std::string& content,
+                  bool revoked,
+                  const std::string& path,
+                  QueryData& results) {
+  if (content.size() < kMinEslSize) {
+    VLOG(1) << "secureboot_certificates: ESL data too short in " << path;
+    return;
+  }
+
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(content.data());
+  std::size_t head = 0;
+  const std::size_t total = content.size();
+
+  while (head < total) {
+    if (head + kEslHeaderSize > total) {
+      break;
+    }
+
+    const uint32_t sig_list_size =
+        boost::endian::load_little_u32(&data[head + 16]);
+    const uint32_t sig_header_size =
+        boost::endian::load_little_u32(&data[head + 20]);
+    const uint32_t sig_size = boost::endian::load_little_u32(&data[head + 24]);
+
+    // Validate sizes before advancing
+    if (sig_list_size == 0 || head + sig_list_size > total) {
+      VLOG(1) << "secureboot_certificates: Invalid sig_list_size at offset "
+              << head << " in " << path;
+      break;
+    }
+
+    // Only process X.509 certificate entries; skip hash entries and others.
+    if (data[head] != kX509GuidFirstByte) {
+      head += sig_list_size;
+      continue;
+    }
+
+    // Each EFI_SIGNATURE_DATA entry is sig_size bytes, prefixed with a 16-byte
+    // owner GUID. Guard against malformed data where sig_size is too small.
+    if (sig_size <= kSignatureOwnerGuidSize) {
+      head += sig_list_size;
+      continue;
+    }
+
+    // The signature data area follows the fixed header and optional
+    // SignatureHeader.
+    const std::size_t sigs_area_offset =
+        head + kEslHeaderSize + sig_header_size;
+    if (sigs_area_offset > head + sig_list_size) {
+      head += sig_list_size;
+      continue;
+    }
+
+    const std::size_t sigs_area_size =
+        (head + sig_list_size) - sigs_area_offset;
+    const std::size_t num_sigs = sigs_area_size / sig_size;
+
+    for (std::size_t i = 0; i < num_sigs; ++i) {
+      const std::size_t sig_offset = sigs_area_offset + (i * sig_size);
+      const std::size_t cert_offset = sig_offset + kSignatureOwnerGuidSize;
+      const std::size_t cert_size = sig_size - kSignatureOwnerGuidSize;
+
+      if (cert_offset + cert_size > total) {
+        break;
+      }
+
+      auto opt_cert_info = parseDerCertificate(&data[cert_offset], cert_size);
+      if (!opt_cert_info.has_value()) {
+        VLOG(1) << "secureboot_certificates: Failed to parse DER certificate "
+                   "at offset "
+                << cert_offset << " in " << path;
+        continue;
+      }
+
+      const auto& cert_info = opt_cert_info.value();
+
+      Row row;
+      row["common_name"] = SQL_TEXT(cert_info.common_name);
+      row["subject"] = SQL_TEXT(cert_info.subject);
+      row["issuer"] = SQL_TEXT(cert_info.issuer);
+      row["not_valid_before"] = INTEGER(cert_info.not_valid_before);
+      row["not_valid_after"] = INTEGER(cert_info.not_valid_after);
+      row["sha1"] = SQL_TEXT(cert_info.sha1);
+      row["serial"] = SQL_TEXT(cert_info.serial);
+      row["revoked"] = INTEGER(revoked ? 1 : 0);
+      row["path"] = SQL_TEXT(path);
+      row["is_ca"] = INTEGER(cert_info.is_ca ? 1 : 0);
+      row["self_signed"] = INTEGER(cert_info.is_self_signed ? 1 : 0);
+      row["key_usage"] = SQL_TEXT(cert_info.key_usage);
+      row["authority_key_id"] = SQL_TEXT(cert_info.authority_key_id);
+      row["subject_key_id"] = SQL_TEXT(cert_info.subject_key_id);
+      row["signing_algorithm"] = SQL_TEXT(cert_info.signing_algorithm);
+      row["key_algorithm"] = SQL_TEXT(cert_info.key_algorithm);
+      row["key_strength"] = SQL_TEXT(cert_info.key_strength);
+
+      results.push_back(std::move(row));
+    }
+
+    head += sig_list_size;
+  }
+}
+
+QueryData genSecureBootCertificates(QueryContext& context) {
+  QueryData results;
+  static const auto kPrivilegeInitializationStatus{
+      enableSystemEnvironmentNamePrivilege()};
+
+  auto opt_firmware_kind = getFirmwareKind();
+  if (!opt_firmware_kind.has_value()) {
+    LOG(ERROR) << "secureboot: Failed to determine the firmware type";
+    return {};
+  }
+
+  const auto& firmware_kind = opt_firmware_kind.value();
+  if (firmware_kind != FirmwareKind::Uefi) {
+    VLOG(1) << "secureboot: Secure boot is only supported on UEFI firmware";
+    return {};
+  }
+
+  if (!kPrivilegeInitializationStatus) {
+    VLOG(1) << "secureboot: SE_SYSTEM_ENVIRONMENT_NAME privilege was not "
+               "acquired. EFI variable reads may fail if not running as "
+               "Administrator.";
+  }
+
+  for (const auto& search_db : {"db", "dbx"}) {
+    auto bytes_read = getEfiVariable(kEfiImageSecurityDbGuid, search_db);
+    if (bytes_read.empty()) {
+      VLOG(1) << "secureboot_certificates: Skipping empty EFI variable "
+              << search_db;
+      continue;
+    }
+    parseEslData(bytes_read, search_db == "dbx", search_db, results);
+  }
+
+  return results;
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wincert_utils.cpp
+++ b/osquery/tables/system/windows/wincert_utils.cpp
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#include <osquery/tables/system/windows/wincert_utils.h>
+
+#include <map>
+
+#include <Wintrust.h>
+
+#include <boost/algorithm/string/join.hpp>
+
+#include <osquery/utils/conversions/windows/strings.h>
+#include <osquery/utils/conversions/windows/windows_time.h>
+
+namespace osquery {
+namespace tables {
+
+namespace {
+
+static constexpr DWORD kCertEncoding = PKCS_7_ASN_ENCODING | X509_ASN_ENCODING;
+
+const std::map<unsigned long, std::wstring> kKeyUsages = {
+    {CERT_DATA_ENCIPHERMENT_KEY_USAGE, L"Data Encipherment"},
+    {CERT_DIGITAL_SIGNATURE_KEY_USAGE, L"Digital Signature"},
+    {CERT_KEY_AGREEMENT_KEY_USAGE, L"Key Agreement"},
+    {CERT_KEY_CERT_SIGN_KEY_USAGE, L"Key Cert Sign"},
+    {CERT_KEY_ENCIPHERMENT_KEY_USAGE, L"Key Encipherment"},
+    {CERT_NON_REPUDIATION_KEY_USAGE, L"Non Repudiation"},
+    {CERT_OFFLINE_CRL_SIGN_KEY_USAGE, L"CRL Sign"}};
+
+/**
+ * @brief Helper to convert a name blob to a wide string.
+ */
+std::wstring getCertNameToStr(const CERT_NAME_BLOB& name_blob, DWORD type) {
+  auto len = CertNameToStrW(
+      kCertEncoding, const_cast<PCERT_NAME_BLOB>(&name_blob), type, nullptr, 0);
+  if (len <= 1) {
+    return {};
+  }
+  std::vector<WCHAR> certName(len);
+  CertNameToStrW(kCertEncoding,
+                 const_cast<PCERT_NAME_BLOB>(&name_blob),
+                 type,
+                 certName.data(),
+                 len);
+  return std::wstring(certName.data());
+}
+
+/**
+ * @brief Decodes a certificate extension into a raw buffer.
+ */
+bool decodeCertificateExtension(PCCERT_CONTEXT certContext,
+                                const char* oid,
+                                const char* structType,
+                                std::vector<BYTE>& buffer) {
+  auto extension = CertFindExtension(oid,
+                                     certContext->pCertInfo->cExtension,
+                                     certContext->pCertInfo->rgExtension);
+  if (extension == nullptr) {
+    return false;
+  }
+
+  DWORD decodedLen = 0;
+  if (!CryptDecodeObjectEx(kCertEncoding,
+                           structType,
+                           extension->Value.pbData,
+                           extension->Value.cbData,
+                           0,
+                           nullptr,
+                           nullptr,
+                           &decodedLen)) {
+    return false;
+  }
+
+  buffer.resize(decodedLen);
+  return CryptDecodeObjectEx(kCertEncoding,
+                             structType,
+                             extension->Value.pbData,
+                             extension->Value.cbData,
+                             0,
+                             nullptr,
+                             buffer.data(),
+                             &decodedLen);
+}
+
+std::wstring cryptOIDToString(const char* objId) {
+  if (objId == nullptr) {
+    return {};
+  }
+  auto oidInfo =
+      CryptFindOIDInfo(CRYPT_OID_INFO_OID_KEY, const_cast<char*>(objId), 0);
+  return oidInfo ? oidInfo->pwszName : L"";
+}
+
+} // namespace
+
+std::wstring getCertificateSubjectName(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  return getCertNameToStr(certContext->pCertInfo->Subject,
+                          CERT_X500_NAME_STR | CERT_NAME_STR_REVERSE_FLAG);
+}
+
+std::wstring getCertificateIssuerName(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  return getCertNameToStr(certContext->pCertInfo->Issuer,
+                          CERT_X500_NAME_STR | CERT_NAME_STR_REVERSE_FLAG);
+}
+
+std::wstring getCertificateCommonName(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr) {
+    return {};
+  }
+  DWORD len = CertGetNameStringW(
+      certContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, nullptr, nullptr, 0);
+  if (len <= 1) {
+    return {};
+  }
+  std::vector<WCHAR> name(len);
+  CertGetNameStringW(
+      certContext, CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, nullptr, name.data(), len);
+  return std::wstring(name.data());
+}
+
+std::wstring getCertificateSerialNumber(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  std::string serial;
+  toHexStr(certContext->pCertInfo->SerialNumber.pbData,
+           certContext->pCertInfo->SerialNumber.pbData +
+               certContext->pCertInfo->SerialNumber.cbData,
+           serial,
+           true);
+  return stringToWstring(serial);
+}
+
+std::wstring getCertificateSHA1Digest(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr) {
+    return {};
+  }
+  std::vector<BYTE> hash;
+  unsigned long hashLen = 0;
+  if (!CertGetCertificateContextProperty(
+          certContext, CERT_HASH_PROP_ID, nullptr, &hashLen)) {
+    return {};
+  }
+  hash.resize(hashLen);
+  if (!CertGetCertificateContextProperty(
+          certContext, CERT_HASH_PROP_ID, hash.data(), &hashLen)) {
+    return {};
+  }
+  std::string digest;
+  toHexStr(hash.begin(), hash.end(), digest);
+  return stringToWstring(digest);
+}
+
+bool isCertificateAuthority(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return false;
+  }
+  std::vector<BYTE> buffer;
+  if (decodeCertificateExtension(certContext,
+                                 szOID_BASIC_CONSTRAINTS2,
+                                 X509_BASIC_CONSTRAINTS2,
+                                 buffer)) {
+    auto constraints =
+        reinterpret_cast<PCERT_BASIC_CONSTRAINTS2_INFO>(buffer.data());
+    return constraints->fCA != FALSE;
+  }
+  return false;
+}
+
+bool isCertificateSelfSigned(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return false;
+  }
+  return WTHelperCertIsSelfSigned(kCertEncoding, certContext->pCertInfo) !=
+         FALSE;
+}
+
+std::wstring getCertificateKeyUsage(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  uint32_t usage = 0;
+  if (!CertGetIntendedKeyUsage(kCertEncoding,
+                               certContext->pCertInfo,
+                               reinterpret_cast<BYTE*>(&usage),
+                               4)) {
+    return {};
+  }
+  std::vector<std::wstring> results;
+  for (const auto& kv : kKeyUsages) {
+    if (usage & kv.first) {
+      results.push_back(kv.second);
+    }
+  }
+  return boost::algorithm::join(results, L", ");
+}
+
+std::wstring getCertificateSigningAlgorithm(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  return cryptOIDToString(certContext->pCertInfo->SignatureAlgorithm.pszObjId);
+}
+
+std::wstring getCertificateKeyAlgorithm(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  return cryptOIDToString(
+      certContext->pCertInfo->SubjectPublicKeyInfo.Algorithm.pszObjId);
+}
+
+DWORD getCertificateKeyStrength(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return 0;
+  }
+  return CertGetPublicKeyLength(kCertEncoding,
+                                &certContext->pCertInfo->SubjectPublicKeyInfo);
+}
+
+std::time_t getCertificateNotValidBefore(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return 0;
+  }
+  return static_cast<std::time_t>(
+      filetimeToUnixtime(certContext->pCertInfo->NotBefore));
+}
+
+std::time_t getCertificateNotValidAfter(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return 0;
+  }
+  return static_cast<std::time_t>(
+      filetimeToUnixtime(certContext->pCertInfo->NotAfter));
+}
+
+std::wstring getCertificateAuthorityKeyID(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  std::vector<BYTE> buffer;
+  if (decodeCertificateExtension(certContext,
+                                 szOID_AUTHORITY_KEY_IDENTIFIER2,
+                                 X509_AUTHORITY_KEY_ID2,
+                                 buffer)) {
+    auto authKeyId =
+        reinterpret_cast<PCERT_AUTHORITY_KEY_ID2_INFO>(buffer.data());
+    if (authKeyId->KeyId.cbData > 0) {
+      std::string keyId;
+      toHexStr(authKeyId->KeyId.pbData,
+               authKeyId->KeyId.pbData + authKeyId->KeyId.cbData,
+               keyId);
+      return stringToWstring(keyId);
+    }
+  }
+  return {};
+}
+
+std::wstring getCertificateSubjectKeyID(PCCERT_CONTEXT certContext) {
+  if (certContext == nullptr || certContext->pCertInfo == nullptr) {
+    return {};
+  }
+  std::vector<BYTE> buffer;
+  if (decodeCertificateExtension(certContext,
+                                 szOID_SUBJECT_KEY_IDENTIFIER,
+                                 szOID_SUBJECT_KEY_IDENTIFIER,
+                                 buffer)) {
+    auto keyId = reinterpret_cast<PCRYPT_DATA_BLOB>(buffer.data());
+    if (keyId->cbData > 0) {
+      std::string skid;
+      toHexStr(keyId->pbData, keyId->pbData + keyId->cbData, skid);
+      return stringToWstring(skid);
+    }
+  }
+  return {};
+}
+
+} // namespace tables
+} // namespace osquery

--- a/osquery/tables/system/windows/wincert_utils.h
+++ b/osquery/tables/system/windows/wincert_utils.h
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2014-present, The osquery authors
+ *
+ * This source code is licensed as defined by the LICENSE file found in the
+ * root directory of this source tree.
+ *
+ * SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <ctime>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#include <wincrypt.h>
+
+#include <boost/algorithm/hex.hpp>
+
+namespace osquery {
+namespace tables {
+
+/**
+ * @brief Helper to convert a byte range to a hex string.
+ */
+template <typename Iterator>
+inline void toHexStr(Iterator begin,
+                     Iterator end,
+                     std::string& output,
+                     bool littleEndian = false) {
+  std::string s = std::string(begin, end);
+  if (littleEndian) {
+    boost::algorithm::hex(s.rbegin(), s.rend(), std::back_inserter(output));
+  } else {
+    boost::algorithm::hex(s, std::back_inserter(output));
+  }
+}
+
+// Public API with mandatory null-checks on PCCERT_CONTEXT
+
+std::wstring getCertificateSubjectName(PCCERT_CONTEXT certContext);
+std::wstring getCertificateIssuerName(PCCERT_CONTEXT certContext);
+std::wstring getCertificateCommonName(PCCERT_CONTEXT certContext);
+std::wstring getCertificateSerialNumber(PCCERT_CONTEXT certContext);
+std::wstring getCertificateSHA1Digest(PCCERT_CONTEXT certContext);
+bool isCertificateAuthority(PCCERT_CONTEXT certContext);
+bool isCertificateSelfSigned(PCCERT_CONTEXT certContext);
+std::wstring getCertificateKeyUsage(PCCERT_CONTEXT certContext);
+std::wstring getCertificateSigningAlgorithm(PCCERT_CONTEXT certContext);
+std::wstring getCertificateKeyAlgorithm(PCCERT_CONTEXT certContext);
+std::wstring getCertificateSubjectKeyID(PCCERT_CONTEXT certContext);
+std::wstring getCertificateAuthorityKeyID(PCCERT_CONTEXT certContext);
+DWORD getCertificateKeyStrength(PCCERT_CONTEXT certContext);
+std::time_t getCertificateNotValidBefore(PCCERT_CONTEXT certContext);
+std::time_t getCertificateNotValidAfter(PCCERT_CONTEXT certContext);
+
+} // namespace tables
+} // namespace osquery

--- a/specs/CMakeLists.txt
+++ b/specs/CMakeLists.txt
@@ -257,6 +257,7 @@ function(generateNativeTables)
     "posix/usb_devices.table:linux,macos"
     "posix/user_events.table:linux,macos"
     "secureboot.table:linux,macos,windows"
+    "secureboot_certificates.table:linux,windows"
     "sleuthkit/device_file.table:linux,macos,windows"
     "sleuthkit/device_hash.table:linux,macos,windows"
     "sleuthkit/device_partitions.table:linux,macos,windows"

--- a/specs/secureboot_certificates.table
+++ b/specs/secureboot_certificates.table
@@ -1,5 +1,6 @@
 table_name("secureboot_certificates")
 description("X.509 certificates from UEFI Secure Boot signature databases (db and dbx EFI variables). Useful for monitoring CA expiry and adoption of updated certificates (e.g. Microsoft UEFI CA 2023).")
+platforms(["linux", "windows"])
 schema([
     Column("common_name", TEXT, "Certificate CommonName"),
     Column("subject", TEXT, "Certificate subject distinguished name"),
@@ -9,7 +10,7 @@ schema([
     Column("sha1", TEXT, "SHA1 hash of the raw certificate contents", collate="nocase"),
     Column("serial", TEXT, "Certificate serial number", collate="nocase"),
     Column("revoked", INTEGER, "1 if the certificate is in the dbx revocation list, 0 if it is in the db allowlist"),
-    Column("path", TEXT, "Path to the EFI variable file"),
+    Column("path", TEXT, "Path to the EFI variable file or EFI variable name"),
     Column("is_ca", INTEGER, "1 if the certificate is a CA, 0 otherwise"),
     Column("self_signed", INTEGER, "1 if the certificate is self-signed, 0 otherwise"),
     Column("key_usage", TEXT, "Certificate key usage extension string"),

--- a/specs/windows/prefetch.table
+++ b/specs/windows/prefetch.table
@@ -13,7 +13,8 @@ schema([
     Column("accessed_files_count", INTEGER, "Number of files accessed."),
     Column("accessed_directories_count", INTEGER, "Number of directories accessed."),
     Column("accessed_files", TEXT, "Files accessed by application within ten seconds of launch."),
-    Column("accessed_directories", TEXT, "Directories accessed by application within ten seconds of launch.")
+    Column("accessed_directories", TEXT, "Directories accessed by application within ten seconds of launch."),
+    Column("executable_path", TEXT, "Full path of the executable.")
 ])
 implementation("prefetch@genPrefetch", generator=True)
 examples([

--- a/tests/integration/tables/prefetch.cpp
+++ b/tests/integration/tables/prefetch.cpp
@@ -32,6 +32,7 @@ TEST_F(PrefetchTest, test_sanity) {
   ValidationMap row_map = {
       {"path", NonEmptyString},
       {"filename", NormalType},
+      {"executable_path", NormalType},
       {"hash", NormalType},
       {"last_run_time", IntType},
       {"other_run_times", NormalType},


### PR DESCRIPTION
# SecureBoot Certificates for Windows

## Summary

This PR adds the Windows implementation of the `secureboot_certificates` table in osquery. It ensures that certificates from the UEFI `db` and `dbx` databases are correctly parsed and reported.

It adds:
- Extraction of certificate attributes (subject, issuer etc)
-  Adding utility functions to be used for certificate parsing 

---

## Changes

### 1. Schema Updates
```
specs/secureboot_certificates.table
```
Added certificate data rows for windows:

- subject
- issuer
- common name
- path  
- is_ca  
- self_signed  
- key_usage  
- authority_key_id  
- subject_key_id  
- signing_algorithm  
- key_algorithm  
- key_strength  

---

### 2. Windows Implementation 
File:
```
osquery/tables/system/windows/secureboot_certificates.cpp
```
- Fixed `parseEslData`
- Aligned parsing with `GetFirmwareEnvironmentVariableA` output format
---
### UEFI Reference

- Spec: UEFI v2.10
- Section: Secure Boot & Driver Signing (32.4.1)

Key validation:
- X.509 detected via `EFI_CERT_X509_GUID`

Closes: [#8884](https://github.com/osquery/osquery/issues/8884)
secureboot_certificates table for windows