### PR TITLE
Scan XDG Base Directory Firefox profiles in firefox_addons

### DIFF
--- a/osquery/tables/applications/browser_firefox.cpp
+++ b/osquery/tables/applications/browser_firefox.cpp
@@ -32,8 +32,15 @@ namespace {
 const std::vector<std::string> kFirefoxPaths = {
     "/Library/Application Support/Firefox/Profiles/"};
 #elif defined(__linux__)
+// Firefox 147 added support for the XDG Base Directory Specification:
+// new profiles are created under $XDG_CONFIG_HOME/mozilla/firefox/
+// (~/.config/mozilla/firefox/ by default), while existing installs keep
+// using ~/.mozilla/firefox/. Both locations need to be scanned since
+// which one is in use depends on when the profile was created.
 const std::vector<std::string> kFirefoxPaths = {
-    "/.mozilla/firefox/", "/snap/firefox/common/.mozilla/firefox/"};
+    "/.mozilla/firefox/",
+    "/snap/firefox/common/.mozilla/firefox/",
+    "/.config/mozilla/firefox/"};
 #elif defined(WIN32)
 const std::vector<std::string> kFirefoxPaths = {
     "\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles"};


### PR DESCRIPTION
Fixes #8985

Firefox 147 shipped support for the XDG Base Directory Specification (https://bugzilla.mozilla.org/show_bug.cgi?id=259356). On Linux, any profile created after that upgrade lives under `$XDG_CONFIG_HOME/mozilla/firefox/` (`~/.config/mozilla/firefox/` by default) instead of the old `~/.mozilla/firefox/`. Existing profiles are left where they are, so both locations can be in use depending on when the profile was created.

`firefox_addons` only scans `kFirefoxPaths`, which on Linux is just `~/.mozilla/firefox/` and the snap path. For a fresh profile with no pre-existing `~/.mozilla`, that means the table silently returns nothing, matching the repro in the issue.

This adds `/.config/mozilla/firefox/` as a third entry, same pattern as the existing snap-vs-native split. `genFirefoxAddons` already skips directories that don't exist (`listDirectoriesInDirectory` failure just continues the loop), so this doesn't change behavior for anyone still on the legacy layout.

I didn't add support for a custom `$XDG_CONFIG_HOME` — osquery enumerates every user on the box from `usersFromContext`, and the running process's own environment variable doesn't necessarily apply to other users' home directories, so hardcoding the spec's own default path felt safer than reading the env var and applying it universally. Happy to revisit if that's wrong.

No build environment available here to run the test suite, so this is verified by reading `browser_firefox.cpp` and confirming the new path only affects the Linux branch and follows the same join logic (`fs::path(directory) / path`) as the other two entries.
