### PR TITLE
Fix macOS SDK auto-detection running before CMAKE_SYSTEM_NAME is set

### DIFF
--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -19,7 +19,7 @@ else()
 endif()
 
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Darwin")
   if(NOT DEFINED CMAKE_OSX_SYSROOT OR "${CMAKE_OSX_SYSROOT}" STREQUAL "")
     execute_process(
       COMMAND xcrun --sdk macosx --show-sdk-path


### PR DESCRIPTION
Fixes #9001.

toolchain.cmake is included before project() (see the comment at the
top of CMakeLists.txt), so CMAKE_SYSTEM_NAME is empty when the Darwin
detection block from #8867 runs — the block silently no-ops and
CMAKE_OSX_SYSROOT never gets set, which is why a plain `cmake ..`
still fails to find sys/types.h.

Swapped to CMAKE_HOST_SYSTEM_NAME, which is populated before project()
for native builds.

No macOS machine to build-test locally — happy to have CI confirm, or
if a maintainer can sanity check the CMake variable timing, that'd
help too.

- [x] Read the `CONTRIBUTING.md` guide at the root of the repo.
- [ ] Ensure the code is formatted building the `format_check` target.
      (N/A — this is a single line in a `.cmake` file, not covered by clang-format)
- [x] Ensure your PR contains a single logical change.
- [ ] Ensure your PR contains tests for the changes you're submitting.
      (This is a build-configuration timing fix; existing macOS CI jobs will validate it)
- [x] Describe your changes with as much detail as you can.
- [x] Link any issues this PR is related to.