### PR TITLE
docs: clarify interface_details type values

### DIFF
--- a/specs/interface_details.table
+++ b/specs/interface_details.table
@@ -3,7 +3,7 @@ description("Detailed information and stats of network interfaces.")
 schema([
     Column("interface", TEXT, "Interface name"),
     Column("mac", TEXT, "MAC of interface (optional)", collate="nocase"),
-    Column("type", INTEGER, "Interface type (includes virtual)"),
+    Column("type", INTEGER, "Platform interface type value: Linux ARPHRD_*, macOS/FreeBSD IFT_*, Windows IF_TYPE_*"),
     Column("mtu", INTEGER, "Network MTU"),
     Column("metric", INTEGER, "Metric based on the speed of the interface"),
     Column("flags", INTEGER, "Flags (netdevice) for the device"),


### PR DESCRIPTION
## Summary
- clarify the source of `interface_details.type` values in the table spec
- call out the platform-specific constants used by Linux, macOS/FreeBSD, and Windows implementations

Refs #8558

## Verification
- `git diff --check`
- `python3 tools/codegen/gentable.py specs/interface_details.table /tmp/interface_details_codegen.cpp`
- `python3 tools/codegen/gentable.py --header specs/interface_details.table /tmp/interface_details_codegen.h`
