### PR TITLE
Fix weekday and timezone extraction in non-English locales

### DIFF
--- a/osquery/tables/utility/time.cpp
+++ b/osquery/tables/utility/time.cpp
@@ -54,7 +54,7 @@ QueryData genTime(QueryContext& context) {
     struct tm local {};
     localtime_r(&osquery_time, &local);
 
-    std::array<char, 5> buffer{};
+    std::array<char, 8> buffer{};
     if (strftime(buffer.data(), buffer.size(), "%Z", &local) == 0) {
       LOG(ERROR)
           << "Failed to extract the local timezone from the current time";
@@ -65,7 +65,7 @@ QueryData genTime(QueryContext& context) {
   }
 
   {
-    std::array<char, 10> buffer{};
+    std::array<char, 32> buffer{};
     if (strftime(buffer.data(), buffer.size(), "%A", &now) == 0) {
       LOG(ERROR) << "Failed to extract the weekday from the current time";
     } else {


### PR DESCRIPTION
Some locales like Hebrew or German require bigger buffers to hold the weekday in the target language.  
For example, Germam `Donnerstag` is 11 bytes and `יום רביעי` is 18.  
With Tzdata 2017a, zones with numeric UTC-offset string and half-/quarter-hour are 5 chars: Asia/Kathmandu '+0545' with a NULL teminator that is 6. I updated to 8 bytes.
