### PR TITLE
docs: fix SECURITY.md vulnerability-reporting link (dead CONTRIBUTING anchor → GitHub advisory)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,9 @@
 # Security Vulnerability Disclosure
 
 This document contains a reference history of osquery's remediated security vulnerabilities. If you find a
-vulnerability, please see CONTRIBUTING.md#how_to_report_vulnerabilities for how to submit a vulnerability report.
+vulnerability, please report it privately via GitHub's security advisory form ("Report a vulnerability" on the
+[Security Advisories](https://github.com/osquery/osquery/security/advisories/new) page). If you believe a CVE should
+be assigned, that can be discussed in the advisory - the maintainers use GitHub's Security Advisory features to request one.
 
 ## Security Issues
 


### PR DESCRIPTION
Fixes #8993.

## What this does

`SECURITY.md` told vulnerability reporters to see `CONTRIBUTING.md#how_to_report_vulnerabilities`, but that anchor/section doesn't exist, so reporters landed nowhere. As discussed in #8993, this replaces that dead link with a direct pointer to GitHub's private vulnerability reporting:

> If you find a vulnerability, please report it privately via GitHub's security advisory form ("Report a vulnerability" on the Security Advisories page). If you believe a CVE should be assigned, that can be discussed in the advisory — the maintainers use GitHub's Security Advisory features to request one.

This is consistent with the existing "Security Issues" section, which already notes the project uses GitHub Security Advisory features for CVE requests. Docs-only, single sentence.

---

*Disclosure: I used an AI tool to help with this; I verified the missing anchor and the advisory flow myself and take responsibility for the change.*
