### PR TITLE
Fix wrong end-iterator guard in vscode_extensions (one-past-end deref)

### DIFF
--- a/osquery/tables/applications/vscode_extensions.cpp
+++ b/osquery/tables/applications/vscode_extensions.cpp
@@ -104,7 +104,7 @@ void genReadJSONAndAddExtensionRows(const std::string& uid,
     // present and in every example checked, metadata.id is present and has the
     // same value (on Windows, macOS, and Linux and multiple VSCode forks)
     it = metadata.FindMember("id");
-    if (it != identifier.MemberEnd() && it->value.IsString()) {
+    if (it != metadata.MemberEnd() && it->value.IsString()) {
       r["uuid"] = it->value.GetString();
     }
 


### PR DESCRIPTION
In `genReadJSONAndAddExtensionRows` (`osquery/tables/applications/vscode_extensions.cpp`), the lookup for `metadata.id` is guarded against the wrong object's end iterator:

```cpp
it = metadata.FindMember("id");
if (it != identifier.MemberEnd() && it->value.IsString()) {
  r["uuid"] = it->value.GetString();
}
```

`identifier` and `metadata` are two separate `rapidjson::Value` objects (they're sibling keys pulled out of the same extension entry a few lines up), each with its own member array and its own `MemberEnd()`. Comparing an iterator from `metadata.FindMember()` against `identifier.MemberEnd()` doesn't do what the surrounding code (and every other FindMember/MemberEnd pair in this function) does - the two sentinels don't correspond to the same container, so this check doesn't actually catch the "not found" case. It looks like a copy/paste from the `identifier` lookup two lines above.

In practice this means: whenever an entry's `metadata` object is missing an `id` key, `it` equals `metadata.MemberEnd()`, but the comparison against `identifier.MemberEnd()` passes anyway, and `it->value` gets dereferenced past the end of `metadata`'s member array.

That's a real path, not just theoretical - VS Code writes a `metadata` object without an `id` for extensions installed from a local `.vsix` (side-loaded rather than pulled from the marketplace), since there's no marketplace id to record. So a machine with any manually-installed extension in `extensions.json` will hit this.

Fix is a one-liner: compare against `metadata.MemberEnd()` instead, matching the pattern used everywhere else in this function.

I didn't do a full osquery build to verify - the CMake setup here is heavy and this seemed like a safe, mechanical fix given the pattern is identical to every other guard in the same function, but flagging that I only verified this by reading the rapidjson semantics and the surrounding code, not by compiling and running against a crafted extensions.json. Happy to build a repro if useful.
