### PR TITLE
Add .devin path to vscode_extensions for the Windsurf rebrand

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -38,6 +38,10 @@ const std::vector<std::pair<std::string, std::string>> KPathList = {
     {".cursor-server", "cursor"},
     {".windsurf", "windsurf"},
     {".windsurf-server", "windsurf"},
+    // Windsurf was rebranded to Devin Desktop in June 2026. New installs
+    // write extensions under .devin instead of .windsurf; the legacy path
+    // above is still read for machines that haven't been touched since.
+    {".devin", "windsurf"},
     {".trae", "trae"},
     {".trae-server", "trae"},
 };


### PR DESCRIPTION
Fixes #8984

Windsurf was rebranded to Devin Desktop in June 2026 (https://devin.ai/blog/windsurf-is-now-devin-desktop/). New installs write their extensions.json under `~/.devin/extensions/` instead of `~/.windsurf/extensions/`, confirmed against Devin's own docs (https://docs.devin.ai/desktop/devin-desktop-faq), which say the app now derives its dot-folder from the current product name and keeps the legacy `.windsurf` path readable for existing machines.

`vscode_extensions` only had `.windsurf` and `.windsurf-server` in `KPathList`, so a fresh Devin Desktop install with no old `.windsurf` folder wouldn't show up in the table at all.

Added `.devin` alongside the existing entries, still labeled `vscode_edition = 'windsurf'` since it's the same application, just renamed. I didn't add a `.devin-server` remote-SSH variant — I couldn't confirm that path actually exists for Devin Desktop, and I'd rather leave it out than guess.

No build available here, verified by reading `vscode_extensions.cpp` — the new entry follows the exact same shape as every other row in `KPathList` and goes through the same `pathExists` guard before anything is read.
