### PR TITLE
Add missing Chromium browser variants to chrome_extensions table

### DIFF
--- a/osquery/tables/applications/chrome/tests/utils.cpp
+++ b/osquery/tables/applications/chrome/tests/utils.cpp
@@ -186,6 +186,39 @@ TEST_F(ChromeUtilsTests, getChromeBrowserName) {
 
   browser_name = getChromeBrowserName(ChromeBrowserType::EdgeBeta);
   EXPECT_EQ(browser_name, "edge_beta");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::GoogleChromeBeta);
+  EXPECT_EQ(browser_name, "chrome_beta");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::GoogleChromeDev);
+  EXPECT_EQ(browser_name, "chrome_dev");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::GoogleChromeCanary);
+  EXPECT_EQ(browser_name, "chrome_canary");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::BraveBeta);
+  EXPECT_EQ(browser_name, "brave_beta");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::BraveNightly);
+  EXPECT_EQ(browser_name, "brave_nightly");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::EdgeDev);
+  EXPECT_EQ(browser_name, "edge_dev");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::EdgeCanary);
+  EXPECT_EQ(browser_name, "edge_canary");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::Vivaldi);
+  EXPECT_EQ(browser_name, "vivaldi");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::Arc);
+  EXPECT_EQ(browser_name, "arc");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::Dia);
+  EXPECT_EQ(browser_name, "dia");
+
+  browser_name = getChromeBrowserName(ChromeBrowserType::PerplexityComet);
+  EXPECT_EQ(browser_name, "comet");
 }
 
 TEST_F(ChromeUtilsTests, getExtensionContentScriptsMatches) {

--- a/osquery/tables/applications/chrome/utils.cpp
+++ b/osquery/tables/applications/chrome/utils.cpp
@@ -56,12 +56,18 @@ const ChromePathSuffixMap kWindowsPathList = {
     {ChromeBrowserType::GoogleChromeDev, "AppData\\Local\\Google\\Chrome Dev\\User Data"},
     {ChromeBrowserType::GoogleChromeCanary, "AppData\\Local\\Google\\Chrome SxS\\User Data"},
     {ChromeBrowserType::Brave, "AppData\\Roaming\\brave"},
+    {ChromeBrowserType::Brave, "AppData\\Local\\BraveSoftware\\Brave-Browser\\User Data"},
+    {ChromeBrowserType::BraveBeta, "AppData\\Local\\BraveSoftware\\Brave-Browser-Beta\\User Data"},
+    {ChromeBrowserType::BraveNightly, "AppData\\Local\\BraveSoftware\\Brave-Browser-Nightly\\User Data"},
     {ChromeBrowserType::Chromium, "AppData\\Local\\Chromium"},
     {ChromeBrowserType::Yandex, "AppData\\Local\\Yandex\\YandexBrowser\\User Data"},
     {ChromeBrowserType::Edge, "AppData\\Local\\Microsoft\\Edge\\User Data"},
     {ChromeBrowserType::EdgeBeta, "AppData\\Local\\Microsoft\\Edge Beta\\User Data"},
+    {ChromeBrowserType::EdgeDev, "AppData\\Local\\Microsoft\\Edge Dev\\User Data"},
+    {ChromeBrowserType::EdgeCanary, "AppData\\Local\\Microsoft\\Edge SxS\\User Data"},
     {ChromeBrowserType::Opera, "AppData\\Roaming\\Opera Software\\Opera Stable"},
-    {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"}};
+    {ChromeBrowserType::Vivaldi, "AppData\\Local\\Vivaldi\\User Data"},
+    {ChromeBrowserType::PerplexityComet, "AppData\\Local\\Perplexity\\Comet\\User Data"}};
 // clang-format on
 
 // clang-format off
@@ -71,13 +77,19 @@ const ChromePathSuffixMap kMacOsPathList = {
     {ChromeBrowserType::GoogleChromeDev, "Library/Application Support/Google/Chrome Dev"},
     {ChromeBrowserType::GoogleChromeCanary, "Library/Application Support/Google/Chrome Canary"},
     {ChromeBrowserType::Brave, "Library/Application Support/BraveSoftware/Brave-Browser"},
+    {ChromeBrowserType::BraveBeta, "Library/Application Support/BraveSoftware/Brave-Browser-Beta"},
+    {ChromeBrowserType::BraveNightly, "Library/Application Support/BraveSoftware/Brave-Browser-Nightly"},
     {ChromeBrowserType::Chromium, "Library/Application Support/Chromium"},
     {ChromeBrowserType::Yandex, "Library/Application Support/Yandex/YandexBrowser"},
     {ChromeBrowserType::Edge, "Library/Application Support/Microsoft Edge"},
     {ChromeBrowserType::EdgeBeta, "Library/Application Support/Microsoft Edge Beta"},
+    {ChromeBrowserType::EdgeDev, "Library/Application Support/Microsoft Edge Dev"},
+    {ChromeBrowserType::EdgeCanary, "Library/Application Support/Microsoft Edge Canary"},
     {ChromeBrowserType::Opera, "Library/Application Support/com.operasoftware.Opera"},
     {ChromeBrowserType::Vivaldi, "Library/Application Support/Vivaldi"},
-    {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"}};
+    {ChromeBrowserType::Arc, "Library/Application Support/Arc/User Data"},
+    {ChromeBrowserType::Dia, "Library/Application Support/Dia/User Data"},
+    {ChromeBrowserType::PerplexityComet, "Library/Application Support/Comet"}};
 // clang-format on
 
 // clang-format off
@@ -87,12 +99,17 @@ const ChromePathSuffixMap kLinuxPathList = {
     {ChromeBrowserType::GoogleChromeDev, ".config/google-chrome-unstable"},
     {ChromeBrowserType::Brave, ".config/BraveSoftware/Brave-Browser"},
     {ChromeBrowserType::Brave, ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser"},
+    {ChromeBrowserType::BraveBeta, ".config/BraveSoftware/Brave-Browser-Beta"},
+    {ChromeBrowserType::BraveBeta, ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser-Beta"},
+    {ChromeBrowserType::BraveNightly, ".config/BraveSoftware/Brave-Browser-Nightly"},
+    {ChromeBrowserType::BraveNightly, ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser-Nightly"},
     {ChromeBrowserType::Chromium, ".config/chromium"},
     {ChromeBrowserType::Chromium, "snap/chromium/common/chromium"},
     {ChromeBrowserType::Chromium, ".var/app/org.chromium.Chromium/config/chromium"},
     {ChromeBrowserType::Yandex, ".config/yandex-browser-beta"},
     {ChromeBrowserType::Edge, ".config/microsoft-edge"},
     {ChromeBrowserType::EdgeBeta, ".config/microsoft-edge-beta"},
+    {ChromeBrowserType::EdgeDev, ".config/microsoft-edge-dev"},
     {ChromeBrowserType::Opera, ".config/opera"},
     {ChromeBrowserType::Vivaldi, ".config/vivaldi"},
     {ChromeBrowserType::Vivaldi, ".var/app/com.vivaldi.Vivaldi/config/vivaldi"},
@@ -107,13 +124,19 @@ const std::unordered_map<ChromeBrowserType, std::string>
         {ChromeBrowserType::GoogleChromeDev, "chrome_dev"},
         {ChromeBrowserType::GoogleChromeCanary, "chrome_canary"},
         {ChromeBrowserType::Brave, "brave"},
+        {ChromeBrowserType::BraveBeta, "brave_beta"},
+        {ChromeBrowserType::BraveNightly, "brave_nightly"},
         {ChromeBrowserType::Chromium, "chromium"},
         {ChromeBrowserType::Yandex, "yandex"},
         {ChromeBrowserType::Opera, "opera"},
         {ChromeBrowserType::Edge, "edge"},
         {ChromeBrowserType::EdgeBeta, "edge_beta"},
+        {ChromeBrowserType::EdgeDev, "edge_dev"},
+        {ChromeBrowserType::EdgeCanary, "edge_canary"},
         {ChromeBrowserType::Vivaldi, "vivaldi"},
         {ChromeBrowserType::Arc, "arc"},
+        {ChromeBrowserType::Dia, "dia"},
+        {ChromeBrowserType::PerplexityComet, "comet"},
 };
 
 /// Base paths for built-in extensions; used to silence warnings for

--- a/osquery/tables/applications/chrome/utils.h
+++ b/osquery/tables/applications/chrome/utils.h
@@ -33,13 +33,19 @@ enum class ChromeBrowserType {
   GoogleChromeDev,
   GoogleChromeCanary,
   Brave,
+  BraveBeta,
+  BraveNightly,
   Chromium,
   Yandex,
   Opera,
   Edge,
   EdgeBeta,
+  EdgeDev,
+  EdgeCanary,
   Vivaldi,
   Arc,
+  Dia,
+  PerplexityComet,
 };
 
 /// Converts the browser type to a printable string

--- a/specs/chrome_extensions.table
+++ b/specs/chrome_extensions.table
@@ -1,7 +1,7 @@
 table_name("chrome_extensions")
 description("Chrome-based browser extensions.")
 schema([
-    Column("browser_type", TEXT, "The browser type (Valid values: chrome, chromium, opera, yandex, brave, edge, edge_beta)"),
+    Column("browser_type", TEXT, "The browser type (Valid values: chrome, chrome_beta, chrome_dev, chrome_canary, chromium, opera, yandex, brave, brave_beta, brave_nightly, edge, edge_beta, edge_dev, edge_canary, vivaldi, arc, dia, comet)"),
     Column("uid", BIGINT, "The local user that owns the extension", index=True, optimized=True),
     Column("name", TEXT, "Extension display name"),
     Column("profile", TEXT, "The name of the Chrome profile that contains this extension"),


### PR DESCRIPTION
## Summary

This PR adds paths and support for several Chromium-based browsers that are not currently captured by the `chrome_extensions` table. It also adds aliasing for some existing browsers in the `browser_type` column keeping with the pattern established when `edge_beta` was added. 

The `chrome_extensions` table recognizes a fixed set of Chromium browsers. Its `browser_type` column emits:
- `chrome`
- `chromium`
- `opera`
- `yandex`
- `brave`
- `edge`
- `edge_beta`

The per-platform profile-path lists in `osquery/tables/applications/chrome/utils.cpp` miss several browsers that are in common use. This PR adds the missing ones so their extensions are reported.

It also adds a new path for Brave Stable on Windows which now follows the pattern used by Brave Beta and Brave Nightly.

New browser types (added to the `ChromeBrowserType` enum, the name map, and the profile-path lists):

- Brave Beta
- Brave Nightly
- Microsoft Edge Dev
- Microsoft Edge Canary
- Dia
- Perplexity Comet

Where possible, paths were added for each platform, there are a couple omissions though due to lack of platform support:
- Google and Microsoft don't distribute Canary channels for Linux
- Dia and Comet are not available on Linux

The `getChromeBrowserName` unit test in `tests/utils.cpp` now asserts every new `browser_type` value, plus the existing `chrome_beta`, `chrome_dev`, `chrome_canary`, `vivaldi`, and `arc` values that previously had no assertions.

## Verification

- [x] Validated the paths for extensions on each browser by installing the browser variants locally and then checking the paths that were used to save extension `manifest.json` files.
- [ ] Build osquery locally and test that it outputs results as anticipated **(Currently blocked on this one)**

## Notes

- I named it `PerplexityComet` which follows the pattern of `GoogleChrome` but is unlike some of the others (eg. `Edge` not `MicrosoftEdge`), I could go either way, and I am open to feedback.
- I omitted OpenAI's Atlas browser because it is due to be sunset August 9th, 2026: https://openai.com/index/chatgpt-for-your-most-ambitious-work/
- I have not yet been able to build osquery locally on my Mac to test these changes due to the Xcode SDK requirements that are incompatible with macOS Tahoe 26 (Xcode 16.2 won't open)

## Related issues

<link here, or "none">