### PR TITLE
Add Microsoft Edge and Flatpak paths to chrome_extensions on Linux

### DIFF
--- a/osquery/tables/applications/chrome/tests/utils.cpp
+++ b/osquery/tables/applications/chrome/tests/utils.cpp
@@ -180,6 +180,12 @@ TEST_F(ChromeUtilsTests, getChromeBrowserName) {
 
   browser_name = getChromeBrowserName(ChromeBrowserType::Opera);
   EXPECT_EQ(browser_name, "opera");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::Edge);
+  EXPECT_EQ(browser_name, "edge");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::EdgeBeta);
+  EXPECT_EQ(browser_name, "edge_beta");
 }
 
 TEST_F(ChromeUtilsTests, getExtensionContentScriptsMatches) {

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -80,17 +80,24 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"}};
 // clang-format on
 
+// clang-format off
 const ChromePathSuffixMap kLinuxPathList = {
     {ChromeBrowserType::GoogleChrome, ".config/google-chrome"},
     {ChromeBrowserType::GoogleChromeBeta, ".config/google-chrome-beta"},
     {ChromeBrowserType::GoogleChromeDev, ".config/google-chrome-unstable"},
     {ChromeBrowserType::Brave, ".config/BraveSoftware/Brave-Browser"},
+    {ChromeBrowserType::Brave, ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser"},
     {ChromeBrowserType::Chromium, ".config/chromium"},
     {ChromeBrowserType::Chromium, "snap/chromium/common/chromium"},
+    {ChromeBrowserType::Chromium, ".var/app/org.chromium.Chromium/config/chromium"},
     {ChromeBrowserType::Yandex, ".config/yandex-browser-beta"},
+    {ChromeBrowserType::Edge, ".config/microsoft-edge"},
+    {ChromeBrowserType::EdgeBeta, ".config/microsoft-edge-beta"},
     {ChromeBrowserType::Opera, ".config/opera"},
     {ChromeBrowserType::Vivaldi, ".config/vivaldi"},
+    {ChromeBrowserType::Vivaldi, ".var/app/com.vivaldi.Vivaldi/config/vivaldi"},
 };
+// clang-format on
 
 /// Maps ChromeBrowserType values to readable strings
 const std::unordered_map<ChromeBrowserType, std::string>
@@ -104,7 +111,7 @@ const std::unordered_map<ChromeBrowserType, std::string>
         {ChromeBrowserType::Yandex, "yandex"},
         {ChromeBrowserType::Opera, "opera"},
         {ChromeBrowserType::Edge, "edge"},
-        {ChromeBrowserType::Edge, "edge_beta"},
+        {ChromeBrowserType::EdgeBeta, "edge_beta"},
         {ChromeBrowserType::Vivaldi, "vivaldi"},
         {ChromeBrowserType::Arc, "arc"},
 };


### PR DESCRIPTION
Related to #7815

`kLinuxPathList` in `chrome/utils.cpp` is missing a few install locations that are common on Linux today:

- Microsoft Edge isn't in the Linux list at all (Windows and macOS both have Edge/EdgeBeta entries, Linux has none). Added `.config/microsoft-edge` and `.config/microsoft-edge-beta`, matching Edge's actual package naming on Debian/Ubuntu.
- No Flatpak paths for any browser, even though Flatpak is the default install channel on Fedora Silverblue and increasingly common elsewhere. Added the three Flatpak paths I could directly confirm: Chromium (`org.chromium.Chromium`), Brave (`com.brave.Browser`), and Vivaldi (`com.vivaldi.Vivaldi`). Each Flatpak app sandboxes its config under `~/.var/app/<app-id>/config/...`, using the same subdirectory name the native package would use, so these just mirror the existing native paths under that prefix.

This doesn't fix the Brave-via-snap path from #7815 itself. I couldn't independently confirm the exact snap layout Brave uses on disk, so I left that alone rather than guess at it. The Edge and Flatpak paths above are a separate, independently-verified gap in the same "we only cover apt-installed browsers on Linux" bug class.

While I was in `kChromeBrowserTypeToString` adding the Edge lookup I noticed the existing `edge_beta` entry is keyed to `ChromeBrowserType::Edge` instead of `ChromeBrowserType::EdgeBeta`:

```
{ChromeBrowserType::Edge, "edge"},
{ChromeBrowserType::Edge, "edge_beta"},
```

Since it's an `unordered_map` built from an initializer list, the first entry for a given key wins and the second is silently dropped, so `EdgeBeta` has no entry at all today. `getChromeBrowserName` returns an empty string for it, even though `specs/chrome_extensions.table` documents `edge_beta` as a valid `browser_type` value. That means any Edge Beta profile on macOS or Windows (both already have EdgeBeta path entries) currently shows up with a blank `browser_type`. Fixed the key and added a test case for it, since it's directly tied to the Edge paths I'm adding here.

Added a couple of `getChromeBrowserName` test cases for Edge and Edge Beta to `chrome/tests/utils.cpp`.

I don't have a build environment set up for this, so I couldn't run the test suite locally. Verified by reading `utils.cpp`/`utils.h` and confirming the new entries follow the same `ChromePathSuffixMap` shape as every other row in the list, and that `getChromeProfiles` already skips paths that don't exist so this is purely additive for anyone not running these browsers.
