### PR TITLE
Key the recursive-glob visited set on (device, inode)

### DIFF
--- a/osquery/filesystem/filesystem.cpp
+++ b/osquery/filesystem/filesystem.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <codecvt>
+#include <set>
 #include <sstream>
 
 #include <fcntl.h>
@@ -306,7 +307,11 @@ Status removePath(const fs::path& path) {
   return Status(0, std::to_string(removed_files));
 }
 
-static bool isDirVisited(std::unordered_set<int>& dir_inos,
+// A directory is identified by (device, inode). An inode number is only
+// unique within its own filesystem, so the device has to be part of the key.
+using DirIdentifier = std::pair<dev_t, ino_t>;
+
+static bool isDirVisited(std::set<DirIdentifier>& dir_inos,
                          const std::string& path) {
   if (path.empty()) {
     return true;
@@ -318,12 +323,12 @@ static bool isDirVisited(std::unordered_set<int>& dir_inos,
     return false;
   }
 
-  auto [_, inserted] = dir_inos.emplace(d_stat.st_ino);
+  auto [_, inserted] = dir_inos.emplace(d_stat.st_dev, d_stat.st_ino);
   return !inserted;
 }
 
 static void dfsTraverseDirectories(const std::string& current_path,
-                                   std::unordered_set<int>& visited_dirs,
+                                   std::set<DirIdentifier>& visited_dirs,
                                    std::vector<std::string>& results,
                                    size_t depth) {
   if (depth >= kMaxRecursiveGlobs) {
@@ -368,7 +373,7 @@ static void genGlobs(std::string path,
   replaceGlobWildcards(path, limits);
 
   // inodes of traversed directories to avoid loops from symlinks
-  std::unordered_set<int> dir_inos;
+  std::set<DirIdentifier> dir_inos;
 
   bool should_expand =
       (path.size() >= 2 && path.substr(path.size() - 2) == "**");

--- a/osquery/tables/system/npm_packages.cpp
+++ b/osquery/tables/system/npm_packages.cpp
@@ -9,10 +9,10 @@
 
 #include <boost/filesystem.hpp>
 
+#include <set>
 #include <stdlib.h>
 #include <string>
 #include <sys/stat.h>
-#include <unordered_set>
 #include <utility>
 
 #include <osquery/core/tables.h>
@@ -70,17 +70,21 @@ const std::string kWinNodeInstallKey = "SOFTWARE\\Node.js\\InstallPath";
 
 const int kDefaultMaxDepth = 100;
 
+// An inode number is only unique within its own filesystem, so the device
+// has to be part of the key.
+using DirIdentifier = std::pair<dev_t, ino_t>;
+
 /**
  * @brief Check if a directory has already been visited using inode tracking.
  *
  * This prevents infinite loops from symlinks pointing back up the directory
  * tree. Uses platformLstat which doesn't follow symlinks.
  *
- * @param visited_inos Set of already-visited inodes
+ * @param visited_inos Set of already-visited (device, inode) pairs
  * @param path Directory path to check
  * @return true if already visited, false if new
  */
-static bool isDirVisited(std::unordered_set<int>& visited_inos,
+static bool isDirVisited(std::set<DirIdentifier>& visited_inos,
                          const std::string& path) {
   if (path.empty()) {
     return true;
@@ -91,7 +95,7 @@ static bool isDirVisited(std::unordered_set<int>& visited_inos,
     return false;
   }
 
-  auto [_, inserted] = visited_inos.emplace(d_stat.st_ino);
+  auto [_, inserted] = visited_inos.emplace(d_stat.st_dev, d_stat.st_ino);
   return !inserted;
 }
 
@@ -157,7 +161,7 @@ void genNodeSiteDirectories(const std::string& site,
                             int max_depth) {
   // Queue of (directory_to_search, current_depth) pairs
   std::vector<std::pair<std::string, int>> dirs_to_search;
-  std::unordered_set<int> visited_inos;
+  std::set<DirIdentifier> visited_inos;
 
   dirs_to_search.emplace_back(site, 0);
 


### PR DESCRIPTION
Fixes #8992.

`isDirVisited()` remembers directories by `st_ino` alone. Inode numbers are only unique within a filesystem, not globally, so as soon as a recursive pattern crosses a mount point two unrelated directories can look like the same one — and the second gets skipped along with everything under it. There's no error; the rows just aren't there. Every ext2/3/4 root directory is inode 2, so two ext4 mounts under one `**` pattern hit this every time.

Reproducing it doesn't need loop devices or root:

```
unshare -Urm --propagation private bash -c '
  mount -t tmpfs tmpfs ./fa; mount -t tmpfs tmpfs ./fb
  touch ./fa/canary_a ./fb/canary_b
  stat -c "%n dev=%D ino=%i" ./fa ./fb'

./fa dev=3b ino=1
./fb dev=3c ino=1
```

Different devices, same inode number. Globbing both together returns `fb/` and nothing beneath it; globbing `fb` on its own returns everything.

The set was also `unordered_set<int>` while `ino_t` is 64-bit here, so inodes differing only above bit 32 collide too — that one doesn't need two filesystems, just XFS with `inode64` or a large btrfs:

```
sizeof(ino_t)=8 sizeof(int)=4
emplace(0x100000002) inserted=1
emplace(0x200000002) inserted=0   <- distinct inodes, treated as already visited
ino 4294967295 stored as int -> -1
```

`std::set<std::pair<dev_t, ino_t>>` fixes both. I kept `std::set` rather than `unordered_set` because `std::pair` has no default hash, and this set stays small.

`npm_packages.cpp` has a copy of the same function with both problems, so I fixed it there as well — the issue only mentions `filesystem.cpp`, but the defect is identical.

Symlink-loop protection still works: with the change, a `link -> parent` symlink is listed once and not descended into, which is what the set was added for.

On testing — I couldn't find a way to express this in `osquery/filesystem/tests/filesystem.cpp`, since the cross-device case needs mount privileges and the narrowing case needs control over inode allocation. I verified the traversal behaviour by driving the real `isDirVisited` logic over the two tmpfs mounts above, before and after. Happy to add a test if you can point me at a pattern for it.
