### PR TITLE
Fix macOS build for Boost

### DIFF
--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -150,10 +150,11 @@ function(importBoostInterfaceLibraries)
 
   # Clang 16+ rejects static_cast<T>(expr) as a non-type template argument for
   # enum types, even in C++17 mode. Force-include a header that pre-defines the
-  # include guard for boost/mpl/aux_/static_cast.hpp and replaces the macro
-  # with a C-style cast, which is the fix Boost applied in 1.82. Also silence
-  # the related enum-constexpr-conversion warning.
+  # include guard for boost/mpl/aux_/static_cast.hpp and replaces the macro with
+  # a constexpr wrapper that returns T, matching the fix Boost applied in 1.82.
+  # Also silence the related enum-constexpr-conversion warning.
   if(PLATFORM_MACOS)
+    # This workaround can hopefully be removed when Boost is updated
     get_filename_component(boost_cmake_dir "${BOOST_ROOT}" DIRECTORY)
     target_compile_options(thirdparty_boost_mpl INTERFACE
       -Wno-enum-constexpr-conversion

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -585,6 +585,8 @@ function(generateBoostThread)
       Threads::Threads
     )
   endif()
+
+  target_compile_features(thirdparty_boost_thread PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostLocale)
@@ -722,6 +724,8 @@ function(generateBoostFilesystem)
       thirdparty_boost_winapi
     )
   endif()
+
+  target_compile_features(thirdparty_boost_filesystem PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostContext)

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -153,7 +153,7 @@ function(importBoostInterfaceLibraries)
   # include guard for boost/mpl/aux_/static_cast.hpp and replaces the macro
   # with a C-style cast, which is the fix Boost applied in 1.82. Also silence
   # the related enum-constexpr-conversion warning.
-  if(PLATFORM_MACOS OR PLATFORM_LINUX)
+  if(PLATFORM_MACOS)
     get_filename_component(boost_cmake_dir "${BOOST_ROOT}" DIRECTORY)
     target_compile_options(thirdparty_boost_mpl INTERFACE
       -Wno-enum-constexpr-conversion

--- a/libraries/cmake/source/boost/CMakeLists.txt
+++ b/libraries/cmake/source/boost/CMakeLists.txt
@@ -38,6 +38,8 @@ function(boostMain)
     thirdparty_boost_scope_exit
     thirdparty_boost_circular_buffer
   )
+
+  target_compile_features(thirdparty_boost INTERFACE cxx_std_17)
 endfunction()
 
 function(importBoostInterfaceLibrary folder_name)
@@ -146,11 +148,17 @@ function(importBoostInterfaceLibraries)
     BOOST_NO_CXX98_FUNCTION_BASE
   )
 
-  # silence enum constexpr conversion for MPL on newer Clang versions
+  # Clang 16+ rejects static_cast<T>(expr) as a non-type template argument for
+  # enum types, even in C++17 mode. Force-include a header that pre-defines the
+  # include guard for boost/mpl/aux_/static_cast.hpp and replaces the macro
+  # with a C-style cast, which is the fix Boost applied in 1.82. Also silence
+  # the related enum-constexpr-conversion warning.
   if(PLATFORM_MACOS OR PLATFORM_LINUX)
-     target_compile_options(thirdparty_boost_mpl INTERFACE
-       -Wno-enum-constexpr-conversion
-      )
+    get_filename_component(boost_cmake_dir "${BOOST_ROOT}" DIRECTORY)
+    target_compile_options(thirdparty_boost_mpl INTERFACE
+      -Wno-enum-constexpr-conversion
+      "-include" "${boost_cmake_dir}/mpl_static_cast_fix.hpp"
+    )
   endif()
 
   # Additional settings for the libraries we just imported
@@ -277,6 +285,8 @@ function(generateBoostSerialization)
       thirdparty_boost_serialization
       thirdparty_boost_array
   )
+
+  target_compile_features(thirdparty_boost_serialization PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostAtomic)
@@ -368,6 +378,8 @@ function(generateBoostAtomic)
       thirdparty_boost_predef
       thirdparty_boost_preprocessor
   )
+
+  target_compile_features(thirdparty_boost_atomic PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostChrono)
@@ -413,6 +425,8 @@ function(generateBoostChrono)
       thirdparty_boost_utility
       thirdparty_boost_winapi
   )
+
+  target_compile_features(thirdparty_boost_chrono PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostContainer)
@@ -467,6 +481,8 @@ function(generateBoostContainer)
       thirdparty_boost_type_traits
       thirdparty_boost_winapi
   )
+
+  target_compile_features(thirdparty_boost_container PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostRandom)
@@ -499,6 +515,8 @@ function(generateBoostRandom)
       thirdparty_boost_type_traits
       thirdparty_boost_utility
   )
+
+  target_compile_features(thirdparty_boost_random PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostThread)
@@ -670,6 +688,8 @@ function(generateBoostLocale)
       thirdparty_boost_thread
       thirdparty_boost_unordered
   )
+
+  target_compile_features(thirdparty_boost_locale PRIVATE cxx_std_17)
 endfunction()
 
 function(generateBoostFilesystem)
@@ -886,6 +906,8 @@ function(generateBoostContext)
       BOOST_CONTEXT_STATIC_LINK
       BOOST_CONTEXT_EXPORT
   )
+
+  target_compile_features(thirdparty_boost_context PRIVATE cxx_std_17)
 endfunction()
 
 boostMain()

--- a/libraries/cmake/source/boost/mpl_static_cast_fix.hpp
+++ b/libraries/cmake/source/boost/mpl_static_cast_fix.hpp
@@ -1,0 +1,79 @@
+// Workaround for Clang 16+ constant expression issues with Boost MPL 1.77.
+// (Fixed in Boost 1.82.)
+//
+// Root cause (two interlocking problems):
+//
+// 1) BOOST_MPL_AUX_STATIC_CAST(T, expr) expands to static_cast<T>(expr) or
+//    (T)(expr). When T is an enum type and expr is int, this is an explicit
+//    int-to-enum conversion. C++17 [temp.arg.nontype] only permits IMPLICIT
+//    conversions ("converted constant expression") in non-type template
+//    arguments, so the explicit cast is rejected.
+//
+//    Fix: Replace the macro with a constexpr function template that returns
+//    type T. Because the return type is already T, no conversion is needed
+//    at the call site. The explicit cast happens inside the constexpr function
+//    body where explicit conversions are fully allowed.
+//
+// 2) The boost::numeric::*_mixture_enum enums (udt_builtin_mixture_enum,
+//    sign_mixture_enum, int_float_mixture_enum) have values 0-3 with no
+//    fixed underlying type. C++17 [dcl.enum] gives them a valid range of
+//    [0,3] (2-bit unsigned). When integral_c<T,0>::prior or
+//    integral_c<T,3>::next is instantiated the compiler computes T(-1) or
+//    T(4), both out-of-range, which is undefined behaviour and therefore not
+//    a constant expression — rejected by Clang 16+.
+//
+//    Fix: Pre-empt those three enum headers and redeclare the enums with a
+//    fixed ": int" underlying type so that every int value is in-range and
+//    the computed prior/next values are valid constant expressions.
+//
+// ── Part 1: fix the boost::numeric enum valid ranges ─────────────────────────
+
+// Pre-empt udt_builtin_mixture_enum.hpp
+#define BOOST_NUMERIC_CONVERSION_UDT_BUILTIN_MIXTURE_ENUM_FLC_12NOV2002_HPP
+namespace boost { namespace numeric {
+  enum udt_builtin_mixture_enum : int {
+     builtin_to_builtin
+    ,builtin_to_udt
+    ,udt_to_builtin
+    ,udt_to_udt
+  };
+} }
+
+// Pre-empt sign_mixture_enum.hpp
+#define BOOST_NUMERIC_CONVERSION_SIGN_MIXTURE_ENUM_FLC_12NOV2002_HPP
+namespace boost { namespace numeric {
+  enum sign_mixture_enum : int {
+     unsigned_to_unsigned
+    ,signed_to_signed
+    ,signed_to_unsigned
+    ,unsigned_to_signed
+  };
+} }
+
+// Pre-empt int_float_mixture_enum.hpp
+#define BOOST_NUMERIC_CONVERSION_INT_FLOAT_MIXTURE_ENUM_FLC_12NOV2002_HPP
+namespace boost { namespace numeric {
+  enum int_float_mixture_enum : int {
+     integral_to_integral
+    ,integral_to_float
+    ,float_to_integral
+    ,float_to_float
+  };
+} }
+
+// ── Part 2: fix BOOST_MPL_AUX_STATIC_CAST ────────────────────────────────────
+
+// Constexpr function returning T directly so the call-site expression has type
+// T and no implicit int→enum conversion is required at the template-argument
+// position. The static_cast happens inside the function body where explicit
+// conversions are allowed, and with the fixed-int underlying type above the
+// cast is always well-defined.
+template<typename T, typename U>
+constexpr T boost_mpl_static_cast_workaround(U x) {
+    return static_cast<T>(x);
+}
+
+// Pre-empt static_cast.hpp (its include guard is BOOST_MPL_AUX_STATIC_CAST_HPP_INCLUDED)
+// so our definition below is not overridden.
+#define BOOST_MPL_AUX_STATIC_CAST_HPP_INCLUDED
+#define BOOST_MPL_AUX_STATIC_CAST(T, expr) (::boost_mpl_static_cast_workaround<T>(expr))

--- a/libraries/cmake/source/boost/mpl_static_cast_fix.hpp
+++ b/libraries/cmake/source/boost/mpl_static_cast_fix.hpp
@@ -1,3 +1,12 @@
+// Copyright (c) 2014-present, The osquery authors
+//
+// This source code is licensed as defined by the LICENSE file found in the
+// root directory of this source tree.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+#pragma once
+
 // Workaround for Clang 16+ constant expression issues with Boost MPL 1.77.
 // (Fixed in Boost 1.82.)
 //


### PR DESCRIPTION
https://github.com/osquery/osquery/pull/8871 seems to have broken the build (not sure why it was not picked up by the initial CI run before merging to master)

This patching will be replaced by the boost updates coming in #8869 